### PR TITLE
get rid of deprecation warnings

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/JsonWebTokenAuthenticator.php
+++ b/src/Ilios/AuthenticationBundle/Service/JsonWebTokenAuthenticator.php
@@ -3,9 +3,9 @@
 namespace Ilios\AuthenticationBundle\Service;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
@@ -14,6 +14,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bridge\Doctrine\Security\User\EntityUserProvider;
 
+/**
+ * Class JsonWebTokenAuthenticator
+ * @package Ilios\AuthenticationBundle\Service
+ */
 class JsonWebTokenAuthenticator implements SimplePreAuthenticatorInterface, AuthenticationFailureHandlerInterface
 {
     /**
@@ -23,16 +27,16 @@ class JsonWebTokenAuthenticator implements SimplePreAuthenticatorInterface, Auth
     
     /**
     * Constructor
-    * @param UserManagerInterface $userManager
-    * @param JsonWebTokenManager            $jwtManager
-    * @param string $secretKey injected kernel secret key
+    * @param JsonWebTokenManager $jwtManager
     */
-    public function __construct(
-        JsonWebTokenManager $jwtManager
-    ) {
+    public function __construct(JsonWebTokenManager $jwtManager)
+    {
         $this->jwtManager = $jwtManager;
     }
-    
+
+    /**
+     * @inheritdoc
+     */
     public function createToken(Request $request, $providerKey)
     {
         $jwt = false;
@@ -52,6 +56,9 @@ class JsonWebTokenAuthenticator implements SimplePreAuthenticatorInterface, Auth
         );
     }
 
+    /**
+     * @inheritdoc
+     */
     public function authenticateToken(TokenInterface $token, UserProviderInterface $userProvider, $providerKey)
     {
         if (!$userProvider instanceof EntityUserProvider) {
@@ -96,11 +103,17 @@ class JsonWebTokenAuthenticator implements SimplePreAuthenticatorInterface, Auth
         return $authenticatedToken;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function supportsToken(TokenInterface $token, $providerKey)
     {
         return $token instanceof PreAuthenticatedToken && $token->getProviderKey() === $providerKey;
     }
-    
+
+    /**
+     * @inheritdoc
+     */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
         return new Response("Authentication Failed. " . $exception->getMessage(), 401);

--- a/src/Ilios/CliBundle/Form/InstallFirstUserType.php
+++ b/src/Ilios/CliBundle/Form/InstallFirstUserType.php
@@ -54,12 +54,4 @@ class InstallFirstUserType extends AbstractType
                 ]
             );
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'ilios_install_first_user';
-    }
 }

--- a/src/Ilios/CoreBundle/Entity/LearningMaterial.php
+++ b/src/Ilios/CoreBundle/Entity/LearningMaterial.php
@@ -3,11 +3,8 @@ namespace Ilios\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Symfony\Component\Security\Core\Util\SecureRandom;
-
 
 use Ilios\CoreBundle\Traits\DescribableEntity;
 use Ilios\CoreBundle\Traits\IdentifiableEntity;
@@ -296,13 +293,12 @@ class LearningMaterial implements LearningMaterialInterface
      */
     public function generateToken()
     {
-        $generator = new SecureRandom();
-        $random = $generator->nextBytes(128);
-        
+        $random = random_bytes(128);
+
         // prepend id to avoid a conflict
         // and current time to prevent a conflict with regeneration
         $key = $this->getId() . microtime() . $random;
-        
+
         // hash the string to give consistent length and URL safe characters
         $this->token = hash('sha256', $key);
     }

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -7,7 +7,6 @@ use JMS\Serializer\Annotation as JMS;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Security\Core\Util\SecureRandom;
 
 use Ilios\CoreBundle\Traits\IdentifiableEntity;
 use Ilios\CoreBundle\Traits\StringableIdEntity;
