### PR TITLE
change alerts command.

### DIFF
--- a/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
+++ b/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
@@ -129,7 +129,7 @@ class SendChangeAlertsCommand extends Command
             }
 
             $schools = $alert->getRecipients();
-            if($schools->isEmpty()) {
+            if ($schools->isEmpty()) {
                 $output->writeln("<error>No alert recipient for offering change alert {$alert->getId()}.</error>");
                 continue;
             }

--- a/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
+++ b/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Ilios\CoreBundle\Entity\Manager\AlertManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\OfferingManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\SchoolManagerInterface;
+use Ilios\CoreBundle\Entity\OfferingInterface;
+use Ilios\CoreBundle\Entity\SchoolInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+/**
+ * Sends change alerts emails.
+ *
+ * Class SendChangeAlertsCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class SendChangeAlertsCommand extends Command
+{
+    /**
+     * @var string
+     */
+    const DEFAULT_TEMPLATE_NAME = 'changealert.text.twig';
+
+    /**
+     * @var AlertManagerInterface
+     */
+    protected $alertManager;
+    /**
+     * @var SchoolManagerInterface
+     */
+    protected $schoolManager;
+
+    /**
+     * @var OfferingManagerInterface
+     */
+    protected $offeringManager;
+
+    /**
+     * @var EngineInterface
+     */
+    protected $templatingEngine;
+
+    /**
+     * @var \Swift_Mailer
+     */
+    protected $mailer;
+
+    /**
+     * @param AlertManagerInterface $alertManager
+     * @param SchoolManagerInterface $schoolManager
+     * @param OfferingManagerInterface $offeringManager
+     * @param \Symfony\Component\Templating\EngineInterface
+     * @param \Swift_Mailer $mailer
+     */
+    public function __construct(
+        AlertManagerInterface $alertManager,
+        SchoolManagerInterface $schoolManager,
+        OfferingManagerInterface $offeringManager,
+        EngineInterface $templatingEngine,
+        $mailer
+    ) {
+        parent::__construct();
+        $this->alertManager = $alertManager;
+        $this->schoolManager = $schoolManager;
+        $this->offeringManager = $offeringManager;
+        $this->templatingEngine = $templatingEngine;
+        $this->mailer = $mailer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:messaging:send-change-alerts')
+            ->setDescription('Sends change alerts on a per-school basis to configured recipients.')
+            ->addOption(
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                'Print out alerts instead of emailing them. Useful for testing/debugging purposes.'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $isDryRun = $input->getOption('dry-run');
+
+        $alerts = $this->alertManager->findAlertsBy(['dispatched' => false, 'tableName' => 'offering']);
+        if (count($alerts)) {
+            $output->writeln("<info>No undispatched offering alerts found.</info>");
+            return;
+        }
+
+        $templateCache = [];
+
+        $sent = 0;
+        // email out change alerts
+        foreach ($alerts as $alert) {
+            $output->writeln("<info>Processing offering change alert {$alert->getId()}.</info>");
+            $offering = $this->offeringManager->findOfferingBy(['id' => $alert->getTableRowId()]);
+            if (! $offering) {
+                $output->writeln(
+                    "<warning>No offering with id {$alert->getTableRowId()},"
+                    . " unable to send change alert with id {$alert->getId()}.</warning>"
+                );
+                continue;
+            }
+
+            $deleted = $offering->getSession()->isDeleted()
+                || $offering->getSession()->getCourse()->isDeleted()
+                || ! $offering->getSession()->getCourse()->getSchool();
+
+            if ($deleted) {
+                // @todo print another warning here? [ST 2015/09/30]
+                continue;
+            }
+
+            $schools = $alert->getRecipients();
+            /** @var SchoolInterface $school */
+            $recipients = [];
+            foreach($schools->toArray() as $school) {
+                $schoolRecipients = trim($school->getChangeAlertRecipients());
+                if ('' === $schoolRecipients) {
+                    continue;
+                }
+                $recipients = array_merge($recipients, array_map('trim', explode(',', strtolower($schoolRecipients))));
+            }
+            array_unique($recipients);
+            if (empty($recipients)) {
+                $output->writeln("<error>No alert recipients for offering change alert {$alert->getId()}.</error>");
+                continue;
+            }
+
+            $subject = $offering->getSession()->getCourse()->getExternalId() . ' - '
+                . $offering->getStartDate()->format('m/d/Y');
+
+
+            $school = $offering->getSession()->getCourse()->getSchool();
+            if (! array_key_exists($school->getId(), $templateCache)) {
+                $template = $this->getTemplatePath($school);
+                $templateCache[$school->getId()] = $template;
+            }
+            $messageBody = $this->templatingEngine->render($template, [
+                'alert' => $alert,
+                'offering' => $offering,
+            ]);
+
+            $message = \Swift_Message::newInstance()
+                ->setSubject($subject)
+                ->setTo($recipients)
+                ->setFrom($offering->getSession()->getCourse()->getSchool()->getIliosAdministratorEmail())
+                ->setContentType('text/plain')
+                ->setBody($messageBody)
+                ->setMaxLineLength(998);
+
+            if ($isDryRun) {
+                $output->writeln($message->getHeaders()->toString());
+                $output->writeln($message->getBody());
+            } else {
+                $this->mailer->send($message);
+            }
+            $sent++;
+        }
+        // mark all alerts as dispatched
+        if ($isDryRun) {
+            foreach ($alerts as $alert) {
+                $alert->setDispatched(true);
+                $this->alertManager->updateAlert($alert);
+            }
+        }
+        $dispatched = count($alerts);
+
+        $output->writeln("<info>Sent {$sent} offering change alert notifications.</info>");
+        $output->writeln("<info>Marked {$dispatched}) offering change alerts as dispatched.</info>");
+    }
+
+    /**
+     * Locates the applicable message template for a given school and returns its path.
+     * @param SchoolInterface $school
+     * @return string The template path.
+     */
+    protected function getTemplatePath(SchoolInterface $school)
+    {
+        $paths = [
+            '@custom_email_templates/' . basename($school->getTemplatePrefix() . '_' . self::DEFAULT_TEMPLATE_NAME),
+            '@custom_email_templates/' . self::DEFAULT_TEMPLATE_NAME,
+        ];
+        foreach ($paths as $path) {
+            if ($this->templatingEngine->exists($path)) {
+                return $path;
+            }
+        }
+        return 'IliosCoreBundle:Email:' .self::DEFAULT_TEMPLATE_NAME;
+    }
+}

--- a/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
+++ b/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
@@ -186,20 +186,20 @@ class SendChangeAlertsCommand extends Command
             }
             $sent++;
         }
