### PR TITLE
Move publishing migration to the right place in time

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20160111222451.php
+++ b/app/Resources/DoctrineMigrations/Version20160111222451.php
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Schema\Schema;
  *
  * NOTICE!  This migration cannot be reversed!  It would do bad things if we let you.
  */
-class Version20151218222451 extends AbstractMigration
+class Version20160111222451 extends AbstractMigration
 {
     /**
      * @param Schema $schema


### PR DESCRIPTION
I forgot to do this despite @stopfstedt reminding me three times.  This should fix it and since we didn’t release with the bad migration name I think this is OK to do.

Refs #1212