### PR TITLE
various bug fixes in method that adds instructors to events

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -648,6 +648,10 @@ class UserRepository extends EntityRepository
             return $event->ilmSession;
         }));
 
+        // array-filtering throws off the array index.
+        // set this right again.
+        $events = array_values($events);
+
         $offeringInstructors = $this->getInstructorsForOfferings($offeringIds);
         $ilmInstructors = $this->getInstructorsForIlmSessions($ilmIds);
 
@@ -656,7 +660,7 @@ class UserRepository extends EntityRepository
                 if (array_key_exists($events[$i]->offering, $offeringInstructors)) {
                     $events[$i]->instructors = array_values($offeringInstructors[$events[$i]->offering]);
                 }
-            } elseif ($events[$i]->ilmSession){ // event maps to ILM session
+            } elseif ($events[$i]->ilmSession) { // event maps to ILM session
                 if (array_key_exists($events[$i]->ilmSession, $ilmInstructors)) {
                     $events[$i]->instructors = array_values($ilmInstructors[$events[$i]->ilmSession]);
                 }

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -656,7 +656,7 @@ class UserRepository extends EntityRepository
                 if (array_key_exists($events[$i]->offering, $offeringInstructors)) {
                     $events[$i]->instructors = array_values($offeringInstructors[$events[$i]->offering]);
                 }
-            } else { // event maps to ILM session
+            } elseif ($events[$i]->ilmSession){ // event maps to ILM session
                 if (array_key_exists($events[$i]->ilmSession, $ilmInstructors)) {
                     $events[$i]->instructors = array_values($ilmInstructors[$events[$i]->ilmSession]);
                 }


### PR DESCRIPTION
1. scheduled events do not possess information about their source type (offering vs. ILM), so they must be ignored when attempting to add instructors.

2. filtering a numeric array with `array_filter()` throws off the index and leaves us with a sparse array. when the `$events` array gets passed to `addInstructorToEvent()`, it may be sparse. deal with it by grabbing the array's items into a new, correctly indexed array via `array_values()`.