### PR TITLE
rm dead (I think) code

### DIFF
--- a/web/application/views/course/course_manager_dom.js
+++ b/web/application/views/course/course_manager_dom.js
@@ -1787,15 +1787,8 @@ ilios.cm.disc_initDialog = function (who, knows, args) {
         modelTitles.sort();
         textFieldContent = modelTitles.join(";");
 
-        element = document.getElementById(inputTextId + "_full");
-        if (element != null) {
-            element.innerHTML = textFieldContent;
-            element = document.getElementById(inputTextId);
-            element.innerHTML = ilios.lang.ellipsisedOfLength(textFieldContent, 75);
-        } else {
-            element = document.getElementById(inputTextId);
-            element.innerHTML = textFieldContent;
-        }
+        element = document.getElementById(inputTextId);
+        element.innerHTML = textFieldContent;
     }; // end function
 
     /*


### PR DESCRIPTION
I don't think `*_discipline_picker_selected_text_list_full` ever exists so element is always null after the first `getElementById()` call and the `else` block is the only code that ever runs.

Look about right to you?
