### PR TITLE
User Management Commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ before_install:
   - mysql -e "create database IF NOT EXISTS ilios;" -uroot
 #install apc extension so composer production install will run
   - echo "extension=apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+#increase our PHP memory limit so test coverage will work
+  - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+#install ldap extension so composer install will run
+  - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - cp ${TRAVIS_BUILD_DIR}/app/config/parameters.yml.travis ${TRAVIS_BUILD_DIR}/app/config/parameters.yml
 
 install:

--- a/app/Resources/DoctrineMigrations/Version20150909231235.php
+++ b/app/Resources/DoctrineMigrations/Version20150909231235.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Username is not required on the authentication table
+ */
+class Version20150909231235 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE authentication CHANGE username username VARCHAR(100) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE authentication CHANGE username username VARCHAR(100) NOT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/app/Resources/DoctrineMigrations/Version20150914052024.php
+++ b/app/Resources/DoctrineMigrations/Version20150914052024.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Move all eppn entries to the username on authentication and drop the eppn column
+ */
+class Version20150914052024 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        
+        $this->addSql('UPDATE authentication SET username=eppn');
+        $this->addSql('DROP INDEX UNIQ_FEB4C9FDFC7885D4 ON authentication');
+        $this->addSql('ALTER TABLE authentication DROP eppn');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE authentication ADD eppn VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_FEB4C9FDFC7885D4 ON authentication (eppn)');
+        $this->addSql('UPDATE authentication SET eppn=username');
+        $this->addSql('UPDATE authentication SET username=null');
+    }
+}

--- a/app/Resources/DoctrineMigrations/Version20150914210711.php
+++ b/app/Resources/DoctrineMigrations/Version20150914210711.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add the pending_user_update table
+ */
+class Version20150914210711 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE pending_user_update (exception_id INT AUTO_INCREMENT NOT NULL, user_id INT DEFAULT NULL, type VARCHAR(32) NOT NULL, property VARCHAR(32) DEFAULT NULL, value VARCHAR(255) DEFAULT NULL, INDEX IDX_A6D3A181A76ED395 (user_id), PRIMARY KEY(exception_id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE pending_user_update ADD CONSTRAINT FK_A6D3A181A76ED395 FOREIGN KEY (user_id) REFERENCES user (user_id)');
+        $this->addSql('DROP TABLE user_sync_exception');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE user_sync_exception (exception_id INT AUTO_INCREMENT NOT NULL, process_id INT NOT NULL, process_name VARCHAR(100) NOT NULL COLLATE utf8_unicode_ci, user_id INT DEFAULT NULL, exception_code INT NOT NULL, mismatched_property_name VARCHAR(30) DEFAULT NULL COLLATE utf8_unicode_ci, mismatched_property_value VARCHAR(150) DEFAULT NULL COLLATE utf8_unicode_ci, INDEX user_id_fkey (user_id), PRIMARY KEY(exception_id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('DROP TABLE pending_user_update');
+    }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -132,7 +132,12 @@ doctrine_migrations:
 
 ilios_core:
     file_system_storage_path: "%file_system_storage_path%"
-    
+    ldap_directory_url: "%ldap_directory_url%"
+    ldap_directory_user: "%ldap_directory_user%"
+    ldap_directory_password: "%ldap_directory_password%"
+    ldap_directory_search_base: "%ldap_directory_search_base%"
+    ldap_directory_campus_id_property: "%ldap_directory_campus_id_property%"
+
 ilios_web:
     environment: staging
     version: b368c34 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -137,6 +137,7 @@ ilios_core:
     ldap_directory_password: "%ldap_directory_password%"
     ldap_directory_search_base: "%ldap_directory_search_base%"
     ldap_directory_campus_id_property: "%ldap_directory_campus_id_property%"
+    ldap_directory_username_property: "%ldap_directory_username_property%"
 
 ilios_web:
     environment: staging

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -24,3 +24,8 @@ parameters:
     ldap_authentication_host: null
     ldap_authentication_port: null
     ldap_authentication_bind_template: null
+    ldap_directory_url: null
+    ldap_directory_user: null
+    ldap_directory_password: null
+    ldap_directory_search_base: null
+    ldap_directory_campus_id_property: null

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -29,3 +29,4 @@ parameters:
     ldap_directory_password: null
     ldap_directory_search_base: null
     ldap_directory_campus_id_property: null
+    ldap_directory_username_property: null

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -21,3 +21,8 @@ parameters:
     ldap_authentication_host: null
     ldap_authentication_port: null
     ldap_authentication_bind_template: null
+    ldap_directory_url: null
+    ldap_directory_user: null
+    ldap_directory_password: null
+    ldap_directory_search_base: null
+    ldap_directory_campus_id_property: null

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -26,3 +26,4 @@ parameters:
     ldap_directory_password: null
     ldap_directory_search_base: null
     ldap_directory_campus_id_property: null
+    ldap_directory_username_property: null

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "friendsofsymfony/rest-bundle": "~1.5",
         "jms/serializer-bundle": "~0.13.0",
         "tdn/php-types": "1.*",
-        "matthiasnoback/symfony-console-form": "^1.1"
+        "matthiasnoback/symfony-console-form": "^1.1",
+        "dreamscapes/ldap-core": "^3.1"
     },
     "require-dev": {
         "sensio/generator-bundle": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "34ce0cc45d67c403de7fab882c4a4218",
+    "hash": "daa9ff6b320db0b78d5e592daa88df1a",
     "packages": [
         {
             "name": "danielstjules/stringy",
@@ -1065,6 +1065,56 @@
             "time": "2015-08-31 12:59:39"
         },
         {
+            "name": "dreamscapes/ldap-core",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dreamscapes/Ldap-Core.git",
+                "reference": "85408988344f04a8a1ee3c00e859a58d02cd6c9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dreamscapes/Ldap-Core/zipball/85408988344f04a8a1ee3c00e859a58d02cd6c9e",
+                "reference": "85408988344f04a8a1ee3c00e859a58d02cd6c9e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ldap": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpdocumentor/phpdocumentor": "~2",
+                "squizlabs/php_codesniffer": "~2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Dreamscapes\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Rossmann",
+                    "email": "rr.rossmann@me.com"
+                }
+            ],
+            "description": "Object encapsulation of PHP's native ldap functions",
+            "keywords": [
+                "OOP",
+                "directory",
+                "ldap",
+                "library",
+                "mock",
+                "openldap",
+                "testing"
+            ],
+            "time": "2015-05-04 14:47:46"
+        },
+        {
             "name": "firebase/php-jwt",
             "version": "v2.2.0",
             "source": {
@@ -1337,21 +1387,21 @@
         },
         {
             "name": "jms/aop-bundle",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "target-dir": "JMS/AopBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/JMSAopBundle.git",
-                "reference": "93f41ab85ed409430bc3bab2e0b7c7677f152aa8"
+                "reference": "66287749c020b4c667c0ff4937b07e66c04bbe71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/JMSAopBundle/zipball/93f41ab85ed409430bc3bab2e0b7c7677f152aa8",
-                "reference": "93f41ab85ed409430bc3bab2e0b7c7677f152aa8",
+                "url": "https://api.github.com/repos/schmittjoh/JMSAopBundle/zipball/66287749c020b4c667c0ff4937b07e66c04bbe71",
+                "reference": "66287749c020b4c667c0ff4937b07e66c04bbe71",
                 "shasum": ""
             },
             "require": {
-                "jms/cg": "1.*",
+                "jms/cg": "^1.1",
                 "symfony/framework-bundle": "2.*"
             },
             "type": "symfony-bundle",
@@ -1367,14 +1417,12 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache"
+                "Apache-2.0"
             ],
             "authors": [
                 {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
-                    "role": "Developer of wrapped JMSSerializerBundle"
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
                 }
             ],
             "description": "Adds AOP capabilities to Symfony2",
@@ -1382,26 +1430,31 @@
                 "annotations",
                 "aop"
             ],
-            "time": "2013-07-29 09:34:26"
+            "time": "2015-09-13 09:02:33"
         },
         {
             "name": "jms/cg",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/cg-library.git",
-                "reference": "ce8ef43dd6bfe6ce54e5e9844ab71be2343bf2fc"
+                "reference": "0af1113c7409b8636c5244bbae10b2e0ff792e9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/cg-library/zipball/ce8ef43dd6bfe6ce54e5e9844ab71be2343bf2fc",
-                "reference": "ce8ef43dd6bfe6ce54e5e9844ab71be2343bf2fc",
+                "url": "https://api.github.com/repos/schmittjoh/cg-library/zipball/0af1113c7409b8636c5244bbae10b2e0ff792e9c",
+                "reference": "0af1113c7409b8636c5244bbae10b2e0ff792e9c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "CG\\": "src/"
@@ -1409,39 +1462,37 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache"
+                "Apache2"
             ],
             "authors": [
                 {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
-                    "role": "Developer of wrapped JMSSerializerBundle"
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
                 }
             ],
             "description": "Toolset for generating PHP code",
             "keywords": [
                 "code generation"
             ],
-            "time": "2012-01-02 20:40:52"
+            "time": "2015-09-13 08:54:43"
         },
         {
             "name": "jms/di-extra-bundle",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "target-dir": "JMS/DiExtraBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/JMSDiExtraBundle.git",
-                "reference": "4a0db1a5469940f83cc7d9c156224469ec8b6c01"
+                "reference": "c9e36dce4014db1f6abf02e94eac225344a5147d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/JMSDiExtraBundle/zipball/4a0db1a5469940f83cc7d9c156224469ec8b6c01",
-                "reference": "4a0db1a5469940f83cc7d9c156224469ec8b6c01",
+                "url": "https://api.github.com/repos/schmittjoh/JMSDiExtraBundle/zipball/c9e36dce4014db1f6abf02e94eac225344a5147d",
+                "reference": "c9e36dce4014db1f6abf02e94eac225344a5147d",
                 "shasum": ""
             },
             "require": {
-                "jms/aop-bundle": ">=1.0.0,<1.2-dev",
+                "jms/aop-bundle": "^1.1.0",
                 "jms/metadata": "1.*",
                 "symfony/finder": "~2.1",
                 "symfony/framework-bundle": "~2.1",
@@ -1488,7 +1539,7 @@
                 "annotations",
                 "dependency injection"
             ],
-            "time": "2014-11-24 08:56:26"
+            "time": "2015-09-13 09:03:50"
         },
         {
             "name": "jms/metadata",
@@ -2770,16 +2821,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.21.2",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "ddce1136beb8db29b9cd7dffa8ab518b978c9db3"
+                "reference": "b7fc2469fa009897871fb95b68237286fc54a5ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ddce1136beb8db29b9cd7dffa8ab518b978c9db3",
-                "reference": "ddce1136beb8db29b9cd7dffa8ab518b978c9db3",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/b7fc2469fa009897871fb95b68237286fc54a5ad",
+                "reference": "b7fc2469fa009897871fb95b68237286fc54a5ad",
                 "shasum": ""
             },
             "require": {
@@ -2792,7 +2843,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.21-dev"
+                    "dev-master": "1.22-dev"
                 }
             },
             "autoload": {
@@ -2827,7 +2878,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2015-09-09 05:28:51"
+            "time": "2015-09-15 06:50:16"
         },
         {
             "name": "willdurand/jsonp-callback-validator",
@@ -3484,16 +3535,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.2",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2d7c03c0e4e080901b8f33b2897b0577be18a13c"
+                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2d7c03c0e4e080901b8f33b2897b0577be18a13c",
-                "reference": "2d7c03c0e4e080901b8f33b2897b0577be18a13c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef1ca6835468857944d5c3b48fa503d5554cff2f",
+                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f",
                 "shasum": ""
             },
             "require": {
@@ -3542,7 +3593,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-08-04 03:42:39"
+            "time": "2015-09-14 06:51:16"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3675,16 +3726,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.6",
+            "version": "1.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3ab72c62e550370a6cd5dc873e1a04ab57562f5b"
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3ab72c62e550370a6cd5dc873e1a04ab57562f5b",
-                "reference": "3ab72c62e550370a6cd5dc873e1a04ab57562f5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
                 "shasum": ""
             },
             "require": {
@@ -3720,7 +3771,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-08-16 08:51:00"
+            "time": "2015-09-15 10:49:45"
         },
         {
             "name": "phpunit/phpunit",

--- a/src/Ilios/AuthenticationBundle/Controller/AuthenticationController.php
+++ b/src/Ilios/AuthenticationBundle/Controller/AuthenticationController.php
@@ -23,8 +23,7 @@ class AuthenticationController extends Controller
      */
     public function loginAction(Request $request)
     {
-        $authenticatorService = $this->container->getParameter('ilios_authentication.authenticatorservice');
-        $authenticator = $this->container->get($authenticatorService);
+        $authenticator = $this->container->get('ilios_authentication.authenticator');
         
         return $authenticator->login($request);
 

--- a/src/Ilios/AuthenticationBundle/Resources/config/services.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/services.yml
@@ -23,3 +23,9 @@ services:
     ilios_authentication.ldap.authentication:
         class: Ilios\AuthenticationBundle\Service\LdapAuthentication
         arguments: ["@ilioscore.authentication.manager", "@ilios_authentication.jwt.manager", '%ilios_authentication.ldap.host%', '%ilios_authentication.ldap.port%', '%ilios_authentication.ldap.bind_template%']
+    ilios_authentication.authenticator_factory:
+        class: Ilios\AuthenticationBundle\Service\AuthenticationFactory
+        arguments: ['@service_container', '%ilios_authentication.authenticatorservice%']
+    ilios_authentication.authenticator:
+        class:   Ilios\AuthenticationBundle\Service\AuthenticationInterface
+        factory: ["@ilios_authentication.authenticator_factory", createAuthenticationService]

--- a/src/Ilios/AuthenticationBundle/Service/AuthenticationFactory.php
+++ b/src/Ilios/AuthenticationBundle/Service/AuthenticationFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\Service;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class AuthenticationFactory
+{
+    /**
+     * @var string
+     */
+    protected $authenticationServiceName;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+    
+    public function __construct(
+        ContainerInterface $container,
+        $authenticationServiceName
+    ) {
+        $this->authenticationServiceName = $authenticationServiceName;
+        $this->container = $container;
+    }
+    
+    public function createAuthenticationService()
+    {
+            return $this->container->get($this->authenticationServiceName);
+    }
+}

--- a/src/Ilios/AuthenticationBundle/Service/AuthenticationInterface.php
+++ b/src/Ilios/AuthenticationBundle/Service/AuthenticationInterface.php
@@ -3,6 +3,7 @@ namespace Ilios\AuthenticationBundle\Service;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Ilios\CoreBundle\Entity\UserInterface;
 
 interface AuthenticationInterface
 {
@@ -13,4 +14,11 @@ interface AuthenticationInterface
      * @return JsonResponse
      */
     public function login(Request $request);
+    
+    /**
+     * Handle any setup tasks on a new user
+     * @param  array         $directoryInformation the stuff we get from LDAP
+     * @param  UserInterface $user
+     */
+    public function setupNewUser(array $directoryInformation, UserInterface $user);
 }

--- a/src/Ilios/AuthenticationBundle/Service/AuthenticationInterface.php
+++ b/src/Ilios/AuthenticationBundle/Service/AuthenticationInterface.php
@@ -14,18 +14,4 @@ interface AuthenticationInterface
      * @return JsonResponse
      */
     public function login(Request $request);
-    
-    /**
-     * Handle any setup tasks on a new user
-     * @param  array         $directoryInformation the stuff we get from LDAP
-     * @param  UserInterface $user
-     */
-    public function setupNewUser(array $directoryInformation, UserInterface $user);
-    
-    /**
-     * Sync an existing user
-     * @param  array         $directoryInformation the stuff we get from LDAP
-     * @param  UserInterface $user
-     */
-    public function syncUser(array $directoryInformation, UserInterface $user);
 }

--- a/src/Ilios/AuthenticationBundle/Service/AuthenticationInterface.php
+++ b/src/Ilios/AuthenticationBundle/Service/AuthenticationInterface.php
@@ -21,4 +21,11 @@ interface AuthenticationInterface
      * @param  UserInterface $user
      */
     public function setupNewUser(array $directoryInformation, UserInterface $user);
+    
+    /**
+     * Sync an existing user
+     * @param  array         $directoryInformation the stuff we get from LDAP
+     * @param  UserInterface $user
+     */
+    public function syncUser(array $directoryInformation, UserInterface $user);
 }

--- a/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
@@ -106,6 +106,14 @@ class FormAuthentication implements AuthenticationInterface
     }
     
     /**
+     * @inheritdoc
+     */
+    public function syncUser(array $directoryInformation, UserInterface $user)
+    {
+        throw new \Exception("Unable to sync users with 'form' authentication setups");
+    }
+    
+    /**
      * Update users to the new password encoding when they login
      * @param  AuthenticationEntityInterface $authEntity
      * @param  string         $password

--- a/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
@@ -10,6 +10,7 @@ use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 
 use Ilios\CoreBundle\Entity\AuthenticationInterface as AuthenticationEntityInterface;
 use Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface;
+use Ilios\CoreBundle\Entity\UserInterface;
 use Ilios\AuthenticationBundle\Traits\AuthenticationService;
 
 class FormAuthentication implements AuthenticationInterface
@@ -94,6 +95,14 @@ class FormAuthentication implements AuthenticationInterface
             'errors' => $errors,
             'jwt' => null,
         ), JsonResponse::HTTP_BAD_REQUEST);
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function setupNewUser(array $directoryInformation, UserInterface $user)
+    {
+        throw new \Exception("Unable to add new users to 'form' authentication setups");
     }
     
     /**

--- a/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
@@ -98,22 +98,6 @@ class FormAuthentication implements AuthenticationInterface
     }
     
     /**
-     * @inheritdoc
-     */
-    public function setupNewUser(array $directoryInformation, UserInterface $user)
-    {
-        throw new \Exception("Unable to add new users to 'form' authentication setups");
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function syncUser(array $directoryInformation, UserInterface $user)
-    {
-        throw new \Exception("Unable to sync users with 'form' authentication setups");
-    }
-    
-    /**
      * Update users to the new password encoding when they login
      * @param  AuthenticationEntityInterface $authEntity
      * @param  string         $password

--- a/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
@@ -102,22 +102,6 @@ class LdapAuthentication implements AuthenticationInterface
     }
     
     /**
-     * @inheritdoc
-     */
-    public function setupNewUser(array $directoryInformation, UserInterface $user)
-    {
-        throw new \Exception("Unable to add new users to 'ldap' authentication setups");
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function syncUser(array $directoryInformation, UserInterface $user)
-    {
-        throw new \Exception("Unable to sync users with 'ldap' authentication setups");
-    }
-    
-    /**
      * Check against ldap to see if the user is valid
      * @param  string $username
      * @param  string $password

--- a/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 use Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface;
 use Ilios\AuthenticationBundle\Traits\AuthenticationService;
+use Ilios\CoreBundle\Entity\UserInterface;
 
 class LdapAuthentication implements AuthenticationInterface
 {
@@ -98,6 +99,14 @@ class LdapAuthentication implements AuthenticationInterface
             'errors' => $errors,
             'jwt' => null,
         ), JsonResponse::HTTP_BAD_REQUEST);
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function setupNewUser(array $directoryInformation, UserInterface $user)
+    {
+        throw new \Exception("Unable to add new users to 'ldap' authentication setups");
     }
     
     /**

--- a/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
@@ -110,6 +110,14 @@ class LdapAuthentication implements AuthenticationInterface
     }
     
     /**
+     * @inheritdoc
+     */
+    public function syncUser(array $directoryInformation, UserInterface $user)
+    {
+        throw new \Exception("Unable to sync users with 'ldap' authentication setups");
+    }
+    
+    /**
      * Check against ldap to see if the user is valid
      * @param  string $username
      * @param  string $password

--- a/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
@@ -100,4 +100,23 @@ class ShibbolethAuthentication implements AuthenticationInterface
         $authentication->setEppn($directoryInformation['eppn']);
         $this->authManager->updateAuthentication($authentication, false);
     }
+    
+    /**
+     * @inheritdoc
+     */
+    public function syncUser(array $directoryInformation, UserInterface $user)
+    {
+        if (!array_key_exists('eppn', $directoryInformation) ||
+            empty($directoryInformation['eppn'])
+        ) {
+            throw new \Exception(
+                "No 'eepn' was found for the user.  Values: " .
+                var_export($directoryInformation, true)
+            );
+        }
+
+        $authentication = $user->getAuthentication();
+        $authentication->setEppn($directoryInformation['eppn']);
+        $this->authManager->updateAuthentication($authentication, false);
+    }
 }

--- a/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
@@ -66,7 +66,7 @@ class ShibbolethAuthentication implements AuthenticationInterface
                 var_export($_SERVER, true)
             );
         }
