### PR TITLE
Stop deactivating new student accounts

### DIFF
--- a/tests/phpunit/Ilios/UserSync/Process/_datasets/student_process/post/user.xml
+++ b/tests/phpunit/Ilios/UserSync/Process/_datasets/student_process/post/user.xml
@@ -167,7 +167,7 @@
             <value>111-111-1112</value>
             <value>Leah.Learner@test.com</value>
             <value>1</value>
-            <value>0</value>
+            <value>1</value>
             <value>xxxx111112</value>
             <null />
             <value>3</value>

--- a/web/application/third_party/Ilios/UserSync/Process/StudentProcess.php
+++ b/web/application/third_party/Ilios/UserSync/Process/StudentProcess.php
@@ -408,7 +408,6 @@ class Ilios_UserSync_Process_StudentProcess extends Ilios_UserSync_Process
             throw new Ilios_UserSync_Exception('Failed to add external user as student to Ilios' . $externalUser);
         }
 
-        $this->_userDao->enableUser($newUserId, false); // disable user record
         $this->_userDao->setUserExaminedBit($newUserId, true); // flag user as examined
 
         return $newUserId;


### PR DESCRIPTION
For some reason new student accounts are being deactivated on creation.  This is not correct. (read bone headed bug I created).