### PR TITLE
Learning Material Downloads

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -14,6 +14,13 @@ ilios_core_uploadfile:
     path: /upload
     defaults:  { _controller: IliosCoreBundle:Upload:upload }
 
+ilios_core_downloadlearningmaterial:
+    pattern:     /lm/{token}
+    defaults:
+        _controller: IliosCoreBundle:Download:learningMaterial
+    requirements:
+        token: "^[a-zA-Z0-9]{64}$"
+
 ilios_web:
     resource: "@IliosWebBundle/Resources/config/routing.yml"
     prefix:   /

--- a/src/Ilios/CliBundle/Command/MigrateIlios2LearningMaterialsCommand.php
+++ b/src/Ilios/CliBundle/Command/MigrateIlios2LearningMaterialsCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFileSystem;
+
+use Ilios\CoreBundle\Entity\Manager\LearningMaterialManagerInterface;
+use Ilios\CoreBundle\Classes\IliosFileSystem;
+
+/**
+ * Sync a user with their directory information
+ *
+ * Class SyncUserCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class MigrateIlios2LearningMaterialsCommand extends Command
+{
+    /**
+     * @var SymfonyFileSystem
+     */
+    protected $symfonyFileSystem;
+    
+    /**
+     * @var IliosFileSystem
+     */
+    protected $iliosFileSystem;
+    
+    /**
+     * @var LearningMaterialManagerInterface
+     */
+    protected $learningMaterialManager;
+    
+    public function __construct(
+        SymfonyFileSystem $symfonyFileSystem,
+        IliosFileSystem $iliosFileSystem,
+        LearningMaterialManagerInterface $learningMaterialManager
+    ) {
+        $this->symfonyFileSystem = $symfonyFileSystem;
+        $this->iliosFileSystem = $iliosFileSystem;
+        $this->learningMaterialManager = $learningMaterialManager;
+        
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:setup:migrate-learning-materials')
+            ->setDescription('Migrate Ilios2 Learning Materials to Ilios3 Structure')
+            ->addArgument(
+                'pathToIlios2',
+                InputArgument::REQUIRED,
+                'The path to your Ilios2 installation.'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $pathToIlios2 = $input->getArgument('pathToIlios2');
+        if (!$this->symfonyFileSystem->exists($pathToIlios2)) {
+            throw new \Exception(
+                "'{$pathToIlios2}' does not exist."
+            );
+        }
+        
+        $learningMaterials = $this->learningMaterialManager->findFileLearningMaterials();
+        
+        $helper = $this->getHelper('question');
+        $output->writeln('');
+        $question = new ConfirmationQuestion(
+            '<question>Ready to copy ' . count($learningMaterials) .
+            ' learning materials. Shall we continue? </question>' . "\n",
+            true
+        );
+        
+        if ($helper->ask($input, $output, $question)) {
+            $migrated = 0;
+            foreach ($learningMaterials as $lm) {
+                $fullPath = $pathToIlios2 . $lm->getRelativePath();
+                if (!$this->symfonyFileSystem->exists($fullPath)) {
+                    throw new \Exception(
+                        'Unable to migrated learning material #' . $lm ->getId() .
+                        ".  No file found at '${fullPath}'."
+                    );
+                }
+                $file = $this->iliosFileSystem->getSymfonyFileForPath($fullPath);
+                $newPath = $this->iliosFileSystem->storeLearningMaterialFile($file);
+                $lm->setRelativePath($newPath);
+                $this->learningMaterialManager->updateLearningMaterial($lm, false);
+                $migrated ++;
+
+                if ($migrated % 500) {
+                    $this->learningMaterialManager->flushAndClear();
+                }
+            }
+            
+            $this->learningMaterialManager->flushAndClear();
+            
+            $output->writeln("<info>Migrated {$migrated} learning materials successfully!</info>");
+        } else {
+            $output->writeln('<comment>Migration canceled.</comment>');
+        }
+        
+    }
+}

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -39,3 +39,8 @@ services:
         arguments: ["@ilioscore.user.manager", "@ilioscore.authentication.manager", "@ilioscore.pendinguserupdate.manager", "@ilioscore.directory", "@doctrine.orm.entity_manager"]
         tags:
             -  { name: console.command }
+    ilioscli.command.migrate_learningmaterials:
+        class: Ilios\CliBundle\Command\MigrateIlios2LearningMaterialsCommand
+        arguments: ["@filesystem", "@ilioscore.filesystem", "@ilioscore.learningmaterial.manager"]
+        tags:
+            -  { name: console.command }

