### PR TITLE
Remove unnecessary API fields from highly trafficked endpoints

### DIFF
--- a/src/Ilios/CoreBundle/Entity/School.php
+++ b/src/Ilios/CoreBundle/Entity/School.php
@@ -115,7 +115,8 @@ class School implements SchoolInterface
      *
      * @ORM\ManyToMany(targetEntity="Alert", mappedBy="recipients")
      *
-     * @JMS\Expose
+     * Don't put alerts in the school API it takes forever to load them all
+     * @JMS\Exclude
      * @JMS\Type("array<string>")
      */
     protected $alerts;

--- a/src/Ilios/CoreBundle/Entity/SessionType.php
+++ b/src/Ilios/CoreBundle/Entity/SessionType.php
@@ -139,7 +139,8 @@ class SessionType implements SessionTypeInterface
      *
      * @ORM\OneToMany(targetEntity="Session", mappedBy="sessionType")
      *
-     * @JMS\Expose
+     * Don't put sessions in the sessionType API it takes forever to load them all
+     * @JMS\Exclude
      * @JMS\Type("array<string>")
      */
     protected $sessions;

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -403,7 +403,8 @@ class User implements UserInterface
      *
      * @ORM\ManyToMany(targetEntity="Alert", mappedBy="instigators")
      *
-     * @JMS\Expose
+     * Don't put alerts in the user API it takes forever to load them all
+     * @JMS\Exclude
      * @JMS\Type("array<string>")
      */
     protected $alerts;

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -259,7 +259,8 @@ class User implements UserInterface
      *
      * @ORM\OneToMany(targetEntity="LearningMaterial", mappedBy="owningUser")
      *
-     * @JMS\Expose
+     * Don't put learningMaterials in the user API it takes forever to load them all
+     * @JMS\Exclude
      * @JMS\Type("array<string>")
      * @JMS\SerializedName("learningMaterials")
      */
@@ -270,7 +271,8 @@ class User implements UserInterface
      *
      * @ORM\OneToMany(targetEntity="PublishEvent", mappedBy="administrator")
      *
-     * @JMS\Expose
+     * Don't put publishEvents in the user API it takes forever to load them all
+     * @JMS\Exclude
      * @JMS\Type("array<string>")
      * @JMS\SerializedName("publishEvents")
      */

--- a/src/Ilios/CoreBundle/Entity/UserRole.php
+++ b/src/Ilios/CoreBundle/Entity/UserRole.php
@@ -64,7 +64,8 @@ class UserRole implements UserRoleInterface
      *
      * @ORM\ManyToMany(targetEntity="User", mappedBy="roles")
      *
-     * @JMS\Expose
+     * Don't put users in the UserRoel API it takes too long to load
+     * @JMS\Exclude
      * @JMS\Type("array<string>")
      */
     protected $users;

--- a/src/Ilios/CoreBundle/Form/Type/SchoolType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SchoolType.php
@@ -24,10 +24,6 @@ class SchoolType extends AbstractType
             ->add('templatePrefix', null, ['required' => false, 'empty_data' => null])
             ->add('iliosAdministratorEmail', null, ['empty_data' => null])
             ->add('changeAlertRecipients', null, ['required' => false, 'empty_data' => null])
-            ->add('alerts', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Alert"
-            ])
             ->add('curriculumInventoryInstitution', 'tdn_single_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryInstitution"

--- a/src/Ilios/CoreBundle/Form/Type/UserRoleType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserRoleType.php
@@ -21,10 +21,6 @@ class UserRoleType extends AbstractType
     {
         $builder
             ->add('title', null, ['empty_data' => null])
-            ->add('users', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:User"
-            ])
         ;
         $builder->get('title')->addViewTransformer(new RemoveMarkupTransformer());
     }

--- a/src/Ilios/CoreBundle/Form/Type/UserType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserType.php
@@ -72,10 +72,6 @@ class UserType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:ProgramYear"
             ])
