### PR TITLE
Handle deleted offerings in the user API

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -76,7 +76,11 @@ fos_rest:
         codes:
             'Symfony\Component\HttpKernel\Exception\NotFoundHttpException': 404
             'Symfony\Component\Routing\Exception\ResourceNotFoundException': 404
+            'Ilios\CoreBundle\Exception\InvalidInputWithSafeUserMessageException': 400
             'Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException': 500
+        messages:
+            'Ilios\CoreBundle\Exception\InvalidInputWithSafeUserMessageException': true
+
 
 nelmio_cors:
     defaults:

--- a/src/Ilios/CoreBundle/Controller/SchooleventsController.php
+++ b/src/Ilios/CoreBundle/Controller/SchooleventsController.php
@@ -6,18 +6,12 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\RouteResource;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
-use FOS\RestBundle\Util\Codes;
-use FOS\RestBundle\View\View as FOSView;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
+use Ilios\CoreBundle\Exception\InvalidInputWithSafeUserMessageException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use FOS\RestBundle\Controller\FOSRestController;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use DateTime;
-use Exception;
 
 /**
  * School event.
@@ -71,10 +65,10 @@ class SchooleventsController extends FOSRestController
         $from = DateTime::createFromFormat('U', $fromTimestamp);
         $to = DateTime::createFromFormat('U', $toTimestamp);
         if (!$from) {
-            throw new Exception("'from' is not a valid timstamp");
+            throw new InvalidInputWithSafeUserMessageException("?from is missing or is not a valid timestamp");
         }
         if (!$to) {
-            throw new Exception("'to' is not a valid timstamp");
+            throw new InvalidInputWithSafeUserMessageException("?to is missing or is not a valid timestamp");
         }
         $result = $schoolHandler->findEventsForSchool(
             $school->getId(),

--- a/src/Ilios/CoreBundle/Controller/UsereventController.php
+++ b/src/Ilios/CoreBundle/Controller/UsereventController.php
@@ -6,18 +6,12 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\RouteResource;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
-use FOS\RestBundle\Util\Codes;
-use FOS\RestBundle\View\View as FOSView;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
+use Ilios\CoreBundle\Exception\InvalidInputWithSafeUserMessageException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use FOS\RestBundle\Controller\FOSRestController;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use DateTime;
-use Exception;
 
 /**
  * User event controller
@@ -57,6 +51,8 @@ class UsereventController extends FOSRestController
    *   requirements="\d+",
    *   description="Time stamp for last event from time"
    * )
+   *
+   * @throws Exception
    */
     public function getAction($id, ParamFetcherInterface $paramFetcher)
     {
@@ -78,10 +74,10 @@ class UsereventController extends FOSRestController
         $from = DateTime::createFromFormat('U', $fromTimestamp);
         $to = DateTime::createFromFormat('U', $toTimestamp);
         if (!$from) {
-            throw new Exception("'from' is not a valid timstamp");
+            throw new InvalidInputWithSafeUserMessageException("?from is missing or is not a valid timestamp");
         }
         if (!$to) {
-            throw new Exception("'to' is not a valid timstamp");
+            throw new InvalidInputWithSafeUserMessageException("?to is missing or is not a valid timestamp");
         }
         $result = $userHandler->findEventsForUser(
             $user->getId(),

--- a/src/Ilios/CoreBundle/Entity/IlmSession.php
+++ b/src/Ilios/CoreBundle/Entity/IlmSession.php
@@ -336,4 +336,12 @@ class IlmSession implements IlmSessionInterface
     {
         return $this->session;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function isDeleted()
+    {
+        return $this->getSession()->isDeleted();
+    }
 }

--- a/src/Ilios/CoreBundle/Entity/IlmSessionInterface.php
+++ b/src/Ilios/CoreBundle/Entity/IlmSessionInterface.php
@@ -105,4 +105,10 @@ interface IlmSessionInterface extends
      * @return SessionInterface
      */
     public function getSession();
+
+    /**
+     * Checks if the session we belong to is deleted
+     * @return boolean
+     */
+    public function isDeleted();
 }

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -474,25 +474,26 @@ class User implements UserInterface
      */
     public function __construct()
     {
-        $this->reminders            = new ArrayCollection();
-        $this->directedCourses      = new ArrayCollection();
-        $this->learnerGroups        = new ArrayCollection();
-        $this->instructorUserGroups = new ArrayCollection();
-        $this->instructorGroups     = new ArrayCollection();
-        $this->offerings            = new ArrayCollection();
-        $this->instructedOfferings  = new ArrayCollection();
-        $this->programYears         = new ArrayCollection();
-        $this->alerts               = new ArrayCollection();
-        $this->roles                = new ArrayCollection();
-        $this->learningMaterials    = new ArrayCollection();
-        $this->publishEvents        = new ArrayCollection();
-        $this->reports              = new ArrayCollection();
-        $this->cohorts              = new ArrayCollection();
-        $this->pendingUserUpdates   = new ArrayCollection();
-        $this->addedViaIlios = false;
-        $this->enabled = true;
-        $this->examined = false;
-        $this->userSyncIgnore = false;
+        $this->reminders                = new ArrayCollection();
+        $this->directedCourses          = new ArrayCollection();
+        $this->learnerGroups            = new ArrayCollection();
+        $this->instructorUserGroups     = new ArrayCollection();
+        $this->instructorGroups         = new ArrayCollection();
+        $this->offerings                = new ArrayCollection();
+        $this->instructedOfferings      = new ArrayCollection();
+        $this->instructorIlmSessions    = new ArrayCollection();
+        $this->programYears             = new ArrayCollection();
+        $this->alerts                   = new ArrayCollection();
+        $this->roles                    = new ArrayCollection();
+        $this->learningMaterials        = new ArrayCollection();
+        $this->publishEvents            = new ArrayCollection();
+        $this->reports                  = new ArrayCollection();
+        $this->cohorts                  = new ArrayCollection();
+        $this->pendingUserUpdates       = new ArrayCollection();
+        $this->addedViaIlios            = false;
+        $this->enabled                  = true;
+        $this->examined                 = false;
+        $this->userSyncIgnore           = false;
         
         $this->generateIcsFeedKey();
     }
@@ -869,14 +870,14 @@ class User implements UserInterface
         $this->instructorIlmSessions = new ArrayCollection();
 
         foreach ($sessions as $session) {
-            $this->addInstructorIlmSessions($session);
+            $this->addInstructorIlmSession($session);
         }
     }
 
     /**
      * @param IlmSessionInterface $session
      */
