### PR TITLE
added 'sender_name' option to "send teaching reminders" command

### DIFF
--- a/src/Ilios/CliBundle/Command/SendTeachingRemindersCommand.php
+++ b/src/Ilios/CliBundle/Command/SendTeachingRemindersCommand.php
@@ -104,6 +104,12 @@ class SendTeachingRemindersCommand extends Command
                 self::DEFAULT_MESSAGE_SUBJECT
             )
             ->addOption(
+                'sender_name',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                "The name of the reminder's sender."
+            )
+            ->addOption(
                 'dry-run',
                 null,
                 InputOption::VALUE_NONE,
@@ -130,6 +136,11 @@ class SendTeachingRemindersCommand extends Command
         $baseUrl = rtrim($input->getArgument('base_url'), '/');
         $subject = $input->getOption('subject');
         $isDryRun = $input->getOption('dry-run');
+        $senderName = $input->getOption('sender_name');
+        $from = $sender;
+        if ($senderName) {
+            $from = [$sender => $senderName];
+        }
 
         // get all applicable offerings.
         $offerings = $this->offeringManager->getOfferingsForTeachingReminders($daysInAdvance);
@@ -174,7 +185,7 @@ class SendTeachingRemindersCommand extends Command
                 ]);
                 $message = \Swift_Message::newInstance()
                     ->setSubject($subject)
-                    ->setFrom($sender)
+                    ->setFrom($from)
                     ->setTo($instructor->getEmail())
                     ->setCharset('UTF-8')
                     ->setContentType('text/plain')

--- a/src/Ilios/CliBundle/Tests/Command/SendTeachingRemindersCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/SendTeachingRemindersCommandTest.php
@@ -188,6 +188,29 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     /**
      * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
+    public function testExecuteDryRunWithSenderName()
+    {
+        $sender = 'foo@bar.edu';
+        $name = 'Horst Krause';
+        $subject = "Custom email subject";
+        $baseUrl = 'https://ilios.bar.edu';
+
+        $this->commandTester->execute([
+            'sender' => $sender,
+            'base_url' => $baseUrl,
+            '--dry-run' => true,
+            '--subject' => $subject,
+            '--sender_name' => $name,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        $this->assertContains("From: {$name} <{$sender}>", $output);
+    }
+
+    /**
+     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
+     */
     public function testExecuteDryRunWithCustomSubject()
     {
         $sender = 'foo@bar.edu';


### PR DESCRIPTION
fixes #1214.

the command option is `--sender_name`. if not specified, then only the provided email address will be used as the email's "from" value.

```
$ bin/console ilios:messaging:send-teaching-reminders --help
Usage:
  ilios:messaging:send-teaching-reminders [options] [--] <sender> <base_url>

Arguments:
  sender                           Email address to send reminders from.
  base_url                         The base URL of your Ilios instance.

Options:
      --days[=DAYS]                How many days in advance of teaching events reminders should be sent. [default: 7]
      --subject[=SUBJECT]          The subject line of reminder emails. [default: "Upcoming Teaching Session"]
      --sender_name[=SENDER_NAME]  The name of the reminder's sender.
      --dry-run                    Prints out notification instead of emailing it. Useful for testing/debugging purposes.
  -h, --help                       Display this help message
  -q, --quiet                      Do not output any message
  -V, --version                    Display this application version
      --ansi                       Force ANSI output
      --no-ansi                    Disable ANSI output
  -n, --no-interaction             Do not ask any interactive question
  -s, --shell                      Launch the shell.
      --process-isolation          Launch commands from shell as a separate process.
  -e, --env=ENV                    The Environment name. [default: "dev"]
      --no-debug                   Switches off debug mode.
  -v|vv|vvv, --verbose             Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
 Sends teaching reminders to educators.

```