### PR TITLE
Allow fractional ILM hours

### DIFF
--- a/src/Ilios/CoreBundle/Entity/IlmSession.php
+++ b/src/Ilios/CoreBundle/Entity/IlmSession.php
@@ -66,14 +66,14 @@ class IlmSession implements IlmSessionInterface
      * @ORM\Column(name="hours", type="decimal", precision=6, scale=2)
      *
      * @Assert\NotBlank()
-     * @Assert\Type(type="integer")
+     * @Assert\Type(type="float")
      * @Assert\Length(
      *      min = 0,
      *      max = 10000
      * )
      *
      * @JMS\Expose
-     * @JMS\Type("integer")
+     * @JMS\Type("float")
      */
     protected $hours;
 
@@ -177,7 +177,7 @@ class IlmSession implements IlmSessionInterface
     }
 
     /**
-     * @param string $hours
+     * @param float $hours
      */
     public function setHours($hours)
     {
@@ -185,7 +185,7 @@ class IlmSession implements IlmSessionInterface
     }
 
     /**
-     * @return string
+     * @return float
      */
     public function getHours()
     {

--- a/src/Ilios/CoreBundle/Entity/IlmSessionInterface.php
+++ b/src/Ilios/CoreBundle/Entity/IlmSessionInterface.php
@@ -16,7 +16,7 @@ interface IlmSessionInterface extends
     LoggableEntityInterface
 {
     /**
-     * @param string $hours
+     * @param float $hours
      */
     public function setHours($hours);
 

--- a/src/Ilios/CoreBundle/Tests/Entity/EntityBase.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/EntityBase.php
@@ -369,6 +369,8 @@ class EntityBase extends TestCase
         switch ($type) {
             case 'integer':
                 return $faker->randomNumber();
+            case 'float':
+                return $faker->randomFloat();
             case 'string':
                 return $faker->text;
             case 'email':

--- a/src/Ilios/CoreBundle/Tests/Entity/IlmSessionTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/IlmSessionTest.php
@@ -33,8 +33,20 @@ class IlmSessionTest extends EntityBase
         $this->validateNotBlanks($notBlank);
 
         $this->object->setSession(new Session());
+        $this->object->setHours(55.1);
+        $this->object->setDueDate(new \DateTime());
+        $this->validate(0);
+    }
+
+    /**
+     * Ensure we can set a float for hours
+     */
+    public function testHourValidation()
+    {
+        $this->object->setSession(new Session());
         $this->object->setHours(55);
         $this->object->setDueDate(new \DateTime());
+        $this->object->setHours(1.33);
         $this->validate(0);
     }
 
@@ -55,7 +67,7 @@ class IlmSessionTest extends EntityBase
      */
     public function testSetHours()
     {
-        $this->basicSetTest('hours', 'string');
+        $this->basicSetTest('hours', 'float');
     }
 
     /**


### PR DESCRIPTION
Validate and display using floats instead of integers.

Fixes #1066