### PR TITLE
Protect learner group related entities from double add

### DIFF
--- a/src/Ilios/CoreBundle/Entity/LearnerGroup.php
+++ b/src/Ilios/CoreBundle/Entity/LearnerGroup.php
@@ -254,7 +254,9 @@ class LearnerGroup implements LearnerGroupInterface
      */
     public function addUser(UserInterface $user)
     {
-        $this->users->add($user);
+        if (!$this->users->contains($user)) {
+            $this->users->add($user);
+        }
     }
 
     /**
@@ -334,7 +336,9 @@ class LearnerGroup implements LearnerGroupInterface
      */
     public function addChild(LearnerGroupInterface $child)
     {
-        $this->children->add($child);
+        if (!$this->children->contains($child)) {
+            $this->children->add($child);
+        }
     }
 
     /**
@@ -366,7 +370,9 @@ class LearnerGroup implements LearnerGroupInterface
      */
     public function addInstructorGroup(InstructorGroupInterface $instructorGroup)
     {
-        $this->instructorGroups->add($instructorGroup);
+        if (!$this->instructorGroups->contains($instructorGroup)) {
+            $this->instructorGroups->add($instructorGroup);
+        }
     }
 
     /**


### PR DESCRIPTION
Users, children, and instructor groups relationships needed the
protection we use on all many to many relationships.

Fixes #1167