### PR TITLE
Add users as a filter on courses endpoint

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
@@ -62,6 +62,44 @@ class CourseRepository extends EntityRepository
             $qb->andWhere($qb->expr()->in('programYear.id', ':programYears'));
             $qb->setParameter(':programYears', $ids);
         }
+        if (array_key_exists('users', $criteria)) {
+            $ids = is_array($criteria['users']) ? $criteria['users'] : [$criteria['users']];
+
+            $qb->leftJoin('c.directors', 'courseDirector');
+            $qb->leftJoin('c.sessions', 'session');
+            $qb->leftJoin('session.offerings', 'offering');
+            $qb->leftJoin('session.ilmSession', 'ilmSession');
+
+            $qb->leftJoin('offering.instructors', 'instructor');
+            $qb->leftJoin('offering.learners', 'learner');
+            $qb->leftJoin('offering.instructorGroups', 'insGroup');
+            $qb->leftJoin('insGroup.users', 'igUser');
+            $qb->leftJoin('offering.learnerGroups', 'learnerGroup');
+            $qb->leftJoin('learnerGroup.users', 'lgUser');
+
+            $qb->leftJoin('ilmSession.instructors', 'ilmInstructor');
+            $qb->leftJoin('ilmSession.learners', 'ilmLearner');
+            $qb->leftJoin('ilmSession.instructorGroups', 'ilmInsGroup');
+            $qb->leftJoin('ilmInsGroup.users', 'ilmIgUser');
+            $qb->leftJoin('ilmSession.learnerGroups', 'ilmLearnerGroup');
+            $qb->leftJoin('ilmLearnerGroup.users', 'ilmLgUser');
+
+            $qb->andWhere($qb->expr()->orX(
+                $qb->expr()->in('learner.id', ':users'),
+                $qb->expr()->in('instructor.id', ':users'),
+                $qb->expr()->in('courseDirector.id', ':users'),
+                $qb->expr()->in('igUser.id', ':users'),
+                $qb->expr()->in('lgUser.id', ':users'),
+                $qb->expr()->in('ilmLearner.id', ':users'),
+                $qb->expr()->in('ilmInstructor.id', ':users'),
+                $qb->expr()->in('ilmIgUser.id', ':users'),
+                $qb->expr()->in('ilmLgUser.id', ':users')
+            ));
+
+
+            $qb->setParameter(':users', $ids);
+
+        }
         if (array_key_exists('instructors', $criteria)) {
             $ids = is_array($criteria['instructors']) ? $criteria['instructors'] : [$criteria['instructors']];
             $qb->leftJoin('c.sessions', 'session');
@@ -142,6 +180,7 @@ class CourseRepository extends EntityRepository
         unset($criteria['topics']);
         unset($criteria['programs']);
         unset($criteria['programYears']);
+        unset($criteria['users']);
         unset($criteria['instructors']);
         unset($criteria['instructorGroups']);
         unset($criteria['learningMaterials']);

--- a/src/Ilios/CoreBundle/Tests/Controller/CourseControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CourseControllerTest.php
@@ -512,6 +512,45 @@ class CourseControllerTest extends AbstractControllerTest
     }
 
     /**
+     * @todo this probably doesn't hit all of the possible ways a user can be connected to a course [JJ 11/2015]
+     * @group controllers
+     */
+    public function testFilterByUser()
+    {
+        $courses = $this->container->get('ilioscore.dataloader.course')->getAll();
+
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl('cget_courses', ['filters[users]' => [1,2]]),
+            null,
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_OK);
+        $data = json_decode($response->getContent(), true)['courses'];
+        $this->assertEquals(3, count($data), var_export($data, true));
+        $this->assertEquals(
+            $this->mockSerialize(
+                $courses[0]
+            ),
+            $data[0]
+        );
+        $this->assertEquals(
+            $this->mockSerialize(
+                $courses[1]
+            ),
+            $data[1]
+        );
+        $this->assertEquals(
+            $this->mockSerialize(
+                $courses[3]
+            ),
+            $data[2]
+        );
+    }
+
+    /**
      * @group controllers
      */
     public function testFilterByProgramYear()


### PR DESCRIPTION
This allows us to quickly retrieve a set of all the courses that belong
to a user which should be faster than building it backwards on the fronted.

Fixes #1125