--- a/src/Ilios/CliBundle/Tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
@@ -1,0 +1,139 @@
+<?php
+namespace Ilios\CliBundle\Tests\Command;
+
+use Ilios\CliBundle\Command\MigrateIlios2LearningMaterialsCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+class MigrateIlios2LearningMaterialsCommandTest extends \PHPUnit_Framework_TestCase
+{
+    const COMMAND_NAME = 'ilios:setup:migrate-learning-materials';
+    
+    protected $symfonyFileSystem;
+    protected $iliosFileSystem;
+    protected $learningMaterialManager;
+    
+    public function setUp()
+    {
+        $this->symfonyFileSystem = m::mock('Symfony\Component\Filesystem\Filesystem');
+        $this->iliosFileSystem = m::mock('Ilios\CoreBundle\Classes\IliosFileSystem');
+        $this->learningMaterialManager = m::mock('Ilios\CoreBundle\Entity\Manager\LearningMaterialManagerInterface');
+
+        $command = new MigrateIlios2LearningMaterialsCommand(
+            $this->symfonyFileSystem,
+            $this->iliosFileSystem,
+            $this->learningMaterialManager
+        );
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+        $this->questionHelper = $command->getHelper('question');
+        
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->symfonyFileSystem);
+        unset($this->iliosFileSystem);
+        unset($this->directory);
+        unset($this->learningMaterialManager);
+        m::close();
+    }
+    
+    public function testExecute()
+    {
+        $this->symfonyFileSystem
+            ->shouldReceive('exists')->with('path')->andReturn(true)
+            ->shouldReceive('exists')->with('path/pathtofile')->andReturn(true);
+        $lm = m::mock('Ilios\CoreBundle\Entity\LearningMaterial')
+            ->shouldReceive('getRelativePath')->andReturn('/pathtofile')->once()
+            ->shouldReceive('setRelativePath')->with('newrelativepath')->once()
+            ->mock();
+        $this->learningMaterialManager
+            ->shouldReceive('findFileLearningMaterials')->andReturn([$lm])->once()
+            ->shouldReceive('updateLearningMaterial')->with($lm, false)->once()
+            ->shouldReceive('flushAndClear')->twice()
+        ;
+        $file = m::mock('Symfony\Component\HttpFoundation\File\File');
+        
+        $this->iliosFileSystem
+            ->shouldReceive('getSymfonyFileForPath')->with('path/pathtofile')->andReturn($file)->once()
+            ->shouldReceive('storeLearningMaterialFile')->with($file)->andReturn('newrelativepath')->once()
+        ;
+        $this->sayYesWhenAsked();
+        
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'pathToIlios2'         => 'path'
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Ready to copy 1 learning materials. Shall we continue?/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Migrated 1 learning materials successfully!/',
+            $output
+        );
+    }
+    
+    public function testExecuteWithBadRelativePath()
+    {
+        $this->symfonyFileSystem
+            ->shouldReceive('exists')->with('path')->andReturn(true)
+            ->shouldReceive('exists')->with('path/pathtofile')->andReturn(false);
+        
+        $lm = m::mock('Ilios\CoreBundle\Entity\LearningMaterial')
+            ->shouldReceive('getId')->andReturn('id')->once()
+            ->shouldReceive('getRelativePath')->andReturn('/pathtofile')->once()
+            ->mock();
+        $this->learningMaterialManager
+            ->shouldReceive('findFileLearningMaterials')->andReturn([$lm])->once()
+        ;
+
+        $this->sayYesWhenAsked();
+        
+        $this->setExpectedException(
+            'Exception',
+            "Unable to migrated learning material #id.  No file found at 'path/pathtofile'."
+        );
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'pathToIlios2'         => 'path'
+        ));
+        
+    }
+    
+    public function testBadIlios2Path()
+    {
+        $this->symfonyFileSystem->shouldReceive('exists')->with('badpath')->andReturn(false);
+        $this->setExpectedException('Exception', "'badpath' does not exist");
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'pathToIlios2'         => 'badpath'
+        ));
+    }
+    
+    public function testIlios2PathRequired()
+    {
+        $this->setExpectedException('RuntimeException');
+        $this->commandTester->execute(array('command' => self::COMMAND_NAME));
+    }
+
+    protected function sayYesWhenAsked()
+    {
+        $stream = fopen('php://memory', 'r+', false);
+        
+        fputs($stream, 'Yes\\n');
+        rewind($stream);
+        
+        $this->questionHelper->setInputStream($stream);
+    }
+}

