### PR TITLE
Added audit log config to phing build

### DIFF
--- a/build.properties.sample
+++ b/build.properties.sample
@@ -151,6 +151,16 @@ tasks.user_sync.ldap.password=XXXXXX
 #tasks.enrollment_export.enabled=true
 #tasks.teaching_reminders.enabled=true
 #tasks.user_sync.enabled=true
+#tasks.audit_log.enabled=true
+
+#------------------------------------------------
+# Settings for the audit log cron task
+#------------------------------------------------
+#
+#tasks.audit_log.daily_log_file_path='/web/ilios/cron/daily_audit_logs.txt'
+#tasks.audit_log.truncate_log_file_path='/web/ilios/cron/audit_logs.txt'
+#tasks.audit_log.days_to_keep=90
+#tasks.audit_log.rotate_logs=true
 
 #================================================
 # DB installation

--- a/build.xml
+++ b/build.xml
@@ -248,6 +248,41 @@
                         text="$config['tasks']['enrollment_export']['enabled'] = ${tasks.enrollment_export.enabled};${line.separator}" />
             </then>
         </if>
+        <if>
+            <isset property="tasks.audit_log.enabled" />
+            <then>
+                <append destFile="${builddir}/application/config/ilios.php"
+                        text="$config['tasks']['audit_log']['enabled'] = ${tasks.audit_log.enabled};${line.separator}" />
+            </then>
+        </if>
+        <if>
+            <isset property="tasks.audit_log.daily_log_file_path" />
+            <then>
+                <append destFile="${builddir}/application/config/ilios.php"
+                        text="$config['tasks']['audit_log']['daily_log_file_path'] = ${tasks.audit_log.daily_log_file_path};${line.separator}" />
+            </then>
+        </if>
+        <if>
+            <isset property="tasks.audit_log.truncate_log_file_path" />
+            <then>
+                <append destFile="${builddir}/application/config/ilios.php"
+                        text="$config['tasks']['audit_log']['truncate_log_file_path'] = ${tasks.audit_log.truncate_log_file_path};${line.separator}" />
+            </then>
+        </if>
+        <if>
+            <isset property="tasks.audit_log.days_to_keep" />
+            <then>
+                <append destFile="${builddir}/application/config/ilios.php"
+                        text="$config['tasks']['audit_log']['days_to_keep'] = ${tasks.audit_log.days_to_keep};${line.separator}" />
+            </then>
+        </if>
+        <if>
+            <isset property="tasks.audit_log.rotate_logs" />
+            <then>
+                <append destFile="${builddir}/application/config/ilios.php"
+                        text="$config['tasks']['audit_log']['rotate_logs'] = ${tasks.audit_log.rotate_logs};${line.separator}" />
+            </then>
+        </if>
     </target>
 
     <!-- ============================================ -->


### PR DESCRIPTION
In order to take advantage of the audit log dump system in
[85f000b85d81386eb6ce3f4df1601aa7d954bd90] this adds the configuration
to the ping build process.
