### PR TITLE
Fix commands and broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ install:
   - composer install --no-interaction --prefer-dist -d ${TRAVIS_BUILD_DIR}
 
 before_script:
-#increase our PHP memory limit so test coverage will work
-  - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 #initialize symfony mysql db
   - bin/console doctrine:database:drop --force --env=dev
   - bin/console doctrine:database:create --env=dev

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -42,6 +42,7 @@ doctrine:
         user:     "%database_user%"
         password: "%database_password%"
         charset:  UTF8
+        server_version: "%database_mysql_version%"
         # if using pdo_sqlite as your database driver, add the path in parameters.yml
         # e.g. database_path: "%kernel.root_dir%/data/data.db3"
         # path:     "%database_path%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,10 +1,11 @@
 parameters:
-    database_driver:   pdo_mysql
-    database_host:     127.0.0.1
-    database_port:     ~
-    database_name:     ilios
-    database_user:     ilios_user
-    database_password: ilios_pass
+    database_driver:        pdo_mysql
+    database_host:          127.0.0.1
+    database_port:          ~
+    database_name:          ilios
+    database_user:          ilios_user
+    database_password:      ilios_pass
+    database_mysql_version: 5.5
 
     mailer_transport:  smtp
     mailer_host:       127.0.0.1

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -6,6 +6,7 @@ parameters:
     database_name: ilios
     database_user: travis
     database_password: ~
+    database_mysql_version: 5.5
     mailer_transport: smtp
     mailer_host: 127.0.0.1
     mailer_user: null

--- a/src/Ilios/CliBundle/Tests/Command/SendTeachingRemindersCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SendTeachingRemindersCommandTest.php
@@ -84,7 +84,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios/CliBundle/Command/SendTeachingReminderCommand::execute
+     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteDryRun()
     {
@@ -155,7 +155,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios/CliBundle/Command/SendTeachingReminderCommand::execute
+     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteDryRunWithNoResult()
     {
@@ -175,7 +175,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios/CliBundle/Command/SendTeachingReminderCommand::execute
+     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteDryRunWithCustomSubject()
     {
@@ -196,7 +196,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios/CliBundle/Command/SendTeachingReminderCommand::execute
+     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecute()
     {
@@ -214,7 +214,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios/CliBundle/Command/SendTeachingReminderCommand::execute
+     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteWithMissingInput()
     {
@@ -229,7 +229,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios/CliBundle/Command/SendTeachingReminderCommand::execute
+     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteWithInvalidInput()
     {


### PR DESCRIPTION
As a result of #1035 and some mysterious internal symphony and doctrine voodoo all of our commands will fail when a database is not present including the command to create a database.  This happens when the UserEntityProvider we use for authentication attempts to detect the version of mysql we are running.  The best (only) way I could find to combat this is to explicit declare a mysql version in our configuration.