### PR TITLE
Sleep between selenium and phantom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,10 +98,10 @@ install:
 
 before_script:
 # Start Selenium standalone server for Behat tests
-  - if [ "$START_LOCAL_SELENIUM" = true ]; then (java -jar ${TRAVIS_BUILD_DIR}/tests/behat/bin/selenium-server.jar -role hub > /dev/null & sleep 10); fi
+  - if [ "$START_LOCAL_SELENIUM" = true ]; then (java -jar ${TRAVIS_BUILD_DIR}/tests/behat/bin/selenium-server.jar -role hub > /dev/null & sleep 30); fi
 
 #Start Phantom for headless Behat tests / have to sleep for a bit to allow selenium hub to start and then sleep again to wait for phantom to start
-  - if [ "$START_LOCAL_SELENIUM" = true ]; then (phantomjs --webdriver=8080 --webdriver-selenium-grid-hub=http://127.0.0.1:4444 --ignore-ssl-errors=true > /dev/null & sleep 10); fi
+  - if [ "$START_LOCAL_SELENIUM" = true ]; then (phantomjs --webdriver=8080 --webdriver-selenium-grid-hub=http://127.0.0.1:4444 --ignore-ssl-errors=true > /dev/null & sleep 30); fi
 
 # This is only necessary while sauce_connect is being disabled in pull requests
   - if [ "$START_SAUCE_CONNECT" = true ]; then (${TRAVIS_BUILD_DIR}/tests/behat/bin/sauce_connect --readyfile /tmp/scready.tmp --tunnel-identifier $TRAVIS_JOB_NUMBER $SAUCE_USERNAME $SAUCE_ACCESS_KEY > /dev/null &); fi


### PR DESCRIPTION
Attempt to fix constant service not found errors by adding some mandatory sleep between selenium and phantom start.  Ran a couple of travis builds with no issues.