--- a/src/Ilios/CoreBundle/Classes/IliosFileSystem.php
+++ b/src/Ilios/CoreBundle/Classes/IliosFileSystem.php
@@ -102,6 +102,16 @@ class IliosFileSystem
     }
     
     /**
+     * Get a symfony FIle for a path
+     * @param  string $path
+     * @return File
+     */
+    public function getSymfonyFileForPath($path)
+    {
+        return new File($path);
+    }
+    
+    /**
      * Turn a relative path into an ilios file store path
      * @param  [string] $relativePath
      * @return [string]               [the full path]

--- a/src/Ilios/CoreBundle/Controller/DownloadController.php
+++ b/src/Ilios/CoreBundle/Controller/DownloadController.php
@@ -1,0 +1,44 @@
+<?php
+namespace Ilios\CoreBundle\Controller;
+
+use Ilios\CoreBundle\Classes\FileSystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use Exception;
+
+/**
+ * Class DownloadController
+ * @package Ilios\CoreBundle\Controller
+ */
+class DownloadController extends Controller
+{
+
+    public function learningMaterialAction($token)
+    {
+        $learningMaterial = $this->container->get('ilioscore.learningmaterial.manager')
+            ->findLearningMaterialBy(['token' => $token]);
+        
+        if (!$learningMaterial) {
+            throw new NotFoundHttpException();
+        }
+        
+        $file = $this->container->get('ilioscore.filesystem')
+            ->getFile($learningMaterial->getRelativePath());
+        
+        if (false === $file) {
+            throw new \Exception('File not found for learning material #' . $learningMaterial->getId());
+        }
+        
+        $headers = array(
+            'Content-Type' => $learningMaterial->getMimetype(),
+            'Content-Disposition' => 'attachment; filename="' . $learningMaterial->getFilename() . '"'
+        );
+
+
+        return new Response(file_get_contents($file->getPathname()), 200, $headers);
+    }
+}

--- a/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
+++ b/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
@@ -200,7 +200,7 @@ class LearningMaterialController extends FOSRestController
 
             $handler = $this->getLearningMaterialHandler();
 
-            $learningMaterial = $handler->post($this->getPostData($request));
+            $learningMaterial = $handler->post($postData);
 
             $authChecker = $this->get('security.authorization_checker');
             if (! $authChecker->isGranted('create', $learningMaterial)) {

--- a/src/Ilios/CoreBundle/Entity/LearningMaterial.php
+++ b/src/Ilios/CoreBundle/Entity/LearningMaterial.php
@@ -7,6 +7,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Symfony\Component\Security\Core\Util\SecureRandom;
 
 
 use Ilios\CoreBundle\Traits\DescribableEntity;
@@ -334,6 +335,8 @@ class LearningMaterial implements LearningMaterialInterface
         $this->uploadDate = new \DateTime();
         $this->sessionLearningMaterials = new ArrayCollection();
         $this->courseLearningMaterials = new ArrayCollection();
+        
+        $this->generateToken();
     }
 
     /**
@@ -366,6 +369,22 @@ class LearningMaterial implements LearningMaterialInterface
     public function getToken()
     {
         return $this->token;
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function generateToken()
+    {
+        $generator = new SecureRandom();
+        $random = $generator->nextBytes(128);
+        
+        // prepend id to avoid a conflict
+        // and current time to prevent a conflict with regeneration
+        $key = $this->getId() . microtime() . $random;
+        
+        // hash the string to give consistent length and URL safe characters
+        $this->token = hash('sha256', $key);
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/LearningMaterial.php
+++ b/src/Ilios/CoreBundle/Entity/LearningMaterial.php
@@ -228,6 +228,7 @@ class LearningMaterial implements LearningMaterialInterface
      *
      * @JMS\Expose
      * @JMS\Type("string")
+     * @JMS\SerializedName("relativePath")
      */
     protected $relativePath;
 
@@ -307,11 +308,6 @@ class LearningMaterial implements LearningMaterialInterface
     * @JMS\Type("integer")
     */
     protected $filesize;