-        // Mark all alerts as dispatched, regardless as to whether an actual email
-        // was sent or not.
-        // This is consistent with the Ilios v2 implementation of this process.
-        // @todo Reassess the validity of this step. [ST 2015/10/01]
-        if ($isDryRun) {
+        if (! $isDryRun) {
+            // Mark all alerts as dispatched, regardless as to whether an actual email
+            // was sent or not.
+            // This is consistent with the Ilios v2 implementation of this process.
+            // @todo Reassess the validity of this step. [ST 2015/10/01]
             foreach ($alerts as $alert) {
                 $alert->setDispatched(true);
                 $this->alertManager->updateAlert($alert);
             }
-        }
-        $dispatched = count($alerts);
 
-        $output->writeln("<info>Sent {$sent} offering change alert notifications.</info>");
-        $output->writeln("<info>Marked {$dispatched} offering change alerts as dispatched.</info>");
+            $dispatched = count($alerts);
+            $output->writeln("<info>Sent {$sent} offering change alert notifications.</info>");
+            $output->writeln("<info>Marked {$dispatched} offering change alerts as dispatched.</info>");
+        }
     }
 
     /**

--- a/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
+++ b/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
@@ -4,8 +4,6 @@ namespace Ilios\CliBundle\Command;
 
 use Ilios\CoreBundle\Entity\Manager\AlertManagerInterface;
 use Ilios\CoreBundle\Entity\Manager\OfferingManagerInterface;
-use Ilios\CoreBundle\Entity\Manager\SchoolManagerInterface;
-use Ilios\CoreBundle\Entity\OfferingInterface;
 use Ilios\CoreBundle\Entity\SchoolInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -25,16 +23,12 @@ class SendChangeAlertsCommand extends Command
     /**
      * @var string
      */
-    const DEFAULT_TEMPLATE_NAME = 'changealert.text.twig';
+    const DEFAULT_TEMPLATE_NAME = 'offeringchangealert.text.twig';
 
     /**
      * @var AlertManagerInterface
      */
     protected $alertManager;
