### PR TITLE
should not assume that builddir exists in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -90,7 +90,7 @@
             </then>
         </if>
         <!-- delete old build directory -->
-        <delete dir="${builddir}" includeemptydirs="true" failonerror="true" />
+        <delete dir="${builddir}" includeemptydirs="true" />
         <!-- re-create build directory -->
         <mkdir dir="${builddir}" />
         <!-- copy codebase to build directory -->


### PR DESCRIPTION
failonerror="true" means that the build will fail if builddir does not already exist. 

Leaving it out means that a warning is printed but the build continues. This is probably what we want.
