### PR TITLE
More schools for a user

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Cohort.php
+++ b/src/Ilios/CoreBundle/Entity/Cohort.php
@@ -207,4 +207,20 @@ class Cohort implements CohortInterface
     {
         return is_null($this->getProgramYear());
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSchool()
+    {
+        if ($programYear = $this->getProgramYear()) {
+            if ($program = $programYear->getProgram()) {
+                if ($school = $program->getSchool()) {
+                    return $school;
+                }
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Ilios/CoreBundle/Entity/CohortInterface.php
+++ b/src/Ilios/CoreBundle/Entity/CohortInterface.php
@@ -66,4 +66,11 @@ interface CohortInterface extends
      * @return ArrayCollection|UserInterface[]
      */
     public function getUsers();
+
+
+    /**
+     * Get the school we belong to
+     * @return SchoolInterface|null
+     */
+    public function getSchool();
 }

--- a/src/Ilios/CoreBundle/Entity/IlmSession.php
+++ b/src/Ilios/CoreBundle/Entity/IlmSession.php
@@ -357,4 +357,18 @@ class IlmSession implements IlmSessionInterface
     {
         return $this->getSession()->isDeleted();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSchool()
+    {
+        if ($session = $this->getSession()) {
+            if ($course = $session->getCourse()) {
+                return $course->getSchool();
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Ilios/CoreBundle/Entity/IlmSessionInterface.php
+++ b/src/Ilios/CoreBundle/Entity/IlmSessionInterface.php
@@ -117,4 +117,11 @@ interface IlmSessionInterface extends
      * @return boolean
      */
     public function isDeleted();
+
+
+    /**
+     * Get the school we belong to
+     * @return SchoolInterface|null
+     */
+    public function getSchool();
 }

--- a/src/Ilios/CoreBundle/Entity/LearnerGroup.php
+++ b/src/Ilios/CoreBundle/Entity/LearnerGroup.php
@@ -404,4 +404,22 @@ class LearnerGroup implements LearnerGroupInterface
     {
         return $this->instructors;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSchool()
+    {
+        if ($cohort = $this->getCohort()) {
+            if ($programYear = $cohort->getProgramYear()) {
+                if ($program = $programYear->getProgram()) {
+                    if ($school = $program->getSchool()) {
+                        return $school;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Ilios/CoreBundle/Entity/LearnerGroupInterface.php
+++ b/src/Ilios/CoreBundle/Entity/LearnerGroupInterface.php
@@ -125,4 +125,11 @@ interface LearnerGroupInterface extends
      * @return ArrayCollection|UserInterface[]
      */
     public function getInstructors();
+
+
+    /**
+     * Get the school we belong to
+     * @return SchoolInterface|null
+     */
+    public function getSchool();
 }

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -1367,9 +1367,10 @@ class User implements UserInterface
             $insIlmSchools->toArray()
         );
         $allSchools[] = $this->getSchool();
+        $allSchools = array_unique($allSchools);
+        $allSchools = array_filter($allSchools);
 
-
-        $schools = new ArrayCollection(array_unique($allSchools));
+        $schools = new ArrayCollection($allSchools);
 
         return $schools;
     }

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -1325,23 +1325,53 @@ class User implements UserInterface
     }
     
     /**
-     * Get all the schools an user is affiliated with
-     * This is used in granting view permissions for faculty
-     * in schools that are a users secondary cohort
+     * Get all the schools an user is affiliated with so we can match
+     * permissions.
      *
      * @return ArrayCollection[School]
      */
     public function getAllSchools()
     {
-        $undeletedCohorts = $this->getCohorts()->filter(function (CohortInterface $cohort) {
+        $cohortSchools = $this->getCohorts()->filter(function (CohortInterface $cohort) {
             return !$cohort->isDeleted();
-        });
-        $schools = $undeletedCohorts->map(function (CohortInterface $cohort) {
+        })->map(function (CohortInterface $cohort) {
             return $cohort->getProgramYear()->getProgram()->getSchool();
         });
-        $schools->add($this->getSchool());
-        
-        
+
+        $directedCourseSchools = $this->getDirectedCourses()->map(function (CourseInterface $course) {
+            return $course->getSchool();
+        });
+
+        $learnerGroupSchools = $this->getLearnerGroups()->map(function (LearnerGroupInterface $lg) {
+            return $lg->getCohort()->getProgramYear()->getProgram()->getSchool();
+        });
+
+        $instructedLgSchools = $this->getInstructedLearnerGroups()->map(function (LearnerGroupInterface $lg) {
+            return $lg->getCohort()->getProgramYear()->getProgram()->getSchool();
+        });
+
+        $instGroupSchools = $this->getInstructorGroups()->map(function (InstructorGroupInterface $ig) {
+            return $ig->getSchool();
+        });
+
+        $insIlmSchools = $this->getInstructorIlmSessions()->map(function (IlmSessionInterface $ilm) {
+            return $ilm->getSession()->getCourse()->getSchool();
+        });
+
+        $allSchools = array_merge(
+            $cohortSchools->toArray(),
+            $directedCourseSchools->toArray(),
+            $learnerGroupSchools->toArray(),
+            $instructedLgSchools->toArray(),
+            $instGroupSchools->toArray(),
+            $insIlmSchools->toArray()
+
+        );
+        $allSchools[] = $this->getSchool();
+
+
+        $schools = new ArrayCollection(array_unique($allSchools));
+
         return $schools;
     }
 }

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -1365,7 +1365,6 @@ class User implements UserInterface
             $instructedLgSchools->toArray(),
             $instGroupSchools->toArray(),
             $insIlmSchools->toArray()
-
         );
         $allSchools[] = $this->getSchool();
 

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -1335,7 +1335,7 @@ class User implements UserInterface
         $cohortSchools = $this->getCohorts()->filter(function (CohortInterface $cohort) {
             return !$cohort->isDeleted();
         })->map(function (CohortInterface $cohort) {
-            return $cohort->getProgramYear()->getProgram()->getSchool();
+            return $cohort->getSchool();
         });
 
         $directedCourseSchools = $this->getDirectedCourses()->map(function (CourseInterface $course) {
@@ -1343,11 +1343,11 @@ class User implements UserInterface
         });
 
         $learnerGroupSchools = $this->getLearnerGroups()->map(function (LearnerGroupInterface $lg) {
-            return $lg->getCohort()->getProgramYear()->getProgram()->getSchool();
+            return $lg->getSchool();
         });
 
         $instructedLgSchools = $this->getInstructedLearnerGroups()->map(function (LearnerGroupInterface $lg) {
-            return $lg->getCohort()->getProgramYear()->getProgram()->getSchool();
+            return $lg->getSchool();
         });
 
         $instGroupSchools = $this->getInstructorGroups()->map(function (InstructorGroupInterface $ig) {
@@ -1355,7 +1355,7 @@ class User implements UserInterface
         });
 
         $insIlmSchools = $this->getInstructorIlmSessions()->map(function (IlmSessionInterface $ilm) {
-            return $ilm->getSession()->getCourse()->getSchool();
+            return $ilm->getSchool();
         });
 
         $allSchools = array_merge(

--- a/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
@@ -19,6 +19,7 @@ class UserControllerTest extends AbstractControllerTest
         return array_merge($fixtures, [
             'Ilios\CoreBundle\Tests\Fixture\LoadUserData',
             'Ilios\CoreBundle\Tests\Fixture\LoadAlertData',
+            'Ilios\CoreBundle\Tests\Fixture\LoadCourseData',
             'Ilios\CoreBundle\Tests\Fixture\LoadLearningMaterialData',
             'Ilios\CoreBundle\Tests\Fixture\LoadInstructorGroupData',
             'Ilios\CoreBundle\Tests\Fixture\LoadLearnerGroupData',

--- a/src/Ilios/CoreBundle/Tests/DataLoader/CourseData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/CourseData.php
@@ -62,13 +62,35 @@ class CourseData extends AbstractDataLoader
             'year' => 2013,
             'startDate' => "2013-09-01T00:00:00+00:00",
             'endDate' => "2013-12-14T00:00:00+00:00",
+            'deleted' => false,
+            'externalId' => $this->faker->text(10),
+            'locked' => false,
+            'archived' => false,
+            'publishedAsTbd' => false,
+            'school' => "1",
+            'directors' => ["4"],
+            'cohorts' => [],
+            'topics' => [],
+            'objectives' => [],
+            'meshDescriptors' => [],
+            'learningMaterials' => [],
+            'sessions' => []
+        );
+
+        //deleted course shoudl to last
+        $arr[] = array(
+            'id' => 4,
+            'title' => $this->faker->text(25),
+            'level' => 1,
+            'year' => 2013,
+            'startDate' => "2013-09-01T00:00:00+00:00",
+            'endDate' => "2013-12-14T00:00:00+00:00",
             'deleted' => true,
             'externalId' => $this->faker->text(10),
             'locked' => false,
             'archived' => false,
             'publishedAsTbd' => false,
             'school' => "1",
-            'clerkshipType' => "1",
             'directors' => ["2"],
             'cohorts' => ["1"],
             'topics' => ["1"],
@@ -85,7 +107,7 @@ class CourseData extends AbstractDataLoader
     public function create()
     {
         return [
-            'id' => 4,
+            'id' => 5,
             'title' => $this->faker->text(25),
             'level' => 1,
             'year' => 2013,

--- a/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
@@ -96,6 +96,35 @@ class UserData extends AbstractDataLoader
             'pendingUserUpdates' => []
         );
 
+        $arr[] = array(
+            'id' => 4,
+            'lastName' => $this->faker->lastName,
+            'middleName' => $this->faker->firstName,
+            'firstName' => $this->faker->firstName,
+            'email' => $this->faker->email,
+            'phone' => $this->faker->phoneNumber,
+            'enabled' => true,
+            'icsFeedKey' => hash('sha256', '4'),
+            'learningMaterials' => [],
+            'publishEvents' => [],
+            'reports' => [],
+            'school' => "2",
+            'directedCourses' => ["3"],
+            'learnerGroups' => [],
+            'instructedLearnerGroups' => [],
+            'instructorGroups' => [],
+            'instructorIlmSessions' => [],
+            'learnerIlmSessions' => [],
+            'offerings' => [],
+            'instructedOfferings' => [],
+            'programYears' => [],
+            'alerts' => [],
+            'roles' => [],
+            'cohorts' => [],
+            'reminders' => [],
+            'pendingUserUpdates' => []
+        );
+
 
 
         return $arr;
@@ -104,14 +133,14 @@ class UserData extends AbstractDataLoader
     public function create()
     {
         return [
-            'id' => 4,
+            'id' => 5,
             'lastName' => $this->faker->lastName,
             'firstName' => $this->faker->firstName,
             'middleName' => $this->faker->firstName,
             'email' => $this->faker->email,
             'phone' => $this->faker->phoneNumber,
             'enabled' => true,
-            'icsFeedKey' => hash('sha256', '4'),
+            'icsFeedKey' => hash('sha256', '5'),
             'learningMaterials' => [],
             'publishEvents' => [],
             'reports' => [],

--- a/src/Ilios/CoreBundle/Tests/Fixture/LoadCourseData.php
+++ b/src/Ilios/CoreBundle/Tests/Fixture/LoadCourseData.php
@@ -41,7 +41,9 @@ class LoadCourseData extends AbstractFixture implements
             $entity->setLocked($arr['locked']);
             $entity->setArchived($arr['archived']);
             $entity->setSchool($this->getReference('schools' . $arr['school']));
-            $entity->setClerkshipType($this->getReference('courseClerkshipTypes' . $arr['clerkshipType']));
+            if (isset($arr['clerkshipType'])) {
+                $entity->setClerkshipType($this->getReference('courseClerkshipTypes' . $arr['clerkshipType']));
+            }
             if (!empty($arr['publishEvent'])) {
                 $entity->setPublishEvent($this->getReference('publishEvents' . $arr['publishEvent']));
             }


### PR DESCRIPTION
Expanded the list of schools related to a user so that the record of a course director for example is available to other directors not in the same primary school.

I added a single test which cover course director, we probably need more tests.

@stopfstedt this needs a security audit.  Am I punching too many holes?  Would it make more sense to just allow privileged users access to the whole user set?