### PR TITLE
Added publish_event_id to calendary query to add draft status styling added to dashboard manager

### DIFF
--- a/web/application/models/canned_queries.php
+++ b/web/application/models/canned_queries.php
@@ -548,7 +548,7 @@ EOL;
         // SELECT clause
         $sql =<<< EOL
 SELECT DISTINCT
-o.offering_id, o.start_date, o.end_date, o.session_id, o.room,
+o.offering_id, o.publish_event_id, o.start_date, o.end_date, o.session_id, o.room,
 c.course_id, c.title AS course_title, c.year, c.course_level,
 s.session_type_id, s.title AS session_title,
 st.session_type_css_class,
@@ -647,7 +647,7 @@ EOL;
                     $sql .= ") AS d";
                 } else {
                     $sql =<<< EOL
-SELECT DISTINCT d.offering_id, d.start_date, d.end_date, d.session_id, d.room,
+SELECT DISTINCT d.offering_id, d.publish_event_id, d.start_date, d.end_date, d.session_id, d.room,
 d.course_id, d.course_title, d.year, d.course_level,
 d.session_type_id, d.session_title, d.session_type_css_class, d.recently_updated
 FROM (

--- a/web/application/models/canned_queries.php
+++ b/web/application/models/canned_queries.php
@@ -548,9 +548,9 @@ EOL;
         // SELECT clause
         $sql =<<< EOL
 SELECT DISTINCT
-o.offering_id, o.publish_event_id, o.start_date, o.end_date, o.session_id, o.room,
+o.offering_id, o.start_date, o.end_date, o.session_id, o.room,
 c.course_id, c.title AS course_title, c.year, c.course_level,
-s.session_type_id, s.title AS session_title,
+s.session_type_id, s.publish_event_id, s.title AS session_title,
 st.session_type_css_class,
 EOL;
         // if a negative value has been given for the "last updated offset"

--- a/web/application/models/canned_queries.php
+++ b/web/application/models/canned_queries.php
@@ -548,9 +548,9 @@ EOL;
         // SELECT clause
         $sql =<<< EOL
 SELECT DISTINCT
-o.offering_id, o.start_date, o.end_date, o.session_id, o.room,
-c.course_id, c.title AS course_title, c.year, c.course_level,
-s.session_type_id, s.publish_event_id, s.title AS session_title,
+o.offering_id, o.publish_event_id AS `offering_publish_event_id`, o.start_date, o.end_date, o.session_id, o.room,
+c.course_id, c.publish_event_id AS `course_publish_event_id`, c.title AS course_title, c.year, c.course_level,
+s.session_type_id, s.title AS session_title, s.publish_event_id AS `session_publish_event_id`,
 st.session_type_css_class,
 EOL;
         // if a negative value has been given for the "last updated offset"
@@ -637,9 +637,9 @@ EOL;
             default :
                 if ($student_role) {
         $sql =<<< EOL
-SELECT DISTINCT d.offering_id, d.start_date, d.end_date, d.session_id, d.room,
-d.course_id, d.course_title, d.year, d.course_level,
-d.session_type_id, d.session_title, d.session_type_css_class, d.recently_updated,
+SELECT DISTINCT d.offering_id, d.offering_publish_event_id AS `offering_publish_event_id`, d.start_date, d.end_date, d.session_id, d.room,
+d.course_id, d.course_publish_event_id AS `course_publish_event_id`, d.course_title, d.year, d.course_level,
+d.session_type_id, d.session_title, d.session_publish_event_id AS `session_publish_event_id`, d.session_type_css_class, d.recently_updated,
 d.published_as_tbd, d.course_published_as_tbd
 FROM (
 EOL;
@@ -647,9 +647,9 @@ EOL;
                     $sql .= ") AS d";
                 } else {
                     $sql =<<< EOL
-SELECT DISTINCT d.offering_id, d.publish_event_id, d.start_date, d.end_date, d.session_id, d.room,
-d.course_id, d.course_title, d.year, d.course_level,
-d.session_type_id, d.session_title, d.session_type_css_class, d.recently_updated
+SELECT DISTINCT d.offering_id, d.offering_publish_event_id AS `offering_publish_event_id`, d.start_date, d.end_date, d.session_id, d.room,
+d.course_id, d.course_publish_event_id AS `course_publish_event_id`, d.course_title, d.year, d.course_level,
+d.session_type_id, d.session_title, d.session_publish_event_id AS `session_publish_event_id`, d.session_type_css_class, d.recently_updated
 FROM (
 EOL;
                     $sql .= implode("\n UNION \n", $subqueries);
@@ -658,6 +658,7 @@ EOL;
                 $sql .= " ORDER BY d.start_date ASC, d.offering_id ASC";
         }
         $queryResults = $this->db->query($sql);
+        error_log($this->db->last_query());
 
         $rhett = array();
         foreach ($queryResults->result_array() as $row) {

--- a/web/application/models/canned_queries.php
+++ b/web/application/models/canned_queries.php
@@ -550,7 +550,7 @@ EOL;
 SELECT DISTINCT
 o.offering_id, o.publish_event_id AS `offering_publish_event_id`, o.start_date, o.end_date, o.session_id, o.room,
 c.course_id, c.publish_event_id AS `course_publish_event_id`, c.title AS course_title, c.year, c.course_level,
-s.session_type_id, s.title AS session_title, s.publish_event_id AS `session_publish_event_id`,
+s.session_type_id, s.title AS session_title, s.publish_event_id AS `session_publish_event_id`, s.publish_event_id AS `publish_event_id`,
 st.session_type_css_class,
 EOL;
         // if a negative value has been given for the "last updated offset"
@@ -637,9 +637,9 @@ EOL;
             default :
                 if ($student_role) {
         $sql =<<< EOL
-SELECT DISTINCT d.offering_id, d.offering_publish_event_id AS `offering_publish_event_id`, d.offering_publish_event_id AS `publish_event_id`, d.start_date, d.end_date, d.session_id, d.room,
+SELECT DISTINCT d.offering_id, d.offering_publish_event_id AS `offering_publish_event_id`, d.start_date, d.end_date, d.session_id, d.room,
 d.course_id, d.course_publish_event_id AS `course_publish_event_id`, d.course_title, d.year, d.course_level,
-d.session_type_id, d.session_title, d.session_publish_event_id AS `session_publish_event_id`, d.session_type_css_class, d.recently_updated,
+d.session_type_id, d.session_title, d.session_publish_event_id AS `session_publish_event_id`, d.session_publish_event_id AS `publish_event_id`, d.session_type_css_class, d.recently_updated,
 d.published_as_tbd, d.course_published_as_tbd
 FROM (
 EOL;
@@ -649,7 +649,7 @@ EOL;
                     $sql =<<< EOL
 SELECT DISTINCT d.offering_id, d.offering_publish_event_id AS `offering_publish_event_id`, d.start_date, d.end_date, d.session_id, d.room,
 d.course_id, d.course_publish_event_id AS `course_publish_event_id`, d.course_title, d.year, d.course_level,
-d.session_type_id, d.session_title, d.session_publish_event_id AS `session_publish_event_id`, d.session_type_css_class, d.recently_updated
+d.session_type_id, d.session_title, d.session_publish_event_id AS `session_publish_event_id`, d.session_publish_event_id AS `publish_event_id`, d.session_type_css_class, d.recently_updated
 FROM (
 EOL;
                     $sql .= implode("\n UNION \n", $subqueries);
@@ -658,6 +658,7 @@ EOL;
                 $sql .= " ORDER BY d.start_date ASC, d.offering_id ASC";
         }
         $queryResults = $this->db->query($sql);
+        error_log($this->db->last_query());
 
         $rhett = array();
         foreach ($queryResults->result_array() as $row) {

--- a/web/application/models/canned_queries.php
+++ b/web/application/models/canned_queries.php
@@ -637,7 +637,7 @@ EOL;
             default :
                 if ($student_role) {
         $sql =<<< EOL
-SELECT DISTINCT d.offering_id, d.offering_publish_event_id AS `offering_publish_event_id`, d.start_date, d.end_date, d.session_id, d.room,
+SELECT DISTINCT d.offering_id, d.offering_publish_event_id AS `offering_publish_event_id`, d.offering_publish_event_id AS `publish_event_id`, d.start_date, d.end_date, d.session_id, d.room,
 d.course_id, d.course_publish_event_id AS `course_publish_event_id`, d.course_title, d.year, d.course_level,
 d.session_type_id, d.session_title, d.session_publish_event_id AS `session_publish_event_id`, d.session_type_css_class, d.recently_updated,
 d.published_as_tbd, d.course_published_as_tbd
@@ -658,7 +658,6 @@ EOL;
                 $sql .= " ORDER BY d.start_date ASC, d.offering_id ASC";
         }
         $queryResults = $this->db->query($sql);
-        error_log($this->db->last_query());
 
         $rhett = array();
         foreach ($queryResults->result_array() as $row) {

--- a/web/application/views/css/ilios-styles.css
+++ b/web/application/views/css/ilios-styles.css
@@ -455,7 +455,7 @@ textarea.validation-failed {
     background-color: #666;
 }
 
-/* set the styling for offerings on the calendar that are in draft mode */
+/* set the styling for offerings on the calendar that are in draft mode using pseudo-class '::before' */
 .event-in-draft .dhx_body::before,
 .event-in-draft.dhx_wa_ev_body::before,
 .event-in-draft.dhx_cal_event_clear::before {
@@ -473,6 +473,23 @@ textarea.validation-failed {
 .event-in-draft.dhx_cal_event_clear {
     border: dashed 1px #FDD403;
     font-style: italic;
+}
+
+/* because the 'laboratory' offering-type class has a color of #ffcc67, which is very similar to
+  the draft-mode dashed border, it is hard to see, so we set white dashed border instead of #FDD403 */
+.event-in-draft.laboratory .dhx_body,
+.event-in-draft.laboratory.dhx_wa_ev_body,
+.event-in-draft.laboratory.dhx_cal_event_clear { 
+    border: dashed 1px #FFFFFF;
+}
+
+/* ...and, finally, because the .dhx_body applies to the offering info body AND the small menu items,
+   we need to make sure that nothing is prepended for the draft mode of the
+   .dhx_body attached to the .dhx_cal_select_menu class */
+.event-in-draft.dhx_cal_select_menu .dhx_body::before {
+  content: "";
+  /* also set content to 'none' for Safari support */
+  content: none;
 }
 
 /********************************/

--- a/web/application/views/css/ilios-styles.css
+++ b/web/application/views/css/ilios-styles.css
@@ -456,9 +456,9 @@ textarea.validation-failed {
 }
 
 /* set the styling for offerings on the calendar that are in draft mode */
-.offering-in-draft .dhx_body::before,
-.offering-in-draft.dhx_wa_ev_body::before,
-.offering-in-draft.dhx_cal_event_clear::before {
+.event-in-draft .dhx_body::before,
+.event-in-draft.dhx_wa_ev_body::before,
+.event-in-draft.dhx_cal_event_clear::before {
     background-color: #FFF;
     color: #FF9C00;
     content: "\2757";
@@ -468,9 +468,9 @@ textarea.validation-failed {
     speak: none;
 }
 
-.offering-in-draft .dhx_body,
-.offering-in-draft.dhx_wa_ev_body,
-.offering-in-draft.dhx_cal_event_clear {
+.event-in-draft .dhx_body,
+.event-in-draft.dhx_wa_ev_body,
+.event-in-draft.dhx_cal_event_clear {
     border: dashed 1px #FDD403;
     font-style: italic;
 }

--- a/web/application/views/home/calendar_item_model.js
+++ b/web/application/views/home/calendar_item_model.js
@@ -17,6 +17,7 @@ function CalendarItemModel (dbObject) {
         this.offeringId = -1;
         this.sessionId = -1;
         this.courseId = -1;
+        this.publishEventId = -1;
 
         this.startDate = null;
         this.endDate = null;
@@ -28,7 +29,10 @@ function CalendarItemModel (dbObject) {
 
     } else {
         this.offeringId = dbObject.offering_id;
-        this.publishEventId = dbObject.publish_event_id;
+        this.publishEventId
+            = ((dbObject.publish_event_id < 1) || (dbObject.publish_event_id == null))
+            ? -1
+            : dbObject.publish_event_id;
         this.sessionId = dbObject.session_id;
         this.courseId = dbObject.course_id;
 

--- a/web/application/views/home/calendar_item_model.js
+++ b/web/application/views/home/calendar_item_model.js
@@ -28,6 +28,7 @@ function CalendarItemModel (dbObject) {
 
     } else {
         this.offeringId = dbObject.offering_id;
+        this.publishEventId = dbObject.publish_event_id;
         this.sessionId = dbObject.session_id;
         this.courseId = dbObject.course_id;
 
@@ -62,6 +63,10 @@ function CalendarItemModel (dbObject) {
 
 CalendarItemModel.prototype.getOfferingId = function () {
     return this.offeringId;
+};
+
+CalendarItemModel.prototype.getPublishEventId = function () {
+    return this.publishEventId;
 };
 
 CalendarItemModel.prototype.getSessionId = function () {

--- a/web/application/views/home/dashboard_calendar_support.js
+++ b/web/application/views/home/dashboard_calendar_support.js
@@ -66,7 +66,7 @@ ilios.home.calendar.initCalendar = function () {
             }
 
             //set the 'event-in-draft' class if the event is in draft mode (no publishEventId value)
-            if ((event.iliosModel.hasOwnProperty('publishEventId')) && (!event.iliosModel.publishEventId)){
+            if (event.iliosModel.publishEventId === -1){
                 rhett += " event-in-draft";
             }
 

--- a/web/application/views/home/dashboard_calendar_support.js
+++ b/web/application/views/home/dashboard_calendar_support.js
@@ -66,7 +66,7 @@ ilios.home.calendar.initCalendar = function () {
             }
 
             //set the 'event-in-draft' class if the event is in draft mode (publishEventId === -1)
-            if (event.iliosModel.publishEventId === -1){
+            if (!event.iliosModel.publishEventId){
                 rhett += " event-in-draft";
             }
 

--- a/web/application/views/home/dashboard_calendar_support.js
+++ b/web/application/views/home/dashboard_calendar_support.js
@@ -65,6 +65,11 @@ ilios.home.calendar.initCalendar = function () {
                 rhett += " selected_calendar_event";
             }
 
+            //set the 'event-in-draft' class if the event is in draft mode (publishEventId === -1)
+            if (event.iliosModel.publishEventId === -1){
+                rhett += " event-in-draft";
+            }
+
             if (event.iliosModel.recentlyUpdated) {
                 rhett += " recently_updated_calendar_event";
             }

--- a/web/application/views/home/dashboard_calendar_support.js
+++ b/web/application/views/home/dashboard_calendar_support.js
@@ -65,7 +65,7 @@ ilios.home.calendar.initCalendar = function () {
                 rhett += " selected_calendar_event";
             }
 
-            //set the 'event-in-draft' class if the event is in draft mode (publishEventId === -1)
+            //set the 'event-in-draft' class if the event is in draft mode (no publishEventId value)
             if ((event.iliosModel.hasOwnProperty('publishEventId')) && (!event.iliosModel.publishEventId)){
                 rhett += " event-in-draft";
             }

--- a/web/application/views/home/dashboard_calendar_support.js
+++ b/web/application/views/home/dashboard_calendar_support.js
@@ -66,7 +66,7 @@ ilios.home.calendar.initCalendar = function () {
             }
 
             //set the 'event-in-draft' class if the event is in draft mode (publishEventId === -1)
-            if (!event.iliosModel.publishEventId){
+            if ((event.iliosModel.hasOwnProperty('publishEventId')) && (!event.iliosModel.publishEventId)){
                 rhett += " event-in-draft";
             }
 

--- a/web/application/views/offering/offering_manager_calendar_support.js
+++ b/web/application/views/offering/offering_manager_calendar_support.js
@@ -64,9 +64,9 @@ ilios.om.calendar.initCalendar = function () {
                 rhett += sessionTypeModel.sessionTypeCssClass;
             }
 
-            //set the 'is-draft' class if the offering is in draft mode (publishEventId === -1)
+            //set the 'event-in-draft' class if the event is in draft mode (publishEventId === -1)
             if (event.iliosModel.publishEventId === -1){
-                rhett += " offering-in-draft";
+                rhett += " event-in-draft";
             }
 
             rhett += event.iliosModel.isReadOnly() ? ' read-only-event' : '';


### PR DESCRIPTION
Added 'publish_event_id' to queried items in canned queries in order to ascertain 'draft' status of an offering for the dashboard manager (in addition to the changes to the offerings manager)