### PR TITLE
Updating a user should not update all of their offerings

### DIFF
--- a/src/Ilios/CoreBundle/EventListener/UpdateOfferingTimestamp.php
+++ b/src/Ilios/CoreBundle/EventListener/UpdateOfferingTimestamp.php
@@ -47,16 +47,7 @@ class UpdateOfferingTimestamp
             switch (get_class($entity)) {
                 case 'Ilios\CoreBundle\Entity\LearnerGroup':
                 case 'Ilios\CoreBundle\Entity\InstructorGroup':
-                case 'Ilios\CoreBundle\Entity\LearnerGroup':
                     foreach ($entity->getOfferings() as $offering) {
-                        $offerings[] = $offering;
-                    }
-                    break;
-                case 'Ilios\CoreBundle\Entity\User':
-                    foreach ($entity->getOfferings() as $offering) {
-                        $offerings[] = $offering;
-                    }
-                    foreach ($entity->getInstructedOfferings() as $offering) {
                         $offerings[] = $offering;
                     }
                     break;

--- a/src/Ilios/CoreBundle/Tests/Controller/OfferingControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/OfferingControllerTest.php
@@ -496,4 +496,66 @@ class OfferingControllerTest extends AbstractControllerTest
         $this->assertJsonResponse($this->client->getResponse(), Codes::HTTP_OK);
         $this->checkUpdatedAtIncreased($firstUpdatedAt);
     }
+
+    /**
+     * @group controllers
+     */
+    public function testUpdatingInstructorUpdatesOfferingStamp()
+    {
+        $offering = $this->container
+            ->get('ilioscore.dataloader.offering')
+            ->getOne();
+
+        $postData = $offering;
+        //unset any parameters which should not be POSTed
+        unset($postData['id']);
+
+        $firstUpdatedAt = $this->getOfferingUpdatedAt();
+        sleep(2); //wait for two seconds
+
+        $postData['instructors'] = ['1'];
+
+        $this->createJsonRequest(
+            'PUT',
+            $this->getUrl(
+                'put_offerings',
+                ['id' => $offering['id']]
+            ),
+            json_encode(['offering' => $postData]),
+            $this->getAuthenticatedUserToken()
+        );
+        $this->assertJsonResponse($this->client->getResponse(), Codes::HTTP_OK);
+        $this->checkUpdatedAtIncreased($firstUpdatedAt);
+    }
+
+    /**
+     * @group controllers
+     */
+    public function testUpdatingILearnerUpdatesOfferingStamp()
+    {
+        $offering = $this->container
+            ->get('ilioscore.dataloader.offering')
+            ->getOne();
+
+        $postData = $offering;
+        //unset any parameters which should not be POSTed
+        unset($postData['id']);
+
+        $firstUpdatedAt = $this->getOfferingUpdatedAt();
+        sleep(2); //wait for two seconds
+
+        $postData['learners'] = ['1'];
+
+        $this->createJsonRequest(
+            'PUT',
+            $this->getUrl(
+                'put_offerings',
+                ['id' => $offering['id']]
+            ),
+            json_encode(['offering' => $postData]),
+            $this->getAuthenticatedUserToken()
+        );
+        $this->assertJsonResponse($this->client->getResponse(), Codes::HTTP_OK);
+        $this->checkUpdatedAtIncreased($firstUpdatedAt);
+    }
 }


### PR DESCRIPTION
This code doesn’t make any sense.  Offering stamps should be updated
from the offering side any time an association changes.