-
-    /**
-     * @var UploadedFile;
-     */
-    protected $resource;
 
 
     /**

--- a/src/Ilios/CoreBundle/Entity/LearningMaterial.php
+++ b/src/Ilios/CoreBundle/Entity/LearningMaterial.php
@@ -20,7 +20,7 @@ use Ilios\CoreBundle\Traits\TimestampableEntity;
  * Class LearningMaterial
  * @package Ilios\CoreBundle\Entity
  *
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="Ilios\CoreBundle\Entity\Repository\LearningMaterialRepository")
  * @ORM\Table(
  *  name="learning_material",
  *  uniqueConstraints={@ORM\UniqueConstraint(name="idx_learning_material_token_unique", columns={"token"})}

--- a/src/Ilios/CoreBundle/Entity/LearningMaterialInterface.php
+++ b/src/Ilios/CoreBundle/Entity/LearningMaterialInterface.php
@@ -39,6 +39,11 @@ interface LearningMaterialInterface extends
      * @return string
      */
     public function getToken();
+    
+    /**
+     * Generate a random token for use in downloading
+     */
+    public function generateToken();
 
     /**
      * @param LearningMaterialStatusInterface $status

--- a/src/Ilios/CoreBundle/Entity/Manager/AbstractManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/AbstractManager.php
@@ -60,10 +60,20 @@ abstract class AbstractManager implements ManagerInterface
     }
 
     /**
-     * @return string
+     * @inheritdoc
      */
     public function getClass()
     {
         return $this->class;
     }
+    
+    /**
+     * @inheritdoc
+     */
+    public function flushAndClear()
+    {
+        $this->em->flush();
+        $this->em->clear();
+    }
+    
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/AbstractManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/AbstractManager.php
@@ -75,5 +75,4 @@ abstract class AbstractManager implements ManagerInterface
         $this->em->flush();
         $this->em->clear();
     }
-    
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManager.php
@@ -90,5 +90,4 @@ class LearningMaterialManager extends AbstractManager implements LearningMateria
     {
         return $this->getRepository()->findFileLearningMaterials();
     }
-    
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManager.php
@@ -82,4 +82,13 @@ class LearningMaterialManager extends AbstractManager implements LearningMateria
         $class = $this->getClass();
         return new $class();
     }
+    
+    /**
+     * @inheritdoc
+     */
+    public function findFileLearningMaterials()
+    {
+        return $this->getRepository()->findFileLearningMaterials();
+    }
+    
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManagerInterface.php
@@ -63,4 +63,9 @@ interface LearningMaterialManagerInterface extends ManagerInterface
      * @return LearningMaterialInterface
      */
     public function createLearningMaterial();
+    
+    /**
+     * Find all the File type learning materials
+     */
+    public function findFileLearningMaterials();
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/ManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/ManagerInterface.php
@@ -12,4 +12,9 @@ interface ManagerInterface
      * @return string
      */
     public function getClass();
+
+    /**
+     * Flush and clear the entity manager when doing bulk updates
+     */
+    public function flushAndClear();
 }

--- a/src/Ilios/CoreBundle/Entity/Repository/AuthenticationRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/AuthenticationRepository.php
@@ -18,8 +18,6 @@ class AuthenticationRepository extends EntityRepository
         $qb->add('select', 'a')->from('IliosCoreBundle:Authentication', 'a');
         $qb->where($qb->expr()->like('u.username', "?1"));
         $qb->setParameter(1, '%' . $username . '%');
-        $result = $this->getEntityManager()
-            ->createQuery($dql)->getSingleResult();
 
         return $qb->getQuery()->getSingleResult();
     }

--- a/src/Ilios/CoreBundle/Entity/Repository/LearningMaterialRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/LearningMaterialRepository.php
@@ -1,0 +1,19 @@
+<?php
+namespace Ilios\CoreBundle\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class LearningMaterialRepository extends EntityRepository
+{
+    /**
+     * Find all the file type learning materials
+     */
+    public function findFileLearningMaterials()
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->add('select', 'lm')->from('IliosCoreBundle:LearningMaterial', 'lm');
+        $qb->where($qb->expr()->isNotNull('lm.relativePath'));
+
+        return $qb->getQuery()->getResult();
+    }
+}

--- a/src/Ilios/CoreBundle/Tests/Classes/IliosFileSystemTest.php
+++ b/src/Ilios/CoreBundle/Tests/Classes/IliosFileSystemTest.php
@@ -4,6 +4,7 @@ namespace Ilios\CoreBundle\Tests\Classes;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Mockery as m;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFileSystem;
+use \Symfony\Component\HttpFoundation\File\File;
 
 use Ilios\CoreBundle\Classes\IliosFileSystem;
 
