### PR TITLE
Stop logging events in dev logs

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -18,6 +18,7 @@ monolog:
             type:   stream
             path:   "%kernel.logs_dir%/%kernel.environment%.log"
             level:  debug
+            channels: [!event]
         console:
             type:   console
             bubble: false


### PR DESCRIPTION
This is in line with what symphony standard edition is now doing.