### PR TITLE
Screenshots for failing steps

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -656,4 +656,26 @@ class FeatureContext extends MinkContext
     {
         $this->getSession()->reset();
     }
+
+    /**
+     * When a step fails take a screen shot.
+     * This should work with any of the selenium2 drivers incuding phantomjs
+     *
+     * It outputs the file location above the failed step.
+     * @todo find a better way to techo the path to the console.
+     * @AfterStep
+     */
+    public function takeScreenshotAfterFailedStep($event)
+    {
+        if ($event->getResult() == 4) {
+            if ($this->getSession()->getDriver() instanceof \Behat\Mink\Driver\Selenium2Driver) {
+                $stepText = $event->getStep()->getText();
+                $fileTitle = preg_replace("#[^a-zA-Z0-9\._-]#", '', $stepText);
+                $fileName = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $fileTitle . '.png';
+                $screenshot = $this->getSession()->getDriver()->getScreenshot();
+                file_put_contents($fileName, $screenshot);
+                print "Screenshot for '{$stepText}' placed in {$fileName}\n";
+            }
+        }
+    }
 }


### PR DESCRIPTION
This will add an automatic screen shot to the system temp directory on each failing test.  This is especially useful for phantomjs where the failure happens headlessly.

I couldn't figure out how to make the path to the screen shots print out pretty like the rest of the behat output, and didn't want to spend any more time on it.
