### PR TITLE
Add /application/directory/search endpoint

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -56,4 +56,18 @@ class AppKernel extends Kernel
     {
         $loader->load(__DIR__.'/config/config_'.$this->getEnvironment().'.yml');
     }
+
+    /**
+     * Register an alternative container for testing which allows us to mock services
+     *
+     * @return string
+     */
+    protected function getContainerBaseClass()
+    {
+        if ('test' == $this->environment) {
+            return '\PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer';
+        }
+
+        return parent::getContainerBaseClass();
+    }
 }

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -4,10 +4,16 @@ security:
             pattern:   ^/api/doc
             anonymous: ~
         anonymous_auth:
-            pattern:    ^/auth/(login|config|logout)
+            pattern:    ^/(auth|application)/(login|config|logout)
             anonymous: ~
         authenticated_auth:
             pattern:    ^/auth
+            stateless: true
+            simple_preauth:
+                authenticator: ilios_authentication.jwt.authenticator
+            provider: ilios_user_entity
+        authenticated_application:
+            pattern:    ^/application
             stateless: true
             simple_preauth:
                 authenticator: ilios_authentication.jwt.authenticator

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "instaclick/base-test-bundle": "^0.5",
         "mockery/mockery": "^0.9.4",
         "fzaninotto/faker": "^1.5",
