### PR TITLE
vagrant: increase PHP memory limit for CLI

### DIFF
--- a/provision/puppet/modules/profile/manifests/common/php.pp
+++ b/provision/puppet/modules/profile/manifests/common/php.pp
@@ -93,7 +93,7 @@ class profile::common::php (
 
     php::config { 'cli_memory_limit':
         setting => 'memory_limit',
-        value => '768M',
+        value => '1280M',
         file => '/etc/php5/cli/php.ini'
     }
 


### PR DESCRIPTION
PHPUnit gobbles up more than 1G now when running the full test suite.

[ci skip]