### PR TITLE
UC_ID and Galen ID references removed

### DIFF
--- a/web/application/controllers/group_management.php
+++ b/web/application/controllers/group_management.php
@@ -474,8 +474,7 @@ class Group_Management extends Ilios_Web_Controller
      *              Middle name
      *              Phone
      *              EMail address
-     *              UC id
-     *              GALEN id
+     *              Campus ID
      *              Other id
      *
      * Expected POST parameters:
@@ -578,13 +577,12 @@ class Group_Management extends Ilios_Web_Controller
                         $middleName = trim($row[2]);
                         $phone = trim($row[3]);
                         $email = trim($row[4]);
-                        $ucUID = trim($row[5]);
-                        $otherId = trim($row[7]);
-
+                        $campusId = trim($row[5]);
+                        $otherId = trim($row[6]);
                         $primarySchoolId = $this->session->userdata('school_id');
 
                         $newId = $this->user->addUserAsStudent($lastName, $firstName, $middleName, $phone,
-                            $email, $ucUID, $otherId, $cohortId, $primarySchoolId, $auditAtoms);
+                            $email, $campusId, $otherId, $cohortId, $primarySchoolId, $auditAtoms);
 
                         if (($newId <= 0) || $this->user->transactionAtomFailed()) {
                             $msg = $this->languagemap->getI18NString('general.error.db_insert');

--- a/web/application/controllers/instructor_group_management.php
+++ b/web/application/controllers/instructor_group_management.php
@@ -110,8 +110,7 @@ class Instructor_Group_Management extends Ilios_Web_Controller
      *     Middle name
      *     EMail address
      *     Phone
-     *     UC id
-     *     GALEN id
+     *     Campus id
      *     Other id
      */
     public function uploadInstructorListCSVFile ()
@@ -194,13 +193,13 @@ class Instructor_Group_Management extends Ilios_Web_Controller
                     $middleName = trim($row[2]);
                     $phone = trim($row[3]);
                     $email = trim($row[4]);
-                    $ucUID = trim($row[5]);
-                    $otherId = trim($row[7]);
+                    $campusId = trim($row[5]);
+                    $otherId = trim($row[6]);
 
                     $primarySchoolId = $this->session->userdata('school_id');
 
                     $newId = $this->user->addUserAsFaculty($lastName, $firstName, $middleName, $phone,
-                        $email, $ucUID, $otherId, $primarySchoolId, $auditAtoms);
+                        $email, $campusId, $otherId, $primarySchoolId, $auditAtoms);
 
                     if (($newId <= 0) || $this->user->transactionAtomFailed()) {
                         $msg = $this->languagemap->getI18NString('general.error.db_insert');

--- a/web/application/language/ilios_strings_en_US.properties
+++ b/web/application/language/ilios_strings_en_US.properties
@@ -333,7 +333,7 @@ general.terms.yes=Yes
 #
 general.text.course_search_instructions=Locate and select courses
 general.text.csv_user_upload_1=This must be a file of lines of comma separated values with each line having the following fields:
-general.text.csv_user_upload_2=Last name, First name, Middle name, Phone, Email, UC ID, Galen ID, Other ID
+general.text.csv_user_upload_2=Last name, First name, Middle name, Phone, Email, Campus ID, Other ID
 general.text.director_search_instructions=Locate and select directors
 general.text.discipline_search_instructions=Locate and select topics
 general.text.instructor_search_instructions=Locate and select instructors and instructor groups
@@ -346,7 +346,7 @@ general.user.last_name=Last Name
 general.user.middle_name=Middle
 general.user.phone=Phone
 general.user.email=Email
-general.user.uc_id=UC Id
+general.user.uc_id=Campus ID
 #
 general.warning.delete_objective=Are you sure you want to delete this Objective?
 general.warning.delete_prefix=Are you sure you want to delete this

--- a/web/application/views/group/student_model.js
+++ b/web/application/views/group/student_model.js
@@ -79,7 +79,6 @@ StudentModel.prototype.clone = function () {
  * 		first name
  * 		middle name
  * 		uc uid
- * 		galen id
  * 		other id
  * 		email address
  * 		phone number

--- a/web/application/views/scripts/models/user_model.js
+++ b/web/application/views/scripts/models/user_model.js
@@ -220,7 +220,6 @@ UserModel.prototype.clone = function () {
  *      first name
  *      middle name
  *      uc uid
- *      galen id
  *      other id
  *      email address
  *      phone number


### PR DESCRIPTION
Fixes the learner and instructor up loaders to no longer look for
galenId, removed it from the instructions for creating a CSV.
Changed UC ID in user creation and CSV uploads to Campus ID.

Fixes #495 
Fixes #496
