### PR TITLE
Add symphony security checker to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ before_install:
 #install ldap extension so composer install will run
   - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - cp ${TRAVIS_BUILD_DIR}/app/config/parameters.yml.travis ${TRAVIS_BUILD_DIR}/app/config/parameters.yml
+#install the symfony security checker
+  - if [ "$CHECK_CODING_STANDARDS" ]; then wget http://get.sensiolabs.org/security-checker.phar -O security-checker.phar; fi
 
 install:
     #Install production first this will fail if production dependencies are messed up
@@ -57,6 +59,7 @@ before_script:
 script:
   - if [ "$VALIDATE_SCHEMA" = true ]; then (bin/console doctrine:schema:validate --env=dev); fi
   - if [ "$CHECK_CODING_STANDARDS" = true ]; then (bin/phpcs --standard=app/phpcs.xml src); fi
+  - if [ "$CHECK_CODING_STANDARDS" = true ]; then (php security-checker.phar security:check); fi
   - if [ "$TEST_PHPUNIT_MESH_DATA_IMPORT" = true ]; then (bin/phpunit -c phpunit.xml.dist --group mesh_data_import); fi
   - if [ "$TEST_PHPUNIT_CONTROLLERS" = true ]; then (bin/phpunit -c phpunit.xml.dist --group controllers); fi
   - if [ "$TEST_PHPUNIT_OTHERS" = true ]; then (bin/phpunit -c phpunit.xml.dist --exclude-group mesh_data_import,controllers); fi

--- a/app/Resources/DoctrineMigrations/Version20151125055054.php
+++ b/app/Resources/DoctrineMigrations/Version20151125055054.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Remove incorrect double index created by doctrine
+ */
+class Version20151125055054 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX UNIQ_32B6E2F4CDB3C93B ON mesh_previous_indexing');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_32B6E2F4CDB3C93B ON mesh_previous_indexing (mesh_descriptor_uid)');
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -989,16 +989,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.5.1",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/doctrine2.git",
-                "reference": "e6a83bedbe67579cb0bfb688e982e617943a2945"
+                "reference": "464b5fdbfbbeb4a65465ac173c4c5d90960f41ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/e6a83bedbe67579cb0bfb688e982e617943a2945",
-                "reference": "e6a83bedbe67579cb0bfb688e982e617943a2945",
+                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/464b5fdbfbbeb4a65465ac173c4c5d90960f41ff",
+                "reference": "464b5fdbfbbeb4a65465ac173c4c5d90960f41ff",
                 "shasum": ""
             },
             "require": {
@@ -1009,12 +1009,12 @@
                 "doctrine/instantiator": "~1.0.1",
                 "ext-pdo": "*",
                 "php": ">=5.4",
-                "symfony/console": "~2.5"
+                "symfony/console": "~2.5|~3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.0",
                 "satooshi/php-coveralls": "dev-master",
-                "symfony/yaml": "~2.1"
+                "symfony/yaml": "~2.3|~3.0"
             },
             "suggest": {
                 "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
@@ -1062,7 +1062,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2015-08-31 12:59:39"
+            "time": "2015-11-23 12:44:25"
         },
         {
             "name": "dreamscapes/ldap-core",
@@ -2643,29 +2643,29 @@
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "2.8.1",
+            "version": "v2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bundle.git",
-                "reference": "7117b9a145722e3c5768db4585f6ad0643ed5c4a"
+                "reference": "84785c4d44801c4dd82829fa2e1820cacfe2c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/7117b9a145722e3c5768db4585f6ad0643ed5c4a",
-                "reference": "7117b9a145722e3c5768db4585f6ad0643ed5c4a",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/84785c4d44801c4dd82829fa2e1820cacfe2c46f",
+                "reference": "84785c4d44801c4dd82829fa2e1820cacfe2c46f",
                 "shasum": ""
             },
             "require": {
                 "monolog/monolog": "~1.8",
                 "php": ">=5.3.2",
-                "symfony/config": "~2.3|3.*",
-                "symfony/dependency-injection": "~2.3|3.*",
-                "symfony/http-kernel": "~2.3|3.*",
-                "symfony/monolog-bridge": "~2.3|3.*"
+                "symfony/config": "~2.3|~3.0",
+                "symfony/dependency-injection": "~2.3|~3.0",
+                "symfony/http-kernel": "~2.3|~3.0",
+                "symfony/monolog-bridge": "~2.3|~3.0"
             },
             "require-dev": {
-                "symfony/console": "~2.3|3.*",
-                "symfony/yaml": "~2.3"
+                "symfony/console": "~2.3|~3.0",
+                "symfony/yaml": "~2.3|~3.0"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -2698,7 +2698,7 @@
                 "log",
                 "logging"
             ],
