### PR TITLE
Fixes for API Issues

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20150914052024.php
+++ b/app/Resources/DoctrineMigrations/Version20150914052024.php
@@ -17,7 +17,7 @@ class Version20150914052024 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
         
-        $this->addSql('UPDATE authentication SET username=eppn');
+        $this->addSql('UPDATE authentication SET username=eppn WHERE eppn IS NOT NULL');
         $this->addSql('DROP INDEX UNIQ_FEB4C9FDFC7885D4 ON authentication');
         $this->addSql('ALTER TABLE authentication DROP eppn');
     }

--- a/src/Ilios/AuthenticationBundle/Voter/UserVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/UserVoter.php
@@ -61,7 +61,7 @@ class UserVoter extends AbstractVoter
                             $requestedUser->getAllSchools()->contains($user->getSchool())
                             || $this->permissionManager->userHasReadPermissionToSchools(
                                 $user,
-                                $requestedUser->getSchool->getAllSchools()
+                                $requestedUser->getAllSchools()
                             )
                         )
                     )
@@ -81,7 +81,7 @@ class UserVoter extends AbstractVoter
                         $requestedUser->getAllSchools()->contains($user->getSchool())
                         || $this->permissionManager->userHasReadPermissionToSchools(
                             $user,
-                            $requestedUser->getSchool->getAllSchools()
+                            $requestedUser->getAllSchools()
                         )
                     )
                 );