-        $authEntity = $this->authManager->findAuthenticationBy(array('eppn' => $eppn));
+        $authEntity = $this->authManager->findAuthenticationBy(array('username' => $eppn));
         if (!$authEntity) {
             return new JsonResponse(array(
                 'status' => 'noAccountExists',
@@ -78,45 +78,5 @@ class ShibbolethAuthentication implements AuthenticationInterface
         $jwt = $this->jwtManager->createJwtFromUser($authEntity->getUser());
         
         return $this->createSuccessResponseFromJWT($jwt);
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function setupNewUser(array $directoryInformation, UserInterface $user)
-    {
-        if (!array_key_exists('eppn', $directoryInformation) ||
-            empty($directoryInformation['eppn'])
-        ) {
-            throw new \Exception(
-                "No 'eepn' was found for the user.  Values: " .
-                var_export($directoryInformation, true)
-            );
-        }
-
-        $authentication = $this->authManager->createAuthentication();
-        $authentication->setUser($user);
-        $user->setAuthentication($authentication);
-        $authentication->setEppn($directoryInformation['eppn']);
-        $this->authManager->updateAuthentication($authentication, false);
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function syncUser(array $directoryInformation, UserInterface $user)
-    {
-        if (!array_key_exists('eppn', $directoryInformation) ||
-            empty($directoryInformation['eppn'])
-        ) {
-            throw new \Exception(
-                "No 'eepn' was found for the user.  Values: " .
-                var_export($directoryInformation, true)
-            );
-        }
-
-        $authentication = $user->getAuthentication();
-        $authentication->setEppn($directoryInformation['eppn']);
-        $this->authManager->updateAuthentication($authentication, false);
     }
 }

--- a/src/Ilios/AuthenticationBundle/Tests/DependencyInjection/IliosAuthenticationExtensionTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/DependencyInjection/IliosAuthenticationExtensionTest.php
@@ -43,6 +43,8 @@ class IliosAuthenticationExtensionTest extends AbstractExtensionTestCase
             'ilios_authentication.form.authentication',
             'ilios_authentication.shibboleth.authentication',
             'ilios_authentication.ldap.authentication',
+            'ilios_authentication.authenticator_factory',
+            'ilios_authentication.authenticator'
         );
         foreach ($services as $service) {
             $this->assertContainerBuilderHasService($service);

--- a/src/Ilios/AuthenticationBundle/Tests/Service/AuthenticationFactoryTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/Service/AuthenticationFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace Ilios\AuthenticationBundle\Tests\Service;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Mockery as m;
+
+use Ilios\AuthenticationBundle\Service\AuthenticationFactory;
+
+class AuthenticationFactoryTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testConstructor()
+    {
+        $container = m::mock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $obj = new AuthenticationFactory(
+            $container,
+            'test-service'
+        );
+        $this->assertTrue($obj instanceof AuthenticationFactory);
+    }
+
+    public function testCreateService()
+    {
+        $container = m::mock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $obj = new AuthenticationFactory(
+            $container,
+            'test-service'
+        );
+        $container->shouldReceive('get')->with('test-service')->andReturn(42);
+        
+        $service = $obj->createAuthenticationService();
+        $this->assertSame(42, $service);
+    }
+}

--- a/src/Ilios/AuthenticationBundle/Tests/Service/FormAuthenticationTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/Service/FormAuthenticationTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ilios\CoreBundle\Tests\Classes;
+namespace Ilios\AuthenticationBundle\Tests\Service;
 
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/src/Ilios/AuthenticationBundle/Tests/Service/JsonWebTokenManagerTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/Service/JsonWebTokenManagerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ilios\CoreBundle\Tests\Classes;
+namespace Ilios\AuthenticationBundle\Tests\Service;
 
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/src/Ilios/AuthenticationBundle/Tests/Service/LdapAuthenticationTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/Service/LdapAuthenticationTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ilios\CoreBundle\Tests\Classes;
+namespace Ilios\AuthenticationBundle\Tests\Service;
 
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/src/Ilios/AuthenticationBundle/Tests/Service/ShibbolethAuthenticationTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/Service/ShibbolethAuthenticationTest.php
@@ -83,7 +83,7 @@ class ShibbolethAuthenticationTest extends TestCase
         $request = m::mock('Symfony\Component\HttpFoundation\Request');
         $request->server = $serverBag;
         $authManager->shouldReceive('findAuthenticationBy')
-            ->with(array('eppn' => 'userid1'))->andReturn(null);
+            ->with(array('username' => 'userid1'))->andReturn(null);
 
         $result = $obj->login($request);
         
@@ -114,7 +114,7 @@ class ShibbolethAuthenticationTest extends TestCase
         $authenticationEntity = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
             ->shouldReceive('getUser')->andReturn($user)->mock();
         $authManager->shouldReceive('findAuthenticationBy')
-            ->with(array('eppn' => 'userid1'))->andReturn($authenticationEntity);
+            ->with(array('username' => 'userid1'))->andReturn($authenticationEntity);
         $jwtManager->shouldReceive('createJwtFromUser')->with($user)->andReturn('jwt123Test');
         
         
@@ -125,62 +125,5 @@ class ShibbolethAuthenticationTest extends TestCase
         $data = json_decode($content);
         $this->assertSame($data->status, 'success');
         $this->assertSame($data->jwt, 'jwt123Test');
-    }
-    
-    public function testAddNewUser()
-    {
-        $authManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface');
-        $jwtManager = m::mock('Ilios\AuthenticationBundle\Service\JsonWebTokenManager');
-        $obj = new ShibbolethAuthentication(
-            $authManager,
-            $jwtManager
-        );
-        
-        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface');
-        $authenticationEntity = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
-            ->shouldReceive('setUser')->with($user)->once()
-            ->shouldReceive('setEppn')->with('abc123')->once()
-            ->mock();
-        $user->shouldReceive('setAuthentication')->with($authenticationEntity)->once();
-        $authManager
-            ->shouldReceive('createAuthentication')->andReturn($authenticationEntity)->once()
-            ->shouldReceive('updateAuthentication')->with($authenticationEntity, false)->once();
-        $fakeDirectoryUser = [
-            'firstName' => 'first',
-            'lastName' => 'last',
-            'email' => 'email',
-            'telephoneNumber' => 'phone',
-            'campusId' => 'abc',
-            'eppn' => 'abc123'
-        ];
-        
-        $obj->setupNewUser($fakeDirectoryUser, $user);
-    }
-    
-    public function testSyncUser()
-    {
-        $authManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface');
-        $jwtManager = m::mock('Ilios\AuthenticationBundle\Service\JsonWebTokenManager');
-        $obj = new ShibbolethAuthentication(
-            $authManager,
-            $jwtManager
-        );
-        
-        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface');
-        $authenticationEntity = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
-            ->shouldReceive('setEppn')->with('abc123')->once()
-            ->mock();
-        $user->shouldReceive('getAuthentication')->andReturn($authenticationEntity)->once();
-        $authManager->shouldReceive('updateAuthentication')->with($authenticationEntity, false)->once();
-        $fakeDirectoryUser = [
-            'firstName' => 'first',
-            'lastName' => 'last',
-            'email' => 'email',
-            'telephoneNumber' => 'phone',
-            'campusId' => 'abc',
-            'eppn' => 'abc123'
-        ];
-        
-        $obj->syncUser($fakeDirectoryUser, $user);
     }
 }

--- a/src/Ilios/AuthenticationBundle/Tests/Service/ShibbolethAuthenticationTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/Service/ShibbolethAuthenticationTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ilios\CoreBundle\Tests\Classes;
+namespace Ilios\AuthenticationBundle\Tests\Service;
 
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/src/Ilios/AuthenticationBundle/Tests/Service/ShibbolethAuthenticationTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/Service/ShibbolethAuthenticationTest.php
@@ -126,4 +126,61 @@ class ShibbolethAuthenticationTest extends TestCase
         $this->assertSame($data->status, 'success');
         $this->assertSame($data->jwt, 'jwt123Test');
     }
+    
+    public function testAddNewUser()
+    {
+        $authManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface');
+        $jwtManager = m::mock('Ilios\AuthenticationBundle\Service\JsonWebTokenManager');
+        $obj = new ShibbolethAuthentication(
+            $authManager,
+            $jwtManager
+        );
+        
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface');
+        $authenticationEntity = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
+            ->shouldReceive('setUser')->with($user)->once()
+            ->shouldReceive('setEppn')->with('abc123')->once()
+            ->mock();
+        $user->shouldReceive('setAuthentication')->with($authenticationEntity)->once();
+        $authManager
+            ->shouldReceive('createAuthentication')->andReturn($authenticationEntity)->once()
+            ->shouldReceive('updateAuthentication')->with($authenticationEntity, false)->once();
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+            'eppn' => 'abc123'
+        ];
+        
+        $obj->setupNewUser($fakeDirectoryUser, $user);
+    }
+    
+    public function testSyncUser()
+    {
+        $authManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface');
+        $jwtManager = m::mock('Ilios\AuthenticationBundle\Service\JsonWebTokenManager');
+        $obj = new ShibbolethAuthentication(
+            $authManager,
+            $jwtManager
+        );
+        
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface');
+        $authenticationEntity = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
+            ->shouldReceive('setEppn')->with('abc123')->once()
+            ->mock();
+        $user->shouldReceive('getAuthentication')->andReturn($authenticationEntity)->once();
+        $authManager->shouldReceive('updateAuthentication')->with($authenticationEntity, false)->once();
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+            'eppn' => 'abc123'
+        ];
+        
+        $obj->syncUser($fakeDirectoryUser, $user);
+    }
 }

--- a/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
@@ -14,7 +14,6 @@ use Ilios\CoreBundle\Entity\Manager\UserManagerInterface;
 use Ilios\CoreBundle\Entity\Manager\SchoolManagerInterface;
 use Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface;
 use Ilios\CoreBundle\Entity\Manager\UserRoleManagerInterface;
-use Ilios\CoreBundle\Entity\UserInterface;
 use Ilios\CoreBundle\Service\Directory;
 
 /**
@@ -82,7 +81,7 @@ class AddNewStudentsToSchoolCommand extends Command
             ->addArgument(
                 'filter',
                 InputArgument::REQUIRED,
-                'An LDAP filter to use in finding students who belong to the school in the direcotry.'
+                'An LDAP filter to use in finding students who belong to the school in the directory.'
             );
     }
 
@@ -152,7 +151,7 @@ class AddNewStudentsToSchoolCommand extends Command
                     $output->writeln(
                         '<error>Unable to add student ' .
                         var_export($userRecord, true) .
-                        ' they have no email address</error>'
+                        ' they have no email address.</error>'
                     );
                     continue;
                 }
@@ -160,7 +159,7 @@ class AddNewStudentsToSchoolCommand extends Command
                     $output->writeln(
                         '<error>Unable to add student ' .
                         var_export($userRecord, true) .
-                        ' they have no campus ID</error>'
+                        ' they have no campus ID.</error>'
                     );
                     continue;
                 }
@@ -168,7 +167,7 @@ class AddNewStudentsToSchoolCommand extends Command
                     $output->writeln(
                         '<error>Unable to add student ' .
                         var_export($userRecord, true) .
-                        ' they have no username</error>'
+                        ' they have no username.</error>'
                     );
                     continue;
                 }
@@ -200,7 +199,7 @@ class AddNewStudentsToSchoolCommand extends Command
                 );
             }
         } else {
-            $output->writeln('<comment>Update Canceled</comment>');
+            $output->writeln('<comment>Update Canceled.</comment>');
         }
         
     }

--- a/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+use Ilios\CoreBundle\Entity\Manager\UserManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\SchoolManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\UserRoleManagerInterface;
+use Ilios\CoreBundle\Entity\UserInterface;
+use Ilios\CoreBundle\Service\Directory;
+use Ilios\AuthenticationBundle\Service\AuthenticationInterface;
+
+/**
+ * Adds all the users in the directory to a school with the student role
+ *
+ * Class AddNewStudentsToSchoolCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class AddNewStudentsToSchoolCommand extends Command
+{
+    /**
+     * @var UserManagerInterface
+     */
+    protected $userManager;
+
+    /**
+     * @var SchoolManagerInterface
+     */
+    protected $schoolManager;
+    
+    /**
+     * @var UserRoleManagerInterface
+     */
+    protected $userRoleManager;
+    
+    /**
+     * @var Directory
+     */
+    protected $directory;
+    
+    /**
+     * @var AuthenticationInterface
+     */
+    protected $authenticationService;
+    
+    public function __construct(
+        UserManagerInterface $userManager,
+        SchoolManagerInterface $schoolManager,
+        UserRoleManagerInterface $userRoleManager,
+        Directory $directory,
+        AuthenticationInterface $authenticationService
+    ) {
+        $this->userManager = $userManager;
+        $this->schoolManager = $schoolManager;
+        $this->userRoleManager = $userRoleManager;
+        $this->directory = $directory;
+        $this->authenticationService = $authenticationService;
+        
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:directory:add-students')
+            ->setDescription('Add students found by a directory filter into a school.')
+            ->addArgument(
+                'schoolId',
+                InputArgument::REQUIRED,
+                'Which school ID to add new students to.'
+            )
+            ->addArgument(
+                'filter',
+                InputArgument::REQUIRED,
+                'An LDAP filter to use in finding students who belong to the school in the direcotry.'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $filter = $input->getArgument('filter');
+        $schoolId = $input->getArgument('schoolId');
+        $school = $this->schoolManager->findSchoolBy(['id' => $schoolId]);
+        if (!$school) {
+            throw new \Exception(
+                "School with id {$schoolId} could not be found."
+            );
+        }
+        
+        $students = $this->directory->findByLdapFilter($filter);
+        
+        if (!$students) {
+            $output->writeln("<error>{$filter} returned no results.</error>");
+            return;
+        }
+        $output->writeln('<info>Found ' . count($students) . ' students in the directory.</info>');
+        
+        $campusIds = $this->userManager->getAllCampusIds();
+        
+        $newStudents = array_filter($students, function (array $arr) use ($campusIds) {
+            return !$campusIds->contains($arr['campusId']);
+        });
+        
+        if (!count($newStudents) > 0) {
+            $output->writeln("<info>There are no new students to add.</info>");
+            return;
+        }
+        $output->writeln(
+            '<info>There are ' .
+            count($newStudents) .
+            ' new students to be added to ' .
+            $school->getTitle() .
+            '.</info>'
+        );
+        $rows =array_map(function (array $arr) {
+            return [
+                $arr['campusId'],
+                $arr['firstName'],
+                $arr['lastName'],
+                $arr['email']
+            ];
+        }, $newStudents);
+        $table = new Table($output);
+        $table->setHeaders(array('Campus ID', 'First', 'Last', 'Email'))->setRows($rows);
+        $table->render();
+
+        $helper = $this->getHelper('question');
+        $output->writeln('');
+        $question = new ConfirmationQuestion(
+            '<question>Do you wish to add these students to ' . $school->getTitle() . '? </question>' . "\n",
+            false
+        );
+        
+        if ($helper->ask($input, $output, $question)) {
+            $studentRole = $this->userRoleManager->findUserRoleBy(array('title' => 'Student'));
+            foreach ($newStudents as $userRecord) {
+                if (empty($userRecord['email'])) {
+                    $output->writeln(
+                        '<error>Unable to add student ' .
+                        var_export($userRecord, true) .
+                        ' they have no email address</error>'
+                    );
+                    continue;
+                }
+                if (empty($userRecord['campusId'])) {
+                    $output->writeln(
+                        '<error>Unable to add student ' .
+                        var_export($userRecord, true) .
+                        ' they have no campus ID</error>'
+                    );
+                    continue;
+                }
+                $user = $this->userManager->createUser();
+                $user->setFirstName($userRecord['firstName']);
+                $user->setLastName($userRecord['lastName']);
+                $user->setEmail($userRecord['email']);
+                $user->setCampusId($userRecord['campusId']);
+                $user->setAddedViaIlios(true);
+                $user->setEnabled(true);
+                $user->setSchool($school);
+                $user->setUserSyncIgnore(false);
+                //persist the user so it can be used in setupUser method
+                $this->userManager->updateUser($user);
+
+                $this->authenticationService->setupNewUser($userRecord, $user);
+                $studentRole->addUser($user);
+                $user->addRole($studentRole);
+                //save again in case setupUser made any changes
+                $this->userManager->updateUser($user, false);
+
+                $output->writeln(
+                    '<info>Success! New student #' .
+                    $user->getId() . ' ' .
+                    $user->getFirstAndLastName() .
+                    ' created.</info>'
+                );
+            }
+            $this->userRoleManager->updateUserRole($studentRole);
+        } else {
+            $output->writeln('<comment>Update Canceled</comment>');
+        }
+        
+    }
+}

--- a/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
@@ -141,7 +141,7 @@ class AddNewStudentsToSchoolCommand extends Command
         $output->writeln('');
         $question = new ConfirmationQuestion(
             '<question>Do you wish to add these students to ' . $school->getTitle() . '? </question>' . "\n",
-            false
+            true
         );
         
         if ($helper->ask($input, $output, $question)) {

--- a/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
@@ -99,6 +99,7 @@ class AddNewStudentsToSchoolCommand extends Command
                 "School with id {$schoolId} could not be found."
             );
         }
+        $output->writeln("<info>Serchign for new students to add to " . $school->getTitle() . ".</info>");
         
         $students = $this->directory->findByLdapFilter($filter);
         
@@ -111,7 +112,7 @@ class AddNewStudentsToSchoolCommand extends Command
         $campusIds = $this->userManager->getAllCampusIds();
         
         $newStudents = array_filter($students, function (array $arr) use ($campusIds) {
-            return !$campusIds->contains($arr['campusId']);
+            return !in_array($arr['campusId'], $campusIds);
         });
         
         if (!count($newStudents) > 0) {

--- a/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
@@ -180,15 +180,15 @@ class AddNewStudentsToSchoolCommand extends Command
                 $user->setEnabled(true);
                 $user->setSchool($school);
                 $user->setUserSyncIgnore(false);
-
+                $user->addRole($studentRole);
+                $this->userManager->updateUser($user);
+                
                 $authentication = $this->authenticationManager->createAuthentication();
                 $authentication->setUser($user);
                 $authentication->setUsername($userRecord['username']);
                 $this->authenticationManager->updateAuthentication($authentication, false);
                 
                 $studentRole->addUser($user);
-                $user->addRole($studentRole);
-                $this->userManager->updateUser($user, false);
                 $this->userRoleManager->updateUserRole($studentRole);
                 
                 $output->writeln(

--- a/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
@@ -99,7 +99,7 @@ class AddNewStudentsToSchoolCommand extends Command
                 "School with id {$schoolId} could not be found."
             );
         }
-        $output->writeln("<info>Serchign for new students to add to " . $school->getTitle() . ".</info>");
+        $output->writeln("<info>Searching for new students to add to " . $school->getTitle() . ".</info>");
         
         $students = $this->directory->findByLdapFilter($filter);
         

--- a/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
@@ -199,7 +199,7 @@ class AddNewStudentsToSchoolCommand extends Command
                 );
             }
         } else {
-            $output->writeln('<comment>Update Canceled.</comment>');
+            $output->writeln('<comment>Update canceled.</comment>');
         }
         
     }

--- a/src/Ilios/CliBundle/Command/AddUserCommand.php
+++ b/src/Ilios/CliBundle/Command/AddUserCommand.php
@@ -99,7 +99,7 @@ class AddUserCommand extends Command
         $userRecord = $this->directory->findByCampusId($campusId);
         
         if (!$userRecord) {
-            $output->writeln("<error>Unable to find campus id {$campusId} in the directory.</error>");
+            $output->writeln("<error>Unable to find campus ID {$campusId} in the directory.</error>");
             return;
         }
         

--- a/src/Ilios/CliBundle/Command/AddUserCommand.php
+++ b/src/Ilios/CliBundle/Command/AddUserCommand.php
@@ -123,7 +123,7 @@ class AddUserCommand extends Command
         $output->writeln('');
         $question = new ConfirmationQuestion(
             "<question>Do you wish to add this user to Ilios?</question>\n",
-            false
+            true
         );
         
         if ($helper->ask($input, $output, $question)) {

--- a/src/Ilios/CliBundle/Command/AddUserCommand.php
+++ b/src/Ilios/CliBundle/Command/AddUserCommand.php
@@ -99,7 +99,7 @@ class AddUserCommand extends Command
         $userRecord = $this->directory->findByCampusId($campusId);
         
         if (!$userRecord) {
-            $output->writeln("<error>Unable to find campus id {$campusId} in the directory</error>");
+            $output->writeln("<error>Unable to find campus id {$campusId} in the directory.</error>");
             return;
         }
         
@@ -147,7 +147,7 @@ class AddUserCommand extends Command
                 '<info>Success! New user #' . $user->getId() . ' ' . $user->getFirstAndLastName() . ' created.</info>'
             );
         } else {
-            $output->writeln('<comment>Canceled</comment>');
+            $output->writeln('<comment>Canceled.</comment>');
         }
         
         

--- a/src/Ilios/CliBundle/Command/AddUserCommand.php
+++ b/src/Ilios/CliBundle/Command/AddUserCommand.php
@@ -136,12 +136,12 @@ class AddUserCommand extends Command
             $user->setEnabled(true);
             $user->setSchool($school);
             $user->setUserSyncIgnore(false);
+            $this->userManager->updateUser($user);
             
             $authentication = $this->authenticationManager->createAuthentication();
             $authentication->setUser($user);
             $authentication->setUsername($userRecord['username']);