@@ -694,8 +693,7 @@ class User implements UserInterface
      */
     public function generateIcsFeedKey()
     {
-        $generator = new SecureRandom();
-        $random = $generator->nextBytes(128);
+        $random = random_bytes(128);
         
         // prepend user id to avoid a conflict
         // and current time to give some more uniqueness

--- a/src/Ilios/CoreBundle/EventListener/ContainerInjector.php
+++ b/src/Ilios/CoreBundle/EventListener/ContainerInjector.php
@@ -2,11 +2,17 @@
 namespace Ilios\CoreBundle\EventListener;
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
-use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class ContainerInjector extends ContainerAware
+/**
+ * Class ContainerInjector
+ * @package Ilios\CoreBundle\EventListener
+ */
+class ContainerInjector
 {
+    use ContainerAwareTrait;
+
     public function postLoad(LifecycleEventArgs $args)
     {
         $entity = $args->getEntity();

--- a/src/Ilios/CoreBundle/EventListener/LogEntityChanges.php
+++ b/src/Ilios/CoreBundle/EventListener/LogEntityChanges.php
@@ -1,21 +1,19 @@
 <?php
 namespace Ilios\CoreBundle\EventListener;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
-use Symfony\Component\DependencyInjection\ContainerAware;
-
 use Ilios\CoreBundle\Service\Logger;
-use Ilios\CoreBundle\Entity\AuditLog;
 use Ilios\CoreBundle\Entity\LoggableEntityInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * LogEntityChanges event listener
- * Listen for every chagne to an entity and log it
- *
- * */
-class LogEntityChanges extends ContainerAware
+ * Listen for every change to an entity and log it
+ */
+class LogEntityChanges
 {
+    use ContainerAwareTrait;
+
     public function getSubscribedEvents()
     {
         return [

--- a/src/Ilios/CoreBundle/Form/Type/AamcMethodType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AamcMethodType.php
@@ -39,12 +39,4 @@ class AamcMethodType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\AamcMethod'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'aamcmethod';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AamcMethodType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AamcMethodType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,7 +23,7 @@ class AamcMethodType extends AbstractType
         $builder
             ->add('id')
             ->add('description', null, ['empty_data' => null])
-            ->add('sessionTypes', 'tdn_many_related', [
+            ->add('sessionTypes', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:SessionType"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/AamcPcrsType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AamcPcrsType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,7 +23,7 @@ class AamcPcrsType extends AbstractType
         $builder
             ->add('id')
             ->add('description', null, ['empty_data' => null])
-            ->add('competencies', 'tdn_many_related', [
+            ->add('competencies', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Competency"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/AamcPcrsType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AamcPcrsType.php
@@ -39,12 +39,4 @@ class AamcPcrsType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\AamcPcrs'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'aamcpcrs';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AbstractType/EntityType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AbstractType/EntityType.php
@@ -49,6 +49,6 @@ class EntityType extends BaseEntityType
 
     public function getParent()
     {
-        return 'entity';
+        return BaseEntityType::class;
     }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AbstractType/EntityType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AbstractType/EntityType.php
@@ -51,9 +51,4 @@ class EntityType extends BaseEntityType
     {
         return 'entity';
     }
-
-    public function getName()
-    {
-        return 'tdn_entity';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AbstractType/ManyRelatedType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AbstractType/ManyRelatedType.php
@@ -57,9 +57,4 @@ class ManyRelatedType extends AbstractType
     {
         return 'text';
     }
-
-    public function getName()
-    {
-        return 'tdn_many_related';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AbstractType/ManyRelatedType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AbstractType/ManyRelatedType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type\AbstractType;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Options;
@@ -55,6 +56,6 @@ class ManyRelatedType extends AbstractType
 
     public function getParent()
     {
-        return 'text';
+        return TextType::class;
     }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AbstractType/PurifiedTextareaType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AbstractType/PurifiedTextareaType.php
@@ -4,6 +4,7 @@ namespace Ilios\CoreBundle\Form\Type\AbstractType;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -39,7 +40,7 @@ class PurifiedTextareaType extends AbstractType
      */
     public function getParent()
     {
-        return 'textarea';
+        return TextareaType::class;
     }
 
     /**

--- a/src/Ilios/CoreBundle/Form/Type/AbstractType/PurifiedTextareaType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AbstractType/PurifiedTextareaType.php
@@ -51,12 +51,4 @@ class PurifiedTextareaType extends AbstractType
             'compound' => false,
         ));
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'purified_textarea';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AbstractType/SingleRelatedType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AbstractType/SingleRelatedType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type\AbstractType;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Options;
@@ -50,6 +51,6 @@ class SingleRelatedType extends AbstractType
 
     public function getParent()
     {
-        return 'text';
+        return TextType::class;
     }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AbstractType/SingleRelatedType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AbstractType/SingleRelatedType.php
@@ -52,9 +52,4 @@ class SingleRelatedType extends AbstractType
     {
         return 'text';
     }
-
-    public function getName()
-    {
-        return 'tdn_single_related';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AlertChangeTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AlertChangeTypeType.php
@@ -38,12 +38,4 @@ class AlertChangeTypeType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\AlertChangeType'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'alertchangetype';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AlertChangeTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AlertChangeTypeType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,7 +22,7 @@ class AlertChangeTypeType extends AbstractType
     {
         $builder
             ->add('title', null, ['empty_data' => null])
-            ->add('alerts', 'tdn_many_related', [
+            ->add('alerts', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Alert"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/AlertType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AlertType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -24,15 +25,15 @@ class AlertType extends AbstractType
             ->add('tableName', null, ['empty_data' => null])
             ->add('additionalText', null, ['required' => false, 'empty_data' => null])
             ->add('dispatched', null, ['required' => false])
-            ->add('changeTypes', 'tdn_many_related', [
+            ->add('changeTypes', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:AlertChangeType"
             ])
-            ->add('instigators', 'tdn_many_related', [
+            ->add('instigators', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('recipients', 'tdn_many_related', [
+            ->add('recipients', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/AlertType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AlertType.php
@@ -52,12 +52,4 @@ class AlertType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Alert',
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'alert';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/AssessmentOptionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AssessmentOptionType.php
@@ -34,12 +34,4 @@ class AssessmentOptionType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\AssessmentOption'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'assessmentoption';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CohortType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CohortType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,15 +23,15 @@ class CohortType extends AbstractType
     {
         $builder
             ->add('title', null, ['empty_data' => null])
-            ->add('programYear', 'tdn_single_related', [
+            ->add('programYear', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:ProgramYear"
             ])
-            ->add('courses', 'tdn_many_related', [
+            ->add('courses', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Course"
             ])
-            ->add('users', 'tdn_many_related', [
+            ->add('users', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CohortType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CohortType.php
@@ -46,12 +46,4 @@ class CohortType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Cohort'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'cohort';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,19 +23,19 @@ class CompetencyType extends AbstractType
     {
         $builder
             ->add('title', null, ['required' => false, 'empty_data' => null])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])
-            ->add('parent', 'tdn_single_related', [
+            ->add('parent', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Competency"
             ])
-            ->add('aamcPcrses', 'tdn_many_related', [
+            ->add('aamcPcrses', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:AamcPcrs"
             ])
-            ->add('programYears', 'tdn_many_related', [
+            ->add('programYears', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:ProgramYear"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
@@ -50,12 +50,4 @@ class CompetencyType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Competency'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'competency';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CourseClerkshipTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseClerkshipTypeType.php
@@ -34,12 +34,4 @@ class CourseClerkshipTypeType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\CourseClerkshipType'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'courseclerkshiptype';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CourseLearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseLearningMaterialType.php
@@ -46,12 +46,4 @@ class CourseLearningMaterialType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\CourseLearningMaterial'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'courselearningmaterial';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CourseLearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseLearningMaterialType.php
@@ -2,6 +2,9 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\PurifiedTextareaType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,18 +22,18 @@ class CourseLearningMaterialType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('notes', 'purified_textarea', ['required' => false])
+            ->add('notes', PurifiedTextareaType::class, ['required' => false])
             ->add('required', null, ['required' => false])
             ->add('publicNotes', null, ['required' => false])
-            ->add('course', 'tdn_single_related', [
+            ->add('course', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Course"
             ])
-            ->add('learningMaterial', 'tdn_single_related', [
+            ->add('learningMaterial', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearningMaterial"
             ])
-            ->add('meshDescriptors', 'tdn_many_related', [
+            ->add('meshDescriptors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CourseType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -34,35 +36,35 @@ class CourseType extends AbstractType
             ->add('archived', null, ['required' => false])
             ->add('publishedAsTbd', null, ['required' => false])
             ->add('published', null, ['required' => false])
-            ->add('clerkshipType', 'tdn_single_related', [
+            ->add('clerkshipType', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CourseClerkshipType"
             ])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])
-            ->add('directors', 'tdn_many_related', [
+            ->add('directors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('cohorts', 'tdn_many_related', [
+            ->add('cohorts', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Cohort"
             ])
-            ->add('topics', 'tdn_many_related', [
+            ->add('topics', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Topic"
             ])
-            ->add('terms', 'tdn_many_related', [
+            ->add('terms', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Term"
             ])
-            ->add('objectives', 'tdn_many_related', [
+            ->add('objectives', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Objective"
             ])
-            ->add('meshDescriptors', 'tdn_many_related', [
+            ->add('meshDescriptors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CourseType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseType.php
@@ -82,12 +82,4 @@ class CourseType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Course'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'course';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryAcademicLevelType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryAcademicLevelType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,7 +24,7 @@ class CurriculumInventoryAcademicLevelType extends AbstractType
             ->add('name', null, ['empty_data' => null])
             ->add('description', null, ['required' => false, 'empty_data' => null])
             ->add('level')
-            ->add('report', 'tdn_single_related', [
+            ->add('report', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryAcademicLevelType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryAcademicLevelType.php
@@ -43,12 +43,4 @@ class CurriculumInventoryAcademicLevelType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'curriculuminventoryacademiclevel';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryExportType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryExportType.php
@@ -2,6 +2,7 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,7 +20,7 @@ class CurriculumInventoryExportType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('report', 'tdn_single_related', [
+            ->add('report', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryExportType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryExportType.php
@@ -31,16 +31,10 @@ class CurriculumInventoryExportType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class' => 'Ilios\CoreBundle\Entity\CurriculumInventoryExport'
-        ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'curriculuminventoryexport';
+        $resolver->setDefaults(
+            array(
+                'data_class' => 'Ilios\CoreBundle\Entity\CurriculumInventoryExport'
+            )
+        );
     }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryInstitutionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryInstitutionType.php
@@ -50,12 +50,4 @@ class CurriculumInventoryInstitutionType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\CurriculumInventoryInstitution'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'curriculuminventoryinstitution';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryInstitutionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryInstitutionType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -34,7 +35,7 @@ class CurriculumInventoryInstitutionType extends AbstractType
             $builder->get($element)->addViewTransformer($transformer);
         }
         $builder
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryReportType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryReportType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -29,15 +30,15 @@ class CurriculumInventoryReportType extends AbstractType
             ->add('endDate', 'datetime', array(
                 'widget' => 'single_text',
             ))
-            ->add('export', 'tdn_single_related', [
+            ->add('export', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryExport"
             ])
-            ->add('sequence', 'tdn_single_related', [
+            ->add('sequence', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventorySequence"
             ])
-            ->add('program', 'tdn_single_related', [
+            ->add('program', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Program"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryReportType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryReportType.php
@@ -57,12 +57,4 @@ class CurriculumInventoryReportType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\CurriculumInventoryReport'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'curriculuminventoryreport';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockSessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockSessionType.php
@@ -40,12 +40,4 @@ class CurriculumInventorySequenceBlockSessionType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlockSession'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'curriculuminventorysequenceblocksession';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockSessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockSessionType.php
@@ -2,6 +2,7 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -20,11 +21,11 @@ class CurriculumInventorySequenceBlockSessionType extends AbstractType
     {
         $builder
             ->add('countOfferingsOnce', null, ['required' => false])
-            ->add('sequenceBlock', 'tdn_single_related', [
+            ->add('sequenceBlock', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventorySequenceBlock"
             ])
-            ->add('session', 'tdn_single_related', [
+            ->add('session', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Session"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -35,19 +36,19 @@ class CurriculumInventorySequenceBlockType extends AbstractType
                 'widget' => 'single_text',
             ))
             ->add('duration')
-            ->add('academicLevel', 'tdn_single_related', [
+            ->add('academicLevel', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryAcademicLevel"
             ])
-            ->add('course', 'tdn_single_related', [
+            ->add('course', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Course"
             ])
-            ->add('parent', 'tdn_single_related', [
+            ->add('parent', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventorySequenceBlock"
             ])
-            ->add('report', 'tdn_single_related', [
+            ->add('report', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockType.php
@@ -67,12 +67,4 @@ class CurriculumInventorySequenceBlockType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'curriculuminventorysequenceblock';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceType.php
@@ -38,12 +38,4 @@ class CurriculumInventorySequenceType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\CurriculumInventorySequence'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'curriculuminventorysequence';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,7 +22,7 @@ class CurriculumInventorySequenceType extends AbstractType
     {
         $builder
             ->add('description', null, ['required' => false, 'empty_data' => null])
-            ->add('report', 'tdn_single_related', [
+            ->add('report', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/DepartmentType.php
+++ b/src/Ilios/CoreBundle/Form/Type/DepartmentType.php
@@ -38,12 +38,4 @@ class DepartmentType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Department'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'department';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/DepartmentType.php
+++ b/src/Ilios/CoreBundle/Form/Type/DepartmentType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,7 +22,7 @@ class DepartmentType extends AbstractType
     {
         $builder
             ->add('title', null, ['empty_data' => null])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/IlmSessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/IlmSessionType.php
@@ -2,6 +2,8 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,23 +25,23 @@ class IlmSessionType extends AbstractType
             ->add('dueDate', 'datetime', array(
                 'widget' => 'single_text',
             ))
-            ->add('learnerGroups', 'tdn_many_related', [
+            ->add('learnerGroups', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearnerGroup"
             ])
-            ->add('instructorGroups', 'tdn_many_related', [
+            ->add('instructorGroups', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:InstructorGroup"
             ])
-            ->add('instructors', 'tdn_many_related', [
+            ->add('instructors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('learners', 'tdn_many_related', [
+            ->add('learners', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('session', 'tdn_single_related', [
+            ->add('session', SingleRelatedType::class, [
                 'required' => true,
                 'entityName' => "IliosCoreBundle:Session"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/IlmSessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/IlmSessionType.php
@@ -55,12 +55,4 @@ class IlmSessionType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\IlmSession'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'ilmsession';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/InstructorGroupType.php
+++ b/src/Ilios/CoreBundle/Form/Type/InstructorGroupType.php
@@ -54,12 +54,4 @@ class InstructorGroupType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\InstructorGroup'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'instructorgroup';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/InstructorGroupType.php
+++ b/src/Ilios/CoreBundle/Form/Type/InstructorGroupType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,23 +23,23 @@ class InstructorGroupType extends AbstractType
     {
         $builder
             ->add('title', null, ['empty_data' => null])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])
-            ->add('learnerGroups', 'tdn_many_related', [
+            ->add('learnerGroups', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearnerGroup"
             ])
-            ->add('ilmSessions', 'tdn_many_related', [
+            ->add('ilmSessions', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:IlmSession"
             ])
-            ->add('users', 'tdn_many_related', [
+            ->add('users', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('offerings', 'tdn_many_related', [
+            ->add('offerings', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Offering"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/LearnerGroupType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearnerGroupType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,31 +24,31 @@ class LearnerGroupType extends AbstractType
         $builder
             ->add('title', null, ['empty_data' => null])
             ->add('location', null, ['required' => false, 'empty_data' => null])
-            ->add('cohort', 'tdn_single_related', [
+            ->add('cohort', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Cohort"
             ])
-            ->add('parent', 'tdn_single_related', [
+            ->add('parent', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearnerGroup"
             ])
-            ->add('ilmSessions', 'tdn_many_related', [
+            ->add('ilmSessions', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:IlmSession"
             ])
-            ->add('offerings', 'tdn_many_related', [
+            ->add('offerings', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Offering"
             ])
-            ->add('instructorGroups', 'tdn_many_related', [
+            ->add('instructorGroups', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:InstructorGroup"
             ])
-            ->add('users', 'tdn_many_related', [
+            ->add('users', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('instructors', 'tdn_many_related', [
+            ->add('instructors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/LearnerGroupType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearnerGroupType.php
@@ -66,12 +66,4 @@ class LearnerGroupType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\LearnerGroup'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'learnergroup';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/LearningMaterialStatusType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearningMaterialStatusType.php
@@ -34,12 +34,4 @@ class LearningMaterialStatusType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\LearningMaterialStatus'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'learningmaterialstatus';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
@@ -84,12 +84,4 @@ class LearningMaterialType extends AbstractType
             },
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'learningmaterial';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
@@ -4,6 +4,8 @@ namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Entity\LearningMaterialInterface;
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\PurifiedTextareaType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,22 +25,22 @@ class LearningMaterialType extends AbstractType
     {
         $builder
             ->add('title', null, ['empty_data' => null])
-            ->add('description', 'purified_textarea')
+            ->add('description', PurifiedTextareaType::class)
             ->add('originalAuthor', null, ['required' => false, 'empty_data' => null])
             ->add('filename', null, ['empty_data' => null])
             ->add('copyrightPermission')
             ->add('copyrightRationale', null, ['empty_data' => null])
             ->add('filesize')
             ->add('mimetype', null, ['empty_data' => null])
-            ->add('userRole', 'tdn_single_related', [
+            ->add('userRole', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearningMaterialUserRole"
             ])
-            ->add('status', 'tdn_single_related', [
+            ->add('status', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearningMaterialStatus"
             ])
-            ->add('owningUser', 'tdn_single_related', [
+            ->add('owningUser', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/LearningMaterialUserRoleType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearningMaterialUserRoleType.php
@@ -32,12 +32,4 @@ class LearningMaterialUserRoleType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\LearningMaterialUserRole'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'learningmaterialuserrole';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/MeshConceptType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshConceptType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -27,13 +28,13 @@ class MeshConceptType extends AbstractType
             ->add('scopeNote', null, ['required' => false, 'empty_data' => null])
             ->add('casn1Name', null, ['required' => false, 'empty_data' => null])
             ->add('registryNumber', null, ['required' => false, 'empty_data' => null])
-            ->add('descriptors', 'tdn_many_related', [
+            ->add('descriptors', ManyRelatedType::class, [
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])
-            ->add('semanticTypes', 'tdn_many_related', [
+            ->add('semanticTypes', ManyRelatedType::class, [
                 'entityName' => "IliosCoreBundle:MeshSemanticType"
             ])
-            ->add('terms', 'tdn_many_related', [
+            ->add('terms', ManyRelatedType::class, [
                 'entityName' => "IliosCoreBundle:MeshTerm"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/MeshConceptType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshConceptType.php
@@ -52,12 +52,4 @@ class MeshConceptType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\MeshConcept'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'meshconcept';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/MeshDescriptorType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshDescriptorType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,35 +25,35 @@ class MeshDescriptorType extends AbstractType
             ->add('id', null, ['empty_data' => null])
             ->add('name', null, ['empty_data' => null])
             ->add('annotation', null, ['required' => false, 'empty_data' => null])
-            ->add('courses', 'tdn_many_related', [
+            ->add('courses', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Course"
             ])
-            ->add('objectives', 'tdn_many_related', [
+            ->add('objectives', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Objective"
             ])
-            ->add('sessions', 'tdn_many_related', [
+            ->add('sessions', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Session"
             ])
-            ->add('sessionLearningMaterials', 'tdn_many_related', [
+            ->add('sessionLearningMaterials', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:SessionLearningMaterial"
             ])
-            ->add('courseLearningMaterials', 'tdn_many_related', [
+            ->add('courseLearningMaterials', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CourseLearningMaterial"
             ])
-            ->add('previousIndexing', 'tdn_single_related', [
+            ->add('previousIndexing', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshPreviousIndexing"
             ])
-            ->add('qualifiers', 'tdn_many_related', [
+            ->add('qualifiers', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshQualifier"
             ])
-            ->add('concepts', 'tdn_many_related', [
+            ->add('concepts', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshConcept"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/MeshDescriptorType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshDescriptorType.php
@@ -71,12 +71,4 @@ class MeshDescriptorType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\MeshDescriptor'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'meshdescriptor';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/MeshPreviousIndexingType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshPreviousIndexingType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,7 +22,7 @@ class MeshPreviousIndexingType extends AbstractType
     {
         $builder
             ->add('previousIndexing', null, ['empty_data' => null])
-            ->add('descriptor', 'tdn_single_related', [
+            ->add('descriptor', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/MeshPreviousIndexingType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshPreviousIndexingType.php
@@ -38,12 +38,4 @@ class MeshPreviousIndexingType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\MeshPreviousIndexing'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'meshpreviousindexing';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/MeshQualifierType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshQualifierType.php
@@ -42,12 +42,4 @@ class MeshQualifierType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\MeshQualifier'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'meshqualifier';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/MeshQualifierType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshQualifierType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,7 +23,7 @@ class MeshQualifierType extends AbstractType
         $builder
             ->add('id', null, ['empty_data' => null])
             ->add('name', null, ['empty_data' => null])
-            ->add('descriptors', 'tdn_many_related', [
+            ->add('descriptors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/MeshSemanticTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshSemanticTypeType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,7 +23,7 @@ class MeshSemanticTypeType extends AbstractType
         $builder
             ->add('id', null, ['empty_data' => null])
             ->add('name', null, ['empty_data' => null])
-            ->add('concepts', 'tdn_many_related', [
+            ->add('concepts', ManyRelatedType::class, [
                 'entityName' => "IliosCoreBundle:MeshConcept"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/MeshSemanticTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshSemanticTypeType.php
@@ -41,12 +41,4 @@ class MeshSemanticTypeType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\MeshSemanticType'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'meshsemantictype';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/MeshTermType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshTermType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -27,7 +28,7 @@ class MeshTermType extends AbstractType
             ->add('recordPreferred')
             ->add('permuted')
             ->add('printable')
-            ->add('concepts', 'tdn_many_related', [
+            ->add('concepts', ManyRelatedType::class, [
                 'entityName' => "IliosCoreBundle:MeshConcept"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/MeshTermType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshTermType.php
@@ -46,12 +46,4 @@ class MeshTermType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\MeshTerm'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'meshterm';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/MeshTreeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshTreeType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,7 +22,7 @@ class MeshTreeType extends AbstractType
     {
         $builder
             ->add('treeNumber', null, ['empty_data' => null])
-            ->add('descriptor', 'tdn_single_related', [
+            ->add('descriptor', SingleRelatedType::class, [
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/MeshTreeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/MeshTreeType.php
@@ -37,12 +37,4 @@ class MeshTreeType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\MeshTree'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'meshtree';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/ObjectiveType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ObjectiveType.php
@@ -60,12 +60,4 @@ class ObjectiveType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Objective'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'objective';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/ObjectiveType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ObjectiveType.php
@@ -2,6 +2,9 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\PurifiedTextareaType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,32 +22,32 @@ class ObjectiveType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('title', 'purified_textarea')
-            ->add('competency', 'tdn_single_related', [
+            ->add('title', PurifiedTextareaType::class)
+            ->add('competency', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Competency"
             ])
-            ->add('courses', 'tdn_many_related', [
+            ->add('courses', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Course"
             ])
-            ->add('programYears', 'tdn_many_related', [
+            ->add('programYears', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:ProgramYear"
             ])
-            ->add('sessions', 'tdn_many_related', [
+            ->add('sessions', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Session"
             ])
-            ->add('parents', 'tdn_many_related', [
+            ->add('parents', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Objective"
             ])
-            ->add('children', 'tdn_many_related', [
+            ->add('children', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Objective"
             ])
-            ->add('meshDescriptors', 'tdn_many_related', [
+            ->add('meshDescriptors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/OfferingType.php
+++ b/src/Ilios/CoreBundle/Form/Type/OfferingType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -27,23 +29,23 @@ class OfferingType extends AbstractType
             ->add('endDate', 'datetime', array(
                 'widget' => 'single_text',
             ))
-            ->add('session', 'tdn_single_related', [
+            ->add('session', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Session"
             ])
-            ->add('learnerGroups', 'tdn_many_related', [
+            ->add('learnerGroups', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearnerGroup"
             ])
-            ->add('instructorGroups', 'tdn_many_related', [
+            ->add('instructorGroups', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:InstructorGroup"
             ])
-            ->add('learners', 'tdn_many_related', [
+            ->add('learners', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('instructors', 'tdn_many_related', [
+            ->add('instructors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/OfferingType.php
+++ b/src/Ilios/CoreBundle/Form/Type/OfferingType.php
@@ -60,12 +60,4 @@ class OfferingType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Offering'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'offering';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/PendingUserUpdateType.php
+++ b/src/Ilios/CoreBundle/Form/Type/PendingUserUpdateType.php
@@ -43,12 +43,4 @@ class PendingUserUpdateType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\PendingUserUpdate'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'pendinguserupdate';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/PendingUserUpdateType.php
+++ b/src/Ilios/CoreBundle/Form/Type/PendingUserUpdateType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,7 +24,7 @@ class PendingUserUpdateType extends AbstractType
             ->add('type', null, ['empty_data' => null])
             ->add('property', null, ['empty_data' => null])
             ->add('value', null, ['empty_data' => null])
-            ->add('user', 'tdn_single_related', [
+            ->add('user', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/PermissionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/PermissionType.php
@@ -40,12 +40,4 @@ class PermissionType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Permission'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'permission';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/PermissionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/PermissionType.php
@@ -2,6 +2,7 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -25,7 +26,7 @@ class PermissionType extends AbstractType
             ->add('canWrite', null)
             ->add('tableRowId', null)
             ->add('tableName', null)
-            ->add('user', 'tdn_single_related', [
+            ->add('user', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ]);

--- a/src/Ilios/CoreBundle/Form/Type/ProgramType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramType.php
@@ -45,12 +45,4 @@ class ProgramType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Program'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'program';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/ProgramType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -25,7 +26,7 @@ class ProgramType extends AbstractType
             ->add('duration')
             ->add('publishedAsTbd', null, ['required' => false])
             ->add('published', null, ['required' => false])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/ProgramYearStewardType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramYearStewardType.php
@@ -43,12 +43,4 @@ class ProgramYearStewardType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\ProgramYearSteward'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'programyearsteward';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/ProgramYearStewardType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramYearStewardType.php
@@ -2,6 +2,7 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,15 +20,15 @@ class ProgramYearStewardType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('department', 'tdn_single_related', [
+            ->add('department', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Department"
             ])
-            ->add('programYear', 'tdn_single_related', [
+            ->add('programYear', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:ProgramYear"
             ])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/ProgramYearType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramYearType.php
@@ -2,6 +2,8 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -24,31 +26,31 @@ class ProgramYearType extends AbstractType
             ->add('archived', null, ['required' => false])
             ->add('publishedAsTbd', null, ['required' => false])
             ->add('published', null, ['required' => false])
-            ->add('program', 'tdn_single_related', [
+            ->add('program', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Program"
             ])
-            ->add('cohort', 'tdn_single_related', [
+            ->add('cohort', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Cohort"
             ])
-            ->add('directors', 'tdn_many_related', [
+            ->add('directors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('competencies', 'tdn_many_related', [
+            ->add('competencies', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Competency"
             ])
-            ->add('topics', 'tdn_many_related', [
+            ->add('topics', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Topic"
             ])
-            ->add('terms', 'tdn_many_related', [
+            ->add('terms', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Term"
             ])
-            ->add('objectives', 'tdn_many_related', [
+            ->add('objectives', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Objective"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/ProgramYearType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramYearType.php
@@ -64,12 +64,4 @@ class ProgramYearType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\ProgramYear'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'programyear';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/ReportType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ReportType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -24,11 +25,11 @@ class ReportType extends AbstractType
             ->add('subject', null, ['empty_data' => null])
             ->add('prepositionalObject', null, ['required' => false, 'empty_data' => null])
             ->add('prepositionalObjectTableRowId', null, ['required' => false, 'empty_data' => null])
-            ->add('user', 'tdn_single_related', [
+            ->add('user', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/ReportType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ReportType.php
@@ -48,12 +48,4 @@ class ReportType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Report'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'report';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/SchoolType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SchoolType.php
@@ -44,12 +44,4 @@ class SchoolType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\School'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'school';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/SchoolType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SchoolType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -24,7 +25,7 @@ class SchoolType extends AbstractType
             ->add('templatePrefix', null, ['required' => false, 'empty_data' => null])
             ->add('iliosAdministratorEmail', null, ['empty_data' => null])
             ->add('changeAlertRecipients', null, ['required' => false, 'empty_data' => null])
-            ->add('curriculumInventoryInstitution', 'tdn_single_related', [
+            ->add('curriculumInventoryInstitution', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryInstitution"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/SessionDescriptionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionDescriptionType.php
@@ -2,6 +2,8 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\PurifiedTextareaType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,8 +21,8 @@ class SessionDescriptionType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('description', 'purified_textarea', ['required' => false])
-            ->add('session', 'tdn_single_related', [
+            ->add('description', PurifiedTextareaType::class, ['required' => false])
+            ->add('session', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Session"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/SessionDescriptionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionDescriptionType.php
@@ -36,12 +36,4 @@ class SessionDescriptionType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\SessionDescription'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'sessiondescription';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/SessionLearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionLearningMaterialType.php
@@ -46,12 +46,4 @@ class SessionLearningMaterialType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\SessionLearningMaterial'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'sessionlearningmaterial';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/SessionLearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionLearningMaterialType.php
@@ -2,6 +2,9 @@
 
 namespace Ilios\CoreBundle\Form\Type;
 
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\PurifiedTextareaType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,18 +22,18 @@ class SessionLearningMaterialType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('notes', 'purified_textarea', ['required' => false])
+            ->add('notes', PurifiedTextareaType::class, ['required' => false])
             ->add('required', null, ['required' => false])
             ->add('publicNotes', null, ['required' => false])
-            ->add('session', 'tdn_single_related', [
+            ->add('session', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Session"
             ])
-            ->add('learningMaterial', 'tdn_single_related', [
+            ->add('learningMaterial', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearningMaterial"
             ])
-            ->add('meshDescriptors', 'tdn_many_related', [
+            ->add('meshDescriptors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/SessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionType.php
@@ -76,12 +76,4 @@ class SessionType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Session'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'session';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/SessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -26,39 +28,39 @@ class SessionType extends AbstractType
             ->add('supplemental', null, ['required' => false])
             ->add('publishedAsTbd', null, ['required' => false])
             ->add('published', null, ['required' => false])
-            ->add('sessionType', 'tdn_single_related', [
+            ->add('sessionType', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:SessionType"
             ])
-            ->add('course', 'tdn_single_related', [
+            ->add('course', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Course"
             ])
             ->add(
                 'ilmSession',
-                'tdn_single_related',
+                SingleRelatedType::class,
                 [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:IlmSession"
                 ]
             )
-            ->add('topics', 'tdn_many_related', [
+            ->add('topics', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Topic"
             ])
-            ->add('terms', 'tdn_many_related', [
+            ->add('terms', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Term"
             ])
-            ->add('objectives', 'tdn_many_related', [
+            ->add('objectives', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Objective"
             ])
-            ->add('meshDescriptors', 'tdn_many_related', [
+            ->add('meshDescriptors', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])
-            ->add('sessionDescription', 'tdn_single_related', [
+            ->add('sessionDescription', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:SessionDescription"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/SessionTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionTypeType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,15 +25,15 @@ class SessionTypeType extends AbstractType
             ->add('title', null, ['empty_data' => null])
             ->add('sessionTypeCssClass', null, ['required' => false, 'empty_data' => null])
             ->add('assessment', null, ['required' => false])
-            ->add('assessmentOption', 'tdn_single_related', [
+            ->add('assessmentOption', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:AssessmentOption"
             ])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])
-            ->add('aamcMethods', 'tdn_many_related', [
+            ->add('aamcMethods', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:AamcMethod"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/SessionTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionTypeType.php
@@ -52,12 +52,4 @@ class SessionTypeType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\SessionType'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'sessiontype';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/TermType.php
+++ b/src/Ilios/CoreBundle/Form/Type/TermType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,12 +22,12 @@ class TermType extends AbstractType
     {
         $builder
             ->add('title', null, ['required' => false, 'empty_data' => null])
-            ->add('vocabulary', 'tdn_single_related', [
+            ->add('vocabulary', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Vocabulary"
             ])
             ->add('description', 'textarea', ['required' => false])
-            ->add('parent', 'tdn_single_related', [
+            ->add('parent', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Term"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/TermType.php
+++ b/src/Ilios/CoreBundle/Form/Type/TermType.php
@@ -47,12 +47,4 @@ class TermType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Term'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'term';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/TopicType.php
+++ b/src/Ilios/CoreBundle/Form/Type/TopicType.php
@@ -39,12 +39,4 @@ class TopicType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Topic'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'topic';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/TopicType.php
+++ b/src/Ilios/CoreBundle/Form/Type/TopicType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,7 +22,7 @@ class TopicType extends AbstractType
     {
         $builder
             ->add('title', null, ['required' => false, 'empty_data' => null])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/UserMadeReminderType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserMadeReminderType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -25,7 +26,7 @@ class UserMadeReminderType extends AbstractType
                 'widget' => 'single_text',
             ))
             ->add('closed', null, ['required' => false])
-            ->add('user', 'tdn_single_related', [
+            ->add('user', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:User"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/UserMadeReminderType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserMadeReminderType.php
@@ -42,12 +42,4 @@ class UserMadeReminderType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\UserMadeReminder'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'usermadereminder';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/UserRoleType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserRoleType.php
@@ -34,12 +34,4 @@ class UserRoleType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\UserRole'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'userrole';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/UserType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserType.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -32,55 +34,55 @@ class UserType extends AbstractType
             ->add('otherId', null, ['required' => false, 'empty_data' => null])
             ->add('examined', null, ['required' => false])
             ->add('userSyncIgnore', null, ['required' => false])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])
-            ->add('directedCourses', 'tdn_many_related', [
+            ->add('directedCourses', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Course"
             ])
-            ->add('learnerGroups', 'tdn_many_related', [
+            ->add('learnerGroups', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearnerGroup"
             ])
-            ->add('instructedLearnerGroups', 'tdn_many_related', [
+            ->add('instructedLearnerGroups', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:LearnerGroup"
             ])
-            ->add('instructorGroups', 'tdn_many_related', [
+            ->add('instructorGroups', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:InstructorGroup"
             ])
-            ->add('instructorIlmSessions', 'tdn_many_related', [
+            ->add('instructorIlmSessions', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:IlmSession"
             ])
-            ->add('learnerIlmSessions', 'tdn_many_related', [
+            ->add('learnerIlmSessions', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:IlmSession"
             ])
-            ->add('offerings', 'tdn_many_related', [
+            ->add('offerings', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Offering"
             ])
-            ->add('instructedOfferings', 'tdn_many_related', [
+            ->add('instructedOfferings', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Offering"
             ])
-            ->add('programYears', 'tdn_many_related', [
+            ->add('programYears', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:ProgramYear"
             ])
-            ->add('roles', 'tdn_many_related', [
+            ->add('roles', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:UserRole"
             ])
-            ->add('primaryCohort', 'tdn_single_related', [
+            ->add('primaryCohort', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Cohort"
             ])
-            ->add('cohorts', 'tdn_many_related', [
+            ->add('cohorts', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Cohort"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/UserType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserType.php
@@ -101,12 +101,4 @@ class UserType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\User'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'user';
-    }
 }

--- a/src/Ilios/CoreBundle/Form/Type/VocabularyType.php
+++ b/src/Ilios/CoreBundle/Form/Type/VocabularyType.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Form\Type;
 
 use Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer;
+use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -21,7 +22,7 @@ class VocabularyType extends AbstractType
     {
         $builder
             ->add('title', null, ['required' => false, 'empty_data' => null])
-            ->add('school', 'tdn_single_related', [
+            ->add('school', SingleRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:School"
             ])

--- a/src/Ilios/CoreBundle/Form/Type/VocabularyType.php
+++ b/src/Ilios/CoreBundle/Form/Type/VocabularyType.php
@@ -39,12 +39,4 @@ class VocabularyType extends AbstractType
             'data_class' => 'Ilios\CoreBundle\Entity\Vocabulary'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'vocabulary';
-    }
 }

--- a/src/Ilios/CoreBundle/Resources/config/abstract_types.yml
+++ b/src/Ilios/CoreBundle/Resources/config/abstract_types.yml
@@ -1,6 +1,6 @@
 parameters:
   tdn.type.tdn_entity.class: Ilios\CoreBundle\Form\Type\AbstractType\EntityType
-  tdn.type.tdn_many_reated.class: Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType
+  tdn.type.tdn_many_related.class: Ilios\CoreBundle\Form\Type\AbstractType\ManyRelatedType
   tdn.type.tdn_single_related.class: Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType
   ilioscore.type.purified_textarea.class: Ilios\CoreBundle\Form\Type\AbstractType\PurifiedTextareaType
 services:
@@ -8,19 +8,19 @@ services:
     class: %tdn.type.tdn_entity.class%
     arguments: ['@doctrine']
     tags:
-        - { name: 'form.type', alias: 'tdn_entity' }
-  tdn.type.tdn_many_reated:
-    class: %tdn.type.tdn_many_reated.class%
+        - { name: 'form.type' }
+  tdn.type.tdn_many_related:
+    class: %tdn.type.tdn_many_related.class%
     arguments: ['@doctrine']
     tags:
-        - { name: 'form.type', alias: 'tdn_many_related' }
+        - { name: 'form.type' }
   tdn.type.tdn_single_related:
     class: %tdn.type.tdn_single_related.class%
     arguments: ['@doctrine']
     tags:
-        - { name: 'form.type', alias: 'tdn_single_related' }
+        - { name: 'form.type' }
   ilioscore.form.type.purified_textarea:
     class: %ilioscore.type.purified_textarea.class%
     arguments: ['@ilioscore.form.transformer.html_purifier']
     tags:
-        - { name: 'form.type', alias: 'purified_textarea' }
+        - { name: 'form.type' }


### PR DESCRIPTION
fixes #1300.

```
$ ./bin/deprecation-detector check ./../ilios/src ./../ilios/vendor 
Checking your application for deprecations - this could take a while ...

Loading RuleSet...

RuleSet loaded.

Parsing files & Searching for deprecations...

Finished searching for deprecations.

Rendering output...

Finished rendering output.

There are no violations - congratulations!
Checked 588 source files in 12.664 seconds, 27 MB memory used
```