### PR TITLE
Allow program years to be removed

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20151118233516.php
+++ b/app/Resources/DoctrineMigrations/Version20151118233516.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Cascade deletes for cohorts and program years
+ */
+class Version20151118233516 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE cohort DROP FOREIGN KEY FK_D3B8C16BCB2B0673');
+        $this->addSql('ALTER TABLE cohort ADD CONSTRAINT FK_D3B8C16BCB2B0673 FOREIGN KEY (program_year_id) REFERENCES program_year (program_year_id) ON DELETE CASCADE');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE cohort DROP FOREIGN KEY FK_D3B8C16BCB2B0673');
+        $this->addSql('ALTER TABLE cohort ADD CONSTRAINT FK_D3B8C16BCB2B0673 FOREIGN KEY (program_year_id) REFERENCES program_year (program_year_id)');
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/Cohort.php
+++ b/src/Ilios/CoreBundle/Entity/Cohort.php
@@ -71,7 +71,7 @@ class Cohort implements CohortInterface
      * @var ProgramYearInterface
      *
      * @ORM\OneToOne(targetEntity="ProgramYear", fetch="EXTRA_LAZY", inversedBy="cohort")
-     * @ORM\JoinColumn(name="program_year_id", referencedColumnName="program_year_id", unique=true)
+     * @ORM\JoinColumn(name="program_year_id", referencedColumnName="program_year_id", unique=true, onDelete="cascade")
      *
      * @JMS\Expose
      * @JMS\Type("string")


### PR DESCRIPTION
Cascade program year / cohort deletes.  This allows empty program years connected to empty cohorts to be deleted.

Fixes #1117