-    public function addInstructorIlmSessions(IlmSessionInterface $session)
+    public function addInstructorIlmSession(IlmSessionInterface $session)
     {
         $this->instructorIlmSessions->add($session);
     }
@@ -886,7 +887,19 @@ class User implements UserInterface
      */
     public function getInstructorIlmSessions()
     {
-        return $this->instructorIlmSessions;
+
+        //criteria not 100% reliable on many to many relationships
+        //fix in https://github.com/doctrine/doctrine2/pull/1399
+        // $criteria = Criteria::create()->where(Criteria::expr()->eq("deleted", false));
+        // return new ArrayCollection($this->directedCourses->matching($criteria)->getValues());
+
+        $arr = $this->instructorIlmSessions->filter(function (IlmSessionInterface $entity) {
+            return !$entity->isDeleted();
+        })->toArray();
+
+        $reIndexed = array_values($arr);
+
+        return new ArrayCollection($reIndexed);
     }
 
 
@@ -1146,7 +1159,18 @@ class User implements UserInterface
      */
     public function getInstructedOfferings()
     {
-        return $this->instructedOfferings;
+        //criteria not 100% reliable on many to many relationships
+        //fix in https://github.com/doctrine/doctrine2/pull/1399
+        // $criteria = Criteria::create()->where(Criteria::expr()->eq("deleted", false));
+        // return new ArrayCollection($this->instructedOfferings->matching($criteria)->getValues());
+
+        $arr = $this->instructedOfferings->filter(function ($entity) {
+            return !$entity->isDeleted();
+        })->toArray();
+
+        $reIndexed = array_values($arr);
+
+        return new ArrayCollection($reIndexed);
     }
 
     /**

--- a/src/Ilios/CoreBundle/Exception/InvalidInputWithSafeUserMessageException.php
+++ b/src/Ilios/CoreBundle/Exception/InvalidInputWithSafeUserMessageException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Ilios\CoreBundle\Exception;
+
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class InvalidInputWithSafeUserMessageException extends BadRequestHttpException
+{
+}

--- a/src/Ilios/CoreBundle/Tests/Entity/UserTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/UserTest.php
@@ -398,7 +398,7 @@ class UserTest extends EntityBase
      */
     public function testAddInstructedOffering()
     {
-        $this->entityCollectionAddTest('instructedOffering', 'Offering');
+        $this->softDeleteEntityCollectionAddTest('instructedOffering', 'Offering');
     }
 
     /**
@@ -406,7 +406,23 @@ class UserTest extends EntityBase
      */
     public function testSetInstructedOffering()
     {
-        $this->entityCollectionSetTest('instructedOffering', 'Offering');
+        $this->softDeleteEntityCollectionSetTest('instructedOffering', 'Offering');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\User::addInstructorIlmSession
+     */
+    public function testAddInstructorIlmSessions()
+    {
+        $this->softDeleteEntityCollectionAddTest('instructorIlmSession', 'IlmSession');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\User::getInstructorIlmSessions
+     */
+    public function testGetInstructorIlmSessions()
+    {
+        $this->softDeleteEntityCollectionSetTest('instructorIlmSession', 'IlmSession');
     }
 
     /**


### PR DESCRIPTION
The main fix is that user instructedOfferings and instructedIlmSessions no longer return deleted offerings or sessions.  

I also added `InvalidInputWithSafeUserMessageException` which when thrown results in a 400 error and the display of the exception message to the API user.