### PR TITLE
Better authentication error handling

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -76,7 +76,8 @@ fos_rest:
         codes:
             'Symfony\Component\HttpKernel\Exception\NotFoundHttpException': 404
             'Symfony\Component\Routing\Exception\ResourceNotFoundException': 404
-            'Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException': 403
+            'Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException': 401
+            'Symfony\Component\Security\Core\Exception\BadCredentialsException': 401
             'Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException': 500
 
 nelmio_cors:

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -3,12 +3,14 @@ security:
         api_docs:
             pattern:   ^/api/doc
             anonymous: ~
-        auth:
-            pattern:    ^/auth
+        authenticated_auth:
+            pattern:    ^/auth/(whoami|refresh)
             stateless: true
             jwt: ~
-            anonymous: ~
             provider: ilios_user_entity
+        anonymous_auth:
+            pattern:    ^/auth/(login|config)
+            anonymous: ~
         upload:
             pattern:    ^/upload
             stateless: true

--- a/src/Ilios/AuthenticationBundle/Jwt/Listener.php
+++ b/src/Ilios/AuthenticationBundle/Jwt/Listener.php
@@ -8,6 +8,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
 use Ilios\AuthenticationBundle\Jwt\Token as JwtToken;
 
@@ -42,18 +43,16 @@ class Listener implements ListenerInterface
             if ($token->isValidJwtRequest()) {
                 $authToken = $this->authenticationManager->authenticate($token);
                 $this->tokenStorage->setToken($authToken);
+                
+                return;
             }
         } catch (\UnexpectedValueException $e) {
             throw new BadCredentialsException('Invalid JSON Web Token: ' . $e->getMessage());
 
             return null;
-        } catch (AuthenticationException $failed) {
-            //We have a token with a bad user id, move on and let
-            //another login method handle this
-            return;
         }
-
-
-        return;
+        
+        throw new AuthenticationCredentialsNotFoundException('No JSON Web Token was found in the request');
+        
     }
 }

--- a/src/Ilios/AuthenticationBundle/Tests/Controller/AuthenticationControllerTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/Controller/AuthenticationControllerTest.php
@@ -248,24 +248,14 @@ class AuthenticationControllerTest extends WebTestCase
     public function testRefreshToken()
     {
         $client = static::createClient();
-    
-        // log in, grab token
-        $client->request('POST', '/auth/login', array(
-            'username' => 'newuser',
-            'password' => 'newuserpass'
-        ));
-        $response = $client->getResponse();
-        $response = json_decode($response->getContent(), true);
-        $token = (array) TokenLib::decode($response['jwt']);
-    
-        // send refresh token request
-        // grab new token
-        $client->request(
-            'GET',
-            '/auth/refresh',
-            array(),
-            array(),
-            array('HTTP_X-JWT-Authorization' => 'Token ' . $response['jwt'])
+        $jwt = $this->getAuthenticatedUserToken();
+        $token = (array) TokenLib::decode($jwt);
+        $this->makeJsonRequest(
+            $client,
+            'get',
+            $this->getUrl('ilios_authentication.refresh'),
+            null,
+            $jwt
         );
         $response = $client->getResponse();
         $response = json_decode($response->getContent(), true);
@@ -295,16 +285,17 @@ class AuthenticationControllerTest extends WebTestCase
     
     public function testRefreshTokenWithNonDefaultTtl()
     {
+        
         $client = static::createClient();
-    
-        // log in, grab token
-        $client->request('POST', '/auth/login', array(
-            'username' => 'newuser',
-            'password' => 'newuserpass'
-        ));
-        $response = $client->getResponse();
-        $response = json_decode($response->getContent(), true);
-        $token = (array) TokenLib::decode($response['jwt']);
+        $jwt = $this->getAuthenticatedUserToken();
+        $token = (array) TokenLib::decode($jwt);
+        $this->makeJsonRequest(
+            $client,
+            'get',
+            $this->getUrl('ilios_authentication.refresh'),
+            null,
+            $jwt
+        );
     
         // we set a non-default issued and expiration date with a delta of 42 days.
         $interval = new \DateInterval('P42D');


### PR DESCRIPTION
I split the /auth sections into two separate firewalls so the JWT
firewall can deny any request that doesn’t work.  This allows us to
give much nicer error messages.

Also mapped the two common authentication exceptions into HTTP 401
error codes which seems like the best fit for this condition.

Fixes #904