### PR TITLE
Add /errors endpoint for capturing errors from frontend

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -18,6 +18,12 @@ security:
             simple_preauth:
                 authenticator: ilios_authentication.jwt.authenticator
             provider: ilios_user_entity
+        errors:
+            pattern:    ^/errors
+            stateless: true
+            simple_preauth:
+                authenticator: ilios_authentication.jwt.authenticator
+            provider: ilios_user_entity
         default:
             pattern:    ^/api
             stateless: true

--- a/src/Ilios/WebBundle/Controller/ErrorController.php
+++ b/src/Ilios/WebBundle/Controller/ErrorController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Ilios\WebBundle\Controller;
+
+use FOS\RestBundle\Util\Codes;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ErrorController extends Controller
+{
+    public function errorAction(Request $request)
+    {
+        if ($request->request->has('data')) {
+            $logger = $this->get('logger');
+            $data = $request->request->get('data');
+            $user = $this->get('security.token_storage')->getToken()->getUser();
+            $data['userId'] = $user->getId();
+            $logger->error(json_encode($data));
+        }
+
+        return new Response('', Codes::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Ilios/WebBundle/Resources/config/routing.yml
+++ b/src/Ilios/WebBundle/Resources/config/routing.yml
@@ -4,6 +4,11 @@ ilios_web_ics:
         _controller: IliosWebBundle:Ics:index
     requirements:
         key: "^[a-zA-Z0-9]{64}$"
+ilios_web_errors:
+    pattern:     /errors
+    defaults:
+        _controller: IliosWebBundle:Error:error
+    methods:  [POST]
 ilios_web_homepage:
     pattern:     /{url}
     defaults:

--- a/src/Ilios/WebBundle/Tests/Controller/ErrorControllerTest.php
+++ b/src/Ilios/WebBundle/Tests/Controller/ErrorControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ilios\WebBundle\Tests\Controller;
+
+use Ilios\CoreBundle\Tests\Traits\JsonControllerTest;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Faker\Factory as FakerFactory;
+use FOS\RestBundle\Util\Codes;
+
+class ErrorControllerTest extends WebTestCase
+{
+    use JsonControllerTest;
+
+    public function testIndex()
+    {
+        $faker = FakerFactory::create();
+
+        $client = static::createClient();
+        $data = [
+            'mainMessage' => $faker->text(100),
+            'stack' => $faker->text(1000)
+        ];
+        $this->makeJsonRequest(
+            $client,
+            'POST',
+            '/errors',
+            json_encode(['data' => $data]),
+            $this->getAuthenticatedUserToken()
+        );
+
+        $response = $client->getResponse();
+        $this->assertEquals(Codes::HTTP_NO_CONTENT, $response->getStatusCode(), $response->getContent());
+
+    }
+}

--- a/src/Ilios/WebBundle/Tests/Controller/ErrorControllerTest.php
+++ b/src/Ilios/WebBundle/Tests/Controller/ErrorControllerTest.php
@@ -2,14 +2,21 @@
 
 namespace Ilios\WebBundle\Tests\Controller;
 
+use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Ilios\CoreBundle\Tests\Traits\JsonControllerTest;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Faker\Factory as FakerFactory;
 use FOS\RestBundle\Util\Codes;
 
 class ErrorControllerTest extends WebTestCase
 {
     use JsonControllerTest;
+
+    public function setUp()
+    {
+        $this->loadFixtures([
+            'Ilios\CoreBundle\Tests\Fixture\LoadAuthenticationData',
+        ]);
+    }
 
     public function testIndex()
     {


### PR DESCRIPTION
Authenticated users can post data here so we can keep track of any
errors encountered in the app.

Fixes #1063