### PR TITLE
gitignore phpunit.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ bin/*
 var/tmp/*
 !var/tmp/.gitkeep
 sauce_connect.log
+phpunit.xml


### PR DESCRIPTION
prevents accidental check-ins of customized phpunit configuration.

[skip-ci]