### PR TITLE
upped VM and PHP memory limits

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,15 +15,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     else
         config.vm.synced_folder ".", "/vagrant", :nfs => { :mount_options => ["dmode=777","fmode=777"], :nfs_version => "3" }, id: "ilios-root"
     end
-    
+
     config.vm.provider "virtualbox" do |vb|
-        vb.customize ["modifyvm", :id, "--memory", "2048"]
+        vb.customize ["modifyvm", :id, "--memory", "3072"]
         vb.name = "ilios3.dev"
     end
 
     config.vm.provider "vmware_workstation" do |vw, override|
         override.vm.box_url = "https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-14.04-64-puppet/versions/1.0.0/providers/vmware_desktop.box"
-        vw.vmx["memsize"] = "2048"
+        vw.vmx["memsize"] = "3072"
         vw.vmx["displayname"] = "ilios3.dev"
     end
 

--- a/provision/puppet/modules/profile/manifests/common/php.pp
+++ b/provision/puppet/modules/profile/manifests/common/php.pp
@@ -63,7 +63,7 @@ class profile::common::php (
 
     php::apache::config { 'memory_limit':
         setting => 'memory_limit',
-        value => '768M',
+        value => '1024M',
         file => '/etc/php5/apache2/php.ini'
     }
 
@@ -99,7 +99,7 @@ class profile::common::php (
 
     php::config { 'cli_memory_limit':
         setting => 'memory_limit',
-        value => '1280M',
+        value => '2048M',
         file => '/etc/php5/cli/php.ini'
     }
 


### PR DESCRIPTION
new values:
- 3GB max memory for VM
- 2GB max memory for PHP/CLI
- 1GB max memory for PHP/Apache


requires [reprovisioning](https://docs.vagrantup.com/v2/provisioning/index.html) of existing VMs.

```
vagrant up
vagrant provision
```

[ci skip]