### PR TITLE
added explode to account for shib 'mail' attributes returned as a 'SAML1...

### DIFF
--- a/web/application/controllers/authentication_controller.php
+++ b/web/application/controllers/authentication_controller.php
@@ -218,7 +218,14 @@ class Authentication_Controller extends Ilios_Base_Controller
         $shibbUserIdAttribute = $this->config->item('ilios_authentication_shibboleth_user_id_attribute');
         $shibUserId = array_key_exists($shibbUserIdAttribute, $_SERVER) ? $_SERVER[$shibbUserIdAttribute] : null; // passed in by Shibboleth
         if (! empty($shibUserId)) {
-            $emailAddress = $shibUserId;
+            /**
+             * Some schools release the 'mail' attribute twice, urn:mace:dir:attribute-def:mail (SAML1) AND
+             * urn:oid:0.9.2342.19200300.100.1.3 (SAML2), as one string of two email addresses separated by a semi-
+             * colon.  They should always be the same value so, to account for this, explode the returned value on the
+             * semicolon and just use the first one...
+             */
+            $mailAttributes = explode(';',$shibUserId);
+            $emailAddress = $mailAttributes[0];
         }
 
 


### PR DESCRIPTION
Added handling for shibboleth authentication 'mail' attribute being returned as the SAML1 AND SAML2 'mail' values in one string, separated by a semicolon. (eg, 'user@example.edu;user@example.edu')
