### PR TITLE
fixes #195

### DIFF
--- a/web/application/models/canned_queries.php
+++ b/web/application/models/canned_queries.php
@@ -254,6 +254,7 @@ EOL;
             array_push($rhett, $row);
         }
 
+        $queryResults->free_result();
         return $rhett;
     }
 


### PR DESCRIPTION
fixes #195.
modified query in `getOfferingForCalendar()` method to include offerings without group association in the student calendar, and offerings without course director or instructor group in the educator calendar.
