### PR TITLE
Add cron tasks to manage audit_atom table  #424

### DIFF
--- a/tests/phpunit/Ilios/LoggerTest.php
+++ b/tests/phpunit/Ilios/LoggerTest.php
@@ -150,6 +150,63 @@ class Ilios_LoggerTest extends Ilios_TestCase
     }
 
     /**
+     * @test
+     * @covers Ilios_Logger::rotate()
+     * @see Ilios_Logger::rotate()
+     * @group ilios
+     * @group log
+     */
+    public function testNoRotate ()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'rotateTest');
+        $length = Ilios_Logger::LOG_FILE_ROTATE_SIZE - 1;
+        $longString = '';
+        for($i = 0; $i < $length; $i++){
+            $longString .= 'a';
+        }
+        file_put_contents($path, $longString);
+        $logger = Ilios_Logger::getInstance($path);
+        $rotated = $logger->rotate();
+        unset($logger);
+        clearstatcache();
+        $this->assertFalse($rotated);
+        $this->assertEquals(filesize($path), $length);
+        unlink($path);
+    }
+
+    /**
+     * @test
+     * @covers Ilios_Logger::rotate()
+     * @see Ilios_Logger::rotate()
+     * @group ilios
+     * @group log
+     */
+    public function testRotate ()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'rotateTest');
+        $length = Ilios_Logger::LOG_FILE_ROTATE_SIZE + 1;
+        $longString = '';
+        for($i = 0; $i < $length; $i++){
+            $longString .= 'a';
+        }
+        file_put_contents($path, $longString);
+        $logger = Ilios_Logger::getInstance($path);
+        $rotated = $logger->rotate();
+        unset($logger);
+        clearstatcache();
+        $this->assertTrue($rotated !== false);
+        $this->assertTrue(file_exists($rotated));
+        $this->assertEquals(filesize($path), 0);
+        $fp = gzopen($rotated, "r");
+        $this->assertTrue($fp !== false);
+        $contents = gzread($fp, $length);
+        $this->assertEquals(strlen($longString), strlen($contents));
+        $this->assertEquals($longString, $contents);
+        unlink($rotated);
+        unlink($path);
+    }
+
+    /**
      * Test-utility function.
      * Returns the static protected "$_registry" property from the Ilios_Logger class
      * by deliberately breaking encapsuling.

--- a/web/application/config/default.ilios.php
+++ b/web/application/config/default.ilios.php
@@ -267,6 +267,29 @@ $config['tasks']['enrollment_export']['learner_schools'] = range(1,5);
 $config['tasks']['enrollment_export']['participant_role'] = 'participant';
 $config['tasks']['enrollment_export']['participant_schools'] = 1;
 
+/*
+|--------------------------------------------------------------------------
+| Audit log dump, rotate, and prune configuration
+|--------------------------------------------------------------------------
+|
+| * Audit log task specific configuration
+|
+| ['tasks']['audit_log']                            configuration container for user sync process
+| ['tasks']['audit_log']['enabled']                 set to TRUE to enable audit log actions, FALSE to turn it off
+| ['tasks']['audit_log']['daily_log_file_path']     Path to the file to store daily log files, FALSE to not store daily logs
+| ['tasks']['audit_log']['history_log_file_path']   Path to the file to save historic logs before the are moved from the database
+|                                                       FALSE to not keep historic logs
+| ['tasks']['audit_log']['days_to_keep']            How many days of log entries to keep in the database, FALSE to never prune them
+| ['tasks']['audit_log']['rotate_logs']             TRUE ilios will rotate and compress log files, FALSE this can be handled by the OS or sysadmins
+|
+*/
+$config['tasks']['audit_log'] = array();
+$config['tasks']['audit_log']['enabled'] = false;
+$config['tasks']['audit_log']['daily_log_file_path'] = '/web/ilios/cron/daily_audit_logs.txt';
+$config['tasks']['audit_log']['truncate_log_file_path'] = '/web/ilios/cron/audit_logs.txt';
+$config['tasks']['audit_log']['days_to_keep'] = 90;
+$config['tasks']['audit_log']['rotate_logs'] = false;
+
 
 /*
 |--------------------------------------------------------------------------

--- a/web/application/models/audit_atom.php
+++ b/web/application/models/audit_atom.php
@@ -48,4 +48,66 @@ class Audit_Atom extends Ilios_Base_Model
         }
         return true;
     }
+
+    /**
+     * Retrieves audit events
+     * @param string $from
+     * @param string $to
+     * @return array a nested array of events
+     */
+    public function getAuditEvents ($from = false, $to = false)
+    {
+        $events = array();
+        $fromTimeStamp = new DateTime($from?$from:'0000-00-00', new DateTimeZone('UTC'));
+        $toTimeStamp = new DateTime($to?$to:'now', new DateTimeZone('UTC'));
+        
+        $this->db->select('*');
+        $this->db->from($this->getTableName());
+        $this->db->join('user', $this->getTableName() . '.created_by = user.user_id', 'left');
+        $this->db->where('created_at >', $fromTimeStamp->format('c'));
+        $this->db->where('created_at <', $toTimeStamp->format('c'));
+        $this->db->order_by("created_at", "asc");
+
+        $query = $this->db->get();
+        foreach ($query->result_array() as $row) {
+            $row['nice_event_type'] = $this->_niceEventType($row['event_type']);
+            $events[] = $row;
+        }
+        $query->free_result();
+        return $events;
+    }
+
+    /**
+     * Remove old audit events
+     * @param string $to
+     * @return array a nested array of events
+     */
+    public function removeEventsOlderThan ($to)
+    {
+        $events = array();
+        $toTimeStamp = new DateTime($to, new DateTimeZone('UTC'));
+        $this->db->where('created_at <', $toTimeStamp->format('c'));
+
+        $query = $this->db->delete($this->getTableName());
+        return $this->db->affected_rows();
+    }
+    
+    protected function _niceEventType($type)
+    {
+        switch($type){
+            case Ilios_Model_AuditUtils::CREATE_EVENT_TYPE:
+                $string = 'Created';
+                break;
+            case Ilios_Model_AuditUtils::UPDATE_EVENT_TYPE:
+                $string = 'Updated';
+                break;
+            case Ilios_Model_AuditUtils::DELETE_EVENT_TYPE:
+                $string = 'Deleted';
+                break;
+            default:
+                $string = '';
+                break;
+        }
+        return $string;
+    }
 }


### PR DESCRIPTION
Resolves #424
Added configurable options to dump daily audit reports and prune older logs from the table with or without dumping them to a file first. Added rotate method to Ilios_Logger which can be used to rotate and compress log files

**Things to take a look at before merging:**
1. default.ilios.php - I followed the patterns already in this file, including default absolute log files paths in the /web/ilios/cron directory.  Is that correct?  I don't know anything about how this file is implemented.
2. I formatted the audit logs in english with the words at update/create/delete, column, on row of the table.  These aren't user facing strings, should the still go through translation?
3. I wrote a phpunit test for the Ilios_Logger::rotate(), but I couldn't find any infrastructure for testing controllers like the cron controller and didn't want to start from scratch.  Did I miss anything there?
