### PR TITLE
Return 200 when user does not have an account

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
@@ -80,7 +80,7 @@ class ShibbolethAuthentication implements AuthenticationInterface
                 'eppn' => $eppn,
                 'errors' => [],
                 'jwt' => null,
-            ), JsonResponse::HTTP_BAD_REQUEST);
+            ), JsonResponse::HTTP_OK);
         }
         $jwt = $this->jwtManager->createJwtFromUser($authEntity->getUser());
         


### PR DESCRIPTION
This vastly simplifies the frontend response since we can just look at
the status and ignore the response code.  Plus I’m not sure that OK
isn’t actually the right response, the request was fulfilled after all.

Fixes ilios/frontend#1054