### PR TITLE
Add the ability to find users by searchTerm

### DIFF
--- a/sfi/src/Ilios/CoreBundle/Controller/UserController.php
+++ b/sfi/src/Ilios/CoreBundle/Controller/UserController.php
@@ -27,7 +27,7 @@ use Ilios\CoreBundle\Entity\UserInterface;
  */
 class UserController extends FOSRestController
 {
-    
+
     /**
      * Get a User
      *
@@ -105,6 +105,11 @@ class UserController extends FOSRestController
      *   array=true,
      *   description="Filter by fields. Must be an array ie. &filters[id]=3"
      * )
+     * @QueryParam(
+     *   name="searchTerm",
+     *   nullable=true,
+     *   description="Find users who match a search term"
+     * )
      */
     public function cgetAction(ParamFetcherInterface $paramFetcher)
     {
@@ -112,6 +117,7 @@ class UserController extends FOSRestController
         $limit = $paramFetcher->get('limit');
         $orderBy = $paramFetcher->get('order_by');
         $criteria = !is_null($paramFetcher->get('filters')) ? $paramFetcher->get('filters') : array();
+        $searchTerm = !is_null($paramFetcher->get('searchTerm')) ? $paramFetcher->get('searchTerm') : false;
 
         $criteria = array_map(function ($item) {
             $item = $item == 'null'?null:$item;
@@ -120,13 +126,23 @@ class UserController extends FOSRestController
             return $item;
         }, $criteria);
 
-        $result = $this->getUserHandler()
-            ->findUsersBy(
+        if ($searchTerm) {
+            $result = $this->getUserHandler()->findUsersBySearchTerm(
+                $searchTerm,
+                $orderBy,
+                $limit,
+                $offset
+            );
+        } else {
+            $result = $this->getUserHandler()->findUsersBy(
                 $criteria,
                 $orderBy,
                 $limit,
                 $offset
             );
+        }
+
+
         //If there are no matches return an empty array
         $answer['users'] =
             $result ? $result : new ArrayCollection([]);

--- a/sfi/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
+++ b/sfi/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
@@ -111,4 +111,21 @@ class UserManager implements UserManagerInterface
         $class = $this->getClass();
         return new $class();
     }
+
+    /**
+     * @param string $searchTerm
+     * @param array $orderBy
+     * @param integer $limit
+     * @param integer $offset
+     *
+     * @return UserInterface[]|Collection
+     */
+    public function findUsersBySearchTerm(
+        $searchTerm,
+        array $orderBy = null,
+        $limit = null,
+        $offset = null
+    ) {
+        return $this->repository->findBySearchTerm($searchTerm, $orderBy, $limit, $offset);
+    }
 }

--- a/sfi/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
+++ b/sfi/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
@@ -10,7 +10,7 @@ class CourseRepository extends EntityRepository
         $dql = 'SELECT DISTINCT c.year FROM IliosCoreBundle:Course c ORDER BY c.year ASC';
         $results = $this->getEntityManager()->createQuery($dql)->getArrayResult();
 
-        $restur = [];
+        $return = [];
         foreach ($results as $arr) {
             $return[] = $arr['year'];
         }

--- a/sfi/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/sfi/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -1,0 +1,45 @@
+<?php
+namespace Ilios\CoreBundle\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+
+class UserRepository extends EntityRepository
+{
+    public function findBySearchTerm($searchTerm, $orderBy, $limit, $offset)
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->add('select', 'u')->from('IliosCoreBundle:User', 'u');
+        $terms = explode(' ', $searchTerm);
+        $terms = array_filter($terms, 'strlen');
+        if (empty($terms)) {
+            return new ArrayCollection([]);
+        }
+
+        foreach ($terms as $key => $term) {
+            $qb->andWhere($qb->expr()->orX(
+                $qb->expr()->like('u.firstName', "?{$key}"),
+                $qb->expr()->like('u.lastName', "?{$key}"),
+                $qb->expr()->like('u.middleName', "?{$key}"),
+                $qb->expr()->like('u.email', "?{$key}")
+            ))
+            ->setParameter($key, '%' . $term . '%');
+        }
+
+        if (is_array($orderBy)) {
+            foreach ($orderBy as $sort => $order) {
+                $qb->addOrderBy('u.' . $sort, $order);
+            }
+        }
+
+        if ($offset) {
+            $qb->setFirstResult($offset);
+        }
+
+        if ($limit) {
+            $qb->setMaxResults($limit);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+}

--- a/sfi/src/Ilios/CoreBundle/Entity/User.php
+++ b/sfi/src/Ilios/CoreBundle/Entity/User.php
@@ -15,7 +15,7 @@ use Ilios\CoreBundle\Traits\StringableIdEntity;
  * @package Ilios\CoreBundle\Entity
  *
  * @ORM\Table(name="user", indexes={@ORM\Index(name="fkey_user_primary_school", columns={"primary_school_id"})})
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="Ilios\CoreBundle\Entity\Repository\UserRepository")
  *
  * @JMS\ExclusionPolicy("all")
  */


### PR DESCRIPTION
searchTerm is a space separated list of terms which will match
firstName, lastName, middleName, and email.  Each additional term will further constrain the results.

Are there any other fields we should be matching?

Fixes #738 