### PR TITLE
lm::link needs to be a string, but not necessarily an URL.

### DIFF
--- a/src/Ilios/CoreBundle/Entity/LearningMaterial.php
+++ b/src/Ilios/CoreBundle/Entity/LearningMaterial.php
@@ -249,7 +249,7 @@ class LearningMaterial implements LearningMaterialInterface
      *
      * @ORM\Column(name="web_link", type="string", length=256, nullable=true)
      *
-     * @Assert\Url(groups={"link"})
+     * @Assert\Type(type="string", groups={"link"})
      */
     protected $link;
 


### PR DESCRIPTION
Per @saschaben's [request](https://github.com/ilios/frontend/issues/1013#issuecomment-153589485).

Refs ilios/frontend#1013.
