### PR TITLE
Feat3061

### DIFF
--- a/web/web.config
+++ b/web/web.config
@@ -25,5 +25,13 @@
                 <add value="index.php" />
             </files>
         </defaultDocument>
+        <rewrite>
+            <rules>
+                <rule name="Ilios front controller" stopProcessing="true">
+                    <match url="^ilios2\.php/(.*)$" />
+                    <action type="Redirect" url="ilios.php/{R:1}" />
+                </rule>
+            </rules>
+        </rewrite>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
added IIS Url_Write rule for front controller (ilios2.php -> ilios.php)
configured "index.php" as default document
