### PR TITLE
Don't allow saving of the many side on a one to many relationship

### DIFF
--- a/src/Ilios/CoreBundle/Entity/AssessmentOption.php
+++ b/src/Ilios/CoreBundle/Entity/AssessmentOption.php
@@ -73,6 +73,14 @@ class AssessmentOption implements AssessmentOptionInterface
     protected $sessionTypes;
 
     /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->sessionTypes = new ArrayCollection();
+    }
+
+    /**
      * @param Collection $sessionTypes
      */
     public function setSessionTypes(Collection $sessionTypes)

--- a/src/Ilios/CoreBundle/Entity/Cohort.php
+++ b/src/Ilios/CoreBundle/Entity/Cohort.php
@@ -118,6 +118,8 @@ class Cohort implements CohortInterface
     public function __construct()
     {
         $this->courses = new ArrayCollection();
+        $this->learnerGroups = new ArrayCollection();
+        $this->users = new ArrayCollection();
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/Competency.php
+++ b/src/Ilios/CoreBundle/Entity/Competency.php
@@ -127,7 +127,6 @@ class Competency implements CompetencyInterface
     protected $aamcPcrses;
 
     /**
-     * @todo: Ask about owning/inverse sides in these relationships...
      * @var ArrayCollection|ProgramYearInterface[]
      *
      * @ORM\ManyToMany(targetEntity="ProgramYear", mappedBy="competencies")
@@ -146,6 +145,7 @@ class Competency implements CompetencyInterface
         $this->aamcPcrses = new ArrayCollection();
         $this->programYears = new ArrayCollection();
         $this->children = new ArrayCollection();
+        $this->objectives = new ArrayCollection();
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/CurriculumInventoryAcademicLevel.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventoryAcademicLevel.php
@@ -125,6 +125,14 @@ class CurriculumInventoryAcademicLevel implements CurriculumInventoryAcademicLev
     protected $sequenceBlocks;
 
     /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->sequenceBlocks = new ArrayCollection();
+    }
+
+    /**
      * @param int $level
      */
     public function setLevel($level)

--- a/src/Ilios/CoreBundle/Entity/CurriculumInventoryReport.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventoryReport.php
@@ -178,6 +178,15 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
     protected $academicLevels;
 
     /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->academicLevels = new ArrayCollection();
+        $this->sequenceBlocks = new ArrayCollection();
+    }
+
+    /**
      * @param int $year
      */
     public function setYear($year)

--- a/src/Ilios/CoreBundle/Entity/CurriculumInventorySequenceBlock.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventorySequenceBlock.php
@@ -279,6 +279,7 @@ class CurriculumInventorySequenceBlock implements CurriculumInventorySequenceBlo
     public function __construct()
     {
         $this->children = new ArrayCollection();
+        $this->sessions = new ArrayCollection();
         $this->required = self::OPTIONAL;
         $this->track = false;
     }

--- a/src/Ilios/CoreBundle/Entity/MeshDescriptor.php
+++ b/src/Ilios/CoreBundle/Entity/MeshDescriptor.php
@@ -209,6 +209,7 @@ class MeshDescriptor implements MeshDescriptorInterface
         $this->sessions = new ArrayCollection();
         $this->sessionLearningMaterials = new ArrayCollection();
         $this->courseLearningMaterials = new ArrayCollection();
+        $this->trees = new ArrayCollection();
         $this->createdAt = new \DateTime();
         $this->updatedAt = new \DateTime();
     }

--- a/src/Ilios/CoreBundle/Entity/MeshDescriptor.php
+++ b/src/Ilios/CoreBundle/Entity/MeshDescriptor.php
@@ -210,6 +210,8 @@ class MeshDescriptor implements MeshDescriptorInterface
         $this->sessionLearningMaterials = new ArrayCollection();
         $this->courseLearningMaterials = new ArrayCollection();
         $this->trees = new ArrayCollection();
+        $this->concepts = new ArrayCollection();
+        $this->qualifiers = new ArrayCollection();
         $this->createdAt = new \DateTime();
         $this->updatedAt = new \DateTime();
     }

--- a/src/Ilios/CoreBundle/Entity/Program.php
+++ b/src/Ilios/CoreBundle/Entity/Program.php
@@ -182,6 +182,7 @@ class Program implements ProgramInterface
         $this->deleted = false;
         $this->publishedAsTbd = false;
         $this->programYears = new ArrayCollection();
+        $this->curriculumInventoryReports = new ArrayCollection();
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/School.php
+++ b/src/Ilios/CoreBundle/Entity/School.php
@@ -420,7 +420,7 @@ class School implements SchoolInterface
      */
     public function getDepartments()
     {
-        //criteria not 100% reliale on many to many relationships
+        //criteria not 100% reliable on many to many relationships
         //fix in https://github.com/doctrine/doctrine2/pull/1399
         // $criteria = Criteria::create()->where(Criteria::expr()->eq("deleted", false));
         // return new ArrayCollection($this->departments->matching($criteria)->getValues());

--- a/src/Ilios/CoreBundle/Entity/School.php
+++ b/src/Ilios/CoreBundle/Entity/School.php
@@ -243,6 +243,8 @@ class School implements SchoolInterface
         $this->topics = new ArrayCollection();
         $this->programs = new ArrayCollection();
         $this->stewards = new ArrayCollection();
+        $this->instructorGroups = new ArrayCollection();
+        $this->sessionTypes = new ArrayCollection();
         $this->deleted = false;
     }
 

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -490,6 +490,7 @@ class User implements UserInterface
         $this->reports                  = new ArrayCollection();
         $this->cohorts                  = new ArrayCollection();
         $this->pendingUserUpdates       = new ArrayCollection();
