### PR TITLE
Remove courses, sessions, and programYears from topic endpoint

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Topic.php
+++ b/src/Ilios/CoreBundle/Entity/Topic.php
@@ -83,8 +83,8 @@ class Topic implements TopicInterface
      *
      * @ORM\ManyToMany(targetEntity="Course", mappedBy="topics")
      *
-     * @JMS\Expose
-     * @JMS\Type("array<string>")
+     * Don't put courses in the topic API it takes forever to load them all
+     * @JMS\Exclude
      */
     protected $courses;
 
@@ -93,9 +93,8 @@ class Topic implements TopicInterface
      *
      * @ORM\ManyToMany(targetEntity="ProgramYear", mappedBy="topics")
      *
-     * @JMS\Expose
-     * @JMS\Type("array<string>")
-     * @JMS\SerializedName("programYears")
+     * Don't put programYears in the topic API it takes forever to load them all
+     * @JMS\Exclude
      */
     protected $programYears;
 
@@ -104,8 +103,8 @@ class Topic implements TopicInterface
      *
      * @ORM\ManyToMany(targetEntity="Session", mappedBy="topics")
      *
-     * @JMS\Expose
-     * @JMS\Type("array<string>")
+     * Don't put sessions in the topic API it takes forever to load them all
+     * @JMS\Exclude
      */
     protected $sessions;
 

--- a/src/Ilios/CoreBundle/Form/Type/TopicType.php
+++ b/src/Ilios/CoreBundle/Form/Type/TopicType.php
@@ -25,18 +25,6 @@ class TopicType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])
-            ->add('courses', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Course"
-            ])
-            ->add('programYears', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:ProgramYear"
-            ])
-            ->add('sessions', 'tdn_many_related', [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Session"
-            ])
         ;
 
         $builder->get('title')->addViewTransformer(new RemoveMarkupTransformer());

--- a/src/Ilios/CoreBundle/Tests/Controller/TopicControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/TopicControllerTest.php
@@ -38,6 +38,9 @@ class TopicControllerTest extends AbstractControllerTest
     protected function getPrivateFields()
     {
         return [
+            'courses',
+            'sessions',
+            'programYears'
         ];
     }
 
@@ -96,6 +99,9 @@ class TopicControllerTest extends AbstractControllerTest
     {
         $data = $this->container->get('ilioscore.dataloader.topic')
             ->create();
+        unset($data['courses']);
+        unset($data['sessions']);
+        unset($data['programYears']);
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
@@ -115,105 +121,6 @@ class TopicControllerTest extends AbstractControllerTest
             json_decode($response->getContent(), true)['topics'][0],
             $response->getContent()
         );
-    }
-
-    /**
-     * @group controllers_b
-     */
-    public function testPostTopicCourse()
-    {
-        $data = $this->container->get('ilioscore.dataloader.topic')->create();
-        $postData = $data;
-        //unset any parameters which should not be POSTed
-        unset($postData['id']);
-
-        $this->createJsonRequest(
-            'POST',
-            $this->getUrl('post_topics'),
-            json_encode(['topic' => $postData]),
-            $this->getAuthenticatedUserToken()
-        );
-
-        $newId = json_decode($this->client->getResponse()->getContent(), true)['topics'][0]['id'];
-        foreach ($postData['courses'] as $id) {
-            $this->createJsonRequest(
-                'GET',
-                $this->getUrl(
-                    'get_courses',
-                    ['id' => $id]
-                ),
-                null,
-                $this->getAuthenticatedUserToken()
-            );
-            $data = json_decode($this->client->getResponse()->getContent(), true)['courses'][0];
-            $this->assertTrue(in_array($newId, $data['topics']));
-        }
-    }
-
-    /**
-     * @group controllers_b
-     */
-    public function testPostTopicProgramYear()
-    {
-        $data = $this->container->get('ilioscore.dataloader.topic')->create();
-        $postData = $data;
-        //unset any parameters which should not be POSTed
-        unset($postData['id']);
-
-        $this->createJsonRequest(
-            'POST',
-            $this->getUrl('post_topics'),
-            json_encode(['topic' => $postData]),
-            $this->getAuthenticatedUserToken()
-        );
-
-        $newId = json_decode($this->client->getResponse()->getContent(), true)['topics'][0]['id'];
-        foreach ($postData['programYears'] as $id) {
-            $this->createJsonRequest(
-                'GET',
-                $this->getUrl(
-                    'get_programyears',
-                    ['id' => $id]
-                ),
-                null,
-                $this->getAuthenticatedUserToken()
-            );
-            $data = json_decode($this->client->getResponse()->getContent(), true)['programYears'][0];
-            $this->assertTrue(in_array($newId, $data['topics']));
-        }
-    }
-
-    /**
-     * @group controllers
-     */
-    public function testPostTopicSession()
-    {
-        $data = $this->container->get('ilioscore.dataloader.topic')->create();
-        $postData = $data;
-        //unset any parameters which should not be POSTed
-        unset($postData['id']);
-
-        $this->createJsonRequest(
-            'POST',
-            $this->getUrl('post_topics'),
-            json_encode(['topic' => $postData]),
-            $this->getAuthenticatedUserToken()
-        );
-
-        $newId = json_decode($this->client->getResponse()->getContent(), true)['topics'][0]['id'];
-        foreach ($postData['sessions'] as $id) {
-            $this->createJsonRequest(
-                'GET',
-                $this->getUrl(
-                    'get_sessions',
-                    ['id' => $id]
-                ),
-                null,
-                $this->getAuthenticatedUserToken()
-            );
-            $data = json_decode($this->client->getResponse()->getContent(), true)['sessions'][0];
-            $this->assertTrue(in_array($newId, $data['topics']));
-        }
     }
 
     /**
@@ -249,6 +156,9 @@ class TopicControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['courses']);
+        unset($postData['sessions']);
+        unset($postData['programYears']);
 
         $this->createJsonRequest(
             'PUT',

--- a/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
@@ -287,7 +287,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserCourse()
     {
@@ -326,7 +326,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserLearnerGroup()
     {
@@ -365,7 +365,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserInstructorLearnerGroup()
     {
@@ -404,7 +404,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserInstructorGroup()
     {
@@ -443,7 +443,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserIlmSession()
     {
@@ -482,7 +482,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserInstructedIlmSession()
     {
@@ -521,7 +521,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserOffering()
     {
@@ -560,7 +560,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserInstructedOffering()
     {
@@ -599,7 +599,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserProgramYear()
     {
@@ -638,7 +638,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostUserCohort()
     {
@@ -677,7 +677,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPostBadUser()
     {
@@ -698,7 +698,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testPutUser()
     {
@@ -739,7 +739,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testDeleteUser()
     {
@@ -775,7 +775,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testUserNotFound()
     {
@@ -791,7 +791,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testFilterByInstructedCourse()
     {
@@ -817,7 +817,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testFilterByInstructedSession()
     {
@@ -843,7 +843,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testFilterByInstructedSessionType()
     {
@@ -869,7 +869,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testFilterByInstructedTopic()
     {
@@ -901,7 +901,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testFilterByInstructedLearningMaterial()
     {
@@ -933,7 +933,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testFilterByInstructorGroup()
     {
@@ -959,7 +959,7 @@ class UserControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers
+     * @group controllers_b
      */
     public function testFilterBySchool()
     {


### PR DESCRIPTION
The data isn’t needed in this direction and it makes loading topic very slow.

Fixes #1203