### PR TITLE
Ensure read access to learners with a secondary school

### DIFF
--- a/src/Ilios/AuthenticationBundle/Voter/UserVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/UserVoter.php
@@ -44,24 +44,24 @@ class UserVoter extends AbstractVoter
         if (!$user instanceof UserInterface) {
             return false;
         }
-
+        
         switch ($attribute) {
             // at least one of these must be true.
             // 1. the requested user is the current user
             // 2. the current user has faculty/course director/developer role
             //    and has the same primary school affiliation as the given user
             // 3. the current user has faculty/course director/developer role
-            //    and has READ rights to the given user's primary school via the permissions system.
+            //    and has READ rights to one of the users affiliated schools.
             case self::VIEW:
                 return (
                     $user->getId() === $requestedUser->getId()
                     || (
                         $this->userHasRole($user, ['Course Director', 'Faculty', 'Developer'])
                         && (
-                            $this->schoolsAreIdentical($user->getSchool(), $requestedUser->getSchool())
-                            || $this->permissionManager->userHasReadPermissionToSchool(
+                            $requestedUser->getAllSchools()->contains($user->getSchool())
+                            || $this->permissionManager->userHasReadPermissionToSchools(
                                 $user,
-                                $requestedUser->getSchool()
+                                $requestedUser->getSchool->getAllSchools()
                             )
                         )
                     )
@@ -71,17 +71,17 @@ class UserVoter extends AbstractVoter
             // 1. the current user has developer role
             //    and has the same primary school affiliation as the given user
             // 2. the current user has developer role
-            //    and has WRITE rights to the given user's primary school via the permissions system.
+            //    and has WRITE rights to one of the users affiliated schools.
             case self::CREATE:
             case self::EDIT:
             case self::DELETE:
                 return (
                     $this->userHasRole($user, ['Developer'])
                     && (
-                        $this->schoolsAreIdentical($user->getSchool(), $requestedUser->getSchool())
-                        || $this->permissionManager->userHasReadPermissionToSchool(
+                        $requestedUser->getAllSchools()->contains($user->getSchool())
+                        || $this->permissionManager->userHasReadPermissionToSchools(
                             $user,
-                            $requestedUser->getSchool()
+                            $requestedUser->getSchool->getAllSchools()
                         )
                     )
                 );

--- a/src/Ilios/CoreBundle/Entity/Cohort.php
+++ b/src/Ilios/CoreBundle/Entity/Cohort.php
@@ -198,4 +198,13 @@ class Cohort implements CohortInterface
     {
         return $this->users;
     }
+    
+    /**
+     * Check if a cohorts program year is deleted
+     * @return boolean
+     */
+    public function isDeleted()
+    {
+        return is_null($this->getProgramYear());
+    }
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
@@ -125,6 +125,58 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
     /**
      * {@inheritdoc}
      */
+    public function userHasReadPermissionToSchools(UserInterface $user, ArrayCollection $schools)
+    {
+        $criteria = [
+            'tableName'     => 'schools',
+            self::CAN_READ  => true,
+            'user'          => $user,
+        ];
+
+        $schoolsWithReadPermission = $this->findPermissionBy($criteria);
+        
+        if ($schoolsWithReadPermission->count() === 0) {
+            return false;
+        }
+        
+        foreach ($schools as $school) {
+            if ($schoolsWithReadPermission->contains($school)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function userHasWritePermissionToSchools(UserInterface $user, ArrayCollection $schools)
+    {
+        $criteria = [
+            'tableName'     => 'schools',
+            self::CAN_WRITE => true,
+            'user'          => $user,
+        ];
+
+        $schoolsWithWritePermission = $this->findPermissionBy($criteria);
+        
+        if ($schoolsWithWritePermission->count() === 0) {
+            return false;
+        }
+        
+        foreach ($schools as $school) {
+            if ($schoolsWithWritePermission->contains($school)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function userHasWritePermissionToCourse(UserInterface $user, CourseInterface $course)
     {
         return $this->userHasPermission($user, self::CAN_WRITE, 'course', $course->getId());

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
@@ -134,18 +134,10 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
         ];
 
         $schoolsWithReadPermission = $this->findPermissionBy($criteria);
-        
-        if ($schoolsWithReadPermission->count() === 0) {
-            return false;
-        }
-        
-        foreach ($schools as $school) {
-            if ($schoolsWithReadPermission->contains($school)) {
-                return true;
-            }
-        }
-        
-        return false;
+        $overlap = array_intersect($schools->toArray(), $schoolsWithReadPermission->toArray());
+
+        return ! empty($overlap);
+
     }
 
     /**
@@ -160,18 +152,9 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
         ];
 
         $schoolsWithWritePermission = $this->findPermissionBy($criteria);
-        
-        if ($schoolsWithWritePermission->count() === 0) {
-            return false;
-        }
-        
-        foreach ($schools as $school) {
-            if ($schoolsWithWritePermission->contains($school)) {
-                return true;
-            }
-        }
-        
-        return false;
+        $overlap = array_intersect($schools->toArray(), $schoolsWithWritePermission->toArray());
+
+        return ! empty($overlap);
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
@@ -91,6 +91,14 @@ interface PermissionManagerInterface extends ManagerInterface
      * @return bool
      */
     public function userHasReadPermissionToSchool(UserInterface $user, SchoolInterface $school);
+    
+    /**
+     * Checks if a given user has "read" permissions for and in an array of schools.
+     * @param UserInterface $user
+     * @param ArrayCollection[SchoolInterface] $schools
+     * @return bool
+     */
+    public function userHasReadPermissionToSchools(UserInterface $user, ArrayCollection $schools);
      
     /**
     * Checks if a given user has "write" permissions for a list of schools

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
@@ -91,13 +91,6 @@ interface PermissionManagerInterface extends ManagerInterface
      * @return bool
      */
     public function userHasReadPermissionToSchool(UserInterface $user, SchoolInterface $school);
-    
-    /**
-     * Checks if a given user has "read" permissions for a list of schools
-     * @param UserInterface $user
-     * @param ArrayCollection[SchoolInterface] $schools
-     * @return bool
-     */
      
     /**
     * Checks if a given user has "write" permissions for a list of schools

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
@@ -83,7 +83,7 @@ interface PermissionManagerInterface extends ManagerInterface
      * @return bool
      */
     public function userHasReadPermissionToProgram(UserInterface $user, ProgramInterface $program);
-
+    
     /**
      * Checks if a given user has "read" permissions for a given school.
      * @param UserInterface $user
@@ -91,6 +91,21 @@ interface PermissionManagerInterface extends ManagerInterface
      * @return bool
      */
     public function userHasReadPermissionToSchool(UserInterface $user, SchoolInterface $school);
+    
+    /**
+     * Checks if a given user has "read" permissions for a list of schools
+     * @param UserInterface $user
+     * @param ArrayCollection[SchoolInterface] $schools
+     * @return bool
+     */
+     
+    /**
+    * Checks if a given user has "write" permissions for a list of schools
+    * @param UserInterface $user
+    * @param ArrayCollection[SchoolInterface] $schools
+    * @return bool
+    */
+    public function userHasWritePermissionToSchools(UserInterface $user, ArrayCollection $schools);
 
     /**
      * Checks if a given user has "write" permissions for a given course.

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -1197,4 +1197,25 @@ class User implements UserInterface
 
         return null; // use the default encoder
     }
+    
+    /**
+     * Get all the schools an user is affiliated with
+     * This is used in granting view permissions for faculty
+     * in schools that are a users secondary cohort
+     *
+     * @return ArrayCollection[School]
+     */
+    public function getAllSchools()
+    {
+        $undeletedCohorts = $this->getCohorts()->filter(function (CohortInterface $cohort) {
+            return !$cohort->isDeleted();
+        });
+        $schools = $undeletedCohorts->map(function (CohortInterface $cohort) {
+            return $cohort->getProgramYear()->getProgram()->getSchool();
+        });
+        $schools->add($this->getSchool());
+        
+        
+        return $schools;
+    }
 }

--- a/src/Ilios/CoreBundle/Entity/UserInterface.php
+++ b/src/Ilios/CoreBundle/Entity/UserInterface.php
@@ -323,4 +323,9 @@ interface UserInterface extends
      * @return string
      */
     public function getUsername();
+    
+    /**
+     * @return ArrayCollection[School]
+     */
+    public function getAllSchools();
 }


### PR DESCRIPTION
This should make it possible for faculty in a school to view all
students with a secondary affiliation to that school.

I’m not sure about this solution, but it is the only one I could come up with.  I think the performance is made tenable by doctrine caching the repeated requests for the same cohort/program/school relationships.

I still need to handle the case of a secondary user school + a secondary learner cohort, but wanted to get some feedback on this path first.

Fixes #1004