### PR TITLE
added description attribute to session clone

### DIFF
--- a/web/application/views/scripts/models/session_model.js
+++ b/web/application/views/scripts/models/session_model.js
@@ -784,6 +784,7 @@ SessionModel.prototype.clone = function () {
 
     rhett.dbId = this.dbId;
     rhett.title = this.title;
+    rhett.description = this.description;
 
     rhett.publishEventId = this.publishEventId;
     rhett.publishedAsTBD = this.publishedAsTBD;


### PR DESCRIPTION
The session attribute 'description' was missing from the session clone after directors list is modified.  This fixes #663.
