### PR TITLE
Instead of sleeping wait for ports to be open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,9 +99,11 @@ install:
 before_script:
 # Start Selenium standalone server for Behat tests
   - if [ "$START_LOCAL_SELENIUM" = true ]; then (java -jar ${TRAVIS_BUILD_DIR}/tests/behat/bin/selenium-server.jar -role hub > /dev/null &); fi
-
+  - if [ "$START_LOCAL_SELENIUM" = true ]; then (until netstat -an 2>/dev/null | grep '4444.*LISTEN'; do true; done); fi
+  
 #Start Phantom for headless Behat tests / have to sleep for a bit to allow selenium hub to start
-  - if [ "$START_LOCAL_SELENIUM" = true ]; then (sleep 5; phantomjs --webdriver=8080 --webdriver-selenium-grid-hub=http://127.0.0.1:4444 --ignore-ssl-errors=true > /dev/null &); fi
+  - if [ "$START_LOCAL_SELENIUM" = true ]; then (phantomjs --webdriver=8080 --webdriver-selenium-grid-hub=http://127.0.0.1:4444 --ignore-ssl-errors=true > /dev/null &); fi
+  - if [ "$START_LOCAL_SELENIUM" = true ]; then (until netstat -an 2>/dev/null | grep '8080.*LISTEN'; do true; done); fi
 
 # This is only necessary while sauce_connect is being disabled in pull requests
   - if [ "$START_SAUCE_CONNECT" = true ]; then (${TRAVIS_BUILD_DIR}/tests/behat/bin/sauce_connect --readyfile /tmp/scready.tmp --tunnel-identifier $TRAVIS_JOB_NUMBER $SAUCE_USERNAME $SAUCE_ACCESS_KEY > /dev/null &); fi


### PR DESCRIPTION
After starting selenium and phantomjs run a loop and wait for the ports to be active for those services.