-            $this->authenticationManager->updateAuthentication($authentication, false);
-            $this->userManager->updateUser($user);
+            $this->authenticationManager->updateAuthentication($authentication);
 
             $output->writeln(
                 '<info>Success! New user #' . $user->getId() . ' ' . $user->getFirstAndLastName() . ' created.</info>'

--- a/src/Ilios/CliBundle/Command/FindUserCommand.php
+++ b/src/Ilios/CliBundle/Command/FindUserCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+
+use Ilios\CoreBundle\Service\Directory;
+
+/**
+ * Find a user in the directory
+ *
+ * Class FindUserCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class FindUserCommand extends Command
+{
+    /**
+     * @var Directory
+     */
+    protected $directory;
+    
+    public function __construct(
+        Directory $directory
+    ) {
+        $this->directory = $directory;
+        
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:directory:find-user')
+            ->setDescription('Find a user in the directory.')
+            ->addArgument(
+                'searchTerms',
+                InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+                'What to search for (separate multiple names with a space).'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $searchTerms = $input->getArgument('searchTerms');
+        $userRecords = $this->directory->find($searchTerms);
+        if (!$userRecords) {
+            $output->writeln('<error>Unable to find anyone matching those terms in the directory.</error>');
+            return;
+        }
+        
+        $rows = array_map(function ($arr) {
+            return [
+                $arr['campusId'],
+                $arr['firstName'],
+                $arr['lastName'],
+                $arr['email'],
+                $arr['telephoneNumber']
+            ];
+        }, $userRecords);
+        $table = new Table($output);
+        $table
+            ->setHeaders(array('Campus ID', 'First', 'Last', 'Email', 'Phone Number'))
+            ->setRows($rows)
+        ;
+        $table->render();
+    }
+}

--- a/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
@@ -70,7 +70,7 @@ class SyncAllUsersCommand extends Command
     {
         $this
             ->setName('ilios:directory:sync-users')
-            ->setDescription('Sync all users against the directory by their campus id.');
+            ->setDescription('Sync all users against the directory by their Campus ID.');
     }
 
     /**
@@ -78,7 +78,7 @@ class SyncAllUsersCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln('<info>Starting User Sync Process</info>');
+        $output->writeln('<info>Starting User Sync Process.</info>');
         $this->userManager->resetExaminedFlagForAllUsers();
         $this->pendingUserUpdateManager->removeAllPendingUserUpdates();
         $campusIds = $this->userManager->getAllCampusIds(false, false);
@@ -91,7 +91,7 @@ class SyncAllUsersCommand extends Command
         $allUserRecords = $this->directory->findByCampusIds($campusIds);
         
         if (!$allUserRecords) {
-            $output->writeln('<error>[E] Unable to find any users in the directory</error>');
+            $output->writeln('<error>[E] Unable to find any users in the directory.</error>');
         }
         $totalRecords = count($allUserRecords);
         $output->writeln("<info>Found {$totalRecords} records in the directory.</info>");
@@ -110,7 +110,7 @@ class SyncAllUsersCommand extends Command
                     //the directory
                     $output->writeln(
                         '<error>[E] Unable to find an enabled sync active user with ' .
-                        'Campus ID ' . $recordArray['campusId'] . '</error>'
+                        'Campus ID ' . $recordArray['campusId'] . '.</error>'
                     );
                     continue;
                 }
@@ -132,7 +132,7 @@ class SyncAllUsersCommand extends Command
                 $output->writeln(
                     '<info>[I] Comparing User #' . $user->getId() . ' ' .
                     $user->getFirstAndLastName() . ' (' . $user->getEmail() . ') ' .
-                    'to directory user by Campus ID ' . $user->getCampusId() . '</info>'
+                    'to directory user by Campus ID ' . $user->getCampusId() . '.</info>'
                 );
                 if (!$this->validateDirectoryRecord($recordArray, $output)) {
                     $user->setExamined(true);
@@ -144,7 +144,7 @@ class SyncAllUsersCommand extends Command
                     $update = true;
                     $output->writeln(
                         '  <comment>[I] Updating first name from "' . $user->getFirstName() .
-                        '" to "' . $recordArray['firstName'] . '"</comment>'
+                        '" to "' . $recordArray['firstName'] . '".</comment>'
                     );
                     $user->setFirstName($recordArray['firstName']);
                 }
@@ -152,7 +152,7 @@ class SyncAllUsersCommand extends Command
                     $update = true;
                     $output->writeln(
                         '  <comment>[I] Updating last name from "' . $user->getLastName() .
-                        '" to "' . $recordArray['lastName'] . '"</comment>'
+                        '" to "' . $recordArray['lastName'] . '".</comment>'
                     );
                     $user->setLastName($recordArray['lastName']);
                 }
@@ -160,7 +160,7 @@ class SyncAllUsersCommand extends Command
                     $update = true;
                     $output->writeln(
                         '  <comment>[I] Updating phone number from "' . $user->getPhone() .
-                        '" to "' . $recordArray['telephoneNumber'] . '"</comment>'
+                        '" to "' . $recordArray['telephoneNumber'] . '".</comment>'
                     );
                     $user->setPhone($recordArray['telephoneNumber']);
                 }
@@ -198,7 +198,7 @@ class SyncAllUsersCommand extends Command
                     $update = true;
                     $output->writeln(
                         '  <comment>[I] Updating username from "' . $authentication->getUsername() .
-                        '" to "' . $recordArray['username'] . '"</comment>'
+                        '" to "' . $recordArray['username'] . '".</comment>'
                     );
                     $authentication->setUsername($recordArray['username']);
                     $this->authenticationManager->updateAuthentication($authentication, false);

--- a/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
@@ -11,8 +11,8 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 use Ilios\CoreBundle\Entity\Manager\UserManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface;
 use Ilios\CoreBundle\Service\Directory;
-use Ilios\AuthenticationBundle\Service\AuthenticationInterface;
 
 /**
  * Sync a user with their directory information
@@ -26,25 +26,25 @@ class SyncAllUsersCommand extends Command
      * @var UserManagerInterface
      */
     protected $userManager;
+
+    /**
+     * @var AuthenticationManagerInterface
+     */
+    protected $authenticationManager;
     
     /**
      * @var Directory
      */
     protected $directory;
     
-    /**
-     * @var AuthenticationInterface
-     */
-    protected $authenticationService;
-    
     public function __construct(
         UserManagerInterface $userManager,
-        Directory $directory,
-        AuthenticationInterface $authenticationService
+        AuthenticationManagerInterface $authenticationManager,
+        Directory $directory
     ) {
         $this->userManager = $userManager;
+        $this->authenticationManager = $authenticationManager;
         $this->directory = $directory;
-        $this->authenticationService = $authenticationService;
         
         parent::__construct();
     }

--- a/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
@@ -7,8 +7,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Doctrine\ORM\EntityManager;
 
 use Ilios\CoreBundle\Entity\Manager\UserManagerInterface;

--- a/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
@@ -177,12 +177,12 @@ class SyncAllUsersCommand extends Command
                             '  <comment>[I] Email address "' . $user->getEmail() .
                             '" differs from "' . $recordArray['email'] . '" logging for further action.</comment>'
                         );
-                        $update = $this->pendingUserUpdateManager->createPendingUserUpdate();
-                        $update->setUser($user);
-                        $update->setProperty('email');
-                        $update->setValue($recordArray['email']);
-                        $update->setType('emailMismatch');
-                        $this->pendingUserUpdateManager->updatePendingUserUpdate($update, false);
+                        $pendingUpdate = $this->pendingUserUpdateManager->createPendingUserUpdate();
+                        $pendingUpdate->setUser($user);
+                        $pendingUpdate->setProperty('email');
+                        $pendingUpdate->setValue($recordArray['email']);
+                        $pendingUpdate->setType('emailMismatch');
+                        $this->pendingUserUpdateManager->updatePendingUserUpdate($pendingUpdate, false);
                     }
                 }
                 

--- a/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
@@ -73,7 +73,7 @@ class SyncAllUsersCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->userManager->resetExaminedFlagForAllUsers();
-        $campusIds = $this->userManager->getAllCampusIds(false, false);
+        $campusIds = $this->userManager->getAllCampusIds(false, false)->toArray();
         $allUserRecoreds = $this->directory->findByCampusIds($campusIds);
         
         if (!$allUserRecoreds) {
@@ -92,7 +92,7 @@ class SyncAllUsersCommand extends Command
                 ]);
                 if (!$user) {
                     //this shouldn't happen unless the user gets updated between
-                    //listing all the IDs on line 68 and getting them back from
+                    //listing all the IDs and getting results back from
                     //the directory
                     $output->writeln(
                         '<error>Unable to find an active sync user with ' .
@@ -103,46 +103,49 @@ class SyncAllUsersCommand extends Command
                 $update = false;
                 $output->writeln(
                     '<info>Comparing User #' . $user->getId() . ' ' .
-                    $user->getFirstAndLastName() . ' to directory user by campus id ' .
-                    $user->getCampusId() . '</info>'
+                    $user->getFirstAndLastName() . ' (' . $user->getEmail() . ') ' .
+                    'to directory user by campus id ' . $user->getCampusId() . '</info>'
                 );
                 if ($user->getFirstName() != $recordArray['firstName']) {
                     $update = true;
-                    $user->setFirstName($recordArray['firstName']);
                     $output->writeln(
-                        '<info>Updating first name from "' . $user->getFirstName() .
-                        '" to "' . $recordArray['firstName'] . '"</info>'
+                        '<comment>Updating first name from "' . $user->getFirstName() .
+                        '" to "' . $recordArray['firstName'] . '"</comment>'
                     );
+                    $user->setFirstName($recordArray['firstName']);
                 }
                 if ($user->getLastName() != $recordArray['lastName']) {
                     $update = true;
-                    $user->setLastName($recordArray['lastName']);
                     $output->writeln(
-                        '<info>Updating last name from "' . $user->getLastName() .
-                        '" to "' . $recordArray['lastName'] . '"</info>'
+                        '<comment>Updating last name from "' . $user->getLastName() .
+                        '" to "' . $recordArray['lastName'] . '"</comment>'
                     );
+                    $user->setLastName($recordArray['lastName']);
                 }
                 if ($user->getPhone() != $recordArray['telephoneNumber']) {
                     $update = true;
-                    $user->setPhone($recordArray['telephoneNumber']);
                     $output->writeln(
-                        '<info>Updating phone number from "' . $user->getPhone() .
-                        '" to "' . $recordArray['telephoneNumber'] . '"</info>'
+                        '<comment>Updating phone number from "' . $user->getPhone() .
+                        '" to "' . $recordArray['telephoneNumber'] . '"</comment>'
                     );
+                    $user->setPhone($recordArray['telephoneNumber']);
                 }
                 
                 $authentication = $user->getAuthentication();
                 if (!$authentication) {
+                    $output->writeln(
+                        '<comment>User had no Authentication data, creating it now.</comment>'
+                    );
                     $authentication = $this->authenticationManager->createAuthentication();
                     $authentication->setUser($user);
                 }
                 if ($authentication->getUsername() != $recordArray['username']) {
                     $update = true;
-                    $authentication->setUsername($recordArray['username']);
                     $output->writeln(
-                        '<info>Updating username from "' . $authentication->getUsername() .
-                        '" to "' . $recordArray['username'] . '"</info>'
+                        '<comment>Updating username from "' . $authentication->getUsername() .
+                        '" to "' . $recordArray['username'] . '"</comment>'
                     );
+                    $authentication->setUsername($recordArray['username']);
                     $this->authenticationManager->updateAuthentication($authentication, false);
                 }
                 

--- a/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
@@ -70,7 +70,7 @@ class SyncAllUsersCommand extends Command
     {
         $this
             ->setName('ilios:directory:sync-users')
-            ->setDescription('Sync all users against the directory by their Campus ID.');
+            ->setDescription('Sync all users against the directory by their campus ID.');
     }
 
     /**
@@ -110,14 +110,14 @@ class SyncAllUsersCommand extends Command
                     //the directory
                     $output->writeln(
                         '<error>[E] Unable to find an enabled sync active user with ' .
-                        'Campus ID ' . $recordArray['campusId'] . '.</error>'
+                        'campus ID ' . $recordArray['campusId'] . '.</error>'
                     );
                     continue;
                 }
                 if (count($users) > 1) {
                     $output->writeln(
                         '<error>[E] Multiple accounts exist for the same ' .
-                        'Campus ID (' . $recordArray['campusId'] . ').  ' .
+                        'campus ID (' . $recordArray['campusId'] . ').  ' .
                         'None of them will be updated.</error>'
                     );
                     foreach ($users as $user) {
@@ -132,7 +132,7 @@ class SyncAllUsersCommand extends Command
                 $output->writeln(
                     '<info>[I] Comparing User #' . $user->getId() . ' ' .
                     $user->getFirstAndLastName() . ' (' . $user->getEmail() . ') ' .
-                    'to directory user by Campus ID ' . $user->getCampusId() . '.</info>'
+                    'to directory user by campus ID ' . $user->getCampusId() . '.</info>'
                 );
                 if (!$this->validateDirectoryRecord($recordArray, $output)) {
                     $user->setExamined(true);
@@ -189,7 +189,7 @@ class SyncAllUsersCommand extends Command
                 $authentication = $user->getAuthentication();
                 if (!$authentication) {
                     $output->writeln(
-                        '  <comment>[I] User had no Authentication data, creating it now.</comment>'
+                        '  <comment>[I] User had no authentication data, creating it now.</comment>'
                     );
                     $authentication = $this->authenticationManager->createAuthentication();
                     $authentication->setUser($user);
@@ -234,7 +234,7 @@ class SyncAllUsersCommand extends Command
         $this->em->flush();
 
         $output->writeln(
-            "<info>Completed Sync Process {$totalRecords} users found in the directory; " .
+            "<info>Completed sync process {$totalRecords} users found in the directory; " .
             "{$updated} users updated.</info>"
         );
         
@@ -249,7 +249,7 @@ class SyncAllUsersCommand extends Command
                 $valid = false;
                 $output->writeln(
                     "  <error>[E]  {$key} is required and it is missing from record with " .
-                    'Campus ID (' . $record['campusId'] . ').  ' .
+                    'campus ID (' . $record['campusId'] . ').  ' .
                     'User will not be updated.</error>'
                 );
             }

--- a/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
@@ -74,86 +74,87 @@ class SyncAllUsersCommand extends Command
     {
         $this->userManager->resetExaminedFlagForAllUsers();
         $campusIds = $this->userManager->getAllCampusIds(false, false);
-        $userRecords = $this->directory->findByCampusIds($campusIds);
+        $allUserRecoreds = $this->directory->findByCampusIds($campusIds);
         
-        if (!$userRecords) {
+        if (!$allUserRecoreds) {
             $output->writeln('<error>Unable to find any users in the directory');
             return;
         }
-        $totalRecords = count($userRecords);
+        $totalRecords = count($allUserRecoreds);
         $updated = 0;
-        foreach ($userRecords as $recordArray) {
-            $user = $this->userManager->findUserBy([
-                'campusId' => $recordArray['campusId'],
-                'enabled' => true,
-                'userSyncIgnore' => false
-            ]);
-            if (!$user) {
-                //this shouldn't happen unless the user gets updated between
-                //listing all the IDs on line 68 and getting them back from
-                //the directory
+        $chunks = array_chunk($allUserRecoreds, 500);
+        foreach ($chunks as $userRecords) {
+            foreach ($userRecords as $recordArray) {
+                $user = $this->userManager->findUserBy([
+                    'campusId' => $recordArray['campusId'],
+                    'enabled' => true,
+                    'userSyncIgnore' => false
+                ]);
+                if (!$user) {
+                    //this shouldn't happen unless the user gets updated between
+                    //listing all the IDs on line 68 and getting them back from
+                    //the directory
+                    $output->writeln(
+                        '<error>Unable to find an active sync user with ' .
+                        'campus id ' . $recordArray['campusId'] . '</error>'
+                    );
+                    continue;
+                }
+                $update = false;
                 $output->writeln(
-                    '<error>Unable to find an active sync user with ' .
-                    'campus id ' . $recordArray['campusId'] . '</error>'
+                    '<info>Comparing User #' . $user->getId() . ' ' .
+                    $user->getFirstAndLastName() . ' to directory user by campus id ' .
+                    $user->getCampusId() . '</info>'
                 );
-                continue;
+                if ($user->getFirstName() != $recordArray['firstName']) {
+                    $update = true;
+                    $user->setFirstName($recordArray['firstName']);
+                    $output->writeln(
+                        '<info>Updating first name from "' . $user->getFirstName() .
+                        '" to "' . $recordArray['firstName'] . '"</info>'
+                    );
+                }
+                if ($user->getLastName() != $recordArray['lastName']) {
+                    $update = true;
+                    $user->setLastName($recordArray['lastName']);
+                    $output->writeln(
+                        '<info>Updating last name from "' . $user->getLastName() .
+                        '" to "' . $recordArray['lastName'] . '"</info>'
+                    );
+                }
+                if ($user->getPhone() != $recordArray['telephoneNumber']) {
+                    $update = true;
+                    $user->setPhone($recordArray['telephoneNumber']);
+                    $output->writeln(
+                        '<info>Updating phone number from "' . $user->getPhone() .
+                        '" to "' . $recordArray['telephoneNumber'] . '"</info>'
+                    );
+                }
+                
+                $authentication = $user->getAuthentication();
+                if (!$authentication) {
+                    $authentication = $this->authenticationManager->createAuthentication();
+                    $authentication->setUser($user);
+                }
+                if ($authentication->getUsername() != $recordArray['username']) {
+                    $update = true;
+                    $authentication->setUsername($recordArray['username']);
+                    $output->writeln(
+                        '<info>Updating username from "' . $authentication->getUsername() .
+                        '" to "' . $recordArray['username'] . '"</info>'
+                    );
+                    $this->authenticationManager->updateAuthentication($authentication, false);
+                }
+                
+                if ($update) {
+                    $updated++;
+                }
+                $user->setExamined(true);
+                $this->userManager->updateUser($user, false);
             }
-            $update = false;
-            $output->writeln(
-                '<info>Comparing User #' . $user->getId() . ' ' .
-                $user->getFirstAndLastName() . ' to directory user by campus id ' .
-                $user->getCampusId() . '</info>'
-            );
-            if ($user->getFirstName() != $recordArray['firstName']) {
-                $update = true;
-                $user->setFirstName($recordArray['firstName']);
-                $output->writeln(
-                    '<info>Updating first name from "' . $user->getFirstName() .
-                    '" to "' . $recordArray['firstName'] . '"</info>'
-                );
-            }
-            if ($user->getLastName() != $recordArray['lastName']) {
-                $update = true;
-                $user->setLastName($recordArray['lastName']);
-                $output->writeln(
-                    '<info>Updating last name from "' . $user->getLastName() .
-                    '" to "' . $recordArray['lastName'] . '"</info>'
-                );
-            }
-            if ($user->getPhone() != $recordArray['telephoneNumber']) {
-                $update = true;
-                $user->setPhone($recordArray['telephoneNumber']);
-                $output->writeln(
-                    '<info>Updating phone number from "' . $user->getPhone() .
-                    '" to "' . $recordArray['telephoneNumber'] . '"</info>'
-                );
-            }
-            
-            $authentication = $user->getAuthentication();
-            if (!$authentication) {
-                $authentication = $this->authenticationManager->createAuthentication();
-                $authentication->setUser($user);
-            }
-            if ($authentication->getUsername() != $recordArray['username']) {
-                $update = true;
-                $authentication->setUsername($recordArray['username']);
-                $output->writeln(
-                    '<info>Updating username from "' . $authentication->getUsername() .
-                    '" to "' . $recordArray['username'] . '"</info>'
-                );
-                $this->authenticationManager->updateAuthentication($authentication, false);
-            }
-            
-            if ($update) {
-                $updated++;
-            }
-            $user->setExamined(true);
-            $this->userManager->updateUser($user, false);
-            
             $this->em->flush();
             $this->em->clear();
         }
-        
         $output->writeln(
             "<info>Completed Sync Process {$totalRecords} users found in the directory; " .
             "{$updated} users updated.</info>"

--- a/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+use Ilios\CoreBundle\Entity\Manager\UserManagerInterface;
+use Ilios\CoreBundle\Service\Directory;
+use Ilios\AuthenticationBundle\Service\AuthenticationInterface;
+
+/**
+ * Sync a user with their directory information
+ *
+ * Class SyncUserCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class SyncAllUsersCommand extends Command
+{
+    /**
+     * @var UserManagerInterface
+     */
+    protected $userManager;
+    
+    /**
+     * @var Directory
+     */
+    protected $directory;
+    
+    /**
+     * @var AuthenticationInterface
+     */
+    protected $authenticationService;
+    
+    public function __construct(
+        UserManagerInterface $userManager,
+        Directory $directory,
+        AuthenticationInterface $authenticationService
+    ) {
+        $this->userManager = $userManager;
+        $this->directory = $directory;
+        $this->authenticationService = $authenticationService;
+        
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:directory:sync-users')
+            ->setDescription('Sync all users against the directory by their campus id.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->userManager->resetExaminedFlagForAllUsers();
+        $campusIds = $this->userManager->getAllCampusIds(false, false);
+        $userRecords = $this->directory->findByCampusIds($campusIds);
+        
+        if (!$userRecords) {
+            $output->writeln('<error>Unable to find any users in the directory');
+            return;
+        }
+        $totalRecords = count($userRecords);
+        $updated = 0;
+        foreach ($userRecords as $recordArray) {
+            $user = $this->userManager->findUserBy([
+                'campusId' => $recordArray['campusId'],
+                'enabled' => true,
+                'userSyncIgnore' => false
+            ]);
+            if (!$user) {
+                //this shouldn't happen unless the user gets updated between
+                //listing all the IDs on line 68 and getting them back from
+                //the directory
+                $output->writeln(
+                    '<error>Unable to find an active sync user with ' .
+                    'campus id ' . $recordArray['campusId'] . '</error>'
+                );
+                continue;
+            }
+            $update = false;
+            $output->writeln(
+                '<info>Comparing User #' . $user->getId() . ' ' .
+                $user->getFirstAndLastName() . ' to directory user by campus id ' .
+                $user->getCampusId() . '</info>'
+            );
+            if ($user->getFirstName() != $recordArray['firstName']) {
+                $update = true;
+                $user->setFirstName($recordArray['firstName']);
+                $output->writeln(
+                    '<info>Updating first name from "' . $user->getFirstName() .
+                    '" to "' . $recordArray['firstName'] . '"</info>'
+                );
+            }
+            if ($user->getLastName() != $recordArray['lastName']) {
+                $update = true;
+                $user->setLastName($recordArray['lastName']);
+                $output->writeln(
+                    '<info>Updating last name from "' . $user->getLastName() .
+                    '" to "' . $recordArray['lastName'] . '"</info>'
+                );
+            }
+            if ($user->getPhone() != $recordArray['telephoneNumber']) {
+                $update = true;
+                $user->setPhone($recordArray['telephoneNumber']);
+                $output->writeln(
+                    '<info>Updating phone number from "' . $user->getPhone() .
+                    '" to "' . $recordArray['telephoneNumber'] . '"</info>'
+                );
+            }
+            if ($update) {
+                $updated++;
+            }
+            $user->setExamined(true);
+            $this->userManager->updateUser($user, false);
+        }
+        
+        $output->writeln(
+            "<info>Completed Sync Process {$totalRecords} users found in the directory; " .
+            "{$updated} users updated.</info>"
+        );
+        
+    }
+}

--- a/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncAllUsersCommand.php
@@ -129,6 +129,7 @@ class SyncAllUsersCommand extends Command
                 $user = $users[0];
 
                 $update = false;
+                $fixSmallThings = true;
                 $output->writeln(
                     '<info>[I] Comparing User #' . $user->getId() . ' ' .
                     $user->getFirstAndLastName() . ' (' . $user->getEmail() . ') ' .
@@ -140,30 +141,6 @@ class SyncAllUsersCommand extends Command
                     //don't do anything else with invalid directory data
                     continue;
                 }
-                if ($user->getFirstName() != $recordArray['firstName']) {
-                    $update = true;
-                    $output->writeln(
-                        '  <comment>[I] Updating first name from "' . $user->getFirstName() .
-                        '" to "' . $recordArray['firstName'] . '".</comment>'
-                    );
-                    $user->setFirstName($recordArray['firstName']);
-                }
-                if ($user->getLastName() != $recordArray['lastName']) {
-                    $update = true;
-                    $output->writeln(
-                        '  <comment>[I] Updating last name from "' . $user->getLastName() .
-                        '" to "' . $recordArray['lastName'] . '".</comment>'
-                    );
-                    $user->setLastName($recordArray['lastName']);
-                }
-                if ($user->getPhone() != $recordArray['telephoneNumber']) {
-                    $update = true;
-                    $output->writeln(
-                        '  <comment>[I] Updating phone number from "' . $user->getPhone() .
-                        '" to "' . $recordArray['telephoneNumber'] . '".</comment>'
-                    );
-                    $user->setPhone($recordArray['telephoneNumber']);
-                }
                 if ($user->getEmail() != $recordArray['email']) {
                     if (strtolower($user->getEmail()) == strtolower($recordArray['email'])) {
                         $update = true;
@@ -173,6 +150,7 @@ class SyncAllUsersCommand extends Command
                         );
                         $user->setEmail($recordArray['email']);
                     } else {
+                        $fixSmallThings = false;
                         $output->writeln(
                             '  <comment>[I] Email address "' . $user->getEmail() .
                             '" differs from "' . $recordArray['email'] . '" logging for further action.</comment>'
@@ -186,6 +164,30 @@ class SyncAllUsersCommand extends Command
                     }
                 }
                 
+                if ($fixSmallThings && $user->getFirstName() != $recordArray['firstName']) {
+                    $update = true;
+                    $output->writeln(
+                        '  <comment>[I] Updating first name from "' . $user->getFirstName() .
+                        '" to "' . $recordArray['firstName'] . '".</comment>'
+                    );
+                    $user->setFirstName($recordArray['firstName']);
+                }
+                if ($fixSmallThings && $user->getLastName() != $recordArray['lastName']) {
+                    $update = true;
+                    $output->writeln(
+                        '  <comment>[I] Updating last name from "' . $user->getLastName() .
+                        '" to "' . $recordArray['lastName'] . '".</comment>'
+                    );
+                    $user->setLastName($recordArray['lastName']);
+                }
+                if ($fixSmallThings && $user->getPhone() != $recordArray['telephoneNumber']) {
+                    $update = true;
+                    $output->writeln(
+                        '  <comment>[I] Updating phone number from "' . $user->getPhone() .
+                        '" to "' . $recordArray['telephoneNumber'] . '".</comment>'
+                    );
+                    $user->setPhone($recordArray['telephoneNumber']);
+                }
                 $authentication = $user->getAuthentication();
                 if (!$authentication) {
                     $output->writeln(
@@ -194,7 +196,7 @@ class SyncAllUsersCommand extends Command
                     $authentication = $this->authenticationManager->createAuthentication();
                     $authentication->setUser($user);
                 }
-                if ($authentication->getUsername() != $recordArray['username']) {
+                if ($fixSmallThings && $authentication->getUsername() != $recordArray['username']) {
                     $update = true;
                     $output->writeln(
                         '  <comment>[I] Updating username from "' . $authentication->getUsername() .

--- a/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+use Ilios\CoreBundle\Entity\Manager\UserManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\UserRoleManagerInterface;
+use Ilios\CoreBundle\Entity\UserInterface;
+use Ilios\CoreBundle\Service\Directory;
+
+/**
+ * Syncs former students from the directory
+ *
+ * Class SyncFormerStudentsCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class SyncFormerStudentsCommand extends Command
+{
+    /**
+     * @var UserManagerInterface
+     */
+    protected $userManager;
+    
+    /**
+     * @var UserRoleManagerInterface
+     */
+    protected $userRoleManager;
+    
+    /**
+     * @var Directory
+     */
+    protected $directory;
+    
+    public function __construct(
+        UserManagerInterface $userManager,
+        UserRoleManagerInterface $userRoleManager,
+        Directory $directory
+    ) {
+        $this->userManager = $userManager;
+        $this->userRoleManager = $userRoleManager;
+        $this->directory = $directory;
+        
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:directory:sync-former-students')
+            ->setDescription('Sync former students from the directory.')
+            ->addArgument(
+                'filter',
+                InputArgument::REQUIRED,
+                'An LDAP filter to use in finding former students in the direcotry.'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $filter = $input->getArgument('filter');
+        
+        $formerStudents = $this->directory->findByLdapFilter($filter);
+        
+        if (!$formerStudents) {
+            $output->writeln("<error>{$filter} returned no results.</error>");
+            return;
+        }
+        $output->writeln('<info>Found ' . count($formerStudents) . ' former students in the directory.</info>');
+        
+        $formerStudentsCampusIds = array_map(function (array $arr) {
+            return $arr['campusId'];
+        }, $formerStudents);
+
+        $notFormerStudents = $this->userManager->findUsersWhoAreNotFormerStudents($formerStudentsCampusIds);
+        $usersToUpdate = $notFormerStudents->filter(function (UserInterface $user) {
+            return !$user->isUserSyncIgnore();
+        });
+        if (!$usersToUpdate->count() > 0) {
+            $output->writeln("<info>There are no students to update.</info>");
+            return;
+        }
+        $output->writeln(
+            '<info>There are ' .
+            $usersToUpdate->count() .
+            ' students in Ilios who will be marked as a Former Student.</info>'
+        );
+        $rows = $usersToUpdate->map(function (UserInterface $user) {
+            return [
+                $user->getCampusId(),
+                $user->getFirstName(),
+                $user->getLastName(),
+                $user->getEmail()
+            ];
+        })->toArray();
+        $table = new Table($output);
+        $table->setHeaders(array('Campus ID', 'First', 'Last', 'Email'))->setRows($rows);
+        $table->render();
+
+        $helper = $this->getHelper('question');
+        $output->writeln('');
+        $question = new ConfirmationQuestion(
+            '<question>Do you wish to mark these users as Former Students? </question>' . "\n",
+            false
+        );
+        
+        if ($helper->ask($input, $output, $question)) {
+            $formerStudentRole = $this->userRoleManager->findUserRoleBy(array('title' => 'Former Student'));
+            foreach ($usersToUpdate as $user) {
+                $formerStudentRole->addUser($user);
+                $user->addRole($formerStudentRole);
+                $this->userManager->updateUser($user, false);
+            }
+            $this->userRoleManager->updateUserRole($formerStudentRole);
+            
+            $output->writeln('<info>Former Students Updated Successfully!</info>');
+        } else {
+            $output->writeln('<comment>Update Canceled</comment>');
+        }
+        
+    }
+}

--- a/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
@@ -70,6 +70,7 @@ class SyncFormerStudentsCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $output->writeln('<info>Starting former student synchronization process.</info>');
         $filter = $input->getArgument('filter');
         
         $formerStudents = $this->directory->findByLdapFilter($filter);

--- a/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
@@ -61,7 +61,7 @@ class SyncFormerStudentsCommand extends Command
             ->addArgument(
                 'filter',
                 InputArgument::REQUIRED,
-                'An LDAP filter to use in finding former students in the direcotry.'
+                'An LDAP filter to use in finding former students in the directory.'
             );
     }
 
@@ -128,7 +128,7 @@ class SyncFormerStudentsCommand extends Command
             
             $output->writeln('<info>Former Students Updated Successfully!</info>');
         } else {
-            $output->writeln('<comment>Update Canceled</comment>');
+            $output->writeln('<comment>Update Canceled,</comment>');
         }
         
     }

--- a/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
@@ -113,7 +113,7 @@ class SyncFormerStudentsCommand extends Command
         $output->writeln('');
         $question = new ConfirmationQuestion(
             '<question>Do you wish to mark these users as Former Students? </question>' . "\n",
-            false
+            true
         );
         
         if ($helper->ask($input, $output, $question)) {

--- a/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
@@ -126,9 +126,9 @@ class SyncFormerStudentsCommand extends Command
             }
             $this->userRoleManager->updateUserRole($formerStudentRole);
             
-            $output->writeln('<info>Former Students Updated Successfully!</info>');
+            $output->writeln('<info>Former students updated successfully!</info>');
         } else {
-            $output->writeln('<comment>Update Canceled,</comment>');
+            $output->writeln('<comment>Update canceled,</comment>');
         }
         
     }

--- a/src/Ilios/CliBundle/Command/SyncUserCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncUserCommand.php
@@ -132,9 +132,9 @@ class SyncUserCommand extends Command
             
             $this->userManager->updateUser($user);
             
-            $output->writeln('<info>User Updated Successfully</info>');
+            $output->writeln('<info>User updated successfully!</info>');
         } else {.
-            $output->writeln('<comment>Update Canceled.</comment>');
+            $output->writeln('<comment>Update canceled.</comment>');
         }
         
     }