--- a/src/Ilios/CoreBundle/Controller/AamcMethodController.php
+++ b/src/Ilios/CoreBundle/Controller/AamcMethodController.php
@@ -140,7 +140,7 @@ class AamcMethodController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['aamcMethods'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/AamcPcrsController.php
+++ b/src/Ilios/CoreBundle/Controller/AamcPcrsController.php
@@ -140,7 +140,7 @@ class AamcPcrsController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['aamcPcrses'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/AlertChangeTypeController.php
+++ b/src/Ilios/CoreBundle/Controller/AlertChangeTypeController.php
@@ -140,7 +140,7 @@ class AlertChangeTypeController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['alertChangeTypes'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/AlertController.php
+++ b/src/Ilios/CoreBundle/Controller/AlertController.php
@@ -140,7 +140,7 @@ class AlertController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['alerts'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/AssessmentOptionController.php
+++ b/src/Ilios/CoreBundle/Controller/AssessmentOptionController.php
@@ -140,7 +140,7 @@ class AssessmentOptionController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['assessmentOptions'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CohortController.php
+++ b/src/Ilios/CoreBundle/Controller/CohortController.php
@@ -140,7 +140,7 @@ class CohortController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['cohorts'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CompetencyController.php
+++ b/src/Ilios/CoreBundle/Controller/CompetencyController.php
@@ -140,7 +140,7 @@ class CompetencyController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['competencies'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CourseClerkshipTypeController.php
+++ b/src/Ilios/CoreBundle/Controller/CourseClerkshipTypeController.php
@@ -140,7 +140,7 @@ class CourseClerkshipTypeController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['courseClerkshipTypes'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CourseController.php
+++ b/src/Ilios/CoreBundle/Controller/CourseController.php
@@ -140,7 +140,7 @@ class CourseController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['courses'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CourseLearningMaterialController.php
+++ b/src/Ilios/CoreBundle/Controller/CourseLearningMaterialController.php
@@ -140,7 +140,7 @@ class CourseLearningMaterialController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['courseLearningMaterials'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventoryAcademicLevelController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventoryAcademicLevelController.php
@@ -140,7 +140,7 @@ class CurriculumInventoryAcademicLevelController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['curriculumInventoryAcademicLevels'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventoryInstitutionController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventoryInstitutionController.php
@@ -140,7 +140,7 @@ class CurriculumInventoryInstitutionController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['curriculumInventoryInstitutions'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventoryReportController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventoryReportController.php
@@ -140,7 +140,7 @@ class CurriculumInventoryReportController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['curriculumInventoryReports'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceBlockController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceBlockController.php
@@ -140,7 +140,7 @@ class CurriculumInventorySequenceBlockController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['curriculumInventorySequenceBlocks'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceBlockSessionController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceBlockSessionController.php
@@ -140,7 +140,7 @@ class CurriculumInventorySequenceBlockSessionController extends FOSRestControlle
 
         //If there are no matches return an empty array
         $answer['curriculumInventorySequenceBlockSessions'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceController.php
@@ -140,7 +140,7 @@ class CurriculumInventorySequenceController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['curriculumInventorySequences'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/DepartmentController.php
+++ b/src/Ilios/CoreBundle/Controller/DepartmentController.php
@@ -140,7 +140,7 @@ class DepartmentController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['departments'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/IlmSessionController.php
+++ b/src/Ilios/CoreBundle/Controller/IlmSessionController.php
@@ -140,7 +140,7 @@ class IlmSessionController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['ilmSessions'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/IngestionExceptionController.php
+++ b/src/Ilios/CoreBundle/Controller/IngestionExceptionController.php
@@ -139,7 +139,7 @@ class IngestionExceptionController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['ingestionExceptions'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/InstructorGroupController.php
+++ b/src/Ilios/CoreBundle/Controller/InstructorGroupController.php
@@ -140,7 +140,7 @@ class InstructorGroupController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['instructorGroups'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/LearnerGroupController.php
+++ b/src/Ilios/CoreBundle/Controller/LearnerGroupController.php
@@ -140,7 +140,7 @@ class LearnerGroupController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['learnerGroups'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
+++ b/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
@@ -146,7 +146,7 @@ class LearningMaterialController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['learningMaterials'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/LearningMaterialStatusController.php
+++ b/src/Ilios/CoreBundle/Controller/LearningMaterialStatusController.php
@@ -140,7 +140,7 @@ class LearningMaterialStatusController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['learningMaterialStatuses'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/LearningMaterialUserRoleController.php
+++ b/src/Ilios/CoreBundle/Controller/LearningMaterialUserRoleController.php
@@ -140,7 +140,7 @@ class LearningMaterialUserRoleController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['learningMaterialUserRoles'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/MeshConceptController.php
+++ b/src/Ilios/CoreBundle/Controller/MeshConceptController.php
@@ -139,7 +139,7 @@ class MeshConceptController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['meshConcepts'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/MeshDescriptorController.php
+++ b/src/Ilios/CoreBundle/Controller/MeshDescriptorController.php
@@ -155,7 +155,7 @@ class MeshDescriptorController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['meshDescriptors'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/MeshPreviousIndexingController.php
+++ b/src/Ilios/CoreBundle/Controller/MeshPreviousIndexingController.php
@@ -139,7 +139,7 @@ class MeshPreviousIndexingController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['meshPreviousIndexings'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/MeshQualifierController.php
+++ b/src/Ilios/CoreBundle/Controller/MeshQualifierController.php
@@ -139,7 +139,7 @@ class MeshQualifierController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['meshQualifiers'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/MeshSemanticTypeController.php
+++ b/src/Ilios/CoreBundle/Controller/MeshSemanticTypeController.php
@@ -155,7 +155,7 @@ class MeshSemanticTypeController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['meshSemanticTypes'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/MeshTermController.php
+++ b/src/Ilios/CoreBundle/Controller/MeshTermController.php
@@ -139,7 +139,7 @@ class MeshTermController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['meshTerms'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/MeshTreeController.php
+++ b/src/Ilios/CoreBundle/Controller/MeshTreeController.php
@@ -139,7 +139,7 @@ class MeshTreeController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['meshTrees'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/ObjectiveController.php
+++ b/src/Ilios/CoreBundle/Controller/ObjectiveController.php
@@ -140,7 +140,7 @@ class ObjectiveController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['objectives'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/OfferingController.php
+++ b/src/Ilios/CoreBundle/Controller/OfferingController.php
@@ -149,7 +149,7 @@ class OfferingController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['offerings'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/PendingUserUpdateController.php
+++ b/src/Ilios/CoreBundle/Controller/PendingUserUpdateController.php
@@ -139,7 +139,7 @@ class PendingUserUpdateController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['pendingUserUpdates'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/ProgramController.php
+++ b/src/Ilios/CoreBundle/Controller/ProgramController.php
@@ -140,7 +140,7 @@ class ProgramController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['programs'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/ProgramYearController.php
+++ b/src/Ilios/CoreBundle/Controller/ProgramYearController.php
@@ -140,7 +140,7 @@ class ProgramYearController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['programYears'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/ProgramYearStewardController.php
+++ b/src/Ilios/CoreBundle/Controller/ProgramYearStewardController.php
@@ -140,7 +140,7 @@ class ProgramYearStewardController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['programYearStewards'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/PublishEventController.php
+++ b/src/Ilios/CoreBundle/Controller/PublishEventController.php
@@ -144,7 +144,7 @@ class PublishEventController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['publishEvents'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/ReportController.php
+++ b/src/Ilios/CoreBundle/Controller/ReportController.php
@@ -143,7 +143,7 @@ class ReportController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['reports'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/SchoolController.php
+++ b/src/Ilios/CoreBundle/Controller/SchoolController.php
@@ -140,7 +140,7 @@ class SchoolController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['schools'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/SchooleventsController.php
+++ b/src/Ilios/CoreBundle/Controller/SchooleventsController.php
@@ -88,7 +88,7 @@ class SchooleventsController extends FOSRestController
         });
 
         //If there are no matches return an empty array
-        $answer['events'] = $result ? $result : new ArrayCollection([]);
+        $answer['events'] = $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/SessionController.php
+++ b/src/Ilios/CoreBundle/Controller/SessionController.php
@@ -143,7 +143,7 @@ class SessionController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['sessions'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/SessionDescriptionController.php
+++ b/src/Ilios/CoreBundle/Controller/SessionDescriptionController.php
@@ -140,7 +140,7 @@ class SessionDescriptionController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['sessionDescriptions'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/SessionLearningMaterialController.php
+++ b/src/Ilios/CoreBundle/Controller/SessionLearningMaterialController.php
@@ -140,7 +140,7 @@ class SessionLearningMaterialController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['sessionLearningMaterials'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/SessionTypeController.php
+++ b/src/Ilios/CoreBundle/Controller/SessionTypeController.php
@@ -140,7 +140,7 @@ class SessionTypeController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['sessionTypes'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/TopicController.php
+++ b/src/Ilios/CoreBundle/Controller/TopicController.php
@@ -140,7 +140,7 @@ class TopicController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['topics'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/UserController.php
+++ b/src/Ilios/CoreBundle/Controller/UserController.php
@@ -154,7 +154,7 @@ class UserController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['users'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/UserMadeReminderController.php
+++ b/src/Ilios/CoreBundle/Controller/UserMadeReminderController.php
@@ -146,7 +146,7 @@ class UserMadeReminderController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['userMadeReminders'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/UserRoleController.php
+++ b/src/Ilios/CoreBundle/Controller/UserRoleController.php
@@ -140,7 +140,7 @@ class UserRoleController extends FOSRestController
 
         //If there are no matches return an empty array
         $answer['userRoles'] =
-            $result ? $result : new ArrayCollection([]);
+            $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Controller/UsereventController.php
+++ b/src/Ilios/CoreBundle/Controller/UsereventController.php
@@ -95,7 +95,7 @@ class UsereventController extends FOSRestController
         });
 
         //If there are no matches return an empty array
-        $answer['userEvents'] = $result ? $result : new ArrayCollection([]);
+        $answer['userEvents'] = $result ? array_values($result) : [];
 
         return $answer;
     }

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
@@ -133,8 +133,8 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
             'user'          => $user,
         ];
 
-        $schoolsWithReadPermission = $this->findPermissionBy($criteria);
-        $overlap = array_intersect($schools->toArray(), $schoolsWithReadPermission->toArray());
+        $schoolsWithReadPermission = $this->findPermissionsBy($criteria);
+        $overlap = array_intersect($schools->toArray(), $schoolsWithReadPermission);
 
         return ! empty($overlap);
 


### PR DESCRIPTION
When data gets filtered for access permissions in any of the controller
cget actions we need to re-index the returned data otherwise the
process of converting it to JSON uses an object instead of an array.

Fixes #1029

Fixed some bad code in the user voter and permission manager.

Fixed the eppn migration, it was destroying all usernames.  Now it should pretty much do nothing.