### PR TITLE
Sauce fix

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -138,7 +138,7 @@ class FeatureContext extends MinkContext
     {
         // Wait for element to appear before trying to press it.
         $this->spin(function ($context) use ($id) {
-            return $this->getSession()->getPage()->find('css', "#{$id}");
+            return $context->getSession()->getPage()->find('css', "#{$id}");
         });
 
         $element = $this->getSession()->getPage()->find('css', "#{$id}");


### PR DESCRIPTION
Add some `spin()` calls to avoid intermittent failures during slow page loads