--- a/src/Ilios/CliBundle/Command/SyncUserCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncUserCommand.php
@@ -14,9 +14,9 @@ use Ilios\CoreBundle\Entity\Manager\UserManagerInterface;
 use Ilios\CoreBundle\Service\Directory;
 
 /**
- * Create a new token for a user
+ * Sync a user with their directory information
  *
- * Class CreateUserTokenCommand
+ * Class SyncUserCommand
  * @package Ilios\CliBUndle\Command
  */
 class SyncUserCommand extends Command
@@ -47,7 +47,7 @@ class SyncUserCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:setup:sync-user')
+            ->setName('ilios:directory:sync-user')
             ->setDescription('Sync a user from the directory.')
             ->addArgument(
                 'userId',
@@ -69,7 +69,7 @@ class SyncUserCommand extends Command
             );
         }
         
-        $userRecord = $this->directory->findUserByCampusId($user->getCampusId());
+        $userRecord = $this->directory->findByCampusId($user->getCampusId());
         
         if (!$userRecord) {
             $output->writeln('<error>Unable to find ' . $user->getCampusId() . ' in the directory');

--- a/src/Ilios/CliBundle/Command/SyncUserCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncUserCommand.php
@@ -113,7 +113,7 @@ class SyncUserCommand extends Command
         $question = new ConfirmationQuestion(
             '<question>Do you wish to update this Ilios User with the data ' .
             'from the Directory User? </question>',
-            false
+            true
         );
         
         if ($helper->ask($input, $output, $question)) {

--- a/src/Ilios/CliBundle/Command/SyncUserCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncUserCommand.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+use Ilios\CoreBundle\Entity\Manager\UserManagerInterface;
+use Ilios\CoreBundle\Service\Directory;
+
+/**
+ * Create a new token for a user
+ *
+ * Class CreateUserTokenCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class SyncUserCommand extends Command
+{
+    /**
+     * @var UserManagerInterface
+     */
+    protected $userManager;
+    
+    /**
+     * @var Directory
+     */
+    protected $directory;
+    
+    public function __construct(
+        UserManagerInterface $userManager,
+        Directory $directory
+    ) {
+        $this->userManager = $userManager;
+        $this->directory = $directory;
+        
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:setup:sync-user')
+            ->setDescription('Sync a user from the directory.')
+            ->addArgument(
+                'userId',
+                InputArgument::REQUIRED,
+                'A valid user id.'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $userId = $input->getArgument('userId');
+        $user = $this->userManager->findUserBy(['id' => $userId]);
+        if (!$user) {
+            throw new \Exception(
+                "No user with id #{$userId} was found."
+            );
+        }
+        
+        $userRecord = $this->directory->findUserByCampusId($user->getCampusId());
+        
+        if (!$userRecord) {
+            $output->writeln('<error>Unable to find ' . $user->getCampusId() . ' in the directory');
+            return;
+        }
+        
+        $table = new Table($output);
+        $table
+            ->setHeaders(array('Record', 'First', 'Last', 'Email', 'Phone Number'))
+            ->setRows(array(
+                [
+                    'Ilios User',
+                    $user->getFirstName(),
+                    $user->getLastName(),
+                    $user->getEmail(),
+                    $user->getPhone()
+                ],
+                [
+                    'Directory User',
+                    $userRecord['firstName'],
+                    $userRecord['lastName'],
+                    $userRecord['email'],
+                    $userRecord['telephoneNumber']
+                ]
+            ))
+        ;
+        $table->render();
+        
+        $helper = $this->getHelper('question');
+        $output->writeln('');
+        $question = new ConfirmationQuestion(
+            '<question>Do you wish to update this Ilios User with the data ' .
+            'from the Directory User? </question>',
+            false
+        );
+        
+        if ($helper->ask($input, $output, $question)) {
+            $user->setFirstName($userRecord['firstName']);
+            $user->setLastName($userRecord['lastName']);
+            $user->setEmail($userRecord['email']);
+            $user->setPhone($userRecord['telephoneNumber']);
+            $this->userManager->updateUser($user);
+            
+            $output->writeln('<info>User Updated Successfully</info>');
+        } else {
+            $output->writeln('<comment>Update Canceled</comment>');
+        }
+        
+    }
+}

--- a/src/Ilios/CliBundle/Command/SyncUserCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncUserCommand.php
@@ -80,7 +80,7 @@ class SyncUserCommand extends Command
         $userRecord = $this->directory->findByCampusId($user->getCampusId());
         
         if (!$userRecord) {
-            $output->writeln('<error>Unable to find ' . $user->getCampusId() . ' in the directory');
+            $output->writeln('<error>Unable to find ' . $user->getCampusId() . ' in the directory.');
             return;
         }
         
@@ -112,7 +112,7 @@ class SyncUserCommand extends Command
         $output->writeln('');
         $question = new ConfirmationQuestion(
             '<question>Do you wish to update this Ilios User with the data ' .
-            'from the Directory User? </question>',
+            'from the Directory User? </question>' . "\n",
             true
         );
         
@@ -133,8 +133,8 @@ class SyncUserCommand extends Command
             $this->userManager->updateUser($user);
             
             $output->writeln('<info>User Updated Successfully</info>');
-        } else {
-            $output->writeln('<comment>Update Canceled</comment>');
+        } else {.
+            $output->writeln('<comment>Update Canceled.</comment>');
         }
         
     }

--- a/src/Ilios/CliBundle/Command/SyncUserCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncUserCommand.php
@@ -133,7 +133,7 @@ class SyncUserCommand extends Command
             $this->userManager->updateUser($user);
             
             $output->writeln('<info>User updated successfully!</info>');
-        } else {.
+        } else {
             $output->writeln('<comment>Update canceled.</comment>');
         }
         

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -24,3 +24,8 @@ services:
         arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.school.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
         tags:
             -  { name: console.command }
+    ilioscli.command.sync_former_students:
+        class: Ilios\CliBundle\Command\SyncFormerStudentsCommand
+        arguments: ["@ilioscore.user.manager", "@ilioscore.userrole.manager", "@ilioscore.directory"]
+        tags:
+            -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -36,6 +36,6 @@ services:
             -  { name: console.command }
     ilioscli.command.sync_all_users:
         class: Ilios\CliBundle\Command\SyncAllUsersCommand
-        arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.directory"]
+        arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.directory", "@doctrine.orm.entity_manager"]
         tags:
             -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -36,6 +36,6 @@ services:
             -  { name: console.command }
     ilioscli.command.sync_all_users:
         class: Ilios\CliBundle\Command\SyncAllUsersCommand
-        arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.directory", "@doctrine.orm.entity_manager"]
+        arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.pendinguserupdate.manager", "@ilioscore.directory", "@doctrine.orm.entity_manager"]
         tags:
             -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -29,3 +29,8 @@ services:
         arguments: ["@ilioscore.user.manager", "@ilioscore.userrole.manager", "@ilioscore.directory"]
         tags:
             -  { name: console.command }
+    ilioscli.command.add_new_students_to_school:
+        class: Ilios\CliBundle\Command\AddNewStudentsToSchoolCommand
+        arguments: ["@ilioscore.user.manager", "@ilioscore.school.manager",, "@ilioscore.userrole.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
+        tags:
+            -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -11,7 +11,7 @@ services:
             -  { name: console.command }
     ilioscli.command.sync_user:
         class: Ilios\CliBundle\Command\SyncUserCommand
-        arguments: ["@ilioscore.user.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
+        arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.directory"]
         tags:
             -  { name: console.command }
     ilioscli.command.find_directory_user:
@@ -21,7 +21,7 @@ services:
             -  { name: console.command }
     ilioscli.command.add_directory_user:
         class: Ilios\CliBundle\Command\AddUserCommand
-        arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.school.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
+        arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.school.manager", "@ilioscore.directory"]
         tags:
             -  { name: console.command }
     ilioscli.command.sync_former_students:
@@ -31,11 +31,11 @@ services:
             -  { name: console.command }
     ilioscli.command.add_new_students_to_school:
         class: Ilios\CliBundle\Command\AddNewStudentsToSchoolCommand
-        arguments: ["@ilioscore.user.manager", "@ilioscore.school.manager",, "@ilioscore.userrole.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
+        arguments: ["@ilioscore.user.manager", "@ilioscore.school.manager", , "@ilioscore.authentication.manager", "@ilioscore.userrole.manager", "@ilioscore.directory"]
         tags:
             -  { name: console.command }
     ilioscli.command.sync_all_users:
         class: Ilios\CliBundle\Command\SyncAllUsersCommand
-        arguments: ["@ilioscore.user.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
+        arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.directory"]
         tags:
             -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -14,3 +14,8 @@ services:
         arguments: ["@ilioscore.user.manager", "@ilioscore.directory"]
         tags:
             -  { name: console.command }
+    ilioscli.command.find_directory_user:
+        class: Ilios\CliBundle\Command\FindUserCommand
+        arguments: ["@ilioscore.directory"]
+        tags:
+            -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -19,3 +19,8 @@ services:
         arguments: ["@ilioscore.directory"]
         tags:
             -  { name: console.command }
+    ilioscli.command.add_directory_user:
+        class: Ilios\CliBundle\Command\AddUserCommand
+        arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.school.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
+        tags:
+            -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -11,7 +11,7 @@ services:
             -  { name: console.command }
     ilioscli.command.sync_user:
         class: Ilios\CliBundle\Command\SyncUserCommand
-        arguments: ["@ilioscore.user.manager", "@ilioscore.directory"]
+        arguments: ["@ilioscore.user.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
         tags:
             -  { name: console.command }
     ilioscli.command.find_directory_user:
@@ -32,5 +32,10 @@ services:
     ilioscli.command.add_new_students_to_school:
         class: Ilios\CliBundle\Command\AddNewStudentsToSchoolCommand
         arguments: ["@ilioscore.user.manager", "@ilioscore.school.manager",, "@ilioscore.userrole.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
+        tags:
+            -  { name: console.command }
+    ilioscli.command.sync_all_users:
+        class: Ilios\CliBundle\Command\SyncAllUsersCommand
+        arguments: ["@ilioscore.user.manager", "@ilioscore.directory", "@ilios_authentication.authenticator"]
         tags:
             -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -9,3 +9,8 @@ services:
         arguments: ["@ilioscore.user.manager", "@ilios_authentication.jwt.manager"]
         tags:
             -  { name: console.command }
+    ilioscli.command.sync_user:
+        class: Ilios\CliBundle\Command\SyncUserCommand
+        arguments: ["@ilioscore.user.manager", "@ilioscore.directory"]
+        tags:
+            -  { name: console.command }

--- a/src/Ilios/CliBundle/Tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -4,7 +4,6 @@ namespace Ilios\CliBundle\Tests\Command;
 use Ilios\CliBundle\Command\AddNewStudentsToSchoolCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Doctrine\Common\Collections\ArrayCollection;
 
 use Mockery as m;
 
@@ -104,7 +103,7 @@ class AddNewStudentsToSchoolCommandTest extends \PHPUnit_Framework_TestCase
             ->with('FILTER')
             ->andReturn([$fakeDirectoryUser1, $fakeDirectoryUser2]);
         $this->userManager->shouldReceive('getAllCampusIds')
-            ->andReturn(new ArrayCollection(['abc2']));
+            ->andReturn(['abc2']);
             
         $this->userManager->shouldReceive('createUser')->andReturn($user);
         $this->userManager

--- a/src/Ilios/CliBundle/Tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -109,7 +109,7 @@ class AddNewStudentsToSchoolCommandTest extends \PHPUnit_Framework_TestCase
         $this->userManager->shouldReceive('createUser')->andReturn($user);
         $this->userManager
             ->shouldReceive('updateUser')
-            ->with($user, false)->once();
+            ->with($user)->once();
         $this->schoolManager->shouldReceive('findSchoolBy')->with(array('id' => 1))->andReturn($school);
         $role = m::mock('Ilios\CoreBundle\Entity\UserRoleInterface')
             ->shouldReceive('addUser')->with($user)

--- a/src/Ilios/CliBundle/Tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -1,0 +1,195 @@
+<?php
+namespace Ilios\CliBundle\Tests\Command;
+
+use Ilios\CliBundle\Command\AddNewStudentsToSchoolCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Doctrine\Common\Collections\ArrayCollection;
+
+use Mockery as m;
+
+class AddNewStudentsToSchoolCommandTest extends \PHPUnit_Framework_TestCase
+{
+    const COMMAND_NAME = 'ilios:directory:add-students';
+    
+    protected $userManager;
+    protected $userRoleManager;
+    protected $schoolManager;
+    protected $commandTester;
+    protected $questionHelper;
+    protected $directory;
+    
+    public function setUp()
+    {
+        $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManagerInterface');
+        $this->userRoleManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserRoleManagerInterface');
+        $this->schoolManager = m::mock('Ilios\CoreBundle\Entity\Manager\SchoolManagerInterface');
+        $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
+        $this->authenticationService = m::mock('Ilios\AuthenticationBundle\Service\AuthenticationInterface');
+        
+        $command = new AddNewStudentsToSchoolCommand(
+            $this->userManager,
+            $this->schoolManager,
+            $this->userRoleManager,
+            $this->directory,
+            $this->authenticationService
+        );
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+        $this->questionHelper = $command->getHelper('question');
+        
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->userManager);
+        unset($this->userRoleManager);
+        unset($this->schoolManager);
+        unset($this->directory);
+        unset($this->authenticationService);
+        unset($this->commandTester);
+        m::close();
+    }
+    
+    public function testExecute()
+    {
+        $fakeDirectoryUser1 = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+        ];
+        $fakeDirectoryUser2 = [
+            'firstName' => 'first2',
+            'lastName' => 'last2',
+            'email' => 'email2',
+            'telephoneNumber' => 'phone2',
+            'campusId' => 'abc2',
+        ];
+        $school = m::mock('Ilios\CoreBundle\Entity\SchoolInterface')
+            ->shouldReceive('getTitle')->andReturn('school 1')
+            ->mock();
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstName')->andReturn('first')
+            ->shouldReceive('getLastName')->andReturn('last')
+            ->shouldReceive('getFirstAndLastName')->andReturn('first last')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setFirstName')->with('first')
+            ->shouldReceive('setLastName')->with('last')
+            ->shouldReceive('setEmail')->with('email')
+            ->shouldReceive('setPhone')->with('phone')
+            ->shouldReceive('setCampusId')->with('abc')
+            ->shouldReceive('setAddedViaIlios')->with(true)
+            ->shouldReceive('setEnabled')->with(true)
+            ->shouldReceive('setUserSyncIgnore')->with(false)
+            ->shouldReceive('setSchool')->with($school)
+            ->shouldReceive('addRole')->with($school)
+            ->mock();
+        $this->directory->shouldReceive('findByLdapFilter')
+            ->with('FILTER')
+            ->andReturn([$fakeDirectoryUser1, $fakeDirectoryUser2]);
+        $this->userManager->shouldReceive('getAllCampusIds')
+            ->andReturn(new ArrayCollection(['abc2']));
+            
+        $this->userManager->shouldReceive('createUser')->andReturn($user);
+        $this->userManager
+            ->shouldReceive('updateUser')
+            ->with($user, false);
+        $this->userManager
+            ->shouldReceive('updateUser')
+            ->with($user);
+        $this->schoolManager->shouldReceive('findSchoolBy')->with(array('id' => 1))->andReturn($school);
+        $role = m::mock('Ilios\CoreBundle\Entity\UserRoleInterface')
+            ->shouldReceive('addUser')->with($user)
+            ->mock();
+        $user->shouldReceive('addRole')->with($role);
+        $this->userRoleManager
+            ->shouldReceive('findUserRoleBy')
+            ->with(array('title' => 'Student'))
+            ->andReturn($role);
+        $this->userRoleManager
+            ->shouldReceive('updateUserRole')
+            ->with($role);
+
+        $this->authenticationService->shouldReceive('setupNewUser')->with($fakeDirectoryUser1, $user);
+        
+        $this->sayYesWhenAsked();
+        $this->commandTester->execute(array(
+            'command'   => self::COMMAND_NAME,
+            'schoolId'    => 1,
+            'filter'    => 'FILTER',
+        ));
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Found 2 students in the directory./',
+            $output
+        );
+        
+        $this->assertRegExp(
+            '/There are 1 new students to be added to school 1./',
+            $output
+        );
+        $this->assertRegExp(
+            '/Do you wish to add these students to school 1?/',
+            $output
+        );
+        $this->assertRegExp(
+            '/abc       \| first \| last \| email /',
+            $output
+        );
+        $this->assertRegExp(
+            '/Success! New student #42 first last created./',
+            $output
+        );
+    }
+    
+    public function testBadSchoolId()
+    {
+        $this->schoolManager->shouldReceive('findSchoolBy')->with(array('id' => 1))->andReturn(null);
+        $this->setExpectedException('Exception', 'School with id 1 could not be found.');
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'filter'         => 'FILTER',
+            'schoolId'         => '1'
+        ));
+        
+    }
+    
+    public function testFilterRequired()
+    {
+        $this->setExpectedException('RuntimeException');
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'schoolId'         => '1'
+        ));
+    }
+    
+    public function testSchoolRequired()
+    {
+        $this->setExpectedException('RuntimeException');
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'filter'         => '1',
+        ));
+    }
+    
+
+    protected function sayYesWhenAsked()
+    {
+        $stream = fopen('php://memory', 'r+', false);
+        
+        fputs($stream, 'Yes\\n');
+        rewind($stream);
+        
+        $this->questionHelper->setInputStream($stream);
+    }
+}

