### PR TITLE
Sessions sort by date in course manager

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -5,6 +5,7 @@ use Behat\Behat\Context\ClosuredContextInterface,
     Behat\Behat\Context\BehatContext,
     Behat\Behat\Context\Step\When,
     Behat\Behat\Context\Step\Then,
+    Behat\Behat\Context\Step\Given,
     Behat\Behat\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode,
     Behat\Gherkin\Node\TableNode;
@@ -646,7 +647,7 @@ class FeatureContext extends MinkContext
         });
     }
 
-    /*
+    /**
      * Checks, that text appears on the page exactly some number of times
      *
      * @Then /^I should see (?P<num>\d+) "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/
@@ -734,16 +735,16 @@ class FeatureContext extends MinkContext
      */
     public function iCreateATestLearnerGroupIn($classYear, $programName)
     {
+        $table = new Behat\Gherkin\Node\TableNode(
+        "\n| first  | last  | email | ucid |" .
+        "\n| Test   | Student | first@example.com | 123456 |"
+        );
         return array(
+            new Given('the following learners exist in the "' . $classYear . '" "' . $programName . '" program:', $table),
             new When('I navigate to the "Learner Groups" tab'),
             new When('I follow "Select Program and Cohort"'),
             new When('I expand "' . $programName . '" tree picker list in "cohort_pick_dialog_c" dialog'),
             new When('I click "Class of ' . $classYear . '" tree picker item in "cohort_pick_dialog_c" dialog'),
-            new When('I press "Add New Members to Cohort"'),
-            new When('I fill in "Test" for "em_last_name"'),
-            new When('I fill in "Student" for "em_first_name"'),
-            new When('I press "Add User"'),
-            new When('I press the "Done" button in "add_new_members_dialog" dialog'),
             new When('I press "Add a New Student Group"'),
             new Then('I should see "Default Group Number 1"')
         );
@@ -779,7 +780,7 @@ class FeatureContext extends MinkContext
         );
     }
 
-    /*
+    /**
      * Delete any existing learner groups in a program
      *
      * @todo - eventually this should be done by directly interacting with the DB

--- a/tests/behat/features/course.feature
+++ b/tests/behat/features/course.feature
@@ -244,7 +244,7 @@ Feature: Course management
       Then I should see "xxx Test Session" in the 3rd ".collapsed_summary_text_div" element
 
       #test for #475 - ILM sessions do not sort by date
-      @javascript @insulated @ignore
+      @javascript @insulated
       Scenario: ILM Sessions sort in order
         Given I create a test course "Test ILM Sort" for class of "2017" in "Test Course Program"
         Then I should see "Test ILM Sort"

--- a/web/application/views/course/course_manager_session_dom.js
+++ b/web/application/views/course/course_manager_session_dom.js
@@ -1052,32 +1052,23 @@ ilios.cm.session.sessionDivComparator = function (div1, div2) {
     var cn1 = div1.getAttribute('cnumber');
     var cn2 = div2.getAttribute('cnumber');
 
-/*
-    if (selectedIndex == 0) {
-        return parseInt(cn1) - parseInt(cn2);
-    } else {
-*/
-        var sm1 = ilios.cm.currentCourseModel.getSessionForContainer(cn1);
-        var sm2 = ilios.cm.currentCourseModel.getSessionForContainer(cn2);
-        var fe1 = null;
-        var fe2 = null;
+    var sm1 = ilios.cm.currentCourseModel.getSessionForContainer(cn1);
+    var sm2 = ilios.cm.currentCourseModel.getSessionForContainer(cn2);
+    var fe1 = null;
+    var fe2 = null;
 
-        switch (selectedIndex) {
-            case 0:
-                return sm1.getTitle().localeCompare(sm2.getTitle());
-            case 1:
-                return sm2.getTitle().localeCompare(sm1.getTitle());
-            case 2:
-                fe1 = sm1.getFirstEventStart();
-                fe2 = sm2.getFirstEventStart();
-                return fe1 - fe2;
-            case 3:
-                fe1 = sm1.getFirstEventStart();
-                fe2 = sm2.getFirstEventStart();
-                return fe2 - fe1;
-        }
-/*
+    switch (selectedIndex) {
+        case 0:
+            return sm1.getTitle().localeCompare(sm2.getTitle());
+        case 1:
+            return sm2.getTitle().localeCompare(sm1.getTitle());
+        case 2:
+            fe1 = sm1.getFirstEventStart();
+            fe2 = sm2.getFirstEventStart();
+            return fe1 - fe2;
+        case 3:
+            fe1 = sm1.getFirstEventStart();
+            fe2 = sm2.getFirstEventStart();
+            return fe2 - fe1;
     }
-    return 0;
-*/
 };

--- a/web/application/views/scripts/models/session_model.js
+++ b/web/application/views/scripts/models/session_model.js
@@ -742,11 +742,16 @@ SessionModel.prototype.getFirstEventStart = function () {
     var rhett = Number.MAX_VALUE;
     var offering = null;
 
-    for (var key in this.offerings) {
-        offering = this.offerings[key];
+    //ILM sessions do not have offerings, just a single due date
+    if(this.independentLearningModel != null){
+        rhett = this.independentLearningModel.getDueDate().getTime();
+    } else {
+        for (var key in this.offerings) {
+            offering = this.offerings[key];
 
-        if (offering.getStartDate().getTime() < rhett) {
-            rhett = offering.getStartDate().getTime();
+            if (offering.getStartDate().getTime() < rhett) {
+                rhett = offering.getStartDate().getTime();
+            }
         }
     }
 


### PR DESCRIPTION
Updated session_model.js to recognize ILM sessions as being different
from other session types which resolves #475

Pulled a commented out if/else out of course_manager_session-dom.js

Also added tests for regular courses to sort.