+        $this->auditLogs                = new ArrayCollection();
         $this->addedViaIlios            = false;
         $this->enabled                  = true;
         $this->examined                 = false;

--- a/src/Ilios/CoreBundle/Form/Type/AssessmentOptionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AssessmentOptionType.php
@@ -21,10 +21,6 @@ class AssessmentOptionType extends AbstractType
     {
         $builder
             ->add('name', null, ['empty_data' => null])
-            ->add('sessionTypes', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:SessionType"
-            ])
         ;
         $builder->get('name')->addViewTransformer(new RemoveMarkupTransformer());
     }

--- a/src/Ilios/CoreBundle/Form/Type/CohortType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CohortType.php
@@ -29,10 +29,6 @@ class CohortType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Course"
             ])
-            ->add('learnerGroups', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:LearnerGroup"
-            ])
             ->add('users', 'tdn_many_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"

--- a/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
@@ -25,10 +25,6 @@ class CompetencyType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])
-            ->add('objectives', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Objective"
-            ])
             ->add('parent', 'tdn_single_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Competency"

--- a/src/Ilios/CoreBundle/Form/Type/CourseClerkshipTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseClerkshipTypeType.php
@@ -21,10 +21,6 @@ class CourseClerkshipTypeType extends AbstractType
     {
         $builder
             ->add('title', null, ['empty_data' => null])
-            ->add('courses', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Course"
-            ])
         ;
         $builder->get('title')->addViewTransformer(new RemoveMarkupTransformer());
     }

--- a/src/Ilios/CoreBundle/Form/Type/CourseType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseType.php
@@ -66,14 +66,6 @@ class CourseType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])
-            ->add('learningMaterials', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:CourseLearningMaterial"
-            ])
-            ->add('sessions', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Session"
-            ])
         ;
         $transformer = new RemoveMarkupTransformer();
         foreach (['title', 'externalId'] as $element) {

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryAcademicLevelType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryAcademicLevelType.php
@@ -27,10 +27,6 @@ class CurriculumInventoryAcademicLevelType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
             ])
-            ->add('sequenceBlocks', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:CurriculumInventorySequenceBlock"
-            ])
         ;
         $transformer = new RemoveMarkupTransformer();
         foreach (['name', 'description'] as $element) {

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryReportType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryReportType.php
@@ -37,17 +37,9 @@ class CurriculumInventoryReportType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventorySequence"
             ])
-            ->add('sequenceBlocks', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:CurriculumInventorySequenceBlock"
-            ])
             ->add('program', 'tdn_single_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Program"
-            ])
-            ->add('academicLevels', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:CurriculumInventoryAcademicLevel"
             ])
         ;
         $transformer = new RemoveMarkupTransformer();

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockType.php
@@ -47,17 +47,9 @@ class CurriculumInventorySequenceBlockType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventorySequenceBlock"
             ])
-            ->add('children', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:CurriculumInventorySequenceBlock"
-            ])
             ->add('report', 'tdn_single_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
-            ])
-            ->add('sessions', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:CurriculumInventorySequenceBlockSession"
             ])
         ;
         $transformer = new RemoveMarkupTransformer();

--- a/src/Ilios/CoreBundle/Form/Type/DepartmentType.php
+++ b/src/Ilios/CoreBundle/Form/Type/DepartmentType.php
@@ -26,10 +26,6 @@ class DepartmentType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])
-            ->add('stewards', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:ProgramYearSteward"
-            ])
         ;
         $builder->get('title')->addViewTransformer(new RemoveMarkupTransformer());
     }

--- a/src/Ilios/CoreBundle/Form/Type/LearnerGroupType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearnerGroupType.php
@@ -30,10 +30,6 @@ class LearnerGroupType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearnerGroup"
             ])
-            ->add('children', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:LearnerGroup"
-            ])
             ->add('ilmSessions', 'tdn_many_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:IlmSession"

--- a/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
@@ -45,14 +45,6 @@ class LearningMaterialType extends AbstractType
             ])
             ->add('citation', 'text', ['required' => false, 'empty_data' => null])
             ->add('link', 'text', ['required' => false, 'empty_data' => null])
-            ->add('sessionLearningMaterials', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:SessionLearningMaterial"
-            ])
-            ->add('courseLearningMaterials', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:CourseLearningMaterial"
-            ])
         ;
         $transformer = new RemoveMarkupTransformer();
         $elements = [

--- a/src/Ilios/CoreBundle/Form/Type/MeshDescriptorType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshDescriptorType.php
@@ -35,14 +35,6 @@ class MeshDescriptorType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Session"
             ])
-            ->add('concepts', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:MeshConcept"
-            ])
-            ->add('qualifiers', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:MeshQualifier"
-            ])
             ->add('sessionLearningMaterials', 'tdn_many_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:SessionLearningMaterial"

--- a/src/Ilios/CoreBundle/Form/Type/MeshDescriptorType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshDescriptorType.php
@@ -43,10 +43,6 @@ class MeshDescriptorType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshQualifier"
             ])
-            ->add('trees', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:MeshTree"
-            ])
             ->add('sessionLearningMaterials', 'tdn_many_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:SessionLearningMaterial"

--- a/src/Ilios/CoreBundle/Form/Type/ProgramType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramType.php
@@ -33,14 +33,6 @@ class ProgramType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])
-            ->add('programYears', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:ProgramYear"
-            ])
-            ->add('curriculumInventoryReports', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
-            ])
         ;
         $transformer = new RemoveMarkupTransformer();
         foreach (['title', 'shortTitle'] as $element) {

--- a/src/Ilios/CoreBundle/Form/Type/ProgramYearType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramYearType.php
@@ -52,10 +52,6 @@ class ProgramYearType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:PublishEvent"
             ])