-            ->add('alerts', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Alert"
-            ])
             ->add('roles', 'tdn_many_related', [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:UserRole"

--- a/src/Ilios/CoreBundle/Tests/Controller/SchoolControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/SchoolControllerTest.php
@@ -35,7 +35,8 @@ class SchoolControllerTest extends AbstractControllerTest
     protected function getPrivateFields()
     {
         return [
-            'templatePrefix'
+            'templatePrefix',
+            'alerts'
         ];
     }
 
@@ -131,47 +132,6 @@ class SchoolControllerTest extends AbstractControllerTest
     /**
      * @group controllers
      */
-    public function testPostSchoolRecipient()
-    {
-        $data = $this->container->get('ilioscore.dataloader.school')->create();
-        $postData = $data;
-        //unset any parameters which should not be POSTed
-        unset($postData['id']);
-        unset($postData['courses']);
-        unset($postData['topics']);
-        unset($postData['departments']);
-        unset($postData['programs']);
-        unset($postData['competencies']);
-        unset($postData['instructorGroups']);
-        unset($postData['stewards']);
-        unset($postData['sessionTypes']);
-
-        $this->createJsonRequest(
-            'POST',
-            $this->getUrl('post_schools'),
-            json_encode(['school' => $postData]),
-            $this->getAuthenticatedUserToken()
-        );
-
-        $newId = json_decode($this->client->getResponse()->getContent(), true)['schools'][0]['id'];
-        foreach ($postData['alerts'] as $id) {
-            $this->createJsonRequest(
-                'GET',
-                $this->getUrl(
-                    'get_alerts',
-                    ['id' => $id]
-                ),
-                null,
-                $this->getAuthenticatedUserToken()
-            );
-            $data = json_decode($this->client->getResponse()->getContent(), true)['alerts'][0];
-            $this->assertTrue(in_array($newId, $data['recipients']));
-        }
-    }
-
-    /**
-     * @group controllers
-     */
     public function testPostBadSchool()
     {
         $invalidSchool = $this->container
@@ -210,6 +170,7 @@ class SchoolControllerTest extends AbstractControllerTest
         unset($postData['instructorGroups']);
         unset($postData['stewards']);
         unset($postData['sessionTypes']);
+        unset($postData['alerts']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/SessionTypeControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/SessionTypeControllerTest.php
@@ -30,7 +30,7 @@ class SessionTypeControllerTest extends AbstractControllerTest
      */
     protected function getPrivateFields()
     {
-        return [];
+        return ['sessions'];
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
@@ -41,6 +41,8 @@ class UserControllerTest extends AbstractControllerTest
             'examined',
             'userSyncIgnore',
             'alerts',
+            'publishEvents',
+            'learningMaterials',
         ];
     }
 

--- a/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
@@ -40,6 +40,7 @@ class UserControllerTest extends AbstractControllerTest
             'addedViaIlios',
             'examined',
             'userSyncIgnore',
+            'alerts',
         ];
     }
 
@@ -605,45 +606,6 @@ class UserControllerTest extends AbstractControllerTest
     /**
      * @group controllers
      */
-    public function testPostUserAlert()
-    {
-        $data = $this->container->get('ilioscore.dataloader.user')->create();
-        $postData = $data;
-        //unset any parameters which should not be POSTed
-        unset($postData['id']);
-        unset($postData['reminders']);
-        unset($postData['learningMaterials']);
-        unset($postData['publishEvents']);
-        unset($postData['reports']);
-        unset($postData['pendingUserUpdates']);
-        unset($postData['permissions']);
-
-        $this->createJsonRequest(
-            'POST',
-            $this->getUrl('post_users'),
-            json_encode(['user' => $postData]),
-            $this->getAuthenticatedUserToken()
-        );
-
-        $newId = json_decode($this->client->getResponse()->getContent(), true)['users'][0]['id'];
-        foreach ($postData['alerts'] as $id) {
-            $this->createJsonRequest(
-                'GET',
-                $this->getUrl(
-                    'get_alerts',
-                    ['id' => $id]
-                ),
-                null,
-                $this->getAuthenticatedUserToken()
-            );
-            $data = json_decode($this->client->getResponse()->getContent(), true)['alerts'][0];
-            $this->assertTrue(in_array($newId, $data['instigators']));
-        }
-    }
-
-    /**
-     * @group controllers
-     */
     public function testPostUserCohort()
     {
         $data = $this->container->get('ilioscore.dataloader.user')->create();
@@ -719,6 +681,7 @@ class UserControllerTest extends AbstractControllerTest
         unset($postData['reports']);
         unset($postData['pendingUserUpdates']);
         unset($postData['permissions']);
+        unset($postData['alerts']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/UserRoleControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/UserRoleControllerTest.php
@@ -27,8 +27,7 @@ class UserRoleControllerTest extends AbstractControllerTest
      */
     protected function getPrivateFields()
     {
-        return [
-        ];
+        return ['users'];
     }
 
     /**
@@ -115,40 +114,6 @@ class UserRoleControllerTest extends AbstractControllerTest
     /**
      * @group controllers
      */
-    public function testPostUserRoleUser()
-    {
-        $data = $this->container->get('ilioscore.dataloader.userrole')
-            ->create();
-        $postData = $data;
-        //unset any parameters which should not be POSTed
-        unset($postData['id']);
-
-        $this->createJsonRequest(
-            'POST',
-            $this->getUrl('post_userroles'),
-            json_encode(['userRole' => $postData]),
-            $this->getAuthenticatedUserToken()
-        );
-
-        $newId = json_decode($this->client->getResponse()->getContent(), true)['userRoles'][0]['id'];
-        foreach ($postData['users'] as $id) {
-            $this->createJsonRequest(
-                'GET',
-                $this->getUrl(
-                    'get_users',
-                    ['id' => $id]
-                ),
-                null,
-                $this->getAuthenticatedUserToken()
-            );
-            $data = json_decode($this->client->getResponse()->getContent(), true)['users'][0];
-            $this->assertTrue(in_array($newId, $data['roles']));
-        }
-    }
-
-    /**
-     * @group controllers
-     */
     public function testPostBadUserRole()
     {
         $invalidUserRole = $this->container
@@ -179,6 +144,7 @@ class UserRoleControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['users']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/DataLoader/SchoolData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/SchoolData.php
@@ -52,7 +52,6 @@ class SchoolData extends AbstractDataLoader
             'title' => $this->faker->word,
             'iliosAdministratorEmail' => $this->faker->email,
             'changeAlertRecipients' => $this->faker->email,
-            'alerts' => ['1'],
             'competencies' => [],
             'courses' => [],
             'programs' => [],

--- a/src/Ilios/CoreBundle/Tests/DataLoader/SessionTypeData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/SessionTypeData.php
@@ -36,8 +36,7 @@ class SessionTypeData extends AbstractDataLoader
             'id' => 3,
             'title' => $this->faker->text(50),
             'school' => '1',
-            'aamcMethods' => [],
-            'sessions' => []
+            'aamcMethods' => []
         );
     }
 

--- a/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
@@ -156,7 +156,6 @@ class UserData extends AbstractDataLoader
             'offerings' => ['1'],
             'instructedOfferings' => ['1'],
             'programYears' => ['1'],
-            'alerts' => ['1'],
             'roles' => ['1'],
             'cohorts' => ['1'],
             'reminders' => [],

--- a/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
@@ -143,8 +143,6 @@ class UserData extends AbstractDataLoader
             'phone' => $this->faker->phoneNumber,
             'enabled' => true,
             'icsFeedKey' => hash('sha256', '5'),
-            'learningMaterials' => [],
-            'publishEvents' => [],
             'reports' => [],
             'school' => "1",
             'directedCourses' => ['1'],

--- a/src/Ilios/CoreBundle/Tests/DataLoader/UserRoleData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/UserRoleData.php
@@ -24,8 +24,7 @@ class UserRoleData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 2,
-            'title' => $this->faker->text(10),
-            'users' => ['1','2'],
+            'title' => $this->faker->text(10)
         );
 
         return $arr[0];


### PR DESCRIPTION
This should speed up load speed on several pages.

Fixes #1100, #1101, #1102