### PR TITLE
Handle course filter params as an array

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
@@ -146,8 +146,9 @@ class CourseRepository extends EntityRepository
 
         if (count($criteria)) {
             foreach ($criteria as $key => $value) {
-                $qb->orWhere($qb->expr()->like("c.{$key}", ":{$key}"));
-                $qb->setParameter(":{$key}", $value);
+                $values = is_array($value) ? $value : [$value];
+                $qb->orWhere($qb->expr()->in("c.{$key}", ":{$key}"));
+                $qb->setParameter(":{$key}", $values);
             }
         }
 

--- a/src/Ilios/CoreBundle/Tests/Controller/CourseControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CourseControllerTest.php
@@ -282,6 +282,38 @@ class CourseControllerTest extends AbstractControllerTest
     /**
      * @group controllers
      */
+    public function testFilterByIds()
+    {
+        $courses = $this->container->get('ilioscore.dataloader.course')->getAll();
+
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl('cget_courses', ['filters[id]' => [1,3]]),
+            null,
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_OK);
+        $data = json_decode($response->getContent(), true)['courses'];
+        $this->assertEquals(2, count($data), var_export($data, true));
+        $this->assertEquals(
+            $this->mockSerialize(
+                $courses[0]
+            ),
+            $data[0]
+        );
+        $this->assertEquals(
+            $this->mockSerialize(
+                $courses[2]
+            ),
+            $data[1]
+        );
+    }
+
+    /**
+     * @group controllers
+     */
     public function testFilterByTopic()
     {
         $courses = $this->container->get('ilioscore.dataloader.course')->getAll();


### PR DESCRIPTION
Filter params which have always existed on course like id, year, etc…
can be passed as an array and should be handled in that way.

Fixes #1112