### PR TITLE
Improved Learning Material Migration

### DIFF
--- a/src/Ilios/CliBundle/Command/MigrateIlios2LearningMaterialsCommand.php
+++ b/src/Ilios/CliBundle/Command/MigrateIlios2LearningMaterialsCommand.php
@@ -120,7 +120,7 @@ class MigrateIlios2LearningMaterialsCommand extends Command
             $output->writeln('');
             
             $output->writeln("<info>Migrated {$migrated} learning materials successfully!</info>");
-            if($skipped){
+            if ($skipped) {
                 $msg = "<comment>Skipped {$skipped} learning materials because they could not be located " .
                 "or were already migrated.</comment>";
                 $output->writeln($msg);

--- a/src/Ilios/CliBundle/Command/MigrateIlios2LearningMaterialsCommand.php
+++ b/src/Ilios/CliBundle/Command/MigrateIlios2LearningMaterialsCommand.php
@@ -5,11 +5,10 @@ namespace Ilios\CliBundle\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFileSystem;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 use Ilios\CoreBundle\Entity\Manager\LearningMaterialManagerInterface;
 use Ilios\CoreBundle\Classes\IliosFileSystem;
@@ -76,40 +75,56 @@ class MigrateIlios2LearningMaterialsCommand extends Command
             );
         }
         