--- a/src/Ilios/CliBundle/Tests/Command/AddUserCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/AddUserCommandTest.php
@@ -1,0 +1,164 @@
+<?php
+namespace Ilios\CliBundle\Tests\Command;
+
+use Ilios\CliBundle\Command\AddUserCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+class AddUserCommandTest extends \PHPUnit_Framework_TestCase
+{
+    const COMMAND_NAME = 'ilios:directory:add-user';
+    
+    protected $userManager;
+    protected $authenticationManager;
+    protected $schoolManager;
+    protected $commandTester;
+    protected $questionHelper;
+    protected $directory;
+    protected $authenticationService;
+    
+    public function setUp()
+    {
+        $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManagerInterface');
+        $this->authenticationManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface');
+        $this->schoolManager = m::mock('Ilios\CoreBundle\Entity\Manager\SchoolManagerInterface');
+        $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
+        $this->authenticationService = m::mock('Ilios\AuthenticationBundle\Service\AuthenticationInterface');
+        
+        $command = new AddUserCommand(
+            $this->userManager,
+            $this->authenticationManager,
+            $this->schoolManager,
+            $this->directory,
+            $this->authenticationService
+        );
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+        $this->questionHelper = $command->getHelper('question');
+        
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->userManager);
+        unset($this->authenticationManager);
+        unset($this->schoolManager);
+        unset($this->directory);
+        unset($this->authenticationService);
+        unset($this->commandTester);
+        unset($this->questionHelper);
+        m::close();
+    }
+    
+    public function testExecute()
+    {
+        $school = m::mock('Ilios\CoreBundle\Entity\SchoolInterface');
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('setFirstName')->with('first')
+            ->shouldReceive('setLastName')->with('last')
+            ->shouldReceive('setEmail')->with('email')
+            ->shouldReceive('setPhone')->with('phone')
+            ->shouldReceive('setCampusId')->with('abc')
+            ->shouldReceive('setAddedViaIlios')->with(true)
+            ->shouldReceive('setEnabled')->with(true)
+            ->shouldReceive('setUserSyncIgnore')->with(false)
+            ->shouldReceive('setSchool')->with($school)
+            ->shouldReceive('getId')->andReturn(1)
+            ->shouldReceive('getFirstAndLastName')->andReturn('Test Person')
+            ->mock();
+        $this->userManager->shouldReceive('findUserBy')->with(array('campusId' => 'abc'))->andReturn(false);
+        $this->schoolManager->shouldReceive('findSchoolBy')->with(array('id' => 1))->andReturn($school);
+        $this->userManager->shouldReceive('createUser')->andReturn($user);
+        $this->userManager->shouldReceive('updateUser')->with($user);
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+            'eppn' => 'abc123'
+        ];
+        $this->directory->shouldReceive('findByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
+        $this->authenticationService->shouldReceive('setupNewUser')->with($fakeDirectoryUser, $user);
+        $this->sayYesWhenAsked();
+        
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'campusId'         => 'abc',
+            'schoolId'         => '1',
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/abc       \| first \| last \| email \| phone/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Success! New user #1 Test Person created./',
+            $output
+        );
+    }
+    
+    public function testBadCampusId()
+    {
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(1)
+            ->mock();
+        $this->userManager->shouldReceive('findUserBy')->with(array('campusId' => 1))->andReturn($user);
+        $this->setExpectedException('Exception', 'User #1 with campus id 1 already exists.');
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'campusId'         => '1',
+            'schoolId'         => '1'
+        ));
+        
+    }
+    
+    public function testBadSchoolId()
+    {
+        $this->userManager->shouldReceive('findUserBy')->with(array('campusId' => 1))->andReturn(null);
+        $this->schoolManager->shouldReceive('findSchoolBy')->with(array('id' => 1))->andReturn(null);
+        $this->setExpectedException('Exception', 'School with id 1 could not be found.');
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'campusId'         => '1',
+            'schoolId'         => '1'
+        ));
+        
+    }
+    
+    public function testUserRequired()
+    {
+        $this->setExpectedException('RuntimeException');
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'schoolId'         => '1'
+        ));
+    }
+    
+    public function testSchoolRequired()
+    {
+        $this->setExpectedException('RuntimeException');
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'campusId'         => '1',
+        ));
+    }
+
+    protected function sayYesWhenAsked()
+    {
+        $stream = fopen('php://memory', 'r+', false);
+        
+        fputs($stream, 'Yes\\n');
+        rewind($stream);
+        
+        $this->questionHelper->setInputStream($stream);
+    }
+}

--- a/src/Ilios/CliBundle/Tests/Command/AddUserCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/AddUserCommandTest.php
@@ -79,7 +79,7 @@ class AddUserCommandTest extends \PHPUnit_Framework_TestCase
         $this->userManager->shouldReceive('createUser')->andReturn($user);
         $this->userManager->shouldReceive('updateUser')->with($user);
         $this->authenticationManager->shouldReceive('createAuthentication')->andReturn($authentication);
-        $this->authenticationManager->shouldReceive('updateAuthentication')->with($authentication, false);
+        $this->authenticationManager->shouldReceive('updateAuthentication')->with($authentication);
         $fakeDirectoryUser = [
             'firstName' => 'first',
             'lastName' => 'last',
@@ -100,7 +100,7 @@ class AddUserCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/abc       \| first \| last \| email \| username \| phone/',
+            '/abc       \| first \| last \| email \| abc123   \| phone/',
             $output
         );
         $this->assertRegExp(

--- a/src/Ilios/CliBundle/Tests/Command/CreateUserTokenCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/CreateUserTokenCommandTest.php
@@ -11,7 +11,7 @@ class CreateUserTokenCommandTest extends \PHPUnit_Framework_TestCase
     const COMMAND_NAME = 'ilios:setup:create-user-token';
     
     protected $userManager;
-    protected $CommandTester;
+    protected $commandTester;
     
     public function setUp()
     {

--- a/src/Ilios/CliBundle/Tests/Command/FindUserCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/FindUserCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace Ilios\CliBundle\Tests\Command;
+
+use Ilios\CliBundle\Command\FindUserCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+class FindUserCommandTest extends \PHPUnit_Framework_TestCase
+{
+    const COMMAND_NAME = 'ilios:directory:find-user';
+    
+    protected $commandTester;
+    protected $directory;
+    
+    public function setUp()
+    {
+        $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
+        $command = new FindUserCommand($this->directory);
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->directory);
+        unset($this->commandTester);
+        m::close();
+    }
+    
+    public function testExecute()
+    {
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+        ];
+        $this->directory->shouldReceive('find')->with(array('a', 'b'))->andReturn(array($fakeDirectoryUser));
+        
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'searchTerms'         => array('a', 'b')
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/abc       | first | last | email | phone/',
+            $output
+        );
+    }
+    
+    public function testTermRequired()
+    {
+        $this->setExpectedException('RuntimeException');
+        $this->commandTester->execute(array('command' => self::COMMAND_NAME));
+    }
+}

--- a/src/Ilios/CliBundle/Tests/Command/InvalidateUserTokenCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/InvalidateUserTokenCommandTest.php
@@ -14,7 +14,7 @@ class InvalidateUserTokenCommandTest extends \PHPUnit_Framework_TestCase
     
     protected $userManager;
     protected $authenticationManager;
-    protected $CommandTester;
+    protected $commandTester;
     
     public function setUp()
     {

--- a/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
@@ -11,18 +11,18 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
     const COMMAND_NAME = 'ilios:directory:sync-users';
     
     protected $userManager;
+    protected $authenticationManager;
     protected $commandTester;
     protected $questionHelper;
     protected $directory;
-    protected $authenticationService;
     
     public function setUp()
     {
         $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManagerInterface');
+        $this->authenticationManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface');
         $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
-        $this->authenticationService = m::mock('Ilios\AuthenticationBundle\Service\AuthenticationInterface');
         
-        $command = new SyncAllUsersCommand($this->userManager, $this->directory, $this->authenticationService);
+        $command = new SyncAllUsersCommand($this->userManager, $this->authenticationManager, $this->directory);
         $application = new Application();
         $application->add($command);
         $commandInApp = $application->find(self::COMMAND_NAME);

--- a/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
@@ -1,0 +1,236 @@
+<?php
+namespace Ilios\CliBundle\Tests\Command;
+
+use Ilios\CliBundle\Command\SyncAllUsersCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
+{
+    const COMMAND_NAME = 'ilios:directory:sync-users';
+    
+    protected $userManager;
+    protected $commandTester;
+    protected $questionHelper;
+    protected $directory;
+    protected $authenticationService;
+    
+    public function setUp()
+    {
+        $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManagerInterface');
+        $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
+        $this->authenticationService = m::mock('Ilios\AuthenticationBundle\Service\AuthenticationInterface');
+        
+        $command = new SyncAllUsersCommand($this->userManager, $this->directory, $this->authenticationService);
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+        $this->questionHelper = $command->getHelper('question');
+        
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->userManager);
+        unset($this->directory);
+        unset($this->authenticationService);
+        unset($this->commandTester);
+        m::close();
+    }
+    
+    public function testExecuteUserWithNoChanges()
+    {
+        $this->userManager->shouldReceive('resetExaminedFlagForAllUsers')->once();
+        $this->userManager->shouldReceive('getAllCampusIds')->with(false, false)->andReturn(['abc']);
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+        ];
+        $this->directory
+            ->shouldReceive('findByCampusIds')
+            ->with(['abc'])
+            ->andReturn([$fakeDirectoryUser]);
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstAndLastName')->andReturn('first last')
+            ->shouldReceive('getFirstName')->andReturn('first')
+            ->shouldReceive('getLastName')->andReturn('last')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getPhone')->andReturn('phone')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setExamined')->with(true)
+            ->mock();
+        $this->userManager
+            ->shouldReceive('findUserBy')
+            ->with(array('campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false))
+            ->andReturn($user)
+            ->once();
+        $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
+                
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            $output
+        );
+    }
+    
+    public function testExecuteWithFirstNameChange()
+    {
+        $this->userManager->shouldReceive('resetExaminedFlagForAllUsers')->once();
+        $this->userManager->shouldReceive('getAllCampusIds')->with(false, false)->andReturn(['abc']);
+        $fakeDirectoryUser = [
+            'firstName' => 'new-first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+        ];
+        $this->directory
+            ->shouldReceive('findByCampusIds')
+            ->with(['abc'])
+            ->andReturn([$fakeDirectoryUser]);
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstAndLastName')->andReturn('first last')
+            ->shouldReceive('getFirstName')->andReturn('first')
+            ->shouldReceive('getLastName')->andReturn('last')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getPhone')->andReturn('phone')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setExamined')->with(true)
+            ->shouldReceive('setFirstName')->with('new-first')
+            ->mock();
+        $this->userManager
+            ->shouldReceive('findUserBy')
+            ->with(array('campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false))
+            ->andReturn($user)
+            ->once();
+        $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
+                
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Updating first name from "first" to "new-first"/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            $output
+        );
+    }
+    
+    public function testExecuteWithLastNameChange()
+    {
+        $this->userManager->shouldReceive('resetExaminedFlagForAllUsers')->once();
+        $this->userManager->shouldReceive('getAllCampusIds')->with(false, false)->andReturn(['abc']);
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'new-last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+        ];
+        $this->directory
+            ->shouldReceive('findByCampusIds')
+            ->with(['abc'])
+            ->andReturn([$fakeDirectoryUser]);
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstAndLastName')->andReturn('first last')
+            ->shouldReceive('getFirstName')->andReturn('first')
+            ->shouldReceive('getLastName')->andReturn('last')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getPhone')->andReturn('phone')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setExamined')->with(true)
+            ->shouldReceive('setLastName')->with('new-last')
+            ->mock();
+        $this->userManager
+            ->shouldReceive('findUserBy')
+            ->with(array('campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false))
+            ->andReturn($user)
+            ->once();
+        $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
+                
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Updating last name from "last" to "new-last"/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            $output
+        );
+    }
+    
+    public function testExecuteWithPhoneNumberChange()
+    {
+        $this->userManager->shouldReceive('resetExaminedFlagForAllUsers')->once();
+        $this->userManager->shouldReceive('getAllCampusIds')->with(false, false)->andReturn(['abc']);
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'new-phone',
+            'campusId' => 'abc',
+        ];
+        $this->directory
+            ->shouldReceive('findByCampusIds')
+            ->with(['abc'])
+            ->andReturn([$fakeDirectoryUser]);
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstAndLastName')->andReturn('first last')
+            ->shouldReceive('getFirstName')->andReturn('first')
+            ->shouldReceive('getLastName')->andReturn('last')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getPhone')->andReturn('phone')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setExamined')->with(true)
+            ->shouldReceive('setPhone')->with('new-phone')
+            ->mock();
+        $this->userManager
+            ->shouldReceive('findUserBy')
+            ->with(array('campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false))
+            ->andReturn($user)
+            ->once();
+        $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
+                
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Updating phone number from "phone" to "new-phone"/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            $output
+        );
+    }
+}

--- a/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
@@ -466,4 +466,196 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             $output
         );
     }
+    
+    public function testExecuteWithEmptyFirstName()
+    {
+        $this->userManager->shouldReceive('getAllCampusIds')
+            ->with(false, false)->andReturn(new ArrayCollection(['abc']));
+        $fakeDirectoryUser = [
+            'firstName' => '',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+            'username' => 'abc123',
+        ];
+        $this->directory
+            ->shouldReceive('findByCampusIds')
+            ->with(['abc'])
+            ->andReturn([$fakeDirectoryUser]);
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstAndLastName')->andReturn('missing person')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setExamined')->with(true)
+            ->mock();
+        $this->userManager
+            ->shouldReceive('findUsersBy')
+            ->with(array('campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false))
+            ->andReturn(new ArrayCollection([$user]))
+            ->once();
+        $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
+
+        $this->em->shouldReceive('flush')->once();
+        $this->em->shouldReceive('clear')->once();
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/firstName is required and it is missing from record with Campus ID \(abc\)\.  User will not be updated./',
+            $output
+        );
+        $this->assertRegExp(
+            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            $output
+        );
+    }
+    
+    public function testExecuteWithEmptyLastName()
+    {
+        $this->userManager->shouldReceive('getAllCampusIds')
+            ->with(false, false)->andReturn(new ArrayCollection(['abc']));
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => '',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+            'username' => 'abc123',
+        ];
+        $this->directory
+            ->shouldReceive('findByCampusIds')
+            ->with(['abc'])
+            ->andReturn([$fakeDirectoryUser]);
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstAndLastName')->andReturn('missing person')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setExamined')->with(true)
+            ->mock();
+        $this->userManager
+            ->shouldReceive('findUsersBy')
+            ->with(array('campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false))
+            ->andReturn(new ArrayCollection([$user]))
+            ->once();
+        $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
+
+        $this->em->shouldReceive('flush')->once();
+        $this->em->shouldReceive('clear')->once();
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/lastName is required and it is missing from record with Campus ID \(abc\)\.  User will not be updated./',
+            $output
+        );
+        $this->assertRegExp(
+            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            $output
+        );
+    }
+    
+    public function testExecuteWithEmptyEmailName()
+    {
+        $this->userManager->shouldReceive('getAllCampusIds')
+            ->with(false, false)->andReturn(new ArrayCollection(['abc']));
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => '',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+            'username' => 'abc123',
+        ];
+        $this->directory
+            ->shouldReceive('findByCampusIds')
+            ->with(['abc'])
+            ->andReturn([$fakeDirectoryUser]);
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstAndLastName')->andReturn('missing person')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setExamined')->with(true)
+            ->mock();
+        $this->userManager
+            ->shouldReceive('findUsersBy')
+            ->with(array('campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false))
+            ->andReturn(new ArrayCollection([$user]))
+            ->once();
+        $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
+
+        $this->em->shouldReceive('flush')->once();
+        $this->em->shouldReceive('clear')->once();
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/email is required and it is missing from record with Campus ID \(abc\)\.  User will not be updated./',
+            $output
+        );
+        $this->assertRegExp(
+            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            $output
+        );
+    }
+    
+    public function testExecuteWithEmptyUsernamelName()
+    {
+        $this->userManager->shouldReceive('getAllCampusIds')
+            ->with(false, false)->andReturn(new ArrayCollection(['abc']));
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+            'username' => '',
+        ];
+        $this->directory
+            ->shouldReceive('findByCampusIds')
+            ->with(['abc'])
+            ->andReturn([$fakeDirectoryUser]);
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstAndLastName')->andReturn('missing person')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setExamined')->with(true)
+            ->mock();
+        $this->userManager
+            ->shouldReceive('findUsersBy')
+            ->with(array('campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false))
+            ->andReturn(new ArrayCollection([$user]))
+            ->once();
+        $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
+
+        $this->em->shouldReceive('flush')->once();
+        $this->em->shouldReceive('clear')->once();
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/username is required and it is missing from record with Campus ID \(abc\)\.  User will not be updated./',
+            $output
+        );
+        $this->assertRegExp(
+            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            $output
+        );
+    }
 }

--- a/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
@@ -15,14 +15,21 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
     protected $commandTester;
     protected $questionHelper;
     protected $directory;
+    protected $em;
     
     public function setUp()
     {
         $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManagerInterface');
         $this->authenticationManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuthenticationManagerInterface');
         $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
+        $this->em = m::mock('Doctrine\Orm\EntityManager');
         
-        $command = new SyncAllUsersCommand($this->userManager, $this->authenticationManager, $this->directory);
+        $command = new SyncAllUsersCommand(
+            $this->userManager,
+            $this->authenticationManager,
+            $this->directory,
+            $this->em
+        );
         $application = new Application();
         $application->add($command);
         $commandInApp = $application->find(self::COMMAND_NAME);
@@ -37,8 +44,9 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         unset($this->userManager);
+        unset($this->authenticationManager);
         unset($this->directory);
-        unset($this->authenticationService);
+        unset($this->em);
         unset($this->commandTester);
         m::close();
     }
@@ -53,11 +61,15 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             'email' => 'email',
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
+            'username' => 'abc123',
         ];
         $this->directory
             ->shouldReceive('findByCampusIds')
             ->with(['abc'])
             ->andReturn([$fakeDirectoryUser]);
+        $authentication = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
+            ->shouldReceive('getUsername')->andReturn('abc123')
+            ->mock();
         $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
             ->shouldReceive('getId')->andReturn(42)
             ->shouldReceive('getFirstAndLastName')->andReturn('first last')
@@ -66,6 +78,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('getEmail')->andReturn('email')
             ->shouldReceive('getPhone')->andReturn('phone')
             ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('getAuthentication')->andReturn($authentication)
             ->shouldReceive('setExamined')->with(true)
             ->mock();
         $this->userManager
@@ -74,7 +87,8 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->andReturn($user)
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
-                
+        $this->em->shouldReceive('flush')->once();
+        $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
@@ -97,11 +111,15 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             'email' => 'email',
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
+            'username' => 'abc123',
         ];
         $this->directory
             ->shouldReceive('findByCampusIds')
             ->with(['abc'])
             ->andReturn([$fakeDirectoryUser]);
+        $authentication = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
+            ->shouldReceive('getUsername')->andReturn('abc123')
+            ->mock();
         $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
             ->shouldReceive('getId')->andReturn(42)
             ->shouldReceive('getFirstAndLastName')->andReturn('first last')
@@ -110,6 +128,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('getEmail')->andReturn('email')
             ->shouldReceive('getPhone')->andReturn('phone')
             ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('getAuthentication')->andReturn($authentication)
             ->shouldReceive('setExamined')->with(true)
             ->shouldReceive('setFirstName')->with('new-first')
             ->mock();
@@ -120,6 +139,8 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
                 
+        $this->em->shouldReceive('flush')->once();
+        $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
@@ -146,11 +167,15 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             'email' => 'email',
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
+            'username' => 'abc123',
         ];
         $this->directory
             ->shouldReceive('findByCampusIds')
             ->with(['abc'])
             ->andReturn([$fakeDirectoryUser]);
+        $authentication = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
+            ->shouldReceive('getUsername')->andReturn('abc123')
+            ->mock();
         $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
             ->shouldReceive('getId')->andReturn(42)
             ->shouldReceive('getFirstAndLastName')->andReturn('first last')
@@ -159,6 +184,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('getEmail')->andReturn('email')
             ->shouldReceive('getPhone')->andReturn('phone')
             ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('getAuthentication')->andReturn($authentication)
             ->shouldReceive('setExamined')->with(true)
             ->shouldReceive('setLastName')->with('new-last')
             ->mock();
@@ -169,6 +195,8 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
                 
+        $this->em->shouldReceive('flush')->once();
+        $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
@@ -195,11 +223,15 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             'email' => 'email',
             'telephoneNumber' => 'new-phone',
             'campusId' => 'abc',
+            'username' => 'abc123',
         ];
         $this->directory
             ->shouldReceive('findByCampusIds')
             ->with(['abc'])
             ->andReturn([$fakeDirectoryUser]);
