### PR TITLE
added learningmaterials to session cloning

### DIFF
--- a/web/application/views/scripts/models/session_model.js
+++ b/web/application/views/scripts/models/session_model.js
@@ -794,6 +794,8 @@ SessionModel.prototype.clone = function () {
 
     rhett.meshTerms = this.meshTerms.concat();
 
+    rhett.learningMaterials = this.learningMaterials;
+
     rhett.objectiveCount = this.objectiveCount;
     rhett.objectives = this.objectives.slice(0);
 


### PR DESCRIPTION
Learning materials are now properly included in the session clone when Directors are added. Fixes #665
