### PR TITLE
Travis speed improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,21 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: "BEHAT_PROFILE='osxsafari' START_SAUCE_CONNECT=true TEST_BEHAT=true"
+    - env: "BEHAT_PROFILE='osxchrome' START_SAUCE_CONNECT=true TEST_BEHAT=true"
     - env: "BEHAT_PROFILE='win7ie9' START_SAUCE_CONNECT=true TEST_BEHAT=true"
+  exclude:
+    #there is no need to test all the browsers against both versions of PHP, the phantomjs test will show if anything is terribly wrong
+    - php: "5.4"
+      env: BEHAT_PROFILE='default' START_SAUCE_CONNECT=true TEST_BEHAT=true
+    - php: "5.4"
+      env: BEHAT_PROFILE='win7ie9' START_SAUCE_CONNECT=true TEST_BEHAT=true
+    - php: "5.4"
+      env: BEHAT_PROFILE='osxsafari' START_SAUCE_CONNECT=true TEST_BEHAT=true
+    - php: "5.4"
+      env: BEHAT_PROFILE='osxchrome' START_SAUCE_CONNECT=true TEST_BEHAT=true
+    #jasmine tests dont' need to be run against multiple PHP versions
+    - php: "5.4"
+      env: TEST_JASMINE=true
 
 php:
   - "5.4"
@@ -32,6 +46,7 @@ env:
     - BEHAT_PROFILE='default' START_SAUCE_CONNECT=true TEST_BEHAT=true
     - BEHAT_PROFILE='win7ie9' START_SAUCE_CONNECT=true TEST_BEHAT=true
     - BEHAT_PROFILE='osxsafari' START_SAUCE_CONNECT=true TEST_BEHAT=true
+    - BEHAT_PROFILE='osxchrome' START_SAUCE_CONNECT=true TEST_BEHAT=true
 
 addons:
   hosts:


### PR DESCRIPTION
Add OSX Chrome to the automated tests on travis to take advantage of extra sauce capacity for Mac hosts.  This test is failing currently on a specific step, so allow it to fail until this is resolved.

Currently sauce is the most buggy slow part of our tests to I've limited its use:
There is no reason to run the sauce tests against both versions of PHP.
If some kind of php change causes an error it will get picked up by the phantomjs tests, not a browser specific issue.  Hopefully our commingled php/js will not make a liar out of me.

Run jasmine once since it is also unlikley to fail in one version of php over another
