### PR TITLE
query cleanup

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
@@ -35,7 +35,7 @@ class CourseRepository extends EntityRepository
 
         if (array_key_exists('sessions', $criteria)) {
             $ids = is_array($criteria['sessions']) ? $criteria['sessions'] : [$criteria['sessions']];
-            $qb->leftJoin('c.sessions', 'se_session');
+            $qb->join('c.sessions', 'se_session');
             $qb->andWhere($qb->expr()->in('se_session.id', ':sessions'));
             $qb->setParameter(':sessions', $ids);
         }
@@ -149,8 +149,8 @@ class CourseRepository extends EntityRepository
 
         if (array_key_exists('competencies', $criteria)) {
             $ids = is_array($criteria['competencies']) ? $criteria['competencies'] : [$criteria['competencies']];
-            $qb->leftJoin('c.objectives', 'c_objective');
-            $qb->leftJoin('c_objective.competency', 'c_competency');
+            $qb->join('c.objectives', 'c_objective');
+            $qb->join('c_objective.competency', 'c_competency');
             $qb->andWhere($qb->expr()->in('c_competency.id', ':competencies'));
             $qb->setParameter(':competencies', $ids);
         }


### PR DESCRIPTION
using `JOIN` instead of `LEFT JOIN` as applicable.

minor issue.