### PR TITLE
get current user from token storage instead of from security context service

### DIFF
--- a/src/Ilios/CoreBundle/Controller/CurrentsessionController.php
+++ b/src/Ilios/CoreBundle/Controller/CurrentsessionController.php
@@ -40,7 +40,7 @@ class CurrentsessionController extends FOSRestController
      */
     public function getCurrentsessionAction()
     {
-        $user = $this->get('security.context')->getToken()->getUser();
+        $user = $this->get('security.token_storage')->getToken()->getUser();
         if (!$user instanceof User) {
             throw new NotFoundHttpException('No current session');
         }

--- a/src/Ilios/CoreBundle/Controller/PublishEventController.php
+++ b/src/Ilios/CoreBundle/Controller/PublishEventController.php
@@ -180,7 +180,7 @@ class PublishEventController extends FOSRestController
             $publishEvent = $handler->post(
                 $this->getPostData($request),
                 $request,
-                $this->get('security.context')->getToken()->getUser()
+                $this->get('security.token_storage')->getToken()->getUser()
             );
 
             $authChecker = $this->get('security.authorization_checker');


### PR DESCRIPTION
see http://symfony.com/blog/new-in-symfony-2-6-security-component-improvements