### PR TITLE
Allow session offerings to be counted only once

### DIFF
--- a/database/install/data_population/set_migration_counter.sql
+++ b/database/install/data_population/set_migration_counter.sql
@@ -1,4 +1,4 @@
 --
 -- Sets the current migration version counter on db install.
 --
-INSERT INTO `migrations` VALUES (26);
+INSERT INTO `migrations` VALUES (27);

--- a/database/install/ilios_tables.sql
+++ b/database/install/ilios_tables.sql
@@ -1514,6 +1514,23 @@ DEFAULT CHARSET='utf8'
 COLLATE='utf8_unicode_ci'
 ENGINE=InnoDB;
 
+-- Table curriculum_inventory_sequence_block_session
+DROP TABLE IF EXISTS `curriculum_inventory_sequence_block_session`;
+CREATE TABLE `curriculum_inventory_sequence_block_session` (
+  `sequence_block_session_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `sequence_block_id` INT(10) UNSIGNED NOT NULL,
+  `session_id` INT(14) UNSIGNED NOT NULL,
+  `count_offerings_once` TINYINT default 1 NOT NULL,
+  PRIMARY KEY (`sequence_block_session_id`),
+  CONSTRAINT `fkey_ci_sequence_block_session_sequence_block_id`
+      FOREIGN KEY (`sequence_block_id`) REFERENCES `curriculum_inventory_sequence_block` (`sequence_block_id`)
+      ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT `fkey_curriculum_inventory_sequence_block_session_session_id`
+      FOREIGN KEY (`session_id`) REFERENCES `session` (`session_id`)
+      ON UPDATE CASCADE ON DELETE CASCADE,
+  UNIQUE INDEX `report_session` (`sequence_block_id`, `session_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
 -- Table curriculum_inventory_export
 DROP TABLE IF EXISTS `curriculum_inventory_export`;
 CREATE TABLE `curriculum_inventory_export` (

--- a/web/application/config/migration.php
+++ b/web/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 26;
+$config['migration_version'] = 27;
 
 /*
 |--------------------------------------------------------------------------

--- a/web/application/controllers/curriculum_inventory_manager.php
+++ b/web/application/controllers/curriculum_inventory_manager.php
@@ -50,6 +50,10 @@ class Curriculum_Inventory_Manager extends Ilios_Web_Controller
             $this->load->model('Curriculum_Inventory_Export', 'invExport', true);
         }
 
+        if (! property_exists($this, 'invSequenceBlockSession')) {
+            $this->load->model('Curriculum_Inventory_Sequence_Block_Session', 'invSequenceBlockSession', true);
+        }
+
         if (! property_exists($this, 'program')) {
             $this->load->model('Program', 'program', true);
         }
@@ -142,7 +146,7 @@ class Curriculum_Inventory_Manager extends Ilios_Web_Controller
      */
     public function create ()
     {
-        
+
         $rhett = array();
 
         // authorization check
@@ -721,6 +725,11 @@ class Curriculum_Inventory_Manager extends Ilios_Web_Controller
         $blockId = $this->invSequenceBlock->create($reportId, $parentBlockId, $title, $description, $startDate,
             $endDate, $duration, $academicLevelId, $required, $maximum, $minimum, $track, $courseId, $childSequenceOrder,
             $orderInSequence);
+        if($this->input->post('count_offerings_once_sessions')){
+            foreach($this->input->post('count_offerings_once_sessions') AS $sessionId){
+                $this->invSequenceBlockSession->create($blockId, $sessionId, 1);
+            }
+        }
         $block = $this->invSequenceBlock->get($blockId);
         $this->db->trans_complete();
         if (false === $this->db->trans_status()) {
@@ -1001,6 +1010,12 @@ class Curriculum_Inventory_Manager extends Ilios_Web_Controller
             }
         }
         $this->invSequenceBlock->update($block->sequence_block_id, $data);
+        $this->invSequenceBlockSession->clearSessionsForBlock($blockId);
+        if($this->input->post('count_offerings_once_sessions')){
+            foreach($this->input->post('count_offerings_once_sessions') AS $sessionId){
+                $this->invSequenceBlockSession->create($blockId, $sessionId, 1);
+            }
+        }
         $block = $this->invSequenceBlock->get($blockId);
         $this->db->trans_complete();
         if (false === $this->db->trans_status()) {

--- a/web/application/language/ilios_strings_en_US.properties
+++ b/web/application/language/ilios_strings_en_US.properties
@@ -626,6 +626,11 @@ curriculum_inventory.update.error.report_name_missing=The report name is missing
 curriculum_inventory.update.status.success=Report updated.
 curriculum_inventory.validate.error.report_does_not_exist=No report exists for the given id.
 curriculum_inventory.validate.error.report_id_missing=Invalid or missing report id.
+curriculum_inventory.sequence_block.description=Below are all sessions for the course attached to this block, listing the total instructional time for each session. To accommodate small group, lab, and other similar breakout sessions, check the “Count as one offering” box for a session. This will provide a total time of the single longest offering of that session. Unchecking the “Count as one offering”  box for a session will provide a total time of the sum of all offerings for that session.
+curriculum_inventory.sequence_block.offering_count=# Offerings
+curriculum_inventory.sequence_block.total_offering_time=Total Time
+curriculum_inventory.sequence_block.count_offerings_once=Count as one offering
+curriculum_inventory.summary.details_link=Show Session/Hours Details
 #
 #
 #

--- a/web/application/language/ilios_strings_xx.properties
+++ b/web/application/language/ilios_strings_xx.properties
@@ -626,6 +626,11 @@ curriculum_inventory.update.error.report_name_missing=X$X$X$X$
 curriculum_inventory.update.status.success=X$X$X$X$
 curriculum_inventory.validate.error.report_does_not_exist=X$X$X$X$
 curriculum_inventory.validate.error.report_id_missing=X$X$X$X$
+curriculum_inventory.sequence_block.description=X$X$X$X$
+curriculum_inventory.sequence_block.offering_count=X$X$X$X$
+curriculum_inventory.sequence_block.total_offering_time=X$X$X$X$
+curriculum_inventory.sequence_block.count_offerings_once=X$X$X$X$
+curriculum_inventory.summary.details_link=X$X$X$X$
 #
 #
 #

--- a/web/application/migrations/027_create_curriculum_sequence_inventory_block_session_table.php
+++ b/web/application/migrations/027_create_curriculum_sequence_inventory_block_session_table.php
@@ -1,0 +1,45 @@
+<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/**
+ * Creates a table for storing metadata for sequence block sessions.
+ * Currently stores the boolean count_offerings_once
+ */
+class Migration_Create_curriculum_sequence_inventory_block_session_table extends CI_Migration
+{
+    /**
+     * @see CI_Migration::up()
+     */
+    public function up ()
+    {
+        $this->db->trans_start();
+        $sql =<<< EOL
+CREATE TABLE `curriculum_inventory_sequence_block_session` (
+  `sequence_block_session_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `sequence_block_id` INT(10) UNSIGNED NOT NULL,
+  `session_id` INT(14) UNSIGNED NOT NULL,
+  `count_offerings_once` TINYINT default 1 NOT NULL,
+  PRIMARY KEY (`sequence_block_session_id`),
+  CONSTRAINT `fkey_ci_sequence_block_session_sequence_block_id`
+      FOREIGN KEY (`sequence_block_id`) REFERENCES `curriculum_inventory_sequence_block` (`sequence_block_id`)
+      ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT `fkey_curriculum_inventory_sequence_block_session_session_id`
+      FOREIGN KEY (`session_id`) REFERENCES `session` (`session_id`)
+      ON UPDATE CASCADE ON DELETE CASCADE,
+  UNIQUE INDEX `report_session` (`sequence_block_id`, `session_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+EOL;
+        $this->db->query($sql);
+        $this->db->trans_complete();
+    }
+
+    /**
+     * @see CI_Migration::down()
+     */
+    public function down ()
+    {
+        $this->db->trans_start();
+        $sql = "DROP TABLE `curriculum_inventory_sequence_block_session`";
+        $this->db->query($sql);
+        $this->db->trans_complete();
+    }
+}

--- a/web/application/models/curriculum_inventory_sequence_block.php
+++ b/web/application/models/curriculum_inventory_sequence_block.php
@@ -41,6 +41,7 @@ class Curriculum_Inventory_Sequence_Block extends Ilios_Base_Model
     public function __construct ()
     {
         parent::__construct('curriculum_inventory_sequence_block', array('sequence_block_id'));
+        $this->load->model('Curriculum_Inventory_Sequence_Block_Session', 'blockSession', TRUE);
     }
 
 
@@ -55,6 +56,7 @@ class Curriculum_Inventory_Sequence_Block extends Ilios_Base_Model
         $query = $this->db->get_where($this->databaseTableName, array('sequence_block_id' => $sequenceBlockId));
         if (0 < $query->num_rows()) {
             $rhett = $query->row_array();
+            $rhett['sessions'] = $this->blockSession->getSessions($rhett['sequence_block_id']);
         }
         $query->free_result();
         return $rhett;
@@ -82,6 +84,7 @@ EOL;
         $query = $this->db->query($sql);
         if (0 < $query->num_rows()) {
             foreach ($query->result_array() as $row) {
+                $row['sessions'] = $this->blockSession->getSessions($row['sequence_block_id']);
                 $rhett[] = $row;
             }
         }

--- a/web/application/models/curriculum_inventory_sequence_block_session.php
+++ b/web/application/models/curriculum_inventory_sequence_block_session.php
@@ -1,0 +1,116 @@
+<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+include_once "ilios_base_model.php";
+
+/**
+ * Data Access Object (DAO) for the "curriculum_inventory_sequence_block_session" table.
+ */
+class Curriculum_Inventory_Sequence_Block_Session extends Ilios_Base_Model
+{
+    /**
+     * Constructor.
+     */
+    public function __construct ()
+    {
+        parent::__construct('curriculum_inventory_sequence_block_session', array('sequence_block_session_id'));
+    }
+
+
+    /**
+     * Retrieves a sequence block session by its given id.
+     * @param int $sequenceBlockSessionId The sequence block session id.
+     * @return array|boolean An associative array representing the sequence block record, or FALSE if none was found.
+     */
+    public function get ($sequenceBlockSessionId)
+    {
+        $rhett = false;
+        $query = $this->db->get_where($this->databaseTableName, array('sequence_block_session_id' => $sequenceBlockSessionId));
+        if (0 < $query->num_rows()) {
+            $rhett = $query->row_array();
+        }
+        $query->free_result();
+        return $rhett;
+    }
+
+    /**
+     * Retrieves the sequence block sessions associated with a given block.
+     * @param int $blockId the block id
+     * @return array of sequence block sessions indexed by sequence_block_session_id
+     */
+    public function getSessions ($blockId)
+    {
+        $rhett = array();
+        $this->db->select('*');
+        $this->db->from($this->getTableName());
+        $this->db->where('sequence_block_id =', $blockId);
+        $query = $this->db->get();
+        foreach ($query->result_array() as $row) {
+            $rhett[$row['sequence_block_session_id']] = $row;
+        }
+        $query->free_result();
+        return $rhett;
+    }
+
+    /**
+     * Clears all the sessions for a sequence block
+     * @param int $blockId the block id
+     * @return int number of affected rows
+     */
+    public function clearSessionsForBlock ($blockId)
+    {
+        $this->db->where('sequence_block_id =', $blockId);
+        $this->db->delete($this->getTableName());
+
+        return $this->db->affected_rows();
+    }
+
+    /**
+     * Creates a new sequence block session.
+     * Note: Input validation according to business rules, like type- and range-checking, is assumed to happen further
+     * upstream. In other words, this function expects validated input.
+     *
+     * @param int $sequenceBlockId
+     * @param int $sessionId
+     * @param boolean $countOfferingsOnce
+     * @return int|boolean the new sequence block session id on success, or FALSE on failure
+     */
+    public function create ($sequenceBlockId, $sessionId, $countOfferingsOnce)
+    {
+        $data = array();
+        $data['sequence_block_id'] = $sequenceBlockId;
+        $data['session_id'] = $sessionId;
+        $data['count_offerings_once'] = $countOfferingsOnce;
+
+        if ($this->db->insert($this->databaseTableName, $data)) {
+            return $this->db->insert_id();
+        }
+        return false;
+    }
+
+    /**
+     * Updates a sequence block session with given data.
+     * Note: Input validation according to business rules, like type- and range-checking, is assumed to happen further
+     * upstream. In other words, this function expects validated input.
+     *
+     * @param int $sequenceBlockId
+     * @param array $data An associative array containing the updated values keyed off by column name.
+     *    May contain values entries for the following keys:
+     *   "sequence_block_id", "session_id", "count_offerings_once"
+     */
+    public function update ($sequenceBlockSessionId, array $data)
+    {
+        $this->db->where('sequence_block_session_id', $sequenceBlockSessionId);
+        $this->db->update($this->databaseTableName, $data);
+
+    }
+
+
+    /**
+     * Deletes a given sequence block session
+     * @param int $sequenceBlockId The sequence block id.
+     */
+    public function delete ($sequenceBlockSessionId)
+    {
+        $this->db->delete($this->databaseTableName, array('sequence_block_session_id' => $sequenceBlockSessionId));
+    }
+}

--- a/web/application/views/curriculum_inventory/js/ilios.cim.js
+++ b/web/application/views/curriculum_inventory/js/ilios.cim.js
@@ -632,6 +632,8 @@
                 { report_id: model.get('reportId'), parent: model }, this);
                 Event.addListener(view.getEditButton(), 'click', this.onSequenceBlockEditButtonClick,
                     { block: model }, this);
+                Event.addListener(view.getDetailLink(), 'click', this.onSequenceBlockEditButtonClick,
+                    { block: model }, this);
             }
 
             if (oData.children) {
@@ -1301,6 +1303,12 @@
         el = rowEl.appendChild(document.createElement('div'));
         el.setAttribute('class', 'label column');
         el.appendChild(document.createTextNode(ilios_i18nVendor.getI18NString('general.terms.course')));
+        el.appendChild(document.createElement('br'));
+        var a = new YAHOO.util.Element(document.createElement('a'));
+        a.appendChild(document.createTextNode(ilios_i18nVendor.getI18NString('curriculum_inventory.summary.details_link')));
+        a.set('id', 'sequence-block-view-edit-link-' + cnumber);
+        a.set('href', '#');
+        el.appendChild(a.get('element'));
         el = rowEl.appendChild(document.createElement('div'));
         el.setAttribute('id', 'sequence-block-view-course-' + cnumber);
         el.setAttribute('class', 'data column');

--- a/web/application/views/curriculum_inventory/js/ilios.cim.view.js
+++ b/web/application/views/curriculum_inventory/js/ilios.cim.view.js
@@ -207,6 +207,18 @@
             });
 
             /**
+             * The "Show Session/Hours Details" link of the view.
+             *
+             * @attribute detailLinkE1
+             * @type {HTMLElement}
+             * @writeOnce
+             */
+            this.setAttributeConfig('detailLinkE1', {
+                writeOnce: true,
+                value: Dom.get('sequence-block-view-edit-link-' + cnumber)
+            });
+
+            /**
              * The "add" button of the view.
              *
              * @attribute addBtnEl
@@ -786,6 +798,16 @@
          */
         getEditButton: function () {
             return this.get('editBtnEl');
+        },
+
+        /**
+         * Retrieves the view's "detail" link.
+         *
+         * @method getDetailLinkE1
+         * @return {HTMLElement}
+         */
+        getDetailLink: function () {
+            return this.get('detailLinkE1');
         },
 
         /**


### PR DESCRIPTION
Sessions like small groups may have many offerings, but each student
only attends a single time.  This change allows users to mark these sessions
specially so they can be counted correctly in reporting.

Fixes #473
