### PR TITLE
Remove the hosts matcher from CORS options

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -92,7 +92,6 @@ nelmio_cors:
         allow_headers: ['*']
         allow_methods: ['POST', 'PUT', 'GET', 'DELETE']
         expose_headers: ['*']
-        hosts: ['*']
         max_age: 3600
     paths:
         '^/':


### PR DESCRIPTION
This is an incorrect configuration value, it should be left off to
allow any host.

[ci skip]