-    /**
-     * @var SchoolManagerInterface
-     */
-    protected $schoolManager;
 
     /**
      * @var OfferingManagerInterface
@@ -53,21 +47,18 @@ class SendChangeAlertsCommand extends Command
 
     /**
      * @param AlertManagerInterface $alertManager
-     * @param SchoolManagerInterface $schoolManager
      * @param OfferingManagerInterface $offeringManager
      * @param \Symfony\Component\Templating\EngineInterface
      * @param \Swift_Mailer $mailer
      */
     public function __construct(
         AlertManagerInterface $alertManager,
-        SchoolManagerInterface $schoolManager,
         OfferingManagerInterface $offeringManager,
         EngineInterface $templatingEngine,
         $mailer
     ) {
         parent::__construct();
         $this->alertManager = $alertManager;
-        $this->schoolManager = $schoolManager;
         $this->offeringManager = $offeringManager;
         $this->templatingEngine = $templatingEngine;
         $this->mailer = $mailer;
@@ -145,12 +136,12 @@ class SendChangeAlertsCommand extends Command
             $subject = $offering->getSession()->getCourse()->getExternalId() . ' - '
                 . $offering->getStartDate()->format('m/d/Y');
 
-
             $school = $offering->getSession()->getCourse()->getSchool();
             if (! array_key_exists($school->getId(), $templateCache)) {
                 $template = $this->getTemplatePath($school);
                 $templateCache[$school->getId()] = $template;
             }
+            $template = $templateCache[$school->getId()];
             $messageBody = $this->templatingEngine->render($template, [
                 'alert' => $alert,
                 'offering' => $offering,

--- a/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
+++ b/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
@@ -82,7 +82,7 @@ class SendChangeAlertsCommand extends Command
     {
         $this
             ->setName('ilios:messaging:send-change-alerts')
-            ->setDescription('Sends change alerts on a per-school basis to configured recipients.')
+            ->setDescription('Sends out change alert message to configured email recipients.')
             ->addOption(
                 'dry-run',
                 null,

--- a/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
+++ b/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
@@ -99,7 +99,7 @@ class SendChangeAlertsCommand extends Command
         $isDryRun = $input->getOption('dry-run');
 
         $alerts = $this->alertManager->findAlertsBy(['dispatched' => false, 'tableName' => 'offering']);
-        if (count($alerts)) {
+        if (! count($alerts)) {
             $output->writeln("<info>No undispatched offering alerts found.</info>");
             return;
         }
@@ -132,7 +132,7 @@ class SendChangeAlertsCommand extends Command
             $history = $this->auditLogManager->findAuditLogsBy([
                 'objectId' => $alert->getId(),
                 'objectClass' => 'alert',
-            ], [ 'createdAt' ]);
+            ], [ 'createdAt' => 'asc']);
             $history = array_filter($history, function (AuditLogInterface $auditLog) {
                 $user =  $auditLog->getUser();
                 return isset($user);
@@ -199,7 +199,7 @@ class SendChangeAlertsCommand extends Command
         $dispatched = count($alerts);
 
         $output->writeln("<info>Sent {$sent} offering change alert notifications.</info>");
-        $output->writeln("<info>Marked {$dispatched}) offering change alerts as dispatched.</info>");
+        $output->writeln("<info>Marked {$dispatched} offering change alerts as dispatched.</info>");
     }
 
     /**

--- a/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
+++ b/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
@@ -132,7 +132,7 @@ class SendChangeAlertsCommand extends Command
             $history = $this->auditLogManager->findAuditLogsBy([
                 'objectId' => $alert->getId(),
                 'objectClass' => 'alert',
-            ], [ 'createdAt' => 'asc']);
+            ], [ 'createdAt' => 'asc' ]);
             $history = array_filter($history, function (AuditLogInterface $auditLog) {
                 $user =  $auditLog->getUser();
                 return isset($user);

--- a/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
+++ b/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
@@ -128,16 +128,6 @@ class SendChangeAlertsCommand extends Command
                 continue;
             }
 
-            // get change alert history from audit logs
-            $history = $this->auditLogManager->findAuditLogsBy([
-                'objectId' => $alert->getId(),
-                'objectClass' => 'alert',
-            ], [ 'createdAt' => 'asc' ]);
-            $history = array_filter($history, function (AuditLogInterface $auditLog) {
-                $user =  $auditLog->getUser();
-                return isset($user);
-            });
-
             // convoluted way of identifying alert recipients
             $schools = $alert->getRecipients();
             /** @var SchoolInterface $school */
@@ -154,6 +144,16 @@ class SendChangeAlertsCommand extends Command
                 $output->writeln("<error>No alert recipients for offering change alert {$alert->getId()}.</error>");
                 continue;
             }
+
+            // get change alert history from audit logs
+            $history = $this->auditLogManager->findAuditLogsBy([
+                'objectId' => $alert->getId(),
+                'objectClass' => 'alert',
+            ], [ 'createdAt' => 'asc' ]);
+            $history = array_filter($history, function (AuditLogInterface $auditLog) {
+                $user =  $auditLog->getUser();
+                return isset($user);
+            });
 
             $subject = $offering->getSession()->getCourse()->getExternalId() . ' - '
                 . $offering->getStartDate()->format('m/d/Y');

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -49,3 +49,8 @@ services:
         arguments: ["@ilioscore.offering.manager", "@templating", "@mailer"]
         tags:
             -  { name: console.command }
+    ilioscli.command.send_change_alerts:
+        class: Ilios\CliBundle\Command\SendChangeAlertsCommand
+        arguments: ["@ilioscore.alert.manager", "@ilioscore.offering.manager", "@templating", "@mailer"]
+        tags:
+            -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -51,6 +51,6 @@ services:
             -  { name: console.command }
     ilioscli.command.send_change_alerts:
         class: Ilios\CliBundle\Command\SendChangeAlertsCommand
-        arguments: ["@ilioscore.alert.manager", "@ilioscore.offering.manager", "@templating", "@mailer"]
+        arguments: ["@ilioscore.alert.manager", "@ilioscore.auditlog.manager", "@ilioscore.offering.manager", "@templating", "@mailer"]
         tags:
             -  { name: console.command }

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -44,7 +44,7 @@ services:
         arguments: ["@filesystem", "@ilioscore.filesystem", "@ilioscore.learningmaterial.manager"]
         tags:
             -  { name: console.command }
-    ilioscli.command.sent_teaching_reminders:
+    ilioscli.command.send_teaching_reminders:
         class: Ilios\CliBundle\Command\SendTeachingRemindersCommand
         arguments: ["@ilioscore.offering.manager", "@templating", "@mailer"]
         tags:

--- a/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
@@ -180,10 +180,11 @@ class SendChangeAlertsCommandTest extends KernelTestCase
      */
     public function testExecute(AlertInterface $alert, OfferingInterface $offering, array $auditLogs)
     {
-        $this->alertManager
-            ->shouldReceive('findAlertsBy')->andReturn([ $alert ])
-            ->shouldReceive('updateAlert');
-        $this->offeringManager->shouldReceive('findOfferingBy')->with([ "id" => $offering->getId() ])->andReturn($offering);
+        $this->alertManager->shouldReceive('findAlertsBy')->andReturn([ $alert ])->shouldReceive('updateAlert');
+        $this->offeringManager
+            ->shouldReceive('findOfferingBy')
+            ->with([ "id" => $offering->getId() ])
+            ->andReturn($offering);
         $this->auditLogManager
             ->shouldReceive('findAuditLogsBy')
             ->with([ 'objectId' => $alert->getId(), 'objectClass' => 'alert' ], [ 'createdAt' => 'asc' ])
@@ -215,10 +216,11 @@ class SendChangeAlertsCommandTest extends KernelTestCase
      */
     public function testExecuteNoRecipientsConfigured(AlertInterface $alert, OfferingInterface $offering)
     {
-        $this->alertManager
-            ->shouldReceive('findAlertsBy')->andReturn([ $alert ])
-            ->shouldReceive('updateAlert');
-        $this->offeringManager->shouldReceive('findOfferingBy')->with([ "id" => $offering->getId() ])->andReturn($offering);
+        $this->alertManager->shouldReceive('findAlertsBy')->andReturn([ $alert ])->shouldReceive('updateAlert');
+        $this->offeringManager
+            ->shouldReceive('findOfferingBy')
+            ->with([ "id" => $offering->getId() ])
+            ->andReturn($offering);
 
         $this->commandTester->execute([]);
         $output = $this->commandTester->getDisplay();
@@ -238,9 +240,11 @@ class SendChangeAlertsCommandTest extends KernelTestCase
     public function testExecuteDeletedOffering(AlertInterface $alert, OfferingInterface $offering)
     {
         $this->alertManager
-            ->shouldReceive('findAlertsBy')->andReturn([ $alert ])
-            ->shouldReceive('updateAlert');
-        $this->offeringManager->shouldReceive('findOfferingBy')->with([ "id" => $offering->getId() ])->andReturn($offering);
+            ->shouldReceive('findAlertsBy')->andReturn([ $alert ])->shouldReceive('updateAlert');
+        $this->offeringManager
+            ->shouldReceive('findOfferingBy')
+            ->with([ "id" => $offering->getId() ])
+            ->andReturn($offering);
 
         $this->commandTester->execute([]);
         $output = $this->commandTester->getDisplay();

--- a/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+namespace Ilios\CliBundle\Tests\Command;
+
+use Ilios\CliBundle\Command\SendChangeAlertsCommand;
+use Ilios\CoreBundle\Entity\Manager\AlertManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\AuditLogManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\OfferingManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+/**
+ * Send Change Alerts command test.
+ *
+ * Class SendChangeAlertsCommandTest
+ * @package Ilios\CliBundle\Tests\Command
+ */
+class SendChangeAlertsCommandTest extends KernelTestCase
+{
+    const COMMAND_NAME = 'ilios:messaging:send-change-alerts';
+
+    /**
+     * @var OfferingManagerInterface
+     */
+    protected $fakeOfferingManager;
+
+    /**
+     * @var AlertManagerInterface
+     */
+    protected $fakeAlertManager;
+
+    /**
+     * @var AuditLogManagerInterface
+     */
+    protected $fakeAuditLogManager;
+
+    /**
+     * @var CommandTester
+     */
+    protected $commandTester;
+
+    public function setUp()
+    {
+        $this->fakeOfferingManager = $this
+            ->getMockBuilder('Ilios\CoreBundle\Entity\Manager\OfferingManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->fakeAlertManager = $this
+            ->getMockBuilder('Ilios\CoreBundle\Entity\Manager\AlertManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->fakeAuditLogManager = $this
+            ->getMockBuilder('Ilios\CoreBundle\Entity\Manager\AuditLogManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $kernel = $this->createKernel();
+        $kernel->boot();
+        $application = new Application($kernel);
+
+        $command = new SendChangeAlertsCommand(
+            $this->fakeAlertManager,
+            $this->fakeAuditLogManager,
+            $this->fakeOfferingManager,
+            $kernel->getContainer()->get('templating'),
+            $kernel->getContainer()->get('mailer')
+        );
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        unset($this->fakeOfferingManager);
+        unset($this->fakeAlertManager);
+        unset($this->fakeAuditLogManager);
+        m::close();
+    }
+
+    /**
+     * @covers Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
+     */
+    public function testExecuteDryRun()
+    {
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+    }
+}

--- a/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
@@ -2,9 +2,27 @@
 namespace Ilios\CliBundle\Tests\Command;
 
 use Ilios\CliBundle\Command\SendChangeAlertsCommand;
+use Ilios\CoreBundle\Entity\Alert;
+use Ilios\CoreBundle\Entity\AlertChangeType;
+use Ilios\CoreBundle\Entity\AlertChangeTypeInterface;
+use Ilios\CoreBundle\Entity\AlertInterface;
+use Ilios\CoreBundle\Entity\AuditLog;
+use Ilios\CoreBundle\Entity\AuditLogInterface;
+use Ilios\CoreBundle\Entity\Course;
+use Ilios\CoreBundle\Entity\InstructorGroup;
+use Ilios\CoreBundle\Entity\LearnerGroup;
+use Ilios\CoreBundle\Entity\LearnerGroupInterface;
 use Ilios\CoreBundle\Entity\Manager\AlertManagerInterface;
 use Ilios\CoreBundle\Entity\Manager\AuditLogManagerInterface;
 use Ilios\CoreBundle\Entity\Manager\OfferingManagerInterface;
+use Ilios\CoreBundle\Entity\Offering;
+use Ilios\CoreBundle\Entity\OfferingInterface;
+use Ilios\CoreBundle\Entity\School;
+use Ilios\CoreBundle\Entity\SchoolInterface;
+use Ilios\CoreBundle\Entity\Session;
+use Ilios\CoreBundle\Entity\SessionType;
+use Ilios\CoreBundle\Entity\User;
+use Ilios\CoreBundle\Entity\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -42,20 +60,42 @@ class SendChangeAlertsCommandTest extends KernelTestCase
 
     public function setUp()
     {
+        $offerings = $this->getOfferings();
+        $alerts = $this->getAlerts();
+        $auditLogs = $this->getAuditLogs();
+
         $this->fakeOfferingManager = $this
             ->getMockBuilder('Ilios\CoreBundle\Entity\Manager\OfferingManager')
             ->disableOriginalConstructor()
             ->getMock();
-
+        $this->fakeOfferingManager
+            ->method('findOfferingBy')
+            ->will($this->returnValueMap(
+                [
+                    [[ "id" => 1 ], null, $offerings[1]],
+                ]
+            ));
         $this->fakeAlertManager = $this
             ->getMockBuilder('Ilios\CoreBundle\Entity\Manager\AlertManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $this->fakeAlertManager
+            ->method('findAlertsBy')
+            ->will($this->returnValue(
+                $alerts
+            ));
 
         $this->fakeAuditLogManager = $this
             ->getMockBuilder('Ilios\CoreBundle\Entity\Manager\AuditLogManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $this->fakeAuditLogManager
+            ->method('findAuditLogsBy')
+            ->will($this->returnValueMap(
+                [
+                    [[ 'objectId' => 1, 'objectClass' => 'alert' ], [ 'createdAt' => 'asc' ], null, null, $auditLogs[1]],
+                ]
+            ));
 
         $kernel = $this->createKernel();
         $kernel->boot();
@@ -89,8 +129,203 @@ class SendChangeAlertsCommandTest extends KernelTestCase
      */
     public function testExecuteDryRun()
     {
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
+        $alert = $this->getAlerts()[1];
+        $offering = $this->getOfferings()[1];
+        $auditLogs = $this->getAuditLogs()[1];
+
+
+        $this->commandTester->execute([
+            '--dry-run' => true,
+        ]);
+        $output = $this->commandTester->getDisplay();
+
+        echo $output;
+
+        // check mail headers
+        $this->assertContains(
+            'From: ' . $offering->getSession()->getCourse()->getSchool()->getIliosAdministratorEmail(), $output);
+        $schools = $alert->getRecipients()->toArray();
+        /** @var SchoolInterface $school */
+        foreach ($schools as $school) {
+            $recipients = explode(',', strtolower($school->getChangeAlertRecipients()));
+            foreach ($recipients as $recipient) {
+                $this->assertRegExp("/To:(.*){$recipient}/", $output);
+            }
+        }
+        $expectedSubject = 'Subject: ' . $offering->getSession()->getCourse()->getExternalId() . ' - '
+            . $offering->getStartDate()->format('m/d/Y');
+        $this->assertContains($expectedSubject, $output);
+
+        // check mail body
+        $this->assertContains("Course:   {$offering->getSession()->getCourse()->getTitle()}", $output);
+        $this->assertContains("Session:  {$offering->getSession()->getTitle()}", $output);
+        $this->assertContains("Type:     {$offering->getSession()->getSessionType()->getTitle()}", $output);
+        $this->assertContains("Date:     {$offering->getStartDate()->format('D M d, Y')}", $output);
+        $this->assertContains(
+            "Time:     {$offering->getStartDate()->format('h:i a')} - {$offering->getEndDate()->format('h:i a')}",
+            $output
         );
+        $this->assertContains("Location: {$offering->getRoom()}", $output);
+        /** @var UserInterface $instructor */
+        foreach ($offering->getAllInstructors()->toArray() as $instructor) {
+            $this->assertContains("- {$instructor->getFirstName()} {$instructor->getLastName()}", $output);
+        }
+        /** @var LearnerGroupInterface $learnerGroup */
+        foreach ($offering->getLearnerGroups()->toArray() as $learnerGroup) {
+            $this->assertContains("- {$learnerGroup->getTitle()}", $output);
+        }
+        /** @var UserInterface $learner */
+        foreach ($offering->getLearners()->toArray() as $learner) {
+            $this->assertContains("- {$learner->getFirstName()} {$learner->getLastName()}", $output);
+        }
+        /** @var AlertChangeTypeInterface $changeType */
+        foreach ($alert->getChangeTypes()->toArray() as $changeType) {
+            $this->assertContains("- {$changeType->getTitle()}", $output);
+        }
+        /** @var AuditLogInterface $log */
+        foreach ($auditLogs as $log) {
+            $user = $log->getUser();
+            $createdAt = $log->getCreatedAt();
+            $this->assertContains(
+                "- Updates made {$createdAt->format('m/d/Y')} at {$createdAt->format('h:i a')}"
+                . " by {$user->getFirstName()} {$user->getLastName()}", $output);
+        }
+    }
+
+    /**
+     * @return OfferingInterface[]
+     */
+    protected function getOfferings()
+    {
+        $rhett = [];
+
+        $school = new School();
+        $school->setId(1);
+        $school->setTitle('Medicine');
+        $school->setIliosAdministratorEmail('iliosadmin@som.edu');
+
+        $course = new Course();
+        $course->setId(1);
+        $course->setTitle('Course A');
+        $course->setExternalId('ILIOS123');
+        $course->setSchool($school);
+
+        $sessionType = new SessionType();
+        $sessionType->setId(1);
+        $sessionType->setTitle('Session Type A');
+
+        $session = new Session();
+        $session->setId(1);
+        $session->setCourse($course);
+        $session->setSessionType($sessionType);
+        $session->setTitle('Session A');
+
+        $instructor1 = new User();
+        $instructor1->setId(1);
+        $instructor1->setFirstName('Jane');
+        $instructor1->setLastName('Doe');
+        $instructor1->setEmail('jane.doe@test.com');
+
+        $instructor2 = new User();
+        $instructor2->setId(2);
+        $instructor2->setFirstName('Mike');
+        $instructor2->setLastName('Smith');
+        $instructor2->setEmail('mike.smith@test.com');
+
+        $instructorGroup = new InstructorGroup();
+        $instructorGroup->setId(1);
+        $instructorGroup->addUser($instructor2);
+
+        $learnerGroup = new LearnerGroup();
+        $learnerGroup->setId(1);
+        $learnerGroup->setTitle('Learner Group A');
+
+        $learner = new User();
+        $learner->setId(2);
+        $learner->setFirstName('Jimmy');
+        $learner->setLastName('Dumas');
+
+        $offering = new Offering();
+        $offering->setId(1);
+        $offering->setSession($session);
+        $offering->setStartDate(new \DateTime('2015-10-01 15:15:00', new \DateTimeZone('UTC')));
+        $offering->setEndDate(new \DateTime('2015-10-01 18:30:00', new \DateTimeZone('UTC')));
+        $offering->setRoom('Library - Room 119');
+        $offering->addInstructorGroup($instructorGroup);
+        $offering->addInstructor($instructor1);
+        $offering->addLearnerGroup($learnerGroup);
+        $offering->addLearner($learner);
+
+        $rhett[$offering->getId()] = $offering;
+        return $rhett;
+    }
+
+    /**
+     * @return AlertInterface[]
+     */
+    protected function getAlerts()
+    {
+        $rhett = [];
+
+        $alert = new Alert();
+        $alert->setId(1);
+        $alert->setDispatched(false);
+        $alert->setTableName('offering');
+        $alert->setTableRowId(1);
+
+        $schoolA = new School();
+        $schoolA->setId(1);
+        $schoolA->setChangeAlertRecipients('recipientA@schoolA.edu,recipientB@schoolA.edu');
+        $alert->addRecipient($schoolA);
+
+        $schoolB = new School();
+        $schoolB->setId(2);
+        $schoolB->setChangeAlertRecipients('recipientA@schoolB.edu');
+        $alert->addRecipient($schoolB);
+
+        $i = 0;
+        foreach (['A', 'B', 'C'] as $letter) {
+            $alertChangeType = new AlertChangeType();
+            $alertChangeType->setId(++$i);
+            $alertChangeType->setTitle("Alert Change Type {$letter}");
+            $alert->addChangeType($alertChangeType);
+        }
+
+        $rhett[$alert->getId()] = $alert;
+        return $rhett;
+    }
+
+    /**
+     * @return AuditLogInterface[][]
+     */
+    protected function getAuditLogs()
+    {
+        $rhett = [];
+
+        $userA = new User();
+        $userA->setId(1);
+        $userA->setFirstName('Jimmy');
+        $userA->setLastName('Miller');
+
+        $userB = new User();
+        $userB->setId(2);
+        $userB->setFirstName('Billy');
+        $userB->setLastName('Brown');
+
+        $logA = new AuditLog();
+        $logA->setObjectClass('alert');
+        $logA->setObjectId(1);
+        $logA->setUser($userA);
+        $logA->setCreatedAt(new \DateTime('2015-09-20 11:12:22', new \DateTimeZone('UTC')));
+
+        $logB = new AuditLog();
+        $logB->setObjectClass('alert');
+        $logB->setObjectId(1);
+        $logB->setUser($userB);
+        $logB->setCreatedAt(new \DateTime('2015-09-20 15:20:15', new \DateTimeZone('UTC')));
+
+        $rhett[$logA->getObjectId()][] = $logA;
+        $rhett[$logB->getObjectId()][] = $logB;
+        return $rhett;
     }
 }

--- a/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
@@ -93,7 +93,13 @@ class SendChangeAlertsCommandTest extends KernelTestCase
             ->method('findAuditLogsBy')
             ->will($this->returnValueMap(
                 [
-                    [[ 'objectId' => 1, 'objectClass' => 'alert' ], [ 'createdAt' => 'asc' ], null, null, $auditLogs[1]],
+                    [
+                        [ 'objectId' => 1, 'objectClass' => 'alert' ],
+                        [ 'createdAt' => 'asc' ],
+                        null,
+                        null,
+                        $auditLogs[1]
+                    ],
                 ]
             ));
 
@@ -143,7 +149,9 @@ class SendChangeAlertsCommandTest extends KernelTestCase
 
         // check mail headers
         $this->assertContains(
-            'From: ' . $offering->getSession()->getCourse()->getSchool()->getIliosAdministratorEmail(), $output);
+            'From: ' . $offering->getSession()->getCourse()->getSchool()->getIliosAdministratorEmail(),
+            $output
+        );
         $schools = $alert->getRecipients()->toArray();
         /** @var SchoolInterface $school */
         foreach ($schools as $school) {
@@ -188,7 +196,9 @@ class SendChangeAlertsCommandTest extends KernelTestCase
             $createdAt = $log->getCreatedAt();
             $this->assertContains(
                 "- Updates made {$createdAt->format('m/d/Y')} at {$createdAt->format('h:i a')}"
-                . " by {$user->getFirstName()} {$user->getLastName()}", $output);
+                . " by {$user->getFirstName()} {$user->getLastName()}",
+                $output
+            );
         }
     }
 

--- a/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SendChangeAlertsCommandTest.php
@@ -139,13 +139,10 @@ class SendChangeAlertsCommandTest extends KernelTestCase
         $offering = $this->getOfferings()[1];
         $auditLogs = $this->getAuditLogs()[1];
 
-
         $this->commandTester->execute([
             '--dry-run' => true,
         ]);
         $output = $this->commandTester->getDisplay();
-
-        echo $output;
 
         // check mail headers
         $this->assertContains(

--- a/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
+++ b/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
@@ -8,9 +8,9 @@
  * - $offering: The offering that this change alert pertains to.
  */
 #}
-Course:    {{ offering.session.course.title|raw }}
-Session:   {{ offering.session.title|raw }}
-Type:      {{ offering.session.sessionType|raw }}
+Course:   {{ offering.session.course.title|raw }}
+Session:  {{ offering.session.title|raw }}
+Type:     {{ offering.session.sessionType|raw }}
 Date:     {{ offering.startDate|date('D M d, Y') }}
 Time:     {{ offering.startDate|date('h:i a') }} - {{ offering.endDate|date('h:i a') }}
 Location: {{ offering.room }}
@@ -30,7 +30,15 @@ Learners:
 - {{ learner.firstName }} {{ learner.lastName }}
 {% endfor %}
 
-List of modifications:
+Modifications:
+{% for changeType in alert.changeTypes %}
+- {{ changeType.title }}
+{% endfor %}
 
-Change History:
+Modifications made by:
+{% for instigator in alert.instigators %}
+- {% instigator.firstName %} {% instigator.lastName %}
+{% endfor %}
 
+Additional change information:
+{{ alert.additionalText|raw }}

--- a/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
+++ b/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
@@ -11,7 +11,7 @@
 #}
 Course:   {{ offering.session.course.title|raw }}
 Session:  {{ offering.session.title|raw }}
-Type:     {{ offering.session.sessionType|raw }}
+Type:     {{ offering.session.sessionType.title|raw }}
 Date:     {{ offering.startDate|date('D M d, Y') }}
 Time:     {{ offering.startDate|date('h:i a') }} - {{ offering.endDate|date('h:i a') }}
 Location: {{ offering.room }}

--- a/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
+++ b/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
@@ -5,6 +5,7 @@
  *
  * Available variables:
  * - $alert:    The change alert.
+ * - $history:  A collection of audit atoms providing the audit trail of this change alert.
  * - $offering: The offering that this change alert pertains to.
  */
 #}
@@ -30,15 +31,13 @@ Learners:
 - {{ learner.firstName }} {{ learner.lastName }}
 {% endfor %}
 
-Modifications:
+List of modifications:
 {% for changeType in alert.changeTypes %}
 - {{ changeType.title }}
 {% endfor %}
 
-Modifications made by:
-{% for instigator in alert.instigators %}
-- {% instigator.firstName %} {% instigator.lastName %}
+Change History:
+{% for item in history %}
+- Updates made {% item.createdAt|date('m/d/Y') %} at {% item.createdAt|date('h:i a') %} by {% item.user.firstName %} {% item.user.lastName %}
 {% endfor %}
 
-Additional change information:
-{{ alert.additionalText|raw }}

--- a/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
+++ b/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Default template for offering change alert emails.
+ *
+ * Available variables:
+ * - $alert:    The change alert.
+ * - $offering: The offering that this change alert pertains to.
+ */
+#}
+Course:    {{ offering.session.course.title|raw }}
+Session:   {{ offering.session.title|raw }}
+Type:      {{ offering.session.sessionType|raw }}
+Date:     {{ offering.startDate|date('D M d, Y') }}
+Time:     {{ offering.startDate|date('h:i a') }} - {{ offering.endDate|date('h:i a') }}
+Location: {{ offering.room }}
+
+Instructors:
+{% for instructor in offering.allInstructors %}
+- {{ instructor.firstName }} {{ instructor.lastName }}
+{% endfor %}
+
+Learner groups:
+{% for learnerGroup in offering.learnerGroups %}
+- {{ learnerGroup.title|raw }}
+{% endfor %}
+
+Learners:
+{% for learner in offering.learners %}
+- {{ learner.firstName }} {{ learner.lastName }}
+{% endfor %}
+
+List of modifications:
+
+Change History:
+

--- a/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
+++ b/src/Ilios/CoreBundle/Resources/views/Email/offeringchangealert.text.twig
@@ -38,6 +38,6 @@ List of modifications:
 
 Change History:
 {% for item in history %}
-- Updates made {% item.createdAt|date('m/d/Y') %} at {% item.createdAt|date('h:i a') %} by {% item.user.firstName %} {% item.user.lastName %}
+- Updates made {{ item.createdAt|date('m/d/Y') }} at {{ item.createdAt|date('h:i a') }} by {{ item.user.firstName }} {{ item.user.lastName }}
 {% endfor %}
 


### PR DESCRIPTION
```
vagrant@ilios:/vagrant$ bin/console ilios:messaging:send-change-alerts --help
Usage:
  ilios:messaging:send-change-alerts [options]

Options:
      --dry-run            Print out alerts instead of emailing them. Useful for testing/debugging purposes.
  -h, --help               Display this help message
  -q, --quiet              Do not output any message
  -V, --version            Display this application version
      --ansi               Force ANSI output
      --no-ansi            Disable ANSI output
  -n, --no-interaction     Do not ask any interactive question
  -s, --shell              Launch the shell.
      --process-isolation  Launch commands from shell as a separate process.
  -e, --env=ENV            The Environment name. [default: "dev"]
      --no-debug           Switches off debug mode.
  -v|vv|vvv, --verbose     Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
 Sends out change alert message to configured email recipients.
```

fixes #992.