### PR TITLE
Handle dates correctly in the filters

### DIFF
--- a/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
+++ b/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
@@ -127,6 +127,9 @@ class LearningMaterialController extends FOSRestController
 
             return $item;
         }, $criteria);
+        if (array_key_exists('uploadDate', $criteria)) {
+            $criteria['uploadDate'] = new \DateTime($criteria['uploadDate']);
+        }
 
         $result = $this->getLearningMaterialHandler()
             ->findLearningMaterialsBy(

--- a/src/Ilios/CoreBundle/Controller/OfferingController.php
+++ b/src/Ilios/CoreBundle/Controller/OfferingController.php
@@ -124,7 +124,16 @@ class OfferingController extends FOSRestController
 
             return $item;
         }, $criteria);
-
+        if (array_key_exists('startDate', $criteria)) {
+            $criteria['startDate'] = new \DateTime($criteria['startDate']);
+        }
+        if (array_key_exists('endDate', $criteria)) {
+            $criteria['endDate'] = new \DateTime($criteria['endDate']);
+        }
+        if (array_key_exists('updatedAt', $criteria)) {
+            $criteria['updatedAt'] = new \DateTime($criteria['updatedAt']);
+        }
+        
         $result = $this->getOfferingHandler()
             ->findOfferingsBy(
                 $criteria,

--- a/src/Ilios/CoreBundle/Controller/ReportController.php
+++ b/src/Ilios/CoreBundle/Controller/ReportController.php
@@ -124,6 +124,9 @@ class ReportController extends FOSRestController
 
             return $item;
         }, $criteria);
+        if (array_key_exists('createdAt', $criteria)) {
+            $criteria['createdAt'] = new \DateTime($criteria['createdAt']);
+        }
 
         $result = $this->getReportHandler()
             ->findReportsBy(

--- a/src/Ilios/CoreBundle/Controller/SessionController.php
+++ b/src/Ilios/CoreBundle/Controller/SessionController.php
@@ -124,6 +124,9 @@ class SessionController extends FOSRestController
 
             return $item;
         }, $criteria);
+        if (array_key_exists('updatedAt', $criteria)) {
+            $criteria['updatedAt'] = new \DateTime($criteria['updatedAt']);
+        }
 
         $result = $this->getSessionHandler()
             ->findSessionsBy(

--- a/src/Ilios/CoreBundle/Controller/UserMadeReminderController.php
+++ b/src/Ilios/CoreBundle/Controller/UserMadeReminderController.php
@@ -124,6 +124,12 @@ class UserMadeReminderController extends FOSRestController
 
             return $item;
         }, $criteria);
+        if (array_key_exists('createdAt', $criteria)) {
+            $criteria['createdAt'] = new \DateTime($criteria['createdAt']);
+        }
+        if (array_key_exists('dueDate', $criteria)) {
+            $criteria['dueDate'] = new \DateTime($criteria['dueDate']);
+        }
 
         $result = $this->getUserMadeReminderHandler()
             ->findUserMadeRemindersBy(

--- a/src/Ilios/CoreBundle/Entity/Offering.php
+++ b/src/Ilios/CoreBundle/Entity/Offering.php
@@ -36,7 +36,6 @@ class Offering implements OfferingInterface
     use DeletableEntity;
 
     /**
-     * @deprecated Replace with trait
      * @var int
      *
      * @ORM\Column(name="offering_id", type="integer")


### PR DESCRIPTION
These aren’t super likely to be used, but if someone wants to send an
exact dateTime then we should handle it as opposed to sending a 500
error when it breaks.

Fixes #806