### PR TITLE
Clean up LDAP login

### DIFF
--- a/web/application/language/ilios_strings_en_US.properties
+++ b/web/application/language/ilios_strings_en_US.properties
@@ -867,6 +867,9 @@ login.error.uid_no_match_1=Your institution ID
 login.error.no_match_2=does not match any user records in Ilios. If you need further assistance, please contact your school’s Ilios administrator.
 login.error.not_logged_in=Your session has expired or you were logged out; please login again.
 login.error.missing_id=There is a problem with your account; please contact an Ilios system administrator.
+login.error.username_missing=Username is Required.
+login.error.password_missing=Password is Required.
+login.error.provider_error=There is a problem with our authentication system; please contact an Ilios system administrator.
 #
 #
 #

--- a/web/application/language/ilios_strings_xx.properties
+++ b/web/application/language/ilios_strings_xx.properties
@@ -867,6 +867,9 @@ login.error.uid_no_match_1=X$X$X$X$
 login.error.no_match_2=X$X$X$X$
 login.error.not_logged_in=X$X$X$X$
 login.error.missing_id=X$X$X$X$
+login.error.username_missing=X$X$X$X$
+login.error.password_missing=X$X$X$X$
+login.error.provider_error=X$X$X$X$
 #
 #
 #


### PR DESCRIPTION
Validate that username and password were entered.  Handle errors more
cleanly and with nice user messages.  Add translation for connection
issue.

Fixes #645 
