### PR TITLE
Fix user event query to match offering entity

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -68,7 +68,7 @@ class UserRepository extends EntityRepository
 
         $events = [];
         $qb = $this->_em->createQueryBuilder();
-        $what = 'o.id, o.startDate, o.endDate, o.room, o.lastUpdatedOn, ' .
+        $what = 'o.id, o.startDate, o.endDate, o.room, o.updatedAt, ' .
           's.title, s.publishedAsTbd, st.sessionTypeCssClass, pe.id as publishEventId';
         $qb->add('select', $what)->from('IliosCoreBundle:User', 'u');
         $qb->leftJoin('u.learnerGroups', 'lg');
@@ -98,7 +98,7 @@ class UserRepository extends EntityRepository
             $event->offering = $arr['id'];
             $event->location = $arr['room'];
             $event->eventClass = $arr['sessionTypeCssClass'];
-            $event->lastModified = $arr['lastUpdatedOn'];
+            $event->lastModified = $arr['updatedAt'];
             $event->isPublished = !empty($arr['publishEventId']);
             $event->isScheduled = $arr['publishedAsTbd'];
 


### PR DESCRIPTION
Offering entity updatedAt replaced lastUpdatedOn in
[546f3d5925532c4d620158ad09b57c05d710575b]

This fixes the issue with getting user events we had when deploying the new API code.