### PR TITLE
rm dead code

### DIFF
--- a/web/application/helpers/template_helper.php
+++ b/web/application/helpers/template_helper.php
@@ -379,34 +379,7 @@ if (! function_exists('generatePickerMarkupAndScript')) {
          * @see ilios.dom.buildDialogPanel
          */
         var <?php echo $uniquer; ?>submitMethod = function () {
-            <?php
-                if ($alternativeSubmitHandlerCode != null) :
-                    echo $alternativeSubmitHandlerCode;
-                else :
-            ?>
-            var textFieldContent = '';
-            var containerNumber = this.containerNumber; // 'this' should be the Dialog instance
-            var inputTextId = containerNumber + '_' + <?php echo $uniquer; ?>listingTextField;
-            var parentModel = <?php echo $parentModelGetterName; ?>(this);
-            var element = null;
-
-            parentModel.<?php echo $localModelSetterName; ?>(<?php echo $uniquer; ?>currentlySelectedModels);
-
-            textFieldContent = ilios.utilities.delimitedStringOfTitledObjects(
-                <?php echo $uniquer ?>currentlySelectedModels, ';');
-
-            element = document.getElementById(inputTextId + "_full");
-            if (element != null) {
-                element.innerHTML = textFieldContent;
-                element = document.getElementById(inputTextId);
-                element.innerHTML = ilios.lang.ellipsisedOfLength(textFieldContent, 75);
-            } else {
-                element = document.getElementById(inputTextId);
-                element.innerHTML = textFieldContent;
-            }
-            <?php
-                endif;
-            ?>
+            <?php echo $alternativeSubmitHandlerCode; ?>
         }; // end function
 
 


### PR DESCRIPTION
Since `$alternativeSubmitHandlerCode` is always defined in all the places that `generatePickerMarkupAndScript()` is called, we can remove the blob of code that is the default for when it is `null`
