### PR TITLE
Fix the Change School test

### DIFF
--- a/tests/behat/features/change_school.feature
+++ b/tests/behat/features/change_school.feature
@@ -6,7 +6,7 @@ Feature: Change School
     Given I am on the Ilios home page
     And I log in as "zero_user" with password "Ch4nge_m3"
 
-  @ignore @javascript @insulated
+  @javascript @insulated
   Scenario: Change Selected School
     Given I have access in the "Medicine" school
     And I have access in the "Pharmacy" school


### PR DESCRIPTION
Stop ignoring the test from #564
In order to account for some delays in loading added some sleep / spin to FeatureContext::accessToSchool to ensure it doesn’t give up too soon.
Use a spinning xpath selector for clicking on tabs.
Wait for permissions to be loaded before attempting to change permissions.
Add FeatureContext:: findXpathElement - makes the behat runs less fragile by searching for elements using path and dying gracefully when they are not found in time.