-        $learningMaterials = $this->learningMaterialManager->findFileLearningMaterials();
-        
+        $totalLearningMaterialsCount = $this->learningMaterialManager->getTotalFileLearningMaterialCount();
+
         $helper = $this->getHelper('question');
         $output->writeln('');
         $question = new ConfirmationQuestion(
-            '<question>Ready to copy ' . count($learningMaterials) .
+            '<question>Ready to copy ' . $totalLearningMaterialsCount .
             ' learning materials. Shall we continue? </question>' . "\n",
             true
         );
         
         if ($helper->ask($input, $output, $question)) {
-            $migrated = 0;
-            foreach ($learningMaterials as $lm) {
-                $fullPath = $pathToIlios2 . $lm->getRelativePath();
-                if (!$this->symfonyFileSystem->exists($fullPath)) {
-                    throw new \Exception(
-                        'Unable to migrated learning material #' . $lm ->getId() .
-                        ".  No file found at '${fullPath}'."
-                    );
-                }
-                $file = $this->iliosFileSystem->getSymfonyFileForPath($fullPath);
-                $newPath = $this->iliosFileSystem->storeLearningMaterialFile($file);
-                $lm->setRelativePath($newPath);
-                $this->learningMaterialManager->updateLearningMaterial($lm, false);
-                $migrated ++;
 
-                if ($migrated % 500) {
-                    $this->learningMaterialManager->flushAndClear();
+            $progress = new ProgressBar($output, $totalLearningMaterialsCount);
+            $progress->setRedrawFrequency(208);
+            $output->writeln("<info>Starting migration of learning materials...</info>");
+            $progress->start();
+
+            $migrated = 0;
+            $skipped = 0;
+            $offset = 0;
+            $limit = 50;
+
+            while ($migrated + $skipped < $totalLearningMaterialsCount) {
+                $learningMaterials = $this->learningMaterialManager->findFileLearningMaterials($limit, $offset);
+                foreach ($learningMaterials as $lm) {
+                    $fullPath = $pathToIlios2 . $lm->getRelativePath();
+                    if (!$this->symfonyFileSystem->exists($fullPath)) {
+                        $skipped++;
+                    } else {
+                        $file = $this->iliosFileSystem->getSymfonyFileForPath($fullPath);
+                        $newPath = $this->iliosFileSystem->storeLearningMaterialFile($file);
+                        $lm->setRelativePath($newPath);
+                        $this->learningMaterialManager->updateLearningMaterial($lm, false);
+                        $migrated ++;
+                    }
+                    $progress->advance();
                 }
+                $this->learningMaterialManager->flushAndClear();
+                $offset += $limit;
             }
-            
-            $this->learningMaterialManager->flushAndClear();
+
+            $progress->finish();
+            $output->writeln('');
             
             $output->writeln("<info>Migrated {$migrated} learning materials successfully!</info>");
+            if($skipped){
+                $msg = "<comment>Skipped {$skipped} learning materials because they could not be located " .
+                "or were already migrated.</comment>";
+                $output->writeln($msg);
+            }
         } else {
             $output->writeln('<comment>Migration canceled.</comment>');
         }

--- a/src/Ilios/CliBundle/Command/ValidateLearningMaterialPathsCommand.php
+++ b/src/Ilios/CliBundle/Command/ValidateLearningMaterialPathsCommand.php
@@ -89,10 +89,10 @@ class ValidateLearningMaterialPathsCommand extends Command
         $output->writeln('');
 
         $output->writeln("<info>Validated {$valid} learning materials file path.</info>");
-        if(count($broken)){
+        if (count($broken)) {
             $msg = "<error>Unable to find the files for " . count($broken) . ' learning material.</error>';
             $output->writeln($msg);
-            $rows = array_map(function($arr){
+            $rows = array_map(function ($arr) {
                 return [
                     $arr['id'],
                     $arr['path']

--- a/src/Ilios/CliBundle/Command/ValidateLearningMaterialPathsCommand.php
+++ b/src/Ilios/CliBundle/Command/ValidateLearningMaterialPathsCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\Table;
+
+use Ilios\CoreBundle\Entity\Manager\LearningMaterialManagerInterface;
+use Ilios\CoreBundle\Classes\IliosFileSystem;
+
+/**
+ * Sync a user with their directory information
+ *
+ * Class SyncUserCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class ValidateLearningMaterialPathsCommand extends Command
+{
+    
+    /**
+     * @var IliosFileSystem
+     */
+    protected $iliosFileSystem;
+    
+    /**
+     * @var LearningMaterialManagerInterface
+     */
+    protected $learningMaterialManager;
+    
+    public function __construct(
+        IliosFileSystem $iliosFileSystem,
+        LearningMaterialManagerInterface $learningMaterialManager
+    ) {
+        $this->iliosFileSystem = $iliosFileSystem;
+        $this->learningMaterialManager = $learningMaterialManager;
+        
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:setup:validate-learning-materials')
+            ->setDescription('Validate file paths for learning materials');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $totalLearningMaterialsCount = $this->learningMaterialManager->getTotalFileLearningMaterialCount();
+
+        $progress = new ProgressBar($output, $totalLearningMaterialsCount);
+        $progress->setRedrawFrequency(208);
+        $output->writeln("<info>Starting validate of learning materials...</info>");
+        $progress->start();
+
+        $valid = 0;
+        $broken = [];
+        $offset = 0;
+        $limit = 500;
+
+        while ($valid + count($broken) < $totalLearningMaterialsCount) {
+            $learningMaterials = $this->learningMaterialManager->findFileLearningMaterials($limit, $offset);
+            foreach ($learningMaterials as $lm) {
+                if ($this->iliosFileSystem->checkLearningMaterialFilePath($lm)) {
+                    $valid++;
+                } else {
+                    $broken[] = [
+                        'id' => $lm->getId(),
+                        'path' => $lm->getRelativePath()
+                    ];
+                }
+                $progress->advance();
+            }
+            $offset += $limit;
+        }
+
+        $progress->finish();
+        $output->writeln('');
+
+        $output->writeln("<info>Validated {$valid} learning materials file path.</info>");
+        if(count($broken)){
+            $msg = "<error>Unable to find the files for " . count($broken) . ' learning material.</error>';
+            $output->writeln($msg);
+            $rows = array_map(function($arr){
+                return [
+                    $arr['id'],
+                    $arr['path']
+                ];
+            }, $broken);
+            $table = new Table($output);
+            $table
+                ->setHeaders(array('Learning Material ID', 'Relative Path'))
+                ->setRows($rows)
+            ;
+            $table->render();
+        }
+    }
+}

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -59,3 +59,8 @@ services:
         arguments: ["@exercise_html_purifier.default", "@doctrine.orm.entity_manager", "@ilioscore.objective.manager", "@ilioscore.learningmaterial.manager", "@ilioscore.courselearningmaterial.manager", "@ilioscore.sessionlearningmaterial.manager", "@ilioscore.sessiondescription.manager"]
         tags:
             -  { name: console.command }
+    ilioscli.command.validate_learning_material_paths:
+        class: Ilios\CliBundle\Command\ValidateLearningMaterialPathsCommand
+        arguments: ["@ilioscore.filesystem", "@ilioscore.learningmaterial.manager"]
+        tags:
+            -  { name: console.command }

--- a/src/Ilios/CliBundle/Tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
@@ -55,9 +55,10 @@ class MigrateIlios2LearningMaterialsCommandTest extends \PHPUnit_Framework_TestC
             ->shouldReceive('setRelativePath')->with('newrelativepath')->once()
             ->mock();
         $this->learningMaterialManager
+            ->shouldReceive('getTotalFileLearningMaterialCount')->andReturn(1)->once()
             ->shouldReceive('findFileLearningMaterials')->andReturn([$lm])->once()
             ->shouldReceive('updateLearningMaterial')->with($lm, false)->once()
-            ->shouldReceive('flushAndClear')->twice()
+            ->shouldReceive('flushAndClear')->once()
         ;
         $file = m::mock('Symfony\Component\HttpFoundation\File\File');
         
@@ -91,23 +92,29 @@ class MigrateIlios2LearningMaterialsCommandTest extends \PHPUnit_Framework_TestC
             ->shouldReceive('exists')->with('path/pathtofile')->andReturn(false);
         
         $lm = m::mock('Ilios\CoreBundle\Entity\LearningMaterial')
-            ->shouldReceive('getId')->andReturn('id')->once()
             ->shouldReceive('getRelativePath')->andReturn('/pathtofile')->once()
             ->mock();
         $this->learningMaterialManager
+            ->shouldReceive('getTotalFileLearningMaterialCount')->andReturn(1)->once()
             ->shouldReceive('findFileLearningMaterials')->andReturn([$lm])->once()
+            ->shouldReceive('flushAndClear')->once()
         ;
 
         $this->sayYesWhenAsked();
-        
-        $this->setExpectedException(
-            'Exception',
-            "Unable to migrated learning material #id.  No file found at 'path/pathtofile'."
-        );
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME,
             'pathToIlios2'         => 'path'
         ));
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Migrated 0 learning materials successfully!/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Skipped 1 learning materials because they could not be located or were already migrated./',
+            $output
+        );
         
     }
     

--- a/src/Ilios/CliBundle/Tests/Command/ValidateLearningMaterialPathsCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/ValidateLearningMaterialPathsCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+namespace Ilios\CliBundle\Tests\Command;
+
+use Ilios\CliBundle\Command\ValidateLearningMaterialPathsCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+class ValidateLearningMaterialPathsCommandTest extends \PHPUnit_Framework_TestCase
+{
+    const COMMAND_NAME = 'ilios:setup:validate-learning-materials';
+    
+    protected $iliosFileSystem;
+    protected $learningMaterialManager;
+    
+    public function setUp()
+    {
+        $this->iliosFileSystem = m::mock('Ilios\CoreBundle\Classes\IliosFileSystem');
+        $this->learningMaterialManager = m::mock('Ilios\CoreBundle\Entity\Manager\LearningMaterialManagerInterface');
+
+        $command = new ValidateLearningMaterialPathsCommand(
+            $this->iliosFileSystem,
+            $this->learningMaterialManager
+        );
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+        
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->iliosFileSystem);
+        unset($this->learningMaterialManager);
+        m::close();
+    }
+    
+    public function testExecute()
+    {
+        $goodLm = m::mock('Ilios\CoreBundle\Entity\LearningMaterial');
+        $badLm = m::mock('Ilios\CoreBundle\Entity\LearningMaterial')
+            ->shouldReceive('getId')->andReturn('42')
+            ->shouldReceive('getRelativePath')->andReturn('path/path')
+            ->mock();
+        $this->learningMaterialManager
+            ->shouldReceive('getTotalFileLearningMaterialCount')->andReturn(1)->once()
+            ->shouldReceive('findFileLearningMaterials')->andReturn([$goodLm, $badLm])->once()
+        ;
+
+        $this->iliosFileSystem
+            ->shouldReceive('checkLearningMaterialFilePath')->with($goodLm)->andReturn(true)->once()
+            ->shouldReceive('checkLearningMaterialFilePath')->with($badLm)->andReturn(false)->once()
+        ;
+
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        
+        
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Validated 1 learning materials file path/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Unable to find the files for 1 learning material./',
+            $output
+        );
+        $this->assertRegExp(
+            '/path/',
+            $output
+        );
+        $this->assertRegExp(
+            '/42/',
+            $output
+        );
+    }
+}

--- a/src/Ilios/CoreBundle/Classes/IliosFileSystem.php
+++ b/src/Ilios/CoreBundle/Classes/IliosFileSystem.php
@@ -5,6 +5,8 @@ namespace Ilios\CoreBundle\Classes;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFileSystem;
 
+use Ilios\CoreBundle\Entity\LearningMaterialInterface;
+
 /**
  * Class FileSystem
  * @package Ilios\CoreBundle\Classes
@@ -110,6 +112,21 @@ class IliosFileSystem
     public function getSymfonyFileForPath($path)
     {
         return new File($path);
+    }
+
+    /**
+     * Get if a learning material file path is valid
+     * @param LearningMaterialInterface $lm
+     *
+     * @return boolean
+     */
+    public function checkLearningMaterialFilePath(LearningMaterialInterface $lm)
+    {
+        $relativePath = $lm->getRelativePath();
+        $fullPath = $this->getPath($relativePath);
+
+        return $this->fileSystem->exists($fullPath);
+
     }
     
     /**

--- a/src/Ilios/CoreBundle/Classes/IliosFileSystem.php
+++ b/src/Ilios/CoreBundle/Classes/IliosFileSystem.php
@@ -55,7 +55,8 @@ class IliosFileSystem
         if ($preserveOriginalFile) {
             $this->fileSystem->copy(
                 $file->getPathname(),
-                $fullPath
+                $fullPath,
+                false
             );
         } else {
             if (!$this->fileSystem->exists($fullPath)) {

--- a/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManager.php
@@ -87,9 +87,19 @@ class LearningMaterialManager extends AbstractManager implements LearningMateria
     /**
      * {@inheritdoc}
      */
-    public function findFileLearningMaterials()
+    public function findFileLearningMaterials($limit, $offset)
     {
-        return $this->getRepository()->findFileLearningMaterials();
+        return $this->getRepository()->findFileLearningMaterials($limit, $offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTotalFileLearningMaterialCount()
+    {
+        $dql = 'SELECT COUNT(l.id) FROM IliosCoreBundle:LearningMaterial l WHERE l.relativePath IS NOT NULL';
+        return $this->em
+            ->createQuery($dql)->getSingleScalarResult();
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/LearningMaterialManagerInterface.php
@@ -82,11 +82,20 @@ interface LearningMaterialManagerInterface extends ManagerInterface
     
     /**
      * Find all the File type learning materials
+     * @param integer $limit
+     * @param integer $offset
+     *
+     * @return LearningMaterialInterface[]
      */
-    public function findFileLearningMaterials();
+    public function findFileLearningMaterials($limit, $offset);
 
     /**
      * @return integer
      */
     public function getTotalLearningMaterialCount();
+
+    /**
+     * @return integer
+     */
+    public function getTotalFileLearningMaterialCount();
 }

--- a/src/Ilios/CoreBundle/Entity/Repository/LearningMaterialRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/LearningMaterialRepository.php
@@ -166,12 +166,19 @@ class LearningMaterialRepository extends EntityRepository
     
     /**
      * Find all the file type learning materials
+     * @param integer $limit
+     * @param integer $offset
+     *
+     * @return LearningMaterialInterface[]
      */
-    public function findFileLearningMaterials()
+    public function findFileLearningMaterials($limit, $offset)
     {
         $qb = $this->_em->createQueryBuilder();
         $qb->add('select', 'lm')->from('IliosCoreBundle:LearningMaterial', 'lm');
         $qb->where($qb->expr()->isNotNull('lm.relativePath'));
+
+        $qb->setFirstResult($offset);
+        $qb->setMaxResults($limit);
 
         return $qb->getQuery()->getResult();
     }

--- a/src/Ilios/CoreBundle/Tests/Classes/IliosFileSystemTest.php
+++ b/src/Ilios/CoreBundle/Tests/Classes/IliosFileSystemTest.php
@@ -56,7 +56,7 @@ class IliosFileSystemTest extends TestCase
         $file = m::mock('Symfony\Component\HttpFoundation\File\File')
             ->shouldReceive('getPathname')->andReturn($path)->getMock();
         $this->mockFileSystem->shouldReceive('copy')
-            ->with($path, $newFilePath);
+            ->with($path, $newFilePath, false);
         $this->mockFileSystem->shouldReceive('mkdir');
         $this->iliosFileSystem->storeLearningMaterialFile($file);
     }
@@ -130,6 +130,22 @@ class IliosFileSystemTest extends TestCase
         $this->assertSame($newFile->getPathname(), $testFilePath);
         $this->assertSame(file_get_contents($newFile->getPathname()), $someJunk);
         $fs->remove($this->fakeTestFileDir . '/learning_materials');
+    }
+
+    public function testCheckLearningMaterialFilePath()
+    {
+        $goodLm = m::mock('Ilios\CoreBundle\Entity\LearningMaterial')
+            ->shouldReceive('getRelativePath')->andReturn('goodfile')
+            ->mock();
+        $badLm = m::mock('Ilios\CoreBundle\Entity\LearningMaterial')
+            ->shouldReceive('getRelativePath')->andReturn('badfile')
+            ->mock();
+        $this->mockFileSystem->shouldReceive('exists')
+            ->with($this->fakeTestFileDir . '/goodfile')->andReturn(true)->once();
+        $this->mockFileSystem->shouldReceive('exists')
+            ->with($this->fakeTestFileDir . '/badfile')->andReturn(false)->once();
+        $this->assertTrue($this->iliosFileSystem->checkLearningMaterialFilePath($goodLm));
+        $this->assertFalse($this->iliosFileSystem->checkLearningMaterialFilePath($badLm));
     }
     
     


### PR DESCRIPTION
Migrate files in blocks and don’t die if they are missing.  This should let the command run many times to move a whole tree.

Also Added a command to validate learning materials in the DB
This is mainly useful after migrating to ensure that everything works, but I guess would be equally useful after any large file operation on the learning materials.

Refs #1168