-            ->add('stewards', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:ProgramYearSteward"
-            ])
         ;
     }
 

--- a/src/Ilios/CoreBundle/Form/Type/PublishEventType.php
+++ b/src/Ilios/CoreBundle/Form/Type/PublishEventType.php
@@ -20,24 +20,7 @@ class PublishEventType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder
-            ->add('sessions', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Session"
-            ])
-            ->add('courses', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Course"
-            ])
-            ->add('programs', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Program"
-            ])
-            ->add('programYears', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:ProgramYear"
-            ])
-        ;
+
     }
 
     /**

--- a/src/Ilios/CoreBundle/Form/Type/SchoolType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SchoolType.php
@@ -29,41 +29,9 @@ class SchoolType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Alert"
             ])
-            ->add('competencies', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Competency"
-            ])
-            ->add('courses', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Course"
-            ])
-            ->add('programs', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Program"
-            ])
-            ->add('departments', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Department"
-            ])
-            ->add('topics', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Topic"
-            ])
-            ->add('instructorGroups', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:InstructorGroup"
-            ])
             ->add('curriculumInventoryInstitution', 'tdn_single_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryInstitution"
-            ])
-            ->add('sessionTypes', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:SessionType"
-            ])
-            ->add('stewards', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:ProgramYearSteward"
             ])
         ;
         $transformer = new RemoveMarkupTransformer();

--- a/src/Ilios/CoreBundle/Form/Type/SessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionType.php
@@ -62,14 +62,6 @@ class SessionType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:SessionDescription"
             ])
-            ->add('learningMaterials', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:SessionLearningMaterial"
-            ])
-            ->add('offerings', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Offering"
-            ])
         ;
 
         $builder->get('title')->addViewTransformer(new RemoveMarkupTransformer());

--- a/src/Ilios/CoreBundle/Form/Type/SessionTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionTypeType.php
@@ -35,10 +35,6 @@ class SessionTypeType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:AamcMethod"
             ])
-            ->add('sessions', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Session"
-            ])
         ;
 
         $transformer = new RemoveMarkupTransformer();

--- a/src/Ilios/CoreBundle/Form/Type/UserType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserType.php
@@ -32,22 +32,6 @@ class UserType extends AbstractType
             ->add('otherId', null, ['required' => false, 'empty_data' => null])
             ->add('examined', null, ['required' => false])
             ->add('userSyncIgnore', null, ['required' => false])
-            ->add('reminders', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:UserMadeReminder"
-            ])
-            ->add('learningMaterials', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:LearningMaterial"
-            ])
-            ->add('publishEvents', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:PublishEvent"
-            ])
-            ->add('reports', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Report"
-            ])
             ->add('school', 'tdn_single_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"

--- a/src/Ilios/CoreBundle/Form/Type/UserType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserType.php
@@ -88,10 +88,6 @@ class UserType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Cohort"
             ])
-            ->add('pendingUserUpdates', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:PendingUserUpdate"
-            ])
         ;
         $transformer = new RemoveMarkupTransformer();
         $textElements = ['firstName', 'lastName', 'middleName', 'phone', 'email', 'campusId', 'icsFeedKey', 'otherId'];

--- a/src/Ilios/CoreBundle/Tests/Controller/AssessmentOptionControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/AssessmentOptionControllerTest.php
@@ -85,6 +85,7 @@ class AssessmentOptionControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sessionTypes']);
 
         $this->createJsonRequest(
             'POST',
@@ -130,6 +131,7 @@ class AssessmentOptionControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sessionTypes']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/CohortControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CohortControllerTest.php
@@ -83,6 +83,7 @@ class CohortControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['stewards']);
 
         $this->createJsonRequest(
             'POST',
@@ -100,6 +101,7 @@ class CohortControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['learnerGroups']);
 
         $this->createJsonRequest(
             'POST',
@@ -144,6 +146,7 @@ class CohortControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['learnerGroups']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/CompetencyControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CompetencyControllerTest.php
@@ -86,6 +86,7 @@ class CompetencyControllerTest extends AbstractControllerTest
         //unset any parameters which should not be POSTed
         unset($postData['id']);
         unset($postData['children']);
+        unset($postData['objectives']);
 
         $this->createJsonRequest(
             'POST',
@@ -132,6 +133,7 @@ class CompetencyControllerTest extends AbstractControllerTest
         //unset any parameters which should not be POSTed
         unset($postData['id']);
         unset($postData['children']);
+        unset($postData['objectives']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/CourseClerkshipTypeControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CourseClerkshipTypeControllerTest.php
@@ -85,6 +85,7 @@ class CourseClerkshipTypeControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['courses']);
 
         $this->createJsonRequest(
             'POST',
@@ -130,6 +131,7 @@ class CourseClerkshipTypeControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['courses']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/CourseControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CourseControllerTest.php
@@ -143,6 +143,8 @@ class CourseControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['learningMaterials']);
+        unset($postData['sessions']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventoryAcademicLevelControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventoryAcademicLevelControllerTest.php
@@ -87,6 +87,7 @@ class CurriculumInventoryAcademicLevelControllerTest extends AbstractControllerT
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sequenceBlocks']);
 
         $this->createJsonRequest(
             'POST',
@@ -132,6 +133,7 @@ class CurriculumInventoryAcademicLevelControllerTest extends AbstractControllerT
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sequenceBlocks']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventoryReportControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventoryReportControllerTest.php
@@ -90,6 +90,8 @@ class CurriculumInventoryReportControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sequenceBlocks']);
+        unset($postData['academicLevels']);
 
         $this->createJsonRequest(
             'POST',
@@ -135,6 +137,8 @@ class CurriculumInventoryReportControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sequenceBlocks']);
+        unset($postData['academicLevels']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventorySequenceBlockControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventorySequenceBlockControllerTest.php
@@ -84,6 +84,8 @@ class CurriculumInventorySequenceBlockControllerTest extends AbstractControllerT
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sessions']);
+        unset($postData['children']);
 
         $this->createJsonRequest(
             'POST',
@@ -129,6 +131,8 @@ class CurriculumInventorySequenceBlockControllerTest extends AbstractControllerT
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sessions']);
+        unset($postData['children']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/DepartmentControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/DepartmentControllerTest.php
@@ -81,6 +81,7 @@ class DepartmentControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['stewards']);
 
         $this->createJsonRequest(
             'POST',
@@ -126,6 +127,7 @@ class DepartmentControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['stewards']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/LearnerGroupControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/LearnerGroupControllerTest.php
@@ -84,6 +84,7 @@ class LearnerGroupControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['children']);
 
         $this->createJsonRequest(
             'POST',
@@ -129,6 +130,7 @@ class LearnerGroupControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['children']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/LearningMaterialControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/LearningMaterialControllerTest.php
@@ -128,7 +128,7 @@ class LearningMaterialControllerTest extends AbstractControllerTest
             $materials[0]['id'],
             $gotMaterials[0]['id']
         );
-//
+
         $this->createJsonRequest(
             'GET',
             $this->getUrl('cget_learningmaterials', array('q' => 'second')),
@@ -174,10 +174,17 @@ class LearningMaterialControllerTest extends AbstractControllerTest
     {
         $data = $this->container->get('ilioscore.dataloader.learningmaterial')
             ->create();
+
+        $postData = $data;
+        //unset any parameters which should not be POSTed
+        unset($postData['id']);
+        unset($postData['courseLearningMaterials']);
+        unset($postData['sessionLearningMaterials']);
+
         $this->createJsonRequest(
             'POST',
             $this->getUrl('post_learningmaterials'),
-            json_encode(['learningMaterial' => $data]),
+            json_encode(['learningMaterial' => $postData]),
             $this->getAuthenticatedUserToken()
         );
 
@@ -202,10 +209,16 @@ class LearningMaterialControllerTest extends AbstractControllerTest
     {
         $data = $this->container->get('ilioscore.dataloader.learningmaterial')
           ->createCitation();
+        $postData = $data;
+        //unset any parameters which should not be POSTed
+        unset($postData['id']);
+        unset($postData['courseLearningMaterials']);
+        unset($postData['sessionLearningMaterials']);
+
         $this->createJsonRequest(
             'POST',
             $this->getUrl('post_learningmaterials'),
-            json_encode(['learningMaterial' => $data]),
+            json_encode(['learningMaterial' => $postData]),
             $this->getAuthenticatedUserToken()
         );
 
@@ -231,10 +244,16 @@ class LearningMaterialControllerTest extends AbstractControllerTest
     {
         $data = $this->container->get('ilioscore.dataloader.learningmaterial')
           ->createLink();
+        $postData = $data;
+        //unset any parameters which should not be POSTed
+        unset($postData['id']);
+        unset($postData['courseLearningMaterials']);
+        unset($postData['sessionLearningMaterials']);
+
         $this->createJsonRequest(
             'POST',
             $this->getUrl('post_learningmaterials'),
-            json_encode(['learningMaterial' => $data]),
+            json_encode(['learningMaterial' => $postData]),
             $this->getAuthenticatedUserToken()
         );
 
@@ -287,10 +306,17 @@ class LearningMaterialControllerTest extends AbstractControllerTest
           ->createFile();
         $data['fileHash'] = $responseData['fileHash'];
         $data['filename'] = $responseData['filename'];
+
+        $postData = $data;
+        //unset any parameters which should not be POSTed
+        unset($postData['id']);
+        unset($postData['courseLearningMaterials']);
+        unset($postData['sessionLearningMaterials']);
+
         $this->createJsonRequest(
             'POST',
             $this->getUrl('post_learningmaterials'),
-            json_encode(['learningMaterial' => $data]),
+            json_encode(['learningMaterial' => $postData]),
             $this->getAuthenticatedUserToken()
         );
 
@@ -391,6 +417,8 @@ class LearningMaterialControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['courseLearningMaterials']);
+        unset($postData['sessionLearningMaterials']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/MeshDescriptorControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/MeshDescriptorControllerTest.php
@@ -231,6 +231,8 @@ class MeshDescriptorControllerTest extends AbstractControllerTest
 
         $postData = $data;
         unset($postData['trees']);
+        unset($postData['qualifiers']);
+        unset($postData['concepts']);
 
         $this->createJsonRequest(
             'POST',
@@ -288,6 +290,8 @@ class MeshDescriptorControllerTest extends AbstractControllerTest
 
         $postData = $data;
         unset($postData['trees']);
+        unset($postData['qualifiers']);
+        unset($postData['concepts']);
 
 
         $this->createJsonRequest(
@@ -302,14 +306,15 @@ class MeshDescriptorControllerTest extends AbstractControllerTest
 
         $response = $this->client->getResponse();
         $this->assertJsonResponse($response, Codes::HTTP_OK);
-        
+
         $responseData = json_decode($response->getContent(), true)['meshDescriptor'];
         $updatedAt = new DateTime($responseData['updatedAt']);
         unset($responseData['updatedAt']);
         unset($responseData['createdAt']);
         $this->assertEquals(
             $this->mockSerialize($data),
-            $responseData
+            $responseData,
+            var_export($responseData, true)
         );
         $now = new DateTime();
         $diffU = $now->diff($updatedAt);

--- a/src/Ilios/CoreBundle/Tests/Controller/MeshDescriptorControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/MeshDescriptorControllerTest.php
@@ -225,8 +225,13 @@ class MeshDescriptorControllerTest extends AbstractControllerTest
 
     public function testPostMeshDescriptor()
     {
-        $postData = $this->container->get('ilioscore.dataloader.meshdescriptor')
+        $data = $this->container->get('ilioscore.dataloader.meshdescriptor')
             ->create();
+
+
+        $postData = $data;
+        unset($postData['trees']);
+
         $this->createJsonRequest(
             'POST',
             $this->getUrl('post_meshdescriptors'),
@@ -237,14 +242,15 @@ class MeshDescriptorControllerTest extends AbstractControllerTest
         $response = $this->client->getResponse();
         $result = json_decode($response->getContent(), true);
         $this->assertTrue(array_key_exists('meshDescriptors', $result), var_export($result, true));
-        $data = $result['meshDescriptors'][0];
-        $updatedAt = new DateTime($data['updatedAt']);
-        $createdAt = new DateTime($data['createdAt']);
-        unset($data['updatedAt']);
-        unset($data['createdAt']);
+
+        $responseData = $result['meshDescriptors'][0];
+        $updatedAt = new DateTime($responseData['updatedAt']);
+        $createdAt = new DateTime($responseData['createdAt']);
+        unset($responseData['updatedAt']);
+        unset($responseData['createdAt']);
         $this->assertEquals(
-            $this->mockSerialize($postData),
-            $data
+            $this->mockSerialize($data),
+            $responseData
         );
         $now = new DateTime();
         $diffU = $now->diff($updatedAt);
@@ -274,16 +280,21 @@ class MeshDescriptorControllerTest extends AbstractControllerTest
 
     public function testPutMeshDescriptor()
     {
-        $postData = $this->container
+        $data = $this->container
             ->get('ilioscore.dataloader.meshdescriptor')
             ->getOne();
-        $postData['annotation'] = 'somethign new';
+        //mutate something
+        $data['annotation'] = 'somethign new';
+
+        $postData = $data;
+        unset($postData['trees']);
+
 
         $this->createJsonRequest(
             'PUT',
             $this->getUrl(
                 'put_meshdescriptors',
-                ['id' => $postData['id']]
+                ['id' => $data['id']]
             ),
             json_encode(['meshDescriptor' => $postData]),
             $this->getAuthenticatedUserToken()
@@ -292,13 +303,13 @@ class MeshDescriptorControllerTest extends AbstractControllerTest
         $response = $this->client->getResponse();
         $this->assertJsonResponse($response, Codes::HTTP_OK);
         
-        $data = json_decode($response->getContent(), true)['meshDescriptor'];
-        $updatedAt = new DateTime($data['updatedAt']);
-        unset($data['updatedAt']);
-        unset($data['createdAt']);
+        $responseData = json_decode($response->getContent(), true)['meshDescriptor'];
+        $updatedAt = new DateTime($responseData['updatedAt']);
+        unset($responseData['updatedAt']);
+        unset($responseData['createdAt']);
         $this->assertEquals(
             $this->mockSerialize($data),
-            $data
+            $responseData
         );
         $now = new DateTime();
         $diffU = $now->diff($updatedAt);

--- a/src/Ilios/CoreBundle/Tests/Controller/OfferingControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/OfferingControllerTest.php
@@ -417,6 +417,8 @@ class OfferingControllerTest extends AbstractControllerTest
         $postData = $lg;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['children']);
+
         $postData['title'] = $lg['title'] . 'some more text';
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/ProgramControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/ProgramControllerTest.php
@@ -88,6 +88,8 @@ class ProgramControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['programYears']);
+        unset($postData['curriculumInventoryReports']);
 
         $this->createJsonRequest(
             'POST',
@@ -133,6 +135,8 @@ class ProgramControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['programYears']);
+        unset($postData['curriculumInventoryReports']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/ProgramYearControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/ProgramYearControllerTest.php
@@ -92,6 +92,7 @@ class ProgramYearControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['stewards']);
 
         $this->createJsonRequest(
             'POST',
@@ -137,6 +138,7 @@ class ProgramYearControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['stewards']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/PublishEventControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/PublishEventControllerTest.php
@@ -93,6 +93,11 @@ class PublishEventControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['programs']);
+        unset($postData['programYears']);
+        unset($postData['courses']);
+        unset($postData['sessions']);
+
         $this->createJsonRequest(
             'POST',
             $this->getUrl('post_publishevents'),

--- a/src/Ilios/CoreBundle/Tests/Controller/SchoolControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/SchoolControllerTest.php
@@ -92,6 +92,14 @@ class SchoolControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['courses']);
+        unset($postData['topics']);
+        unset($postData['departments']);
+        unset($postData['programs']);
+        unset($postData['competencies']);
+        unset($postData['instructorGroups']);
+        unset($postData['stewards']);
+        unset($postData['sessionTypes']);
 
         $this->createJsonRequest(
             'POST',
@@ -137,6 +145,14 @@ class SchoolControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['courses']);
+        unset($postData['programs']);
+        unset($postData['topics']);
+        unset($postData['departments']);
+        unset($postData['competencies']);
+        unset($postData['instructorGroups']);
+        unset($postData['stewards']);
+        unset($postData['sessionTypes']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/SessionControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/SessionControllerTest.php
@@ -110,6 +110,8 @@ class SessionControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['offerings']);
+        unset($postData['learningMaterials']);
 
         $this->createJsonRequest(
             'POST',
@@ -161,6 +163,8 @@ class SessionControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['offerings']);
+        unset($postData['learningMaterials']);
 
         $this->createJsonRequest(
             'PUT',
@@ -436,6 +440,9 @@ class SessionControllerTest extends AbstractControllerTest
         $postData = $lm;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['courseLearningMaterials']);
+        unset($postData['sessionLearningMaterials']);
+
         $postData['status'] = '2';
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/SessionTypeControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/SessionTypeControllerTest.php
@@ -93,6 +93,7 @@ class SessionTypeControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sessions']);
 
         $this->createJsonRequest(
             'POST',
@@ -138,6 +139,7 @@ class SessionTypeControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sessions']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
@@ -175,6 +175,11 @@ class UserControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['reminders']);
+        unset($postData['learningMaterials']);
+        unset($postData['publishEvents']);
+        unset($postData['reports']);
+        unset($postData['pendingUserUpdates']);
 
         $this->createJsonRequest(
             'POST',
@@ -220,6 +225,11 @@ class UserControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['reminders']);
+        unset($postData['learningMaterials']);
+        unset($postData['publishEvents']);
+        unset($postData['reports']);
+        unset($postData['pendingUserUpdates']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/DataLoader/AssessmentOptionData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/AssessmentOptionData.php
@@ -27,7 +27,7 @@ class AssessmentOptionData extends AbstractDataLoader
         return [
             'id' => 3,
             'name' => $this->faker->text(10),
-            'sessionTypes' => [2]
+            'sessionTypes' => []
         ];
     }
 
@@ -35,8 +35,7 @@ class AssessmentOptionData extends AbstractDataLoader
     {
         return [
             'id' => 'something',
-            'name' => $this->faker->text,
-            'sessionTypes' => [10000]
+            'name' => $this->faker->text
         ];
     }
 }

--- a/src/Ilios/CoreBundle/Tests/DataLoader/CurriculumInventoryAcademicLevelData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/CurriculumInventoryAcademicLevelData.php
@@ -35,7 +35,7 @@ class CurriculumInventoryAcademicLevelData extends AbstractDataLoader
             'description' => $this->faker->text(100),
             'level' => 2,
             'report' => '1',
-            'sequenceBlocks' => [],
+            'sequenceBlocks' => []
         );
         return $arr;
     }

--- a/src/Ilios/CoreBundle/Tests/DataLoader/ProgramData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/ProgramData.php
@@ -46,9 +46,8 @@ class ProgramData extends AbstractDataLoader
             'duration' => 4,
             'deleted' => false,
             'publishedAsTbd' => true,
-
             'school' => "1",
-            'programYears' => ['1'],
+            'programYears' => [],
             'curriculumInventoryReports' => []
         );
     }

--- a/src/Ilios/CoreBundle/Tests/DataLoader/PublishEventData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/PublishEventData.php
@@ -49,7 +49,7 @@ class PublishEventData extends AbstractDataLoader
             'id' => 5,
             'programs' => [],
             'programYears' => [],
-            'courses' => ['1'],
+            'courses' => [],
             'sessions' => [],
         ];
     }

--- a/src/Ilios/CoreBundle/Tests/DataLoader/SchoolData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/SchoolData.php
@@ -58,7 +58,7 @@ class SchoolData extends AbstractDataLoader
             'alerts' => [],
             'competencies' => [],
             'courses' => [],
-            'programs' => [1],
+            'programs' => [],
             'departments' => [],
             'topics' => [],
             'instructorGroups' => [],

--- a/src/Ilios/CoreBundle/Tests/DataLoader/SessionData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/SessionData.php
@@ -98,8 +98,8 @@ class SessionData extends AbstractDataLoader
             'topics' => ['1', '2'],
             'objectives' => ['1', '2'],
             'meshDescriptors' => [],
-            'learningMaterials' => ["1"],
-            'offerings' => ['1']
+            'learningMaterials' => [],
+            'offerings' => []
         );
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/AssessmentOptionTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/AssessmentOptionTest.php
@@ -35,6 +35,14 @@ class AssessmentOptionTest extends EntityBase
     }
 
     /**
+     * @covers Ilios\CoreBundle\Entity\AssessmentOption::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertEmpty($this->object->getSessionTypes());
+    }
+
+    /**
      * @covers Ilios\CoreBundle\Entity\AssessmentOption::setName
      * @covers Ilios\CoreBundle\Entity\AssessmentOption::getName
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/CohortTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CohortTest.php
@@ -40,6 +40,8 @@ class CohortTest extends EntityBase
     public function testConstructor()
     {
         $this->assertEmpty($this->object->getCourses());
+        $this->assertEmpty($this->object->getLearnerGroups());
+        $this->assertEmpty($this->object->getUsers());
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Entity/CompetencyTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CompetencyTest.php
@@ -29,6 +29,8 @@ class CompetencyTest extends EntityBase
     {
         $this->assertEmpty($this->object->getAamcPcrses());
         $this->assertEmpty($this->object->getProgramYears());
+        $this->assertEmpty($this->object->getChildren());
+        $this->assertEmpty($this->object->getObjectives());
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Entity/CourseClerkshipTypeTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CourseClerkshipTypeTest.php
@@ -32,6 +32,15 @@ class CourseClerkshipTypeTest extends EntityBase
         $this->object->setTitle('20 max title');
         $this->validate(0);
     }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\CourseClerkshipType::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertEmpty($this->object->getCourses());
+    }
+
     /**
      * @covers Ilios\CoreBundle\Entity\CourseClerkshipType::setTitle
      * @covers Ilios\CoreBundle\Entity\CourseClerkshipType::getTitle

--- a/src/Ilios/CoreBundle/Tests/Entity/CourseTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CourseTest.php
@@ -51,6 +51,8 @@ class CourseTest extends EntityBase
         $this->assertEmpty($this->object->getTopics());
         $this->assertEmpty($this->object->getMeshDescriptors());
         $this->assertEmpty($this->object->getObjectives());
+        $this->assertEmpty($this->object->getLearningMaterials());
+        $this->assertEmpty($this->object->getSessions());
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventoryAcademicLevelTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventoryAcademicLevelTest.php
@@ -36,6 +36,14 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     }
 
     /**
+     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertEmpty($this->object->getSequenceBlocks());
+    }
+
+    /**
      * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::setLevel
      * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getLevel
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventoryReportTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventoryReportTest.php
@@ -38,6 +38,15 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
+     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertEmpty($this->object->getAcademicLevels());
+        $this->assertEmpty($this->object->getSequenceBlocks());
+    }
+
+    /**
      * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setYear
      * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getYear
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventorySequenceBlockTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventorySequenceBlockTest.php
@@ -50,6 +50,15 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
+     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertEmpty($this->object->getChildren());
+        $this->assertEmpty($this->object->getSessions());
+    }
+
+    /**
      * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setRequired
      * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getRequired
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/LearnerGroupTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/LearnerGroupTest.php
@@ -43,6 +43,7 @@ class LearnerGroupTest extends EntityBase
         $this->assertEmpty($this->object->getInstructors());
         $this->assertEmpty($this->object->getOfferings());
         $this->assertEmpty($this->object->getUsers());
+        $this->assertEmpty($this->object->getChildren());
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Entity/LearningMaterialTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/LearningMaterialTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace Ilios\CoreBundle\Tests\Entity;
+
+use Ilios\CoreBundle\Entity\LearningMaterial;
+use Mockery as m;
+
+/**
+ * Tests for Entity LearningMaterial
+ */
+class LearningMaterialTest extends EntityBase
+{
+    /**
+     * @var LearningMaterial
+     */
+    protected $object;
+
+    /**
+     * Instantiate a LearningMaterial object
+     */
+    protected function setUp()
+    {
+        $this->object = new LearningMaterial;
+    }
+
+    public function testNotBlankValidation()
+    {
+        $notBlank = array(
+            'title',
+            'description',
+        );
+        $this->validateNotBlanks($notBlank);
+
+        $this->object->setTitle('test');
+        $this->object->setDescription('description');
+        $this->validate(0);
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\LearningMaterial::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertEmpty($this->object->getCourseLearningMaterials());
+        $this->assertEmpty($this->object->getSessionLearningMaterials());
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\LearningMaterial::setTitle
+     * @covers Ilios\CoreBundle\Entity\LearningMaterial::getTitle
+     */
+    public function testSetTitle()
+    {
+        $this->basicSetTest('title', 'string');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\LearningMaterial::setDescription
+     * @covers Ilios\CoreBundle\Entity\LearningMaterial::getDescription
+     */
+    public function testSetDescription()
+    {
+        $this->basicSetTest('description', 'string');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\LearningMaterial::setOriginalAuthor
+     * @covers Ilios\CoreBundle\Entity\LearningMaterial::getOriginalAuthor
+     */
+    public function testSetOriginalAuthor()
+    {
+        $this->basicSetTest('originalAuthor', 'string');
+    }
+}

--- a/src/Ilios/CoreBundle/Tests/Entity/MeshDescriptorTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/MeshDescriptorTest.php
@@ -43,6 +43,7 @@ class MeshDescriptorTest extends EntityBase
         $this->assertEmpty($this->object->getObjectives());
         $this->assertEmpty($this->object->getSessions());
         $this->assertEmpty($this->object->getSessionLearningMaterials());
+        $this->assertEmpty($this->object->getTrees());
         $now = new \DateTime();
         $createdAt = $this->object->getCreatedAt();
         $this->assertTrue($createdAt instanceof \DateTime);

--- a/src/Ilios/CoreBundle/Tests/Entity/ProgramTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/ProgramTest.php
@@ -36,6 +36,15 @@ class ProgramTest extends EntityBase
     }
 
     /**
+     * @covers Ilios\CoreBundle\Entity\Program::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertEmpty($this->object->getProgramYears());
+        $this->assertEmpty($this->object->getCurriculumInventoryReports());
+    }
+
+    /**
      * @covers Ilios\CoreBundle\Entity\Program::setTitle
      * @covers Ilios\CoreBundle\Entity\Program::getTitle
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/PublishEventTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/PublishEventTest.php
@@ -43,6 +43,17 @@ class PublishEventTest extends EntityBase
     // }
 
     /**
+     * @covers Ilios\CoreBundle\Entity\PublishEvent::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertEmpty($this->object->getPrograms());
+        $this->assertEmpty($this->object->getProgramYears());
+        $this->assertEmpty($this->object->getCourses());
+        $this->assertEmpty($this->object->getSessions());
+    }
+
+    /**
      * @covers Ilios\CoreBundle\Entity\PublishEvent::setAdministrator
      * @covers Ilios\CoreBundle\Entity\PublishEvent::getAdministrator
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/SchoolTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/SchoolTest.php
@@ -42,6 +42,13 @@ class SchoolTest extends EntityBase
     {
         $this->assertEmpty($this->object->getAlerts());
         $this->assertEmpty($this->object->getStewards());
+        $this->assertEmpty($this->object->getCourses());
+        $this->assertEmpty($this->object->getPrograms());
+        $this->assertEmpty($this->object->getTopics());
+        $this->assertEmpty($this->object->getDepartments());
+        $this->assertEmpty($this->object->getInstructorGroups());
+        $this->assertEmpty($this->object->getCompetencies());
+        $this->assertEmpty($this->object->getSessionTypes());
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Entity/SessionTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/SessionTest.php
@@ -38,6 +38,7 @@ class SessionTest extends EntityBase
         $this->assertEmpty($this->object->getTopics());
         $this->assertEmpty($this->object->getMeshDescriptors());
         $this->assertEmpty($this->object->getObjectives());
+        $this->assertEmpty($this->object->getOfferings());
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Entity/SessionTypeTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/SessionTypeTest.php
@@ -38,6 +38,7 @@ class SessionTypeTest extends EntityBase
     public function testConstructor()
     {
         $this->assertEmpty($this->object->getAamcMethods());
+        $this->assertEmpty($this->object->getSessions());
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Entity/UserTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/UserTest.php
@@ -55,6 +55,10 @@ class UserTest extends EntityBase
         $this->assertEmpty($this->object->getLearnerGroups());
         $this->assertEmpty($this->object->getLearningMaterials());
         $this->assertEmpty($this->object->getCohorts());
+        $this->assertEmpty($this->object->getAuditLogs());
+        $this->assertEmpty($this->object->getPublishEvents());
+        $this->assertEmpty($this->object->getReports());
+        $this->assertEmpty($this->object->getPendingUserUpdates());
     }
 
     /**

--- a/src/Ilios/CoreBundle/Traits/CoursesEntity.php
+++ b/src/Ilios/CoreBundle/Traits/CoursesEntity.php
@@ -39,7 +39,7 @@ trait CoursesEntity
     */
     public function getCourses()
     {
-        //criteria not 100% reliale on many to many relationships
+        //criteria not 100% reliable on many to many relationships
         //fix in https://github.com/doctrine/doctrine2/pull/1399
         // $criteria = Criteria::create()->where(Criteria::expr()->eq("deleted", false));
         // return new ArrayCollection($this->courses->matching($criteria)->getValues());

--- a/src/Ilios/CoreBundle/Traits/OfferingsEntity.php
+++ b/src/Ilios/CoreBundle/Traits/OfferingsEntity.php
@@ -39,7 +39,7 @@ trait OfferingsEntity
     */
     public function getOfferings()
     {
-        //criteria not 100% reliale on many to many relationships
+        //criteria not 100% reliable on many to many relationships
         //fix in https://github.com/doctrine/doctrine2/pull/1399
         // $criteria = Criteria::create()->where(Criteria::expr()->eq("deleted", false));
         // return new ArrayCollection($this->offerings->matching($criteria)->getValues());

--- a/src/Ilios/CoreBundle/Traits/ProgramYearsEntity.php
+++ b/src/Ilios/CoreBundle/Traits/ProgramYearsEntity.php
@@ -39,7 +39,7 @@ trait ProgramYearsEntity
     */
     public function getProgramYears()
     {
-        //criteria not 100% reliale on many to many relationships
+        //criteria not 100% reliable on many to many relationships
         //fix in https://github.com/doctrine/doctrine2/pull/1399
         // $criteria = Criteria::create()->where(Criteria::expr()->eq("deleted", false));
         // return new ArrayCollection($this->programYears->matching($criteria)->getValues());

--- a/src/Ilios/CoreBundle/Traits/ProgramsEntity.php
+++ b/src/Ilios/CoreBundle/Traits/ProgramsEntity.php
@@ -39,7 +39,7 @@ trait ProgramsEntity
     */
     public function getPrograms()
     {
-        //criteria not 100% reliale on many to many relationships
+        //criteria not 100% reliable on many to many relationships
         //fix in https://github.com/doctrine/doctrine2/pull/1399
         // $criteria = Criteria::create()->where(Criteria::expr()->eq("deleted", false));
         // return new ArrayCollection($this->programs->matching($criteria)->getValues());

--- a/src/Ilios/CoreBundle/Traits/SessionsEntity.php
+++ b/src/Ilios/CoreBundle/Traits/SessionsEntity.php
@@ -39,7 +39,7 @@ trait SessionsEntity
     */
     public function getSessions()
     {
-        //criteria not 100% reliale on many to many relationships
+        //criteria not 100% reliable on many to many relationships
         //fix in https://github.com/doctrine/doctrine2/pull/1399
         // $criteria = Criteria::create()->where(Criteria::expr()->eq("deleted", false));
         // return new ArrayCollection($this->sessions->matching($criteria)->getValues());


### PR DESCRIPTION
- Ember data doesn’t send this data, and symphony won’t update from this side, so we shouldn’t allow the form field at all.
- Ensure that entities __construct method sets up necessary empty properties on creation.
- Test to ensure that these are set in the entity unit tests
- Don't submit the many side of a one to many relationship in controller tests

Fixes #1059