-            "time": "2015-10-02 11:51:59"
+            "time": "2015-11-17 10:02:29"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -2759,23 +2759,23 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v2.7.6",
+            "version": "v2.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "66b2e9662c44d478b69e48278aa54079a006eb42"
+                "reference": "cc69dbd24b4b2e6de60b2414ef95da2794f459a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/66b2e9662c44d478b69e48278aa54079a006eb42",
-                "reference": "66b2e9662c44d478b69e48278aa54079a006eb42",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/cc69dbd24b4b2e6de60b2414ef95da2794f459a2",
+                "reference": "cc69dbd24b4b2e6de60b2414ef95da2794f459a2",
                 "shasum": ""
             },
             "require": {
                 "doctrine/common": "~2.4",
                 "php": ">=5.3.9",
                 "psr/log": "~1.0",
-                "twig/twig": "~1.20|~2.0"
+                "twig/twig": "~1.23|~2.0"
             },
             "replace": {
                 "symfony/asset": "self.version",
@@ -2855,6 +2855,9 @@
                 ],
                 "files": [
                     "src/Symfony/Component/Intl/Resources/stubs/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "**/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2876,7 +2879,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2015-10-27 19:07:24"
+            "time": "2015-11-23 11:58:08"
         },
         {
             "name": "tdn/php-types",
@@ -4613,16 +4616,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.3.4",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "11a2545c44a5915f883e2e5ec12e14ed345e3ab2"
+                "reference": "32a879f4f35019d78d568db2885d7779ca084a33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/11a2545c44a5915f883e2e5ec12e14ed345e3ab2",
-                "reference": "11a2545c44a5915f883e2e5ec12e14ed345e3ab2",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/32a879f4f35019d78d568db2885d7779ca084a33",
+                "reference": "32a879f4f35019d78d568db2885d7779ca084a33",
                 "shasum": ""
             },
             "require": {
@@ -4683,7 +4686,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2015-09-09 00:18:50"
+            "time": "2015-11-23 21:30:59"
         }
     ],
     "aliases": [],

--- a/src/Ilios/AuthenticationBundle/Voter/LearningMaterialVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/LearningMaterialVoter.php
@@ -42,12 +42,12 @@ class LearningMaterialVoter extends AbstractVoter
                 // users with 'Faculty', 'Course director' or 'Developer' role can create materials.
                 return $this->userHasRole($user, ['Faculty', 'Course Director', 'Developer']);
                 break;
-            case self::EDIT:
-            case self::DELETE:
-                // in order to grant EDIT and DELETE privileges on the given learning material to the given user,
-                // at least one of the following statements must be true:
-                // 1. the user owns the learning material
-                // 2. the user has at least one of 'Faculty', 'Course Director' or 'Developer' roles.
+                case self::EDIT:
+                case self::DELETE:
+                    // in order to grant EDIT and DELETE privileges on the given learning material to the given user,
+                    // at least one of the following statements must be true:
+                    // 1. the user owns the learning material
+                    // 2. the user has at least one of 'Faculty', 'Course Director' or 'Developer' roles.
                 return (
                     $this->usersAreIdentical($user, $material->getOwningUser())
                     || $this->userHasRole($user, ['Faculty', 'Course Director', 'Developer'])

--- a/src/Ilios/AuthenticationBundle/Voter/SchoolVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/SchoolVoter.php
@@ -62,14 +62,14 @@ class SchoolVoter extends AbstractVoter
                 // only developers can create schools.
                 return $this->userHasRole($user, ['Developer']);
                 break;
-            case self::EDIT:
-            case self::DELETE:
-                // Only grant EDIT and DELETE permissions if the user has the 'Developer' role.
-                // - and -
-                // the user must be associated with the given school,
-                // either by its primary school attribute
-                //     - or - by WRITE rights for the school
-                // via the permissions system.
+                case self::EDIT:
+                case self::DELETE:
+                    // Only grant EDIT and DELETE permissions if the user has the 'Developer' role.
+                    // - and -
+                    // the user must be associated with the given school,
+                    // either by its primary school attribute
+                    //     - or - by WRITE rights for the school
+                    // via the permissions system.
                 return (
                     $this->userHasRole($user, ['Developer'])
                     && (


### PR DESCRIPTION
This should detect some security issues with our install to help us stay ahead of problems.  I put it in the same build as code style.  Does it belong somewhere else?

One vulnerability was detected so I updated libraries as well:
- symfony/symfony v2.7.6 to v2.7.7
- doctrine/orm v2.5.1 to v2.5.2
- symfony/monolog-bundle 2.8.1 to v2.8.2
- squizlabs/php_codesniffer 2.3.4 to 2.4.0