### PR TITLE
Don't set relativePath for learning materials

### DIFF
--- a/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
+++ b/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
@@ -200,6 +200,7 @@ class LearningMaterialController extends FOSRestController
         try {
             $postData = $this->getPostData($request);
             $file = false;
+            $relativePath = false;
             if (array_key_exists('fileHash', $postData)) {
                 $fileHash = $postData['fileHash'];
                 $temporaryFileSystem = $this->container->get('ilioscore.temporary_filesystem');
@@ -214,7 +215,7 @@ class LearningMaterialController extends FOSRestController
                 unset($postData['fileHash']);
                 unset($postData['uploadDate']);
                 $postData['mimetype'] = $file->getMimeType();
-                $postData['relativePath'] = $fs->getLearningMaterialFilePath($file);
+                $relativePath = $fs->getLearningMaterialFilePath($file);
                 $postData['filesize'] = $file->getSize();
             }
 
@@ -227,10 +228,14 @@ class LearningMaterialController extends FOSRestController
                 throw $this->createAccessDeniedException('Unauthorized access!');
             }
 
-            $this->getLearningMaterialHandler()->updateLearningMaterial($learningMaterial, true, false);
             if ($file) {
                 $fs->storeLearningMaterialFile($file, true);
             }
+
+            if ($relativePath) {
+                $learningMaterial->setRelativePath($relativePath);
+            }
+            $handler->updateLearningMaterial($learningMaterial, true, false);
 
             $factory = $this->get('ilioscore.learningmaterial_decorator.factory');
 

--- a/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
@@ -25,7 +25,6 @@ class LearningMaterialType extends AbstractType
             ->add('title', null, ['empty_data' => null])
             ->add('description', 'purified_textarea')
             ->add('originalAuthor', null, ['required' => false, 'empty_data' => null])
-            ->add('relativePath', null, ['empty_data' => null])
             ->add('filename', null, ['empty_data' => null])
             ->add('copyrightPermission')
             ->add('copyrightRationale', null, ['empty_data' => null])
@@ -50,7 +49,6 @@ class LearningMaterialType extends AbstractType
         $elements = [
             'title',
             'originalAuthor',
-            'relativePath',
             'filename',
             'copyrightRationale',
             'mimetype',


### PR DESCRIPTION
This isn’t needed in the API and wasn’t being sent from the fronted
anyway.

Fixes #1253