### PR TITLE
Fix for session not opening on course manager

### DIFF
--- a/web/application/controllers/course_management.php
+++ b/web/application/controllers/course_management.php
@@ -28,7 +28,7 @@ class Course_Management extends Ilios_Web_Controller
      * Expects the following GET parameters:
      *     'course_id' ... the course identifier
      *
-      * Expects the following POST parameters:
+      * Expects the following GET or POST parameters:
       *     'session_id' ... the session identifier
      */
     public function index ()
@@ -49,7 +49,7 @@ class Course_Management extends Ilios_Web_Controller
         $courseId = $this->input->get('course_id');
         if ($courseId != '') {
             $data['course_id'] = $courseId;
-            $data['session_id'] = $this->input->post('session_id');
+            $data['session_id'] = $this->input->get_post('session_id');
             if ($data['session_id'] == '') {
                 $data['session_id'] = -1;
             }


### PR DESCRIPTION
revert change in [30e9c8d0227758c593a61923de8f3174829e66d8] that stopped
accepting GET parameters for the session_id on the course manager.