@@ -144,5 +145,30 @@ class IliosFileSystemTest extends TestCase
             $hash
         ];
         return implode($parts, '/');
+    }
+
+    public function testGetSymfonyFileForPath()
+    {
+        $fs = new SymfonyFileSystem();
+        $someJunk = 'whatever dude';
+        $hash = md5($someJunk);
+        $hashDirectory = substr($hash, 0, 2);
+        $parts = [
+            $this->fakeTestFileDir,
+            'learning_materials',
+            'lm',
+            $hashDirectory
+        ];
+        $dir = implode($parts, '/');
+        $fs->mkdir($dir);
+        $testFilePath = $dir . '/' . $hash;
+        file_put_contents($testFilePath, $someJunk);
+        $file = $this->iliosFileSystem->getSymfonyFileForPath($testFilePath);
+        
+        $this->assertTrue($file instanceof File);
+        $this->assertSame($testFilePath, $file->getPathname());
+        $this->assertSame(file_get_contents($file->getPathname()), $someJunk);
+
+        $fs->remove($this->fakeTestFileDir . '/learning_materials');
     }
 }

--- a/src/Ilios/CoreBundle/Tests/Controller/DownloadControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/DownloadControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+namespace Ilios\CoreBundle\Tests\Controller;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use FOS\RestBundle\Util\Codes;
+
+use Ilios\CoreBundle\Tests\Traits\JsonControllerTest;
+
+/**
+ * Download controller Test.
+ * @package Ilios\CoreBundle\Test\Controller;
+ */
+class DownloadControllerTest extends WebTestCase
+{
+    use JsonControllerTest;
+
+    public function setUp()
+    {
+        $this->loadFixtures([
+            'Ilios\CoreBundle\Tests\Fixture\LoadLearningMaterialData'
+        ]);
+    }
+
+    public function tearDown()
+    {
+    }
+    
+    public function testDownloadLearningMaterial()
+    {
+        $client = $this->createClient();
+        $learningMaterials = $client->getContainer()
+            ->get('ilioscore.dataloader.learningmaterial')
+            ->getAll();
+        $fileLearningMaterials = array_filter($learningMaterials, function ($arr) {
+            return !empty($arr['relativePath']);
+        });
+        $learningMaterial = array_values($fileLearningMaterials)[0];
+
+        $client->request(
+            'GET',
+            '/lm/' . $learningMaterial['token']
+        );
+        
+        $response = $client->getResponse();
+        
+        $this->assertEquals(CODES::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        $learningMaterialLoaderPath = realpath(__DIR__ . '/../Fixture/LoadLearningMaterialData.php');
+        $this->assertEquals(file_get_contents($learningMaterialLoaderPath), $response->getContent());
+        
+    }
+    
+    public function testBadLearningMaterialToken()
+    {
+        $client = $this->createClient();
+        //sending bad hash
+        $client->request(
+            'GET',
+            '/lm/a7a8e202e9655ab81155c4c3e52b95098fcaa1c975f63f0327b467a981f6428f'
+        );
+        
+        $response = $client->getResponse();
+        $this->assertEquals(
+            CODES::HTTP_NOT_FOUND,
+            $response->getStatusCode()
+        );
+    }
+}

--- a/src/Ilios/CoreBundle/Tests/Controller/LearningMaterialControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/LearningMaterialControllerTest.php
@@ -114,6 +114,8 @@ class LearningMaterialControllerTest extends AbstractControllerTest
         $uploadDate = new DateTime($responseData['uploadDate']);
         unset($responseData['id']);
         unset($responseData['uploadDate']);
+        $this->assertEquals(64, strlen($responseData['token']));
+        unset($responseData['token']);
         $this->assertEquals(
             $data,
             $responseData,
@@ -143,6 +145,8 @@ class LearningMaterialControllerTest extends AbstractControllerTest
         unset($responseData['id']);
         unset($responseData['uploadDate']);
         unset($responseData['copyrightPermission']);
+        $this->assertEquals(64, strlen($responseData['token']));
+        unset($responseData['token']);
         $this->assertEquals(
             $data,
             $responseData,
@@ -172,6 +176,38 @@ class LearningMaterialControllerTest extends AbstractControllerTest
         unset($responseData['id']);
         unset($responseData['uploadDate']);
         unset($responseData['copyrightPermission']);
+        $this->assertEquals(64, strlen($responseData['token']));
+        unset($responseData['token']);
+        $this->assertEquals(
+            $data,
+            $responseData,
+            $response->getContent()
+        );
+        $now = new DateTime();
+        $diff = $now->diff($uploadDate);
+        $this->assertTrue($diff->i < 10, 'The uploadDate timestamp is within the last 10 minutes');
+    }
+
+    public function testPostLearningMaterialFile()
+    {
+        $data = $this->container->get('ilioscore.dataloader.learningmaterial')
+          ->createFile();
+        $this->createJsonRequest(
+            'POST',
+            $this->getUrl('post_learningmaterials'),
+            json_encode(['learningMaterial' => $data]),
+            $this->getAuthenticatedUserToken()
+        );
+
+        $response = $this->client->getResponse();
+
+        $this->assertEquals(Codes::HTTP_CREATED, $response->getStatusCode(), $response->getContent());
+        $responseData = json_decode($response->getContent(), true)['learningMaterials'][0];
+        $uploadDate = new DateTime($responseData['uploadDate']);
+        unset($responseData['id']);
+        unset($responseData['uploadDate']);
+        $this->assertEquals(64, strlen($responseData['token']));
+        unset($responseData['token']);
         $this->assertEquals(
             $data,
             $responseData,

--- a/src/Ilios/CoreBundle/Tests/DataLoader/LearningMaterialData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/LearningMaterialData.php
@@ -23,6 +23,7 @@ class LearningMaterialData extends AbstractDataLoader
             'copyrightPermission' => true,
             'sessionLearningMaterials' => [1],
             'courseLearningMaterials' => [1],
+            'token' => 'token1',
             'citation' => $this->faker->text,
         );
 
@@ -38,7 +39,27 @@ class LearningMaterialData extends AbstractDataLoader
             'copyrightPermission' => true,
             'sessionLearningMaterials' => [],
             'courseLearningMaterials' => [2],
+            'token' => 'token2',
             'link' => $this->faker->url,
+        );
+
+        $arr[] = array(
+            'id' => 3,
+            'title' => $this->faker->text(30),
+            'description' => $this->faker->text,
+            'originalAuthor' => $this->faker->name,
+            'userRole' => "2",
+            'status' => "1",
+            'owningUser' => "1",
+            'copyrightRationale' => $this->faker->text,
+            'copyrightPermission' => true,
+            'sessionLearningMaterials' => [],
+            'courseLearningMaterials' => [],
+            'token' => $this->faker->sha256,
+            'relativePath' => 'testfile',
+            'filename' => 'testfile.txt',
+            'mimetype' => 'text/plain',
+            'filesize' => 1000,
         );
 
         return $arr;
@@ -105,7 +126,22 @@ class LearningMaterialData extends AbstractDataLoader
      */
     public function createFile()
     {
-        throw new \Exception('Not implemented yet');
+        return array(
+            'title' => $this->faker->text(30),
+            'description' => $this->faker->text,
+            'originalAuthor' => $this->faker->name,
+            'userRole' => "2",
+            'status' => "1",
+            'owningUser' => "1",
+            'sessionLearningMaterials' => [],
+            'courseLearningMaterials' => [],
+            'copyrightRationale' => $this->faker->text,
+            'copyrightPermission' => true,
+            'relativePath' => 'testfile',
+            'filename' => 'testfile.txt',
+            'mimetype' => 'text/plain',
+            'filesize' => 1000,
+        );
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
@@ -16,7 +16,7 @@ class UserData extends AbstractDataLoader
             'email' => $this->faker->email,
             'phone' => $this->faker->phoneNumber,
             'enabled' => true,
-            'learningMaterials' => ['1', '2'],
+            'learningMaterials' => ['1', '2', '3'],
             'publishEvents' => [],
             'reports' => [],
             'school' => '1',


### PR DESCRIPTION
Tokens for learning materials are created automatically when new materials are created.  They are pretty random so we can rely on them to access files without any further authentication.

Old Ilios2 learning materials can be moved into v3 compatible locations using the ilios:setup:migrate-learning-materials command.  It takes the Ilios2 Source Root which is is where the relateive_file_path in the database expects to search for learning materials.

Materials can be downloaded at 
/lm/TOKEN.  Maybe this should be /download/lm/TOKEN, but the token is already 64 characters long so it might run into URL length  issues already.

Fixes #1019
