### PR TITLE
Improved schema for ILMSession

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20150826215733.php
+++ b/app/Resources/DoctrineMigrations/Version20150826215733.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Make IlmSession the owning side of the session facet relationship
+ */
+class Version20150826215733 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE ilm_session_facet ADD session_id INT DEFAULT NULL');
+        $this->addSql(
+            'ALTER TABLE ilm_session_facet ADD CONSTRAINT FK_8C070D9613FECDF FOREIGN KEY (session_id) ' .
+            'REFERENCES session (session_id) ON DELETE CASCADE'
+        );
+        $this->addSql(
+            'UPDATE ilm_session_facet f SET session_id = ' .
+            '(SELECT session_id FROM session s WHERE s.ilm_session_facet_id = f.ilm_session_facet_id)'
+        );
+        $this->addSql('DELETE FROM ilm_session_facet WHERE session_id IS NULL');
+        $this->addSql('ALTER TABLE ilm_session_facet MODIFY session_id INT NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8C070D9613FECDF ON ilm_session_facet (session_id)');
+        
+        $this->addSql('ALTER TABLE session DROP FOREIGN KEY FK_D044D5D4504270C1');
+        $this->addSql('DROP INDEX UNIQ_D044D5D4504270C1 ON session');
+        $this->addSql('DROP INDEX session_ibfk_3 ON session');
+        $this->addSql('ALTER TABLE session DROP ilm_session_facet_id');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE ilm_session_facet DROP FOREIGN KEY FK_8C070D9613FECDF');
+        $this->addSql('DROP INDEX UNIQ_8C070D9613FECDF ON ilm_session_facet');
+        $this->addSql('ALTER TABLE session ADD ilm_session_facet_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE session ADD CONSTRAINT FK_D044D5D4504270C1 FOREIGN KEY (ilm_session_facet_id) REFERENCES ilm_session_facet (ilm_session_facet_id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_D044D5D4504270C1 ON session (ilm_session_facet_id)');
+        $this->addSql('CREATE INDEX session_ibfk_3 ON session (ilm_session_facet_id)');
+        $this->addSql(
+            'UPDATE session s SET ilm_session_facet_id = ' .
+            '(SELECT ilm_session_facet_id FROM ilm_session_facet f WHERE f.session_id = s.session_id)'
+        );
+        $this->addSql('ALTER TABLE ilm_session_facet DROP session_id');
+    }
+}

--- a/src/Ilios/AuthenticationBundle/Voter/IlmSessionVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/IlmSessionVoter.php
@@ -43,19 +43,8 @@ class IlmSessionVoter extends SessionVoter
      */
     protected function isGranted($attribute, $ilmFacet, $user = null)
     {
-        $session = $this->sessionManager->findSessionBy(['ilmSession' => $ilmFacet->getId()]);
-
-        // OH NOES!
-        // we got an orphaned facet.
-        // this should be dealt with, but not here.
-        // just reject all access to it.
-        // TODO: revisit after issue #925 has been resolved. [ST 2015/08/04]
-        if (empty($session)) {
-            return false;
-        }
-
         // grant perms based on the session
-        return parent::isGranted($attribute, $session, $user);
+        return parent::isGranted($attribute, $ilmFacet->getSession(), $user);
 
     }
 }

--- a/src/Ilios/CoreBundle/Entity/IlmSession.php
+++ b/src/Ilios/CoreBundle/Entity/IlmSession.php
@@ -41,6 +41,26 @@ class IlmSession implements IlmSessionInterface
     protected $id;
 
     /**
+     * @var Session
+     *
+     * @ORM\OneToOne(targetEntity="Session", inversedBy="ilmSession")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(
+     *      name="session_id",
+     *      referencedColumnName="session_id",
+     *      nullable=false,
+     *      unique=true,
+     *      onDelete="CASCADE"
+     *   )
+     * })
+     * @Assert\NotBlank()
+     *
+     * @JMS\Expose
+     * @JMS\Type("string")
+     */
+    protected $session;
+
+    /**
      * @var float
      *
      * @ORM\Column(name="hours", type="decimal", precision=6, scale=2)
@@ -144,16 +164,6 @@ class IlmSession implements IlmSessionInterface
      * @JMS\Type("array<string>")
      */
     protected $learners;
-
-    /**
-     * @var SessionInterface
-     *
-     * @ORM\OneToOne(targetEntity="Session", mappedBy="ilmSession")
-     *
-     * @JMS\Expose
-     * @JMS\Type("string")
-     */
-    protected $session;
 
     /**
      * Constructor
@@ -324,10 +334,6 @@ class IlmSession implements IlmSessionInterface
      */
     public function getSession()
     {
-        if ($this->session && !$this->session->isDeleted()) {
-            return $this->session;
-        }
-
-        return null;
+        return $this->session;
     }
 }

--- a/src/Ilios/CoreBundle/Entity/Session.php
+++ b/src/Ilios/CoreBundle/Entity/Session.php
@@ -24,7 +24,6 @@ use Ilios\CoreBundle\Traits\IdentifiableEntity;
  *     @ORM\Index(name="session_type_id_k", columns={"session_type_id"}),
  *     @ORM\Index(name="course_id_k", columns={"course_id"}),
  *     @ORM\Index(name="session_course_type_title_k", columns={"session_id", "course_id", "session_type_id", "title"}),
- *     @ORM\Index(name="session_ibfk_3", columns={"ilm_session_facet_id"})
  *   }
  * )
  *
