### PR TITLE
Cache index.html for 60 seconds only

### DIFF
--- a/src/Ilios/WebBundle/Controller/IndexController.php
+++ b/src/Ilios/WebBundle/Controller/IndexController.php
@@ -16,6 +16,9 @@ class IndexController extends Controller
         $response = new Response($file);
         $response->headers->set('Content-Type', 'text/html');
 
+        $response->setPublic();
+        $response->setMaxAge(60);
+
         return $response;
     }
 }

--- a/src/Ilios/WebBundle/Tests/Controller/IndexControllerTest.php
+++ b/src/Ilios/WebBundle/Tests/Controller/IndexControllerTest.php
@@ -21,5 +21,7 @@ class IndexControllerTest extends WebTestCase
 
         $this->assertSame($text, $content);
 
+        //ensure we have a 60 second max age
+        $this->assertSame(60, $response->getMaxAge());
     }
 }


### PR DESCRIPTION
This file which is always available at index.html is actually
dynamically tied to the latest fronted version tag.  This change
ensures that the browser will attempt to reload it at least once a
minute.

Fixes #1156