### PR TITLE
forced ilios.om.inspector.getSessionTypeTitleForId() to always return a ...

### DIFF
--- a/web/system/application/views/offering/offering_manager_inspector_support.js
+++ b/web/system/application/views/offering/offering_manager_inspector_support.js
@@ -117,17 +117,18 @@ ilios.om.inspector.generateGroupMarkup = function (groupArray) {
 
 /*
  * This is a helper method to get the human display text for a session type given the session type's
- * 	database id.
- *
- * Should be considered @private
+ * database id.
+ * @method getSessionTypeTitleForId
+ * @param {Number} sessionTypeId the session type record id
+ * @return {String} the session type title, or a blank string if none could be found.
+ * @private
  */
 ilios.om.inspector.getSessionTypeTitleForId = function (sessionTypeId) {
-	var model = ilios.om.loadedSessionTypes[sessionTypeId];
-
-	if (model) {
-		return model.title;
-	}
-	return null;
+    var model = ilios.om.loadedSessionTypes[sessionTypeId];
+    if (model) {
+        return (model.title || '');
+    }
+    return '';
 };
 
 /**


### PR DESCRIPTION
...String. this fixed the "null" display issue with IE for ILMs. refs #2937