@@ -185,10 +184,7 @@ class Session implements SessionInterface
     /**
      * @var IlmSessionInterface
      *
-     * @ORM\OneToOne(targetEntity="IlmSession", inversedBy="session")
-     * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="ilm_session_facet_id", referencedColumnName="ilm_session_facet_id", nullable=true)
-     * })
+     * @ORM\OneToOne(targetEntity="IlmSession", mappedBy="session")
      *
      * @JMS\Expose
      * @JMS\Type("string")
@@ -317,6 +313,22 @@ class Session implements SessionInterface
         $this->offerings = new ArrayCollection();
         
         $this->updatedAt = new \DateTime();
+    }
+
+    /**
+     * @param SessionInterface $session
+     */
+    public function setSession(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * @return SessionInterface
+     */
+    public function getSession()
+    {
+        return $this->session;
     }
 
     /**

--- a/src/Ilios/CoreBundle/Form/Type/IlmSessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/IlmSessionType.php
@@ -36,7 +36,7 @@ class IlmSessionType extends AbstractType
                 'entityName' => "IliosCoreBundle:User"
             ])
             ->add('session', 'tdn_single_related', [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Session"
             ])
         ;

--- a/src/Ilios/CoreBundle/Tests/Controller/SessionControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/SessionControllerTest.php
@@ -25,6 +25,7 @@ class SessionControllerTest extends AbstractControllerTest
             'Ilios\CoreBundle\Tests\Fixture\LoadSessionLearningMaterialData',
             'Ilios\CoreBundle\Tests\Fixture\LoadCourseLearningMaterialData',
             'Ilios\CoreBundle\Tests\Fixture\LoadLearningMaterialStatusData',
+            'Ilios\CoreBundle\Tests\Fixture\LoadIlmSessionData',
         ]);
     }
 

--- a/src/Ilios/CoreBundle/Tests/DataLoader/IlmSessionData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/IlmSessionData.php
@@ -70,7 +70,8 @@ class IlmSessionData extends AbstractDataLoader
             'learnerGroups' => ['1', '2'],
             'instructorGroups' => ['1', '2'],
             'instructors' => ['1', '2'],
-            'learners' => ['1', '2']
+            'learners' => ['1', '2'],
+            'session' => 1
         );
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/IlmSessionTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/IlmSessionTest.php
@@ -2,6 +2,7 @@
 namespace Ilios\CoreBundle\Tests\Entity;
 
 use Ilios\CoreBundle\Entity\IlmSession;
+use Ilios\CoreBundle\Entity\Session;
 use Mockery as m;
 
 /**
@@ -25,11 +26,13 @@ class IlmSessionTest extends EntityBase
     public function testNotBlankValidation()
     {
         $notBlank = array(
+            'session',
             'hours',
             'dueDate'
         );
         $this->validateNotBlanks($notBlank);
 
+        $this->object->setSession(new Session());
         $this->object->setHours(55);
         $this->object->setDueDate(new \DateTime());
         $this->validate(0);
@@ -126,5 +129,14 @@ class IlmSessionTest extends EntityBase
     public function testGetLearners()
     {
         $this->entityCollectionSetTest('learner', 'User');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\IlmSession::setSession
+     * @covers Ilios\CoreBundle\Entity\IlmSession::getSession
+     */
+    public function testSetSession()
+    {
+        $this->entitySetTest('session', 'Session');
     }
 }

--- a/src/Ilios/CoreBundle/Tests/Fixture/LoadIlmSessionData.php
+++ b/src/Ilios/CoreBundle/Tests/Fixture/LoadIlmSessionData.php
@@ -33,6 +33,7 @@ class LoadIlmSessionData extends AbstractFixture implements
             $entity->setId($arr['id']);
             $entity->setHours($arr['hours']);
             $entity->setDueDate(new \DateTime($arr['dueDate']));
+            $entity->setSession($this->getReference('sessions' . $arr['session']));
             foreach ($arr['instructors'] as $id) {
                 $entity->addInstructor($this->getReference('users' . $id));
             }
@@ -58,6 +59,7 @@ class LoadIlmSessionData extends AbstractFixture implements
             'Ilios\CoreBundle\Tests\Fixture\LoadUserData',
             'Ilios\CoreBundle\Tests\Fixture\LoadInstructorGroupData',
             'Ilios\CoreBundle\Tests\Fixture\LoadLearnerGroupData',
+            'Ilios\CoreBundle\Tests\Fixture\LoadSessionData',
         );
     }
 }

--- a/src/Ilios/CoreBundle/Tests/Fixture/LoadSessionData.php
+++ b/src/Ilios/CoreBundle/Tests/Fixture/LoadSessionData.php
@@ -42,9 +42,6 @@ class LoadSessionData extends AbstractFixture implements
             if (!empty($arr['publishEvent'])) {
                 $entity->setPublishEvent($this->getReference('publishEvents' . $arr['publishEvent']));
             }
-            if (!empty($arr['ilmSession'])) {
-                $entity->setIlmSession($this->getReference('ilmSessions' . $arr['ilmSession']));
-            }
             $related = array(
                 'disciplines' => 'addDiscipline',
                 'objectives' => 'addObjective'
@@ -69,7 +66,6 @@ class LoadSessionData extends AbstractFixture implements
             'Ilios\CoreBundle\Tests\Fixture\LoadCourseData',
             'Ilios\CoreBundle\Tests\Fixture\LoadObjectiveData',
             'Ilios\CoreBundle\Tests\Fixture\LoadPublishEventData',
-            'Ilios\CoreBundle\Tests\Fixture\LoadIlmSessionData',
         );
     }
 }


### PR DESCRIPTION
Now the IlmSession owns the foreign key and is responsible for deleting
itself when the session is deleted.  Since session_id is required on
ILMSession it shouldn’t be possible to have an IlmSession without a
corresponding session relationship.

Fixes #925
Fixes #850