### PR TITLE
Configurable forcing of https

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -35,3 +35,4 @@ parameters:
     ldap_directory_campus_id_property: null
     ldap_directory_username_property: null
     timezone: 'America/Los_Angeles'
+    forceProtocol: https

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -31,3 +31,4 @@ parameters:
     ldap_directory_search_base: null
     ldap_directory_campus_id_property: null
     ldap_directory_username_property: null
+    forceProtocol: http

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,18 +1,22 @@
 IliosAuthenticationBundle:
     resource: "@IliosAuthenticationBundle/Resources/config/routing.yml"
     prefix:   /auth
+    schemes:  [%forceProtocol%]
 
 NelmioApiDocBundle:
     resource: "@NelmioApiDocBundle/Resources/config/routing.yml"
     prefix:   /api/doc
+    schemes:  [%forceProtocol%]
 
 IliosCoreBundle:
     resource: "@IliosCoreBundle/Resources/config/routing.yml"
     prefix:   /api
+    schemes:  [%forceProtocol%]
     
 ilios_core_uploadfile:
     path: /upload
     defaults:  { _controller: IliosCoreBundle:Upload:upload }
+    schemes:  [%forceProtocol%]
 
 ilios_core_downloadlearningmaterial:
     pattern:     /lm/{token}
@@ -20,7 +24,9 @@ ilios_core_downloadlearningmaterial:
         _controller: IliosCoreBundle:Download:learningMaterial
     requirements:
         token: "^[a-zA-Z0-9]{64}$"
+    schemes:  [%forceProtocol%]
 
 ilios_web:
     resource: "@IliosWebBundle/Resources/config/routing.yml"
     prefix:   /
+    schemes:  [%forceProtocol%]


### PR DESCRIPTION
If forceProtocol is set to https all requests will be redirected, this
is the default, but it can be overridden in parameters.yml.

Fixes #1261