### PR TITLE
Add a userSearchType value to config

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -43,5 +43,8 @@ swiftmailer:
     disable_delivery: true
 #    delivery_address: me@example.com
 
+ilios_core:
+    ldap_directory_url: null
+
 ilios_authentication:
     type: "form"

--- a/src/Ilios/WebBundle/Controller/ConfigController.php
+++ b/src/Ilios/WebBundle/Controller/ConfigController.php
@@ -14,13 +14,21 @@ class ConfigController extends Controller
     public function indexAction()
     {
         $configuration = [];
-        $type = $this->container->getParameter('ilios_authentication.type');
-        $configuration['type'] = $type;
-        if ($type == 'shibboleth') {
+        $authenticationType = $this->container->getParameter('ilios_authentication.type');
+        $configuration['type'] = $authenticationType;
+        if ($authenticationType == 'shibboleth') {
             $url = $this->get('request')->getSchemeAndHttpHost();
             $configuration['loginUrl'] = $url . '/Shibboleth.sso/Login';
         }
         $configuration['locale'] = $this->container->getParameter('locale');
+
+        $ldapUrl = $this->container->getParameter('ilios_core.ldap.url');
+        if (!empty($ldapUrl)) {
+            $configuration['userSearchType'] = 'ldap';
+        } else {
+            $configuration['userSearchType'] = 'local';
+        }
+
         return new JsonResponse(array('config' => $configuration));
     }
 }

--- a/src/Ilios/WebBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Ilios/WebBundle/Tests/Controller/ConfigControllerTest.php
@@ -24,7 +24,7 @@ class ConfigControllerTest extends WebTestCase
         $this->assertJsonResponse($response, Codes::HTTP_OK);
 
         $this->assertEquals(
-            array('config' => array('type' => 'form', 'locale' => 'en')),
+            array('config' => array('type' => 'form', 'locale' => 'en', 'userSearchType' => 'local')),
             json_decode($response->getContent(), true)
         );
     }


### PR DESCRIPTION
This will allow the fronted to choose the correct workflow for adding
new users to Ilios.

Fixes #1291