+        $authentication = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
+            ->shouldReceive('getUsername')->andReturn('abc123')
+            ->mock();
         $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
             ->shouldReceive('getId')->andReturn(42)
             ->shouldReceive('getFirstAndLastName')->andReturn('first last')
@@ -208,6 +240,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('getEmail')->andReturn('email')
             ->shouldReceive('getPhone')->andReturn('phone')
             ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('getAuthentication')->andReturn($authentication)
             ->shouldReceive('setExamined')->with(true)
             ->shouldReceive('setPhone')->with('new-phone')
             ->mock();
@@ -218,6 +251,8 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
                 
+        $this->em->shouldReceive('flush')->once();
+        $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
@@ -226,6 +261,63 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Updating phone number from "phone" to "new-phone"/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            $output
+        );
+    }
+    
+    public function testExecuteWithUsernameChange()
+    {
+        $this->userManager->shouldReceive('resetExaminedFlagForAllUsers')->once();
+        $this->userManager->shouldReceive('getAllCampusIds')->with(false, false)->andReturn(['abc']);
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+            'username' => 'new-abc123',
+        ];
+        $this->directory
+            ->shouldReceive('findByCampusIds')
+            ->with(['abc'])
+            ->andReturn([$fakeDirectoryUser]);
+        $authentication = m::mock('Ilios\CoreBundle\Entity\AuthenticationInterface')
+            ->shouldReceive('getUsername')->andReturn('abc123')
+            ->shouldReceive('setUsername')->with('new-abc123')
+            ->mock();
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstAndLastName')->andReturn('first last')
+            ->shouldReceive('getFirstName')->andReturn('first')
+            ->shouldReceive('getLastName')->andReturn('last')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getPhone')->andReturn('phone')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('getAuthentication')->andReturn($authentication)
+            ->shouldReceive('setExamined')->with(true)
+            ->mock();
+        $this->userManager
+            ->shouldReceive('findUserBy')
+            ->with(array('campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false))
+            ->andReturn($user)
+            ->once();
+        $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
+                
+        $this->authenticationManager->shouldReceive('updateAuthentication')->with($authentication, false)->once();
+        $this->em->shouldReceive('flush')->once();
+        $this->em->shouldReceive('clear')->once();
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Updating username from "abc123" to "new-abc123"/',
             $output
         );
         $this->assertRegExp(

--- a/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
@@ -108,11 +108,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Comparing User #42 first last \(email\) to directory user by Campus ID abc/',
+            '/Comparing User #42 first last \(email\) to directory user by campus ID abc./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            '/Completed sync process 1 users found in the directory; 0 users updated./',
             $output
         );
     }
@@ -169,11 +169,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Updating first name from "first" to "new-first"/',
+            '/Updating first name from "first" to "new-first"./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            '/Completed sync process 1 users found in the directory; 1 users updated./',
             $output
         );
     }
@@ -230,11 +230,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Updating last name from "last" to "new-last"/',
+            '/Updating last name from "last" to "new-last"./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            '/Completed sync process 1 users found in the directory; 1 users updated./',
             $output
         );
     }
@@ -291,11 +291,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Updating phone number from "phone" to "new-phone"/',
+            '/Updating phone number from "phone" to "new-phone"./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            '/Completed sync process 1 users found in the directory; 1 users updated./',
             $output
         );
     }
@@ -363,7 +363,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            '/Completed sync process 1 users found in the directory; 0 users updated./',
             $output
         );
     }
@@ -424,7 +424,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            '/Completed sync process 1 users found in the directory; 1 users updated./',
             $output
         );
     }
@@ -482,11 +482,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Updating username from "abc123" to "new-abc123"/',
+            '/Updating username from "abc123" to "new-abc123"./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            '/Completed sync process 1 users found in the directory; 1 users updated./',
             $output
         );
     }
@@ -547,15 +547,15 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Updating username from "" to "abc123"/',
+            '/Updating username from "" to "abc123"./',
             $output
         );
         $this->assertRegExp(
-            '/User had no Authentication data, creating it now\./',
+            '/User had no authentication data, creating it now./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 1 users updated./',
+            '/Completed sync process 1 users found in the directory; 1 users updated./',
             $output
         );
     }
@@ -620,11 +620,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Multiple accounts exist for the same Campus ID \(abc\)\.  None of them will be updated\./',
+            '/Multiple accounts exist for the same campus ID \(abc\)\.  None of them will be updated./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            '/Completed sync process 1 users found in the directory; 0 users updated./',
             $output
         );
     }
@@ -673,11 +673,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/firstName is required and it is missing from record with Campus ID \(abc\)\.  User will not be updated./',
+            '/firstName is required and it is missing from record with campus ID \(abc\)\.  User will not be updated./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            '/Completed sync process 1 users found in the directory; 0 users updated./',
             $output
         );
     }
@@ -726,11 +726,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/lastName is required and it is missing from record with Campus ID \(abc\)\.  User will not be updated./',
+            '/lastName is required and it is missing from record with campus ID \(abc\)\.  User will not be updated./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            '/Completed sync process 1 users found in the directory; 0 users updated./',
             $output
         );
     }
@@ -779,11 +779,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/email is required and it is missing from record with Campus ID \(abc\)\.  User will not be updated./',
+            '/email is required and it is missing from record with campus ID \(abc\)\.  User will not be updated./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            '/Completed sync process 1 users found in the directory; 0 users updated./',
             $output
         );
     }
@@ -832,11 +832,11 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/username is required and it is missing from record with Campus ID \(abc\)\.  User will not be updated./',
+            '/username is required and it is missing from record with campus ID \(abc\)\.  User will not be updated./',
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 1 users found in the directory; 0 users updated./',
+            '/Completed sync process 1 users found in the directory; 0 users updated./',
             $output
         );
     }
@@ -888,7 +888,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             $output
         );
         $this->assertRegExp(
-            '/Completed Sync Process 0 users found in the directory; 0 users updated./',
+            '/Completed sync process 0 users found in the directory; 0 users updated./',
             $output
         );
     }

--- a/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncAllUsersCommandTest.php
@@ -95,7 +95,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -155,7 +155,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -216,7 +216,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -277,7 +277,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -337,7 +337,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -406,7 +406,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -467,7 +467,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -531,7 +531,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -605,7 +605,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user1, false)->once();
@@ -659,7 +659,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -712,7 +712,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -765,7 +765,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -818,7 +818,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->once();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('updateUser')->with($user, false)->once();
@@ -865,7 +865,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
             ->mock();
         $this->userManager
             ->shouldReceive('findUsersBy')
-            ->with(array('examined' => false, 'enabled' => true, 'userSyncIgnore' => false))
+            ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([$user])
             ->once();
         
@@ -884,7 +884,7 @@ class SyncAllUsersCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/User not found in the directory.  Logged for further study/',
+            '/User #42 missing person email not found in the directory.  Logged for further study/',
             $output
         );
         $this->assertRegExp(

--- a/src/Ilios/CliBundle/Tests/Command/SyncFormerStudentsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncFormerStudentsCommandTest.php
@@ -114,7 +114,7 @@ class SyncFormerStudentsCommandTest extends \PHPUnit_Framework_TestCase
             $output
         );
         $this->assertRegExp(
-            '/Former Students Updated Successfully!/',
+            '/Former students updated successfully!/',
             $output
         );
     }

--- a/src/Ilios/CliBundle/Tests/Command/SyncFormerStudentsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncFormerStudentsCommandTest.php
@@ -1,0 +1,137 @@
+<?php
+namespace Ilios\CliBundle\Tests\Command;
+
+use Ilios\CliBundle\Command\SyncFormerStudentsCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Doctrine\Common\Collections\ArrayCollection;
+
+use Mockery as m;
+
+class SyncFormerStudentsCommandTest extends \PHPUnit_Framework_TestCase
+{
+    const COMMAND_NAME = 'ilios:directory:sync-former-students';
+    
+    protected $userManager;
+    protected $userRoleManager;
+    protected $commandTester;
+    protected $questionHelper;
+    protected $directory;
+    
+    public function setUp()
+    {
+        $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManagerInterface');
+        $this->userRoleManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserRoleManagerInterface');
+        $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
+        
+        $command = new SyncFormerStudentsCommand($this->userManager, $this->userRoleManager, $this->directory);
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+        $this->questionHelper = $command->getHelper('question');
+        
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->userManager);
+        unset($this->userRoleManager);
+        unset($this->directory);
+        unset($this->commandTester);
+        m::close();
+    }
+    
+    public function testExecute()
+    {
+        $fakeDirectoryUser1 = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+        ];
+        $fakeDirectoryUser2 = [
+            'firstName' => 'first2',
+            'lastName' => 'last2',
+            'email' => 'email2',
+            'telephoneNumber' => 'phone2',
+            'campusId' => 'abc2',
+        ];
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstName')->andReturn('first')
+            ->shouldReceive('getLastName')->andReturn('last')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('isUserSyncIgnore')->andReturn(false)
+            ->mock();
+        $this->directory->shouldReceive('findByLdapFilter')
+            ->with('FILTER')
+            ->andReturn([$fakeDirectoryUser1, $fakeDirectoryUser2]);
+        $this->userManager->shouldReceive('findUsersWhoAreNotFormerStudents')
+            ->with(array('abc', 'abc2'))
+            ->andReturn(new ArrayCollection([$user]));
+        $this->userManager->shouldReceive('updateUser')
+            ->with($user, false);
+        $role = m::mock('Ilios\CoreBundle\Entity\UserRoleInterface')
+            ->shouldReceive('addUser')->with($user)
+            ->mock();
+        $user->shouldReceive('addRole')->with($role);
+        $this->userRoleManager
+            ->shouldReceive('findUserRoleBy')
+            ->with(array('title' => 'Former Student'))
+            ->andReturn($role);
+        $this->userRoleManager
+            ->shouldReceive('updateUserRole')
+            ->with($role);
+        
+        $this->sayYesWhenAsked();
+        $this->commandTester->execute(array(
+            'command'   => self::COMMAND_NAME,
+            'filter'    => 'FILTER'
+        ));
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Found 2 former students in the directory./',
+            $output
+        );
+        
+        $this->assertRegExp(
+            '/There are 1 students in Ilios who will be marked as a Former Student./',
+            $output
+        );
+        $this->assertRegExp(
+            '/Do you wish to mark these users as Former Students?/',
+            $output
+        );
+        $this->assertRegExp(
+            '/abc       \| first \| last \| email /',
+            $output
+        );
+        $this->assertRegExp(
+            '/Former Students Updated Successfully!/',
+            $output
+        );
+    }
+    
+    public function testFilterRequired()
+    {
+        $this->setExpectedException('RuntimeException');
+        $this->commandTester->execute(array('command' => self::COMMAND_NAME));
+    }
+
+    protected function sayYesWhenAsked()
+    {
+        $stream = fopen('php://memory', 'r+', false);
+        
+        fputs($stream, 'Yes\\n');
+        rewind($stream);
+        
+        $this->questionHelper->setInputStream($stream);
+    }
+}

--- a/src/Ilios/CliBundle/Tests/Command/SyncUserCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncUserCommandTest.php
@@ -14,13 +14,15 @@ class SyncUserCommandTest extends \PHPUnit_Framework_TestCase
     protected $commandTester;
     protected $questionHelper;
     protected $directory;
+    protected $authenticationService;
     
     public function setUp()
     {
         $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManagerInterface');
         $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
+        $this->authenticationService = m::mock('Ilios\AuthenticationBundle\Service\AuthenticationInterface');
         
-        $command = new SyncUserCommand($this->userManager, $this->directory);
+        $command = new SyncUserCommand($this->userManager, $this->directory, $this->authenticationService);
         $application = new Application();
         $application->add($command);
         $commandInApp = $application->find(self::COMMAND_NAME);
@@ -36,6 +38,7 @@ class SyncUserCommandTest extends \PHPUnit_Framework_TestCase
     {
         unset($this->userManager);
         unset($this->directory);
+        unset($this->authenticationService);
         unset($this->commandTester);
         m::close();
     }
@@ -62,6 +65,7 @@ class SyncUserCommandTest extends \PHPUnit_Framework_TestCase
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
         ];
+        $this->authenticationService->shouldReceive('syncUser')->with($fakeDirectoryUser, $user)->once();
         $this->directory->shouldReceive('findByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
         $this->sayYesWhenAsked();
         
@@ -73,11 +77,11 @@ class SyncUserCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Ilios User     \| old-first \| old-last \| old-email \| old-phone/',
+            '/Ilios User     | abc       | old-first | old-last | old-email | old-phone/',
             $output
         );
         $this->assertRegExp(
-            '/Directory User \| first     \| last     \| email     \| phone/',
+            '/Directory User | abc       | first     | last     | email     | phone/',
             $output
         );
     }

--- a/src/Ilios/CliBundle/Tests/Command/SyncUserCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncUserCommandTest.php
@@ -8,11 +8,12 @@ use Mockery as m;
 
 class SyncUserCommandTest extends \PHPUnit_Framework_TestCase
 {
-    const COMMAND_NAME = 'ilios:setup:sync-user';
+    const COMMAND_NAME = 'ilios:directory:sync-user';
     
     protected $userManager;
     protected $commandTester;
     protected $questionHelper;
+    protected $directory;
     
     public function setUp()
     {
@@ -61,7 +62,7 @@ class SyncUserCommandTest extends \PHPUnit_Framework_TestCase
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
         ];
-        $this->directory->shouldReceive('findUserByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
+        $this->directory->shouldReceive('findByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
         $this->sayYesWhenAsked();
         
         $this->commandTester->execute(array(

--- a/src/Ilios/CliBundle/Tests/Command/SyncUserCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SyncUserCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Ilios\CliBundle\Tests\Command;
+
+use Ilios\CliBundle\Command\SyncUserCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+class SyncUserCommandTest extends \PHPUnit_Framework_TestCase
+{
+    const COMMAND_NAME = 'ilios:setup:sync-user';
+    
+    protected $userManager;
+    protected $commandTester;
+    protected $questionHelper;
+    
+    public function setUp()
+    {
+        $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManagerInterface');
+        $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
+        
+        $command = new SyncUserCommand($this->userManager, $this->directory);
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+        $this->questionHelper = $command->getHelper('question');
+        
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->userManager);
+        unset($this->directory);
+        unset($this->commandTester);
+        m::close();
+    }
+    
+    public function testExecute()
+    {
+        $user = m::mock('Ilios\CoreBundle\Entity\UserInterface')
+            ->shouldReceive('getFirstName')->andReturn('old-first')
+            ->shouldReceive('getLastName')->andReturn('old-last')
+            ->shouldReceive('getEmail')->andReturn('old-email')
+            ->shouldReceive('getPhone')->andReturn('old-phone')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('setFirstName')->with('first')
+            ->shouldReceive('setLastName')->with('last')
+            ->shouldReceive('setEmail')->with('email')
+            ->shouldReceive('setPhone')->with('phone')
+            ->mock();
+        $this->userManager->shouldReceive('findUserBy')->with(array('id' => 1))->andReturn($user);
+        $this->userManager->shouldReceive('updateUser')->with($user);
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+        ];
+        $this->directory->shouldReceive('findUserByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
+        $this->sayYesWhenAsked();
+        
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'userId'         => '1'
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Ilios User     \| old-first \| old-last \| old-email \| old-phone/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Directory User \| first     \| last     \| email     \| phone/',
+            $output
+        );
+    }
+    
+    public function testBadUserId()
+    {
+        $this->userManager->shouldReceive('findUserBy')->with(array('id' => 1))->andReturn(null);
+        $this->setExpectedException('Exception', 'No user with id #1');
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'userId'         => '1'
+        ));
+        
+    }
+    
+    public function testUserRequired()
+    {
+        $this->setExpectedException('RuntimeException');
+        $this->commandTester->execute(array('command' => self::COMMAND_NAME));
+    }
+
+    protected function sayYesWhenAsked()
+    {
+        $stream = fopen('php://memory', 'r+', false);
+        
+        fputs($stream, 'Yes\\n');
+        rewind($stream);
+        
+        $this->questionHelper->setInputStream($stream);
+    }
+}

--- a/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('ldap_directory_password')->end()
                 ->scalarNode('ldap_directory_search_base')->end()
                 ->scalarNode('ldap_directory_campus_id_property')->end()
+                ->scalarNode('ldap_directory_username_property')->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
@@ -29,6 +29,11 @@ class Configuration implements ConfigurationInterface
                         'should store permanent data like learning materials'
                     )
                 ->end()
+                ->scalarNode('ldap_directory_url')->end()
+                ->scalarNode('ldap_directory_user')->end()
+                ->scalarNode('ldap_directory_password')->end()
+                ->scalarNode('ldap_directory_search_base')->end()
+                ->scalarNode('ldap_directory_campus_id_property')->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
@@ -28,6 +28,7 @@ class IliosCoreExtension extends Extension
         $container->setParameter('ilios_core.ldap.password', $config['ldap_directory_password']);
         $container->setParameter('ilios_core.ldap.search_base', $config['ldap_directory_search_base']);
         $container->setParameter('ilios_core.ldap.campus_id_property', $config['ldap_directory_campus_id_property']);
