### PR TITLE
go back to SHA-256

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -251,18 +251,6 @@ class FeatureContext extends MinkContext
     }
 
     /**
-     * @Then /^the length of the value of "([^"]*)" should be less than (\d+)$/
-     */
-    public function theLengthOfTheValueOfShouldBeLessThan($selector, $maxLength)
-    {
-        $el = $this->getSession()->getPage()->find('css', $selector);
-        $length = strlen($el->getValue());
-        if ($length >= $maxLength) {
-            throw new Exception("Length of value of $selector ($length) not less than $maxLength");
-        }
-    }
-
-    /**
      * @AfterScenario
      *
      * PhantomJS does not clear the session properly, so we must

--- a/tests/behat/features/calendar_feed.feature
+++ b/tests/behat/features/calendar_feed.feature
@@ -22,8 +22,3 @@ Feature: Calendar Feed
     #
     And I should see "This URL is like a password. Anyone who knows it can view your calendar! If you wish to invalidate this URL and generate a new one, press Generate."
 
-    #
-    # Google Calendar currently chokes on URLs longer than 116 characters.
-    # Check that ours is less than 100 to give us some room for longer hostnames.
-    #
-    And the length of the value of "#apiurl" should be less than 100

--- a/tests/phpunit/Ilios/PasswordUtilsTest.php
+++ b/tests/phpunit/Ilios/PasswordUtilsTest.php
@@ -105,7 +105,7 @@ class Ilios_PasswordUtilsTest extends Ilios_TestCase
         $this->assertNotEquals($token, $token2);
 
         // 40 char length.
-        $this->assertEquals(strlen($token), 40);
+        $this->assertEquals(strlen($token), 64);
 
         // check if the key contains only (lowercase) hexadecimal chars
         $this->assertEquals(preg_match('/^[\da-f]+$/', $token), 1);

--- a/web/application/third_party/Ilios/PasswordUtils.php
+++ b/web/application/third_party/Ilios/PasswordUtils.php
@@ -186,8 +186,7 @@ class Ilios_PasswordUtils
      */
     public static function generateToken ()
     {
-        // generate random 40-char string. 64-char (sha256) can too easily result
-        //    in a URL of length > 116 which means Google Calendar will choke on it
+        // generate unpredictable 64-char string
         if (function_exists('openssl_random_pseudo_bytes')) {
             $key = bin2hex(openssl_random_pseudo_bytes(32));
         } else {
@@ -201,7 +200,7 @@ class Ilios_PasswordUtils
         $key = microtime() . '_' . $key;
 
         // hash the string
-        $key = hash('sha1', $key);
+        $key = hash('sha256', $key);
 
         return $key;
     }


### PR DESCRIPTION
This will eliminate the need to change CHAR to VARCHAR for the token column in the database. We now believe the issue has to do with a failure to open port 80 in the border firewall as apparently Google Calendar will try to get a robots.txt file via HTTP even if the feed is served over HTTPS. At least, that's our current best theory. Will find out for sure when they open the campus firewall. Until then, good idea to roll back changes, I think. Get rid of confusion in the code comments and algorithms about the source of the problem etc.
