### PR TITLE
Get rid of DB warnings on CI phpunit tests using PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - pear channel-discover pear.phing.info
   - pear install phing/phing
   - phpenv rehash
-  - phing -propertyfile build.properties.sample -Ddb.username=root -Ddb.password='' -Dencryption_key=lorem_ipsum init copy configure package
+  - phing -propertyfile build.properties.sample -Ddb.username=root -Ddb.password='' -Dencryption_key=lorem_ipsum build
   - tar xzf /tmp/ilios/bundles/* -C web/
   - cp tests/phpunit/default.phpunit.xml tests/phpunit/phpunit.xml
   - mysql -e 'create database ilios;'


### PR DESCRIPTION
Use phing for travis build, get rid of DB warnings in PHP 5.4