+        $container->setParameter('ilios_core.ldap.username_property', $config['ldap_directory_username_property']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
@@ -23,6 +23,11 @@ class IliosCoreExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('ilios_core.file_store_path', $config['file_system_storage_path']);
+        $container->setParameter('ilios_core.ldap.url', $config['ldap_directory_url']);
+        $container->setParameter('ilios_core.ldap.user', $config['ldap_directory_user']);
+        $container->setParameter('ilios_core.ldap.password', $config['ldap_directory_password']);
+        $container->setParameter('ilios_core.ldap.search_base', $config['ldap_directory_search_base']);
+        $container->setParameter('ilios_core.ldap.campus_id_property', $config['ldap_directory_campus_id_property']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Ilios/CoreBundle/Entity/Authentication.php
+++ b/src/Ilios/CoreBundle/Entity/Authentication.php
@@ -33,10 +33,9 @@ class Authentication implements AuthenticationInterface
     protected $user;
 
     /**
-    * @ORM\Column(name="username", type="string", unique=true, length=100)
+    * @ORM\Column(name="username", type="string", unique=true, length=100, nullable=true)
     * @var string
     *
-    * @Assert\NotBlank()
     * @Assert\Type(type="string")
     * @Assert\Length(
     *      min = 1,

--- a/src/Ilios/CoreBundle/Entity/Authentication.php
+++ b/src/Ilios/CoreBundle/Entity/Authentication.php
@@ -72,19 +72,6 @@ class Authentication implements AuthenticationInterface
     private $passwordBcrypt;
 
     /**
-    * @ORM\Column(name="eppn", type="string", nullable=true, unique=true)
-    * @var string
-    *
-    * @Assert\Type(type="string")
-    * @Assert\Length(
-    *      min = 1,
-    *      max = 250
-    * )
-    *
-    */
-    private $eppn;
-
-    /**
      * @ORM\Column(name="invalidate_token_issued_before", type="datetime", nullable=true)
      *
      * @Assert\DateTime()
@@ -161,22 +148,6 @@ class Authentication implements AuthenticationInterface
     public function getUser()
     {
         return $this->user;
-    }
-
-    /**
-     * @param string $eppn
-     */
-    public function setEppn($eppn)
-    {
-        $this->eppn = $eppn;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEppn()
-    {
-        return $this->eppn;
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/Manager/PendingUserUpdateManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PendingUserUpdateManager.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Ilios\CoreBundle\Entity\Manager;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Id\AssignedGenerator;
+use Ilios\CoreBundle\Entity\PendingUserUpdateInterface;
+
+/**
+ * Class PendingUserUpdateManager
+ * @package Ilios\CoreBundle\Entity\Manager
+ */
+class PendingUserUpdateManager extends AbstractManager implements PendingUserUpdateManagerInterface
+{
+    /**
+     * @param array $criteria
+     * @param array $orderBy
+     *
+     * @return PendingUserUpdateInterface
+     */
+    public function findPendingUserUpdateBy(
+        array $criteria,
+        array $orderBy = null
+    ) {
+        return $this->getRepository()->findOneBy($criteria, $orderBy);
+    }
+
+    /**
+     * @param array $criteria
+     * @param array $orderBy
+     * @param integer $limit
+     * @param integer $offset
+     *
+     * @return ArrayCollection|PendingUserUpdateInterface[]
+     */
+    public function findPendingUserUpdatesBy(
+        array $criteria,
+        array $orderBy = null,
+        $limit = null,
+        $offset = null
+    ) {
+        return $this->getRepository()->findBy($criteria, $orderBy, $limit, $offset);
+    }
+
+    /**
+     * @param PendingUserUpdateInterface $pendingUserUpdate
+     * @param bool $andFlush
+     * @param bool $forceId
+     */
+    public function updatePendingUserUpdate(
+        PendingUserUpdateInterface $pendingUserUpdate,
+        $andFlush = true,
+        $forceId = false
+    ) {
+        $this->em->persist($pendingUserUpdate);
+
+        if ($forceId) {
+            $metadata = $this->em->getClassMetaData(get_class($pendingUserUpdate));
+            $metadata->setIdGenerator(new AssignedGenerator());
+        }
+
+        if ($andFlush) {
+            $this->em->flush();
+        }
+    }
+
+    /**
+     * @param PendingUserUpdateInterface $pendingUserUpdate
+     */
+    public function deletePendingUserUpdate(
+        PendingUserUpdateInterface $pendingUserUpdate
+    ) {
+        $this->em->remove($pendingUserUpdate);
+        $this->em->flush();
+    }
+
+    /**
+     * @return PendingUserUpdateInterface
+     */
+    public function createPendingUserUpdate()
+    {
+        $class = $this->getClass();
+        return new $class();
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function removeAllPendingUserUpdates()
+    {
+        return $this->getRepository()->removeAllPendingUserUpdates();
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/Manager/PendingUserUpdateManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PendingUserUpdateManagerInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Ilios\CoreBundle\Entity\Manager;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Ilios\CoreBundle\Entity\PendingUserUpdateInterface;
+
+/**
+ * Interface PendingUserUpdateManagerInterface
+ * @package Ilios\CoreBundle\Entity\Manager
+ */
+interface PendingUserUpdateManagerInterface extends ManagerInterface
+{
+    /**
+     * @param array $criteria
+     * @param array $orderBy
+     *
+     * @return PendingUserUpdateInterface
+     */
+    public function findPendingUserUpdateBy(
+        array $criteria,
+        array $orderBy = null
+    );
+
+    /**
+     * @param array $criteria
+     * @param array $orderBy
+     * @param integer $limit
+     * @param integer $offset
+     *
+     * @return ArrayCollection|PendingUserUpdateInterface[]
+     */
+    public function findPendingUserUpdatesBy(
+        array $criteria,
+        array $orderBy = null,
+        $limit = null,
+        $offset = null
+    );
+
+    /**
+     * @param PendingUserUpdateInterface $pendingUserUpdate
+     * @param bool $andFlush
+     * @param bool $forceId
+     *
+     * @return void
+     */
+    public function updatePendingUserUpdate(
+        PendingUserUpdateInterface $pendingUserUpdate,
+        $andFlush = true,
+        $forceId = false
+    );
+
+    /**
+     * @param PendingUserUpdateInterface $pendingUserUpdate
+     *
+     * @return void
+     */
+    public function deletePendingUserUpdate(
+        PendingUserUpdateInterface $pendingUserUpdate
+    );
+
+    /**
+     * @return PendingUserUpdateInterface
+     */
+    public function createPendingUserUpdate();
+
+    /**
+     * Clear all the pending updates
+     */
+    public function removeAllPendingUserUpdates();
+}

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
@@ -32,7 +32,7 @@ class UserManager extends AbstractManager implements UserManagerInterface
      * @param integer $limit
      * @param integer $offset
      *
-     * @return ArrayCollection|UserInterface[]
+     * @return UserInterface[]
      */
     public function findUsersBy(
         array $criteria,

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
@@ -115,4 +115,12 @@ class UserManager extends AbstractManager implements UserManagerInterface
     ) {
         return $this->getRepository()->findEventsForUser($userId, $from, $to);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function findUsersWhoAreNotFormerStudents(array $campusIdFilter = array())
+    {
+        return $this->getRepository()->findUsersWhoAreNotFormerStudents($campusIdFilter);
+    }
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
@@ -123,4 +123,13 @@ class UserManager extends AbstractManager implements UserManagerInterface
     {
         return $this->getRepository()->findUsersWhoAreNotFormerStudents($campusIdFilter);
     }
+    
+    /**
+     * @inheritdoc
+     */
+    public function getAllCampusIds()
+    {
+        return $this->getRepository()->getAllCampusIds();
+        
+    }
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
@@ -127,9 +127,17 @@ class UserManager extends AbstractManager implements UserManagerInterface
     /**
      * @inheritdoc
      */
-    public function getAllCampusIds()
+    public function getAllCampusIds($includeDisabled = true, $includeSyncIgnore = true)
     {
-        return $this->getRepository()->getAllCampusIds();
+        return $this->getRepository()->getAllCampusIds($includeDisabled, $includeSyncIgnore);
         
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function resetExaminedFlagForAllUsers()
+    {
+        return $this->getRepository()->resetExaminedFlagForAllUsers();
     }
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
@@ -79,4 +79,11 @@ interface UserManagerInterface extends ManagerInterface
         $limit = null,
         $offset = null
     );
+    
+    /**
+     * @param array $campusIdFilter an array of the campusIDs to include in our search if empty then all users
+     *
+     * @return Collection[UserInterface]
+     */
+    public function findUsersWhoAreNotFormerStudents(array $campusIdFilter = array());
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
@@ -89,8 +89,15 @@ interface UserManagerInterface extends ManagerInterface
     
     /**
      * Get all the campus IDs for every user
-     *
+     * @param $includeDisabled
+     * @param $includeSyncIgnore
+     * 
      * @return Collection[]
      */
-    public function getAllCampusIds();
+    public function getAllCampusIds($includeDisabled = true, $includeSyncIgnore = true);
+    
+    /**
+     * Reset the examined flags on every user
+     */
+    public function resetExaminedFlagForAllUsers();
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
@@ -91,7 +91,7 @@ interface UserManagerInterface extends ManagerInterface
      * Get all the campus IDs for every user
      * @param $includeDisabled
      * @param $includeSyncIgnore
-     * 
+     *
      * @return Collection[]
      */
     public function getAllCampusIds($includeDisabled = true, $includeSyncIgnore = true);

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
@@ -92,7 +92,7 @@ interface UserManagerInterface extends ManagerInterface
      * @param $includeDisabled
      * @param $includeSyncIgnore
      *
-     * @return Collection[]
+     * @return []
      */
     public function getAllCampusIds($includeDisabled = true, $includeSyncIgnore = true);
     

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManagerInterface.php
@@ -86,4 +86,11 @@ interface UserManagerInterface extends ManagerInterface
      * @return Collection[UserInterface]
      */
     public function findUsersWhoAreNotFormerStudents(array $campusIdFilter = array());
+    
+    /**
+     * Get all the campus IDs for every user
+     *
+     * @return Collection[]
+     */
+    public function getAllCampusIds();
 }

--- a/src/Ilios/CoreBundle/Entity/PendingUserUpdate.php
+++ b/src/Ilios/CoreBundle/Entity/PendingUserUpdate.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Ilios\CoreBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as JMS;
+use Symfony\Component\Validator\Constraints as Assert;
+
+use Ilios\CoreBundle\Traits\IdentifiableEntity;
+use Ilios\CoreBundle\Traits\StringableIdEntity;
+
+/**
+ * Class PendingUserUpdate
+ * @package Ilios\CoreBundle\Entity
+ *
+ * @ORM\Table(name="pending_user_update")
+ * @ORM\Entity(repositoryClass="Ilios\CoreBundle\Entity\Repository\PendingUserUpdateRepository")
+ *
+ * @JMS\ExclusionPolicy("all")
+ * @JMS\AccessType("public_method")
+ */
+class PendingUserUpdate implements PendingUserUpdateInterface
+{
+    use IdentifiableEntity;
+    use StringableIdEntity;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="exception_id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     *
+     * @Assert\Type(type="integer")
+     *
+     * @JMS\Expose
+     * @JMS\Type("integer")
+     */
+    protected $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=32)
+     *
+     * @Assert\NotBlank()
+     * @Assert\Type(type="string")
+     * @Assert\Length(
+     *      min = 1,
+     *      max = 32
+     * )
+     *
+     * @JMS\Expose
+     * @JMS\Type("string")
+     */
+    protected $type;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=32, nullable=true)
+     *
+     * @Assert\NotBlank()
+     * @Assert\Type(type="string")
+     * @Assert\Length(
+     *      min = 1,
+     *      max = 32
+     * )
+     *
+     * @JMS\Expose
+     * @JMS\Type("string")
+     */
+    protected $property;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=255, nullable=true)
+     *
+     * @Assert\NotBlank()
+     * @Assert\Type(type="string")
+     * @Assert\Length(
+     *      min = 1,
+     *      max = 255
+     * )
+     *
+     * @JMS\Expose
+     * @JMS\Type("string")
+     */
+    protected $value;
+
+    /**
+     * @var UserInterface
+     *
+     * @ORM\ManyToOne(targetEntity="User", inversedBy="reminders")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="user_id", referencedColumnName="user_id")
+     * })
+     *
+     * @JMS\Expose
+     * @JMS\Type("string")
+     */
+    protected $user;
+
+    /**
+     * @param string $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Set property
+     *
+     * @param string $property
+     */
+    public function setProperty($property)
+    {
+        $this->property = $property;
+    }
+
+    /**
+     * Get property
+     *
+     * @return string
+     */
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    /**
+     * Set value
+     *
+     * @param string $value
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Get value
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param UserInterface $user
+     */
+    public function setUser(UserInterface $user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * @return UserInterface
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/PendingUserUpdateInterface.php
+++ b/src/Ilios/CoreBundle/Entity/PendingUserUpdateInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Ilios\CoreBundle\Entity;
+
+use Ilios\CoreBundle\Traits\IdentifiableEntityInterface;
+
+/**
+ * Interface PendingUserUpdateInterface
+ * @package Ilios\CoreBundle\Entity
+ */
+interface PendingUserUpdateInterface extends
+    IdentifiableEntityInterface
+{
+    /**
+     * @param string $type
+     */
+    public function setType($type);
+
+    /**
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * Set property
+     *
+     * @param string $property
+     */
+    public function setProperty($property);
+
+    /**
+     * Get property
+     *
+     * @return string
+     */
+    public function getProperty();
+
+    /**
+     * Set value
+     *
+     * @param string $value
+     */
+    public function setValue($value);
+
+    /**
+     * Get value
+     *
+     * @return string
+     */
+    public function getValue();
+
+    /**
+     * @param UserInterface $user
+     */
+    public function setUser(UserInterface $user);
+
+    /**
+     * @return UserInterface
+     */
+    public function getUser();
+}

--- a/src/Ilios/CoreBundle/Entity/Repository/PendingUserUpdateRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/PendingUserUpdateRepository.php
@@ -1,0 +1,22 @@
+<?php
+namespace Ilios\CoreBundle\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Type as DoctrineType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Ilios\CoreBundle\Classes\UserEvent;
+
+class PendingUserUpdateRepository extends EntityRepository
+{
+    
+    /**
+     * Remove all pending user updates from the database
+     */
+    public function removeAllPendingUserUpdates()
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->delete('IliosCoreBundle:PendingUserUpdate', 'p');
+        $qb->getQuery()->execute();
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -159,10 +159,10 @@ class UserRepository extends EntityRepository
     
     /**
      * Get all the campus IDs for all users
-     * 
+     *
      * @param $includeDisabled
      * @param $includeSyncIgnore
-     * 
+     *
      * @return Collection
      */
     public function getAllCampusIds($includeDisabled, $includeSyncIgnore)

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -159,19 +159,39 @@ class UserRepository extends EntityRepository
     
     /**
      * Get all the campus IDs for all users
-     *
+     * 
+     * @param $includeDisabled
+     * @param $includeSyncIgnore
+     * 
      * @return Collection
      */
-    public function getAllCampusIds()
+    public function getAllCampusIds($includeDisabled, $includeSyncIgnore)
     {
         $qb = $this->_em->createQueryBuilder();
         $qb->add('select', 'u.campusId')->from('IliosCoreBundle:User', 'u');
+        if (!$includeDisabled) {
+            $qb->andWhere('u.enabled=1');
+        }
+        if (!$includeSyncIgnore) {
+            $qb->andWhere('u.userSyncIgnore=0');
+        }
         
         $campusIds = array_map(function (array $arr) {
             return $arr['campusId'];
         }, $qb->getQuery()->getScalarResult());
         
         return new ArrayCollection($campusIds);
+    }
+    
+    /**
+     * Reset examined flag for all users
+     */
+    public function resetExaminedFlagForAllUsers()
+    {
+        $dql = 'UPDATE IliosCoreBundle:User SET examined=0';
+        $query = $this->_em->createQuery($dql);
+
+        $query->execute();
     }
     
     /**

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -163,7 +163,7 @@ class UserRepository extends EntityRepository
      * @param $includeDisabled
      * @param $includeSyncIgnore
      *
-     * @return Collection
+     * @return []
      */
     public function getAllCampusIds($includeDisabled, $includeSyncIgnore)
     {
@@ -180,7 +180,7 @@ class UserRepository extends EntityRepository
             return $arr['campusId'];
         }, $qb->getQuery()->getScalarResult());
         
-        return new ArrayCollection($campusIds);
+        return $campusIds;
     }
     
     /**

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -160,10 +160,10 @@ class UserRepository extends EntityRepository
     /**
      * Get all the campus IDs for all users
      *
-     * @param $includeDisabled
-     * @param $includeSyncIgnore
+     * @param boolean $includeDisabled
+     * @param boolean $includeSyncIgnore
      *
-     * @return []
+     * @return array
      */
     public function getAllCampusIds($includeDisabled, $includeSyncIgnore)
     {

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -158,6 +158,23 @@ class UserRepository extends EntityRepository
     }
     
     /**
+     * Get all the campus IDs for all users
+     *
+     * @return Collection
+     */
+    public function getAllCampusIds()
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->add('select', 'u.campusId')->from('IliosCoreBundle:User', 'u');
+        
+        $campusIds = array_map(function (array $arr) {
+            return $arr['campusId'];
+        }, $qb->getQuery()->getScalarResult());
+        
+        return new ArrayCollection($campusIds);
+    }
+    
+    /**
       * Use the query builder and the $joins to get a set of
       * offering based user events
       *

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -188,10 +188,12 @@ class UserRepository extends EntityRepository
      */
     public function resetExaminedFlagForAllUsers()
     {
-        $dql = 'UPDATE IliosCoreBundle:User SET examined=0';
-        $query = $this->_em->createQuery($dql);
-
-        $query->execute();
+        $qb = $this->_em->createQueryBuilder();
+        
+        $qb->update('IliosCoreBundle:User', 'u')
+            ->set('u.examined', $qb->expr()->literal(false));
+            
+        $qb->getQuery()->execute();
     }
     
     /**

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -171,9 +171,9 @@ class User implements UserInterface
      *
      * @JMS\Expose
      * @JMS\Type("string")
-     * @JMS\SerializedName("ucUid")
+     * @JMS\SerializedName("campusId")
      */
-    protected $ucUid;
+    protected $campusId;
 
     /**
      * @var string
@@ -583,19 +583,19 @@ class User implements UserInterface
     }
 
     /**
-     * @param string $ucUid
+     * @param string $campusId
      */
-    public function setUcUid($ucUid)
+    public function setCampusId($campusId)
     {
-        $this->ucUid = $ucUid;
+        $this->campusId = $ucUid;
     }
 
     /**
      * @return string
      */
-    public function getUcUid()
+    public function getCampusId()
     {
-        return $this->ucUid;
+        return $this->campusId;
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -587,7 +587,7 @@ class User implements UserInterface
      */
     public function setCampusId($campusId)
     {
-        $this->campusId = $ucUid;
+        $this->campusId = $campusId;
     }
 
     /**
@@ -1136,7 +1136,7 @@ class User implements UserInterface
     {
         return serialize(array(
                 $this->id,
-                $this->ucUid,
+                $this->campusId,
                 $this->email
             ));
 
@@ -1149,7 +1149,7 @@ class User implements UserInterface
     {
         list (
             $this->id,
-            $this->ucUid,
+            $this->campusId,
             $this->email
             ) = unserialize($serialized);
     }

--- a/src/Ilios/CoreBundle/Entity/UserInterface.php
+++ b/src/Ilios/CoreBundle/Entity/UserInterface.php
@@ -110,14 +110,14 @@ interface UserInterface extends
     public function isEnabled();
 
     /**
-     * @param string $ucUid
+     * @param string $campusId
      */
-    public function setUcUid($ucUid);
+    public function setCampusId($campusId);
 
     /**
      * @return string
      */
-    public function getUcUid();
+    public function getCampusId();
 
     /**
      * @param string $otherId

--- a/src/Ilios/CoreBundle/Form/Type/UserType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserType.php
@@ -22,7 +22,7 @@ class UserType extends AbstractType
             ->add('email')
             ->add('addedViaIlios', null, ['required' => false])
             ->add('enabled', null, ['required' => false])
-            ->add('ucUid', null, ['required' => false])
+            ->add('campusId', null, ['required' => false])
             ->add('otherId', null, ['required' => false])
             ->add('examined', null, ['required' => false])
             ->add('userSyncIgnore', null, ['required' => false])

--- a/src/Ilios/CoreBundle/Resources/config/managers.yml
+++ b/src/Ilios/CoreBundle/Resources/config/managers.yml
@@ -35,6 +35,7 @@ parameters:
     ilioscore.objective.manager.class: Ilios\CoreBundle\Entity\Manager\ObjectiveManager
     ilioscore.offering.manager.class: Ilios\CoreBundle\Entity\Manager\OfferingManager
     ilioscore.permission.manager.class: Ilios\CoreBundle\Entity\Manager\PermissionManager
+    ilioscore.pendinguserupdate.manager.class: Ilios\CoreBundle\Entity\Manager\PendingUserUpdateManager
     ilioscore.program.manager.class: Ilios\CoreBundle\Entity\Manager\ProgramManager
     ilioscore.programyear.manager.class: Ilios\CoreBundle\Entity\Manager\ProgramYearManager
     ilioscore.programyearsteward.manager.class: Ilios\CoreBundle\Entity\Manager\ProgramYearStewardManager
@@ -163,6 +164,9 @@ services:
     ilioscore.permission.manager:
         class: %ilioscore.permission.manager.class%
         arguments: ['@doctrine', Ilios\CoreBundle\Entity\Permission]
+    ilioscore.pendinguserupdate.manager:
+        class: %ilioscore.pendinguserupdate.manager.class%
+        arguments: ['@doctrine', Ilios\CoreBundle\Entity\PendingUserUpdate]
     ilioscore.program.manager:
         class: %ilioscore.program.manager.class%
         arguments: ['@doctrine', Ilios\CoreBundle\Entity\Program]

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -34,7 +34,7 @@ services:
         arguments: ['@security.token_storage', '@ilioscore.auditlog.manager']
     ilioscore.ldapmanager:
         class: Ilios\CoreBundle\Service\LdapManager
-        arguments: ['%ilios_core.ldap.url%', '%ilios_core.ldap.user%', '%ilios_core.ldap.password%', '%ilios_core.ldap.search_base%', '%ilios_core.ldap.campus_id_property%']
+        arguments: ['%ilios_core.ldap.url%', '%ilios_core.ldap.user%', '%ilios_core.ldap.password%', '%ilios_core.ldap.search_base%', '%ilios_core.ldap.campus_id_property%', '%ilios_core.ldap.username_property%']
     ilioscore.directory:
         class: Ilios\CoreBundle\Service\Directory
         arguments: ['@ilioscore.ldapmanager', '%ilios_core.ldap.campus_id_property%']

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -32,3 +32,9 @@ services:
     ilioscore.logger:
         class: Ilios\CoreBundle\Service\Logger
         arguments: ['@security.token_storage', '@ilioscore.auditlog.manager']
+    ilioscore.ldapmanager:
+        class: Ilios\CoreBundle\Service\LdapManager
+        arguments: ['%ilios_core.ldap.url%', '%ilios_core.ldap.user%', '%ilios_core.ldap.password%', '%ilios_core.ldap.search_base%', '%ilios_core.ldap.campus_id_property%']
+    ilioscore.directory:
+        class: Ilios\CoreBundle\Service\Directory
+        arguments: ['@ilioscore.ldapmanager', '%ilios_core.ldap.campus_id_property%']

--- a/src/Ilios/CoreBundle/Service/Directory.php
+++ b/src/Ilios/CoreBundle/Service/Directory.php
@@ -45,6 +45,28 @@ class Directory
     }
     
     /**
+     * Get directory information for a list of users
+     * @param  array $campusIds
+     *
+     * @return array | false
+     */
+    public function findByCampusIds(array $campusIds)
+    {
+        $filterTerms = array_map(function ($campusId) {
+            return "({$this->ldapCampusIdProperty}={$campusId})";
+        }, $campusIds);
+        $filterTermsString = implode($filterTerms, '');
+        $filter = "(|{$filterTermsString})";
+        
+        $users = $this->ldapManager->search($filter);
+        if (count($users)) {
+            return $users;
+        }
+        
+        return false;
+    }
+    
+    /**
      * Find everyone in the directory matching these terms
      * @param  array $searchTerms
      *

--- a/src/Ilios/CoreBundle/Service/Directory.php
+++ b/src/Ilios/CoreBundle/Service/Directory.php
@@ -65,4 +65,20 @@ class Directory
         
         return false;
     }
+    
+    /**
+     * Find all users matching LDAP filter
+     * @param  string $filter
+     *
+     * @return array | false
+     */
+    public function findByLdapFilter($filter)
+    {
+        $users = $this->ldapManager->search($filter);
+        if (count($users)) {
+            return $users;
+        }
+        
+        return false;
+    }
 }

--- a/src/Ilios/CoreBundle/Service/Directory.php
+++ b/src/Ilios/CoreBundle/Service/Directory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Ilios\CoreBundle\Service;
+
+use Ilios\CoreBundle\Service\LdapManager;
+
+class Directory
+{
+    /**
+     * @var LdapManager
+     */
+    protected $ldapManager;
+
+    /**
+     * @var string
+     */
+    protected $ldapCampusIdProperty;
+
+    /**
+     * Constructor
+     * @param LdapManager   $ldapManager
+     * @param string        $ldapCampusIdProperty  injected from configuration
+     */
+    public function __construct(LdapManager $ldapManager, $ldapCampusIdProperty)
+    {
+        $this->ldapManager = $ldapManager;
+        $this->ldapCampusIdProperty = $ldapCampusIdProperty;
+    }
+    
+    /**
+     * Get directory information for a single user
+     * @param  string $campusId
+     *
+     * @return array | false
+     */
+    public function findUserByCampusId($campusId)
+    {
+        $filter = "({$this->ldapCampusIdProperty}={$campusId})";
+        $users = $this->ldapManager->search($filter);
+        if (count($users)) {
+            return $users[0];
+        }
+        
+        return false;
+    }
+}

--- a/src/Ilios/CoreBundle/Service/Directory.php
+++ b/src/Ilios/CoreBundle/Service/Directory.php
@@ -57,7 +57,7 @@ class Directory
         }, $searchTerms);
         $filterTermsString = implode($filterTerms, '');
         $filter = "(&{$filterTermsString})";
-        $users = $this->ldapManager->search($filter, 'sn');
+        $users = $this->ldapManager->search($filter);
 
         if (count($users)) {
             return $users;

--- a/src/Ilios/CoreBundle/Service/Directory.php
+++ b/src/Ilios/CoreBundle/Service/Directory.php
@@ -52,6 +52,7 @@ class Directory
      */
     public function findByCampusIds(array $campusIds)
     {
+        $campusIds = array_unique($campusIds);
         $filterTerms = array_map(function ($campusId) {
             return "({$this->ldapCampusIdProperty}={$campusId})";
         }, $campusIds);

--- a/src/Ilios/CoreBundle/Service/Directory.php
+++ b/src/Ilios/CoreBundle/Service/Directory.php
@@ -33,12 +33,34 @@ class Directory
      *
      * @return array | false
      */
-    public function findUserByCampusId($campusId)
+    public function findByCampusId($campusId)
     {
         $filter = "({$this->ldapCampusIdProperty}={$campusId})";
         $users = $this->ldapManager->search($filter);
         if (count($users)) {
             return $users[0];
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Find everyone in the directory matching these terms
+     * @param  array $searchTerms
+     *
+     * @return array | false
+     */
+    public function find(array $searchTerms)
+    {
+        $filterTerms = array_map(function ($term) {
+            return "(|(sn={$term}*)(givenname={$term}*)(mail={$term}*))";
+        }, $searchTerms);
+        $filterTermsString = implode($filterTerms, '');
+        $filter = "(&{$filterTermsString})";
+        $users = $this->ldapManager->search($filter, 'sn');
+
+        if (count($users)) {
+            return $users;
         }
         
         return false;

--- a/src/Ilios/CoreBundle/Service/Directory.php
+++ b/src/Ilios/CoreBundle/Service/Directory.php
@@ -2,8 +2,6 @@
 
 namespace Ilios\CoreBundle\Service;
 
-use Ilios\CoreBundle\Service\LdapManager;
-
 class Directory
 {
     /**

--- a/src/Ilios/CoreBundle/Service/LdapManager.php
+++ b/src/Ilios/CoreBundle/Service/LdapManager.php
@@ -103,11 +103,12 @@ class LdapManager
     /**
      * Performs an LDAP search
      * @param string $filter
+     * @param string $sortBy
      *
      * @return array
      * @throws Exception
      */
-    public function search($filter)
+    public function search($filter, $sortBy = null)
     {
         $rhett = [];
         $attributes = [
@@ -122,6 +123,9 @@ class LdapManager
             $results = $ldap->search($this->ldapSearchBase, $filter, $attributes);
             
             if ($results->countEntries()) {
+                if ($sortBy) {
+                    $results = $results->sort($sortBy);
+                }
                 $arr = $results->getEntries();
                 unset($arr['count']);
                 $campusIdKey = strtolower($this->ldapCampusIdProperty);

--- a/src/Ilios/CoreBundle/Service/LdapManager.php
+++ b/src/Ilios/CoreBundle/Service/LdapManager.php
@@ -119,7 +119,7 @@ class LdapManager
      * @param string $filter
      *
      * @return array
-     * @throws Exception
+     * @throws \Exception
      */
     public function search($filter)
     {
@@ -186,7 +186,7 @@ class LdapManager
             }
             
         } catch (\UserException $e) {
-            throw new Exception("Failed to search external user source: {$e->getMessage()}");
+            throw new \Exception("Failed to search external user source: {$e->getMessage()}");
         }
     
         return $rhett;

--- a/src/Ilios/CoreBundle/Service/LdapManager.php
+++ b/src/Ilios/CoreBundle/Service/LdapManager.php
@@ -29,6 +29,16 @@ class LdapManager
     protected $ldapBindPassword;
     
     /**
+     * @var string
+     */
+    protected $ldapCampusIdProperty;
+    
+    /**
+     * @var string
+     */
+    protected $ldapUsernameProperty;
+    
+    /**
      * @var LDAP
      */
     protected $ldap;
@@ -46,19 +56,22 @@ class LdapManager
      * @param string $ldapBindPassword      injected from configuration
      * @param string $ldapSearchBase        injected from configuration
      * @param string $ldapCampusIdProperty  injected from configuration
+     * @param string $ldapUsernameProperty  injected from configuration
      */
     public function __construct(
         $ldapUrl,
         $ldapBindUser,
         $ldapBindPassword,
         $ldapSearchBase,
-        $ldapCampusIdProperty
+        $ldapCampusIdProperty,
+        $ldapUsernameProperty
     ) {
         $this->ldapUrl = $ldapUrl;
         $this->ldapBindUser = $ldapBindUser;
         $this->ldapBindPassword = $ldapBindPassword;
         $this->ldapSearchBase = $ldapSearchBase;
         $this->ldapCampusIdProperty = $ldapCampusIdProperty;
+        $this->ldapUsernameProperty = $ldapUsernameProperty;
 
         $this->ldap = null;
         $this->connectionCreatedAt = null;
@@ -116,8 +129,8 @@ class LdapManager
             'sn',
             'givenName',
             'telephoneNumber',
-            'eduPersonPrincipalName',
-            $this->ldapCampusIdProperty
+            $this->ldapCampusIdProperty,
+            $this->ldapUsernameProperty
         ];
         try {
             $ldap = $this->getLdap();
@@ -135,14 +148,15 @@ class LdapManager
 
             if (count($results)) {
                 $campusIdKey = strtolower($this->ldapCampusIdProperty);
-                $rhett = array_map(function ($userData) use ($campusIdKey) {
+                $usernameKey = strtolower($this->ldapUsernameProperty);
+                $rhett = array_map(function ($userData) use ($campusIdKey, $usernameKey) {
                     $keys = [
                         'givenname',
                         'sn',
                         'mail',
                         'telephonenumber',
-                        'edupersonprincipalname',
-                        $campusIdKey
+                        $campusIdKey,
+                        $usernameKey
                     ];
                     $values = [];
                     foreach ($keys as $key) {
@@ -154,8 +168,8 @@ class LdapManager
                         'lastName' => $values['sn'],
                         'email' => $values['mail'],
                         'telephoneNumber' => $values['telephonenumber'],
-                        'eppn' => $values['edupersonprincipalname'],
                         'campusId' => $values[$campusIdKey],
+                        'username' => $values[$usernameKey],
                     ];
                 }, $results);
                 

--- a/src/Ilios/CoreBundle/Service/LdapManager.php
+++ b/src/Ilios/CoreBundle/Service/LdapManager.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Ilios\CoreBundle\Service;
+
+use Dreamscapes\Ldap\Core\Ldap;
+
+class LdapManager
+{
+    /**
+     * Reset timeout - if more than this many seconds have passed since the
+     * last request we should reset the ldap connection
+     * @var int
+     */
+    const RESET_TIMEOUT = 120;
+
+    /**
+     * @var string
+     */
+    protected $ldapUrl;
+    
+    /**
+     * @var string
+     */
+    protected $ldapBindUser;
+    
+    /**
+     * @var string
+     */
+    protected $ldapBindPassword;
+    
+    /**
+     * @var LDAP
+     */
+    protected $ldap;
+    
+    /**
+     * LDAP connection times tells us when to reset
+     * @var int
+     */
+    protected $connectionLastUsed;
+
+    /**
+     * Constructor
+     * @param string $ldapUrl               injected from configuration
+     * @param string $ldapBindUser          injected from configuration
+     * @param string $ldapBindPassword      injected from configuration
+     * @param string $ldapSearchBase        injected from configuration
+     * @param string $ldapCampusIdProperty  injected from configuration
+     */
+    public function __construct(
+        $ldapUrl,
+        $ldapBindUser,
+        $ldapBindPassword,
+        $ldapSearchBase,
+        $ldapCampusIdProperty
+    ) {
+        $this->ldapUrl = $ldapUrl;
+        $this->ldapBindUser = $ldapBindUser;
+        $this->ldapBindPassword = $ldapBindPassword;
+        $this->ldapSearchBase = $ldapSearchBase;
+        $this->ldapCampusIdProperty = $ldapCampusIdProperty;
+
+        $this->ldap = null;
+        $this->connectionCreatedAt = null;
+    }
+    
+    /**
+     * Destroy the connection
+     */
+    public function __destruct()
+    {
+        if ($this->ldap) {
+            $this->ldap->close();
+        }
+    }
+    
+    /**
+     * Get an instance of the LDAP object
+     *
+     * @return LDAP
+     */
+    protected function getLdap()
+    {
+        $now = time();
+        if ($this->connectionLastUsed &&
+            $this->ldap &&
+            $now - $this->connectionLastUsed > self::RESET_TIMEOUT
+        ) {
+            $this->ldap->close();
+            $this->ldap = null;
+        }
+        $this->connectionLastUsed = $now;
+        if (!empty($this->ldap)) {
+            return $this->ldap;
+        }
+        
+        $this->ldap = new Ldap($this->ldapUrl);
+        $this->ldap->bind($this->ldapBindUser, $this->ldapBindPassword);
+
+        return $this->ldap;
+    }
+
+    /**
+     * Performs an LDAP search
+     * @param string $filter
+     *
+     * @return array
+     * @throws Exception
+     */
+    public function search($filter)
+    {
+        $rhett = [];
+        $attributes = [
+            'mail',
+            'sn',
+            'givenName',
+            'telephoneNumber',
+            $this->ldapCampusIdProperty
+        ];
+        try {
+            $ldap = $this->getLdap();
+            $results = $ldap->search($this->ldapSearchBase, $filter, $attributes);
+            
+            if ($results->countEntries()) {
+                $arr = $results->getEntries();
+                unset($arr['count']);
+                $campusIdKey = strtolower($this->ldapCampusIdProperty);
+                $rhett = array_map(function ($userData) use ($campusIdKey) {
+                    $firstName = array_key_exists('givenname', $userData)?$userData['givenname'][0]:null;
+                    $lastName = array_key_exists('sn', $userData)?$userData['sn'][0]:null;
+                    $email = array_key_exists('mail', $userData)?$userData['mail'][0]:null;
+                    $phone = array_key_exists('telephoneNumber', $userData)?$userData['telephoneNumber'][0]:null;
+                    $campusId = array_key_exists($campusIdKey, $userData)?$userData[$campusIdKey][0]:null;
+                    return [
+                        'firstName' => $firstName,
+                        'lastName' => $lastName,
+                        'email' => $email,
+                        'telephoneNumber' => $phone,
+                        'campusId' => $campusId,
+                    ];
+                }, $arr);
+            }
+            
+        } catch (\UserException $e) {
+            throw new Exception("Failed to search external user source: {$e->getMessage()}");
+        }
+    
+        return $rhett;
+        
+    }
+}

--- a/src/Ilios/CoreBundle/Tests/DependencyInjection/IliosCoreExtensionTest.php
+++ b/src/Ilios/CoreBundle/Tests/DependencyInjection/IliosCoreExtensionTest.php
@@ -18,8 +18,18 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
     public function testParametersSet()
     {
         $fileSystemStoragePath = '/tmp/test';
+        $ldapUrl = 'ldap.url';
+        $ldapUser = 'ldap.user';
+        $ldapPassword = 'ldap.pass';
+        $ldapSearchBase = 'ldap.base';
+        $ldapCampusIdProperty = 'ldap.camp';
         $this->load(array(
             'file_system_storage_path' => $fileSystemStoragePath,
+            'ldap_directory_url' => $ldapUrl,
+            'ldap_directory_user' => $ldapUser,
+            'ldap_directory_password' => $ldapPassword,
+            'ldap_directory_search_base' => $ldapSearchBase,
+            'ldap_directory_campus_id_property' => $ldapCampusIdProperty,
         ));
         $parameters = array(
             'ilioscore.aamcmethod.manager.class' => 'Ilios\CoreBundle\Entity\Manager\AamcMethodManager',
@@ -200,7 +210,11 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
             'ilioscore.dataloader.usermadereminder.class' => 'Ilios\CoreBundle\Tests\DataLoader\UserMadeReminderData',
             'ilioscore.dataloader.userrole.class' => 'Ilios\CoreBundle\Tests\DataLoader\UserRoleData',
             'ilioscore.dataloader.user.class' => 'Ilios\CoreBundle\Tests\DataLoader\UserData',
-            'ilios_core.file_store_path' => $fileSystemStoragePath,
+            'ilios_core.ldap.url' => $ldapUrl,
+            'ilios_core.ldap.user' => $ldapUser,
+            'ilios_core.ldap.password' => $ldapPassword,
+            'ilios_core.ldap.search_base' => $ldapSearchBase,
+            'ilios_core.ldap.campus_id_property' => $ldapCampusIdProperty,
         );
         foreach ($parameters as $name => $value) {
             $this->assertContainerBuilderHasParameter($name, $value);
@@ -346,6 +360,9 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
             'ilioscore.listener.updatesession',
             'ilioscore.temporary_filesystem',
             'ilioscore.filesystem',
+            'ilioscore.logger',
+            'ilioscore.ldapmanager',
+            'ilioscore.directory',
         );
         foreach ($services as $service) {
             $this->assertContainerBuilderHasService($service);

--- a/src/Ilios/CoreBundle/Tests/DependencyInjection/IliosCoreExtensionTest.php
+++ b/src/Ilios/CoreBundle/Tests/DependencyInjection/IliosCoreExtensionTest.php
@@ -23,6 +23,7 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
         $ldapPassword = 'ldap.pass';
         $ldapSearchBase = 'ldap.base';
         $ldapCampusIdProperty = 'ldap.camp';
+        $ldapUsernameProperty = 'ldap.username';
         $this->load(array(
             'file_system_storage_path' => $fileSystemStoragePath,
             'ldap_directory_url' => $ldapUrl,
@@ -30,6 +31,7 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
             'ldap_directory_password' => $ldapPassword,
             'ldap_directory_search_base' => $ldapSearchBase,
             'ldap_directory_campus_id_property' => $ldapCampusIdProperty,
+            'ldap_directory_username_property' => $ldapUsernameProperty,
         ));
         $parameters = array(
             'ilioscore.aamcmethod.manager.class' => 'Ilios\CoreBundle\Entity\Manager\AamcMethodManager',
@@ -215,6 +217,7 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
             'ilios_core.ldap.password' => $ldapPassword,
             'ilios_core.ldap.search_base' => $ldapSearchBase,
             'ilios_core.ldap.campus_id_property' => $ldapCampusIdProperty,
+            'ilios_core.ldap.username_property' => $ldapUsernameProperty,
         );
         foreach ($parameters as $name => $value) {
             $this->assertContainerBuilderHasParameter($name, $value);

--- a/src/Ilios/CoreBundle/Tests/Entity/AuthenticationTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/AuthenticationTest.php
@@ -41,7 +41,7 @@ class AuthenticationTest extends EntityBase
 
     /**
      * @covers Ilios\CoreBundle\Entity\Authentication::setEppn
-     * @covers Ilios\CoreBundle\Entity\Authentication:gsetEppn
+     * @covers Ilios\CoreBundle\Entity\Authentication::getEppn
      */
     public function testSetEppn()
     {

--- a/src/Ilios/CoreBundle/Tests/Entity/AuthenticationTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/AuthenticationTest.php
@@ -40,6 +40,15 @@ class AuthenticationTest extends EntityBase
     }
 
     /**
+     * @covers Ilios\CoreBundle\Entity\Authentication::setEppn
+     * @covers Ilios\CoreBundle\Entity\Authentication:gsetEppn
+     */
+    public function testSetEppn()
+    {
+        $this->basicSetTest('eppn', 'string');
+    }
+
+    /**
      * @covers Ilios\CoreBundle\Entity\Authentication::setUser
      * @covers Ilios\CoreBundle\Entity\Authentication::getUser
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/AuthenticationTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/AuthenticationTest.php
@@ -40,15 +40,6 @@ class AuthenticationTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Authentication::setEppn
-     * @covers Ilios\CoreBundle\Entity\Authentication::getEppn
-     */
-    public function testSetEppn()
-    {
-        $this->basicSetTest('eppn', 'string');
-    }
-
-    /**
      * @covers Ilios\CoreBundle\Entity\Authentication::setUser
      * @covers Ilios\CoreBundle\Entity\Authentication::getUser
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/UserTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/UserTest.php
@@ -121,12 +121,12 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setUcUid
-     * @covers Ilios\CoreBundle\Entity\User::getUcUid
+     * @covers Ilios\CoreBundle\Entity\User::setCampusId
+     * @covers Ilios\CoreBundle\Entity\User::getCampusId
      */
-    public function testSetUcUid()
+    public function testSetCampusId()
     {
-        $this->basicSetTest('ucUid', 'string');
+        $this->basicSetTest('campusId', 'string');
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Ilios\CoreBundle\Tests\Service;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Mockery as m;
+
+use Ilios\CoreBundle\Service\Directory;
+
+class DirectoryTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testConstructor()
+    {
+        $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
+        $obj = new Directory($ldapManager, 'campusId');
+        $this->assertTrue($obj instanceof Directory);
+    }
+
+    public function testFindUserByCampusId()
+    {
+        $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
+        $obj = new Directory($ldapManager, 'campusId');
+        $ldapManager->shouldReceive('search')->with('(campusId=1234)')->andReturn(array(1));
+        
+        $result = $obj->findUserByCampusId(1234);
+        $this->assertSame($result, 1);
+    }
+}

--- a/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
@@ -13,6 +13,9 @@ class DirectoryTest extends TestCase
         m::close();
     }
 
+    /**
+     * @covers Ilios\CoreBundle\Service\Directory::__construct
+     */
     public function testConstructor()
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
@@ -20,6 +23,9 @@ class DirectoryTest extends TestCase
         $this->assertTrue($obj instanceof Directory);
     }
 
+    /**
+     * @covers Ilios\CoreBundle\Service\Directory::findByCampusId
+     */
     public function testFindByCampusId()
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
@@ -30,6 +36,9 @@ class DirectoryTest extends TestCase
         $this->assertSame($result, 1);
     }
 
+    /**
+     * @covers Ilios\CoreBundle\Service\Directory::findByCampusId
+     */
     public function testFindByCampusIds()
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
@@ -40,6 +49,9 @@ class DirectoryTest extends TestCase
         $this->assertSame($result, [1]);
     }
 
+    /**
+     * @covers Ilios\CoreBundle\Service\Directory::findByCampusId
+     */
     public function testFindByCampusIdsOnlyUseUnique()
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
@@ -51,6 +63,9 @@ class DirectoryTest extends TestCase
         $this->assertSame($result, [1]);
     }
 
+    /**
+     * @covers Ilios\CoreBundle\Service\Directory::find
+     */
     public function testFind()
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
@@ -62,6 +77,9 @@ class DirectoryTest extends TestCase
         $this->assertSame($result, array(1,2));
     }
 
+    /**
+     * @covers Ilios\CoreBundle\Service\Directory::findByLdapFilter
+     */
     public function testFindByLdapFilter()
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');

--- a/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
@@ -30,6 +30,16 @@ class DirectoryTest extends TestCase
         $this->assertSame($result, 1);
     }
 
+    public function testFindByCampusIds()
+    {
+        $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
+        $obj = new Directory($ldapManager, 'campusId');
+        $ldapManager->shouldReceive('search')->with('(|(campusId=1234)(campusId=1235))')->andReturn(array(1));
+        
+        $result = $obj->findByCampusIds([1234, 1235]);
+        $this->assertSame($result, [1]);
+    }
+
     public function testFind()
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');

--- a/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
@@ -40,4 +40,15 @@ class DirectoryTest extends TestCase
         $result = $obj->find(array('a', 'b'));
         $this->assertSame($result, array(1,2));
     }
+
+    public function testFindByLdapFilter()
+    {
+        $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
+        $obj = new Directory($ldapManager, 'campusId');
+        $filter= '(one)(two)';
+        $ldapManager->shouldReceive('search')->with($filter)->andReturn(array(1,2));
+        
+        $result = $obj->findByLdapFilter($filter);
+        $this->assertSame($result, array(1,2));
+    }
 }

--- a/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
@@ -40,6 +40,16 @@ class DirectoryTest extends TestCase
         $this->assertSame($result, [1]);
     }
 
+    public function testFindByCampusIdsOnlyUseUnique()
+    {
+        $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
+        $obj = new Directory($ldapManager, 'campusId');
+        $ldapManager->shouldReceive('search')->with(m::mustBe('(|(campusId=1234)(campusId=1235))'))->andReturn(array(1));
+        
+        $result = $obj->findByCampusIds([1234, 1235, 1234, 1235]);
+        $this->assertSame($result, [1]);
+    }
+
     public function testFind()
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');

--- a/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
@@ -44,7 +44,8 @@ class DirectoryTest extends TestCase
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
         $obj = new Directory($ldapManager, 'campusId');
-        $ldapManager->shouldReceive('search')->with(m::mustBe('(|(campusId=1234)(campusId=1235))'))->andReturn(array(1));
+        $ldapManager->shouldReceive('search')
+            ->with(m::mustBe('(|(campusId=1234)(campusId=1235))'))->andReturn(array(1));
         
         $result = $obj->findByCampusIds([1234, 1235, 1234, 1235]);
         $this->assertSame($result, [1]);

--- a/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
@@ -20,13 +20,24 @@ class DirectoryTest extends TestCase
         $this->assertTrue($obj instanceof Directory);
     }
 
-    public function testFindUserByCampusId()
+    public function testFindByCampusId()
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
         $obj = new Directory($ldapManager, 'campusId');
         $ldapManager->shouldReceive('search')->with('(campusId=1234)')->andReturn(array(1));
         
-        $result = $obj->findUserByCampusId(1234);
+        $result = $obj->findByCampusId(1234);
         $this->assertSame($result, 1);
+    }
+
+    public function testFind()
+    {
+        $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
+        $obj = new Directory($ldapManager, 'campusId');
+        $filter= '(&(|(sn=a*)(givenname=a*)(mail=a*))(|(sn=b*)(givenname=b*)(mail=b*)))';
+        $ldapManager->shouldReceive('search')->with($filter, 'sn')->andReturn(array(1,2));
+        
+        $result = $obj->find(array('a', 'b'));
+        $this->assertSame($result, array(1,2));
     }
 }

--- a/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
@@ -35,7 +35,7 @@ class DirectoryTest extends TestCase
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
         $obj = new Directory($ldapManager, 'campusId');
         $filter= '(&(|(sn=a*)(givenname=a*)(mail=a*))(|(sn=b*)(givenname=b*)(mail=b*)))';
-        $ldapManager->shouldReceive('search')->with($filter, 'sn')->andReturn(array(1,2));
+        $ldapManager->shouldReceive('search')->with($filter)->andReturn(array(1,2));
         
         $result = $obj->find(array('a', 'b'));
         $this->assertSame($result, array(1,2));

--- a/src/Ilios/CoreBundle/Tests/Service/LdapManagerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/LdapManagerTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Ilios\CoreBundle\Tests\Service;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Ilios\CoreBundle\Service\LdapManager;
+
+class LdapManagerTest extends TestCase
+{
+
+    public function testConstructor()
+    {
+        $obj = new LdapManager('url', 'user', 'password', 'searchBase', 'campusId');
+        $this->assertTrue($obj instanceof LdapManager);
+    }
+}

--- a/src/Ilios/CoreBundle/Tests/Service/LdapManagerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/LdapManagerTest.php
@@ -9,7 +9,7 @@ class LdapManagerTest extends TestCase
 
     public function testConstructor()
     {
-        $obj = new LdapManager('url', 'user', 'password', 'searchBase', 'campusId');
+        $obj = new LdapManager('url', 'user', 'password', 'searchBase', 'campusId', 'username');
         $this->assertTrue($obj instanceof LdapManager);
     }
 }


### PR DESCRIPTION
Adds commands for managing users:
- `ilios:directory:add-students` takes a schoolId and an LDAP query and adds anyone it find in the query to the school.
- `ilios:directory:add-user` adds a single user by campusId
- `ilios:directory:sync-former-students` takes and LDAP query and marks anyone it finds as a former student
- `ilios:directory:sync-user` looks up a single user in LDAP and syncs their user record with the directory.
- `ilios:directory:sync-users` looks for every Ilios user in LDAP by their campusId.  It updated name / phone / and changes to the case of email automatically and addes PendingUserUpdate entries for other differences that require intervention.

Together these are the base of User synchronization.

Fixes #1011
Fixes #991

I didn't include the API (controller, form, tests) for PendingUserUpdate.  I will do those separately.