-        "liip/functional-test-bundle": "~1.3"
+        "liip/functional-test-bundle": "~1.3",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },
     "scripts": {
         "post-root-package-install": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "078a4b377923bba43cc1db1d876921a7",
-    "content-hash": "a257458a09837a5349a8a96c936f808e",
+    "hash": "e5f12857345870080e5badd02bfdd12e",
+    "content-hash": "1a2fed97c0d1f16c0f26cce40e686451",
     "packages": [
         {
             "name": "danielstjules/stringy",
@@ -4545,6 +4545,58 @@
                 "xunit"
             ],
             "time": "2014-05-14 17:42:22"
+        },
+        {
+            "name": "polishsymfonycommunity/symfony-mocker-container",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer.git",
+                "reference": "392a4d28baa6279dd0ecc2c3e4da7a7feac7e6b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PolishSymfonyCommunity/SymfonyMockerContainer/zipball/392a4d28baa6279dd0ecc2c3e4da7a7feac7e6b7",
+                "reference": "392a4d28baa6279dd0ecc2c3e4da7a7feac7e6b7",
+                "shasum": ""
+            },
+            "require": {
+                "mockery/mockery": ">=0.7.0",
+                "php": ">=5.3.2",
+                "symfony/dependency-injection": ">=2.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PSS\\SymfonyMockerContainer": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Zalas",
+                    "email": "jakub@zalas.pl",
+                    "homepage": "http://www.zalas.eu/"
+                },
+                {
+                    "name": "Polish Symfony Community",
+                    "homepage": "http://symfonylab.pl"
+                }
+            ],
+            "description": "Provides base Symfony dependency injection container enabling service mocking.",
+            "homepage": "http://symfonylab.pl",
+            "keywords": [
+                "BDD",
+                "Behat",
+                "TDD",
+                "mock",
+                "mockery",
+                "test"
+            ],
+            "time": "2013-01-19 23:12:22"
         },
         {
             "name": "sebastian/comparator",

--- a/src/Ilios/CoreBundle/Service/Directory.php
+++ b/src/Ilios/CoreBundle/Service/Directory.php
@@ -74,7 +74,7 @@ class Directory
     public function find(array $searchTerms)
     {
         $filterTerms = array_map(function ($term) {
-            return "(|(sn={$term}*)(givenname={$term}*)(mail={$term}*))";
+            return "(|(sn={$term}*)(givenname={$term}*)(mail={$term}*)({$this->ldapCampusIdProperty}={$term}*))";
         }, $searchTerms);
         $filterTermsString = implode($filterTerms, '');
         $filter = "(&{$filterTermsString})";

--- a/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
+++ b/src/Ilios/CoreBundle/Tests/Service/DirectoryTest.php
@@ -70,7 +70,7 @@ class DirectoryTest extends TestCase
     {
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
         $obj = new Directory($ldapManager, 'campusId');
-        $filter= '(&(|(sn=a*)(givenname=a*)(mail=a*))(|(sn=b*)(givenname=b*)(mail=b*)))';
+        $filter= '(&(|(sn=a*)(givenname=a*)(mail=a*)(campusId=a*))(|(sn=b*)(givenname=b*)(mail=b*)(campusId=b*)))';
         $ldapManager->shouldReceive('search')->with($filter)->andReturn(array(1,2));
         
         $result = $obj->find(array('a', 'b'));

--- a/src/Ilios/WebBundle/Controller/DirectoryController.php
+++ b/src/Ilios/WebBundle/Controller/DirectoryController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ilios\WebBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Class DirectoryController
+ * @package Ilios\WebBundle\Controller
+ */
+class DirectoryController extends Controller
+{
+    public function searchAction(Request $request)
+    {
+        $user = $this->get('security.token_storage')->getToken()->getUser();
+        if (!$user->hasRole(['Developer'])) {
+            throw new AccessDeniedException();
+        }
+        $results = [];
+
+        if ($request->query->has('searchTerms')) {
+            $searchTerms = explode(' ', $request->query->get('searchTerms'));
+
+            $directory = $this->container->get('ilioscore.directory');
+            $searchResults = $directory->find($searchTerms);
+
+            if (is_array($searchResults)) {
+                $results = $searchResults;
+            }
+
+        }
+
+        return new JsonResponse(array('results' => $results));
+    }
+}

--- a/src/Ilios/WebBundle/Resources/config/routing.yml
+++ b/src/Ilios/WebBundle/Resources/config/routing.yml
@@ -14,6 +14,11 @@ ilios_web_errors:
     defaults:
         _controller: IliosWebBundle:Error:error
     methods:  [POST]
+ilios_web_directory_search:
+    path:     /application/directory/search
+    defaults:
+        _controller: IliosWebBundle:Directory:search
+    methods: [GET]
 ilios_web_homepage:
     pattern:     /{url}
     defaults:

--- a/src/Ilios/WebBundle/Tests/Controller/DirectoryControllerTest.php
+++ b/src/Ilios/WebBundle/Tests/Controller/DirectoryControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Ilios\WebBundle\Tests\Controller;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Ilios\CoreBundle\Tests\Traits\JsonControllerTest;
+use FOS\RestBundle\Util\Codes;
+use Mockery as m;
+
+class DirectoryControllerTest extends WebTestCase
+{
+    use JsonControllerTest;
+
+    protected $client;
+
+    public function setUp()
+    {
+        $this->client = static::createClient();
+        $this->loadFixtures([
+            'Ilios\CoreBundle\Tests\Fixture\LoadUserData',
+            'Ilios\CoreBundle\Tests\Fixture\LoadAuthenticationData',
+        ]);
+    }
+
+    public function tearDown()
+    {
+        foreach ($this->client->getContainer()->getMockedServices() as $id => $service) {
+            $this->client->getContainer()->unmock($id);
+        }
+
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testSearch()
+    {
+        $container = $this->client->getContainer();
+
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+        ];
+
+        $container->mock('ilioscore.directory', 'Ilios\CoreBundle\Service\Directory')
+            ->shouldReceive('find')
+            ->with(array('a', 'b'))
+            ->once()
+            ->andReturn(array($fakeDirectoryUser));
+
+        $this->makeJsonRequest(
+            $this->client,
+            'GET',
+            $this->getUrl(
+                'ilios_web_directory_search',
+                ['searchTerms' => 'a b']
+            ),
+            $this->getAuthenticatedUserToken()
+        );
+
+        $response = $this->client->getResponse();
+        $content = $response->getContent();
+        $this->assertEquals(Codes::HTTP_OK, $response->getStatusCode(), var_export($content, true));
+
+        $this->assertEquals(
+            array('results' => array($fakeDirectoryUser)),
+            json_decode($content, true),
+            var_export($content, true)
+        );
+
+    }
+}

--- a/src/Ilios/WebBundle/Tests/Controller/DirectoryControllerTest.php
+++ b/src/Ilios/WebBundle/Tests/Controller/DirectoryControllerTest.php
@@ -58,6 +58,7 @@ class DirectoryControllerTest extends WebTestCase
                 'ilios_web_directory_search',
                 ['searchTerms' => 'a b']
             ),
+            null,
             $this->getAuthenticatedUserToken()
         );
 


### PR DESCRIPTION
Allows us to search for users with the API that passes through to LDAP or another directory store.

Fixes #1290