### PR TITLE
Course as a Data Transfer Object

### DIFF
--- a/src/Ilios/AuthenticationBundle/DependencyInjection/IliosAuthenticationExtension.php
+++ b/src/Ilios/AuthenticationBundle/DependencyInjection/IliosAuthenticationExtension.php
@@ -34,7 +34,8 @@ class IliosAuthenticationExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('voters.yml');
-        
+        $loader->load('dto_voters.yml');
+
         switch ($config['type']) {
             case 'form':
                 $container->setParameter(

--- a/src/Ilios/AuthenticationBundle/DependencyInjection/IliosAuthenticationExtension.php
+++ b/src/Ilios/AuthenticationBundle/DependencyInjection/IliosAuthenticationExtension.php
@@ -34,6 +34,7 @@ class IliosAuthenticationExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('voters.yml');
+        $loader->load('entity_voters.yml');
         $loader->load('dto_voters.yml');
 
         switch ($config['type']) {

--- a/src/Ilios/AuthenticationBundle/Resources/config/dto_voters.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/dto_voters.yml
@@ -1,0 +1,7 @@
+services:
+    security.access.api_proxy_course_voter:
+        class: Ilios\AuthenticationBundle\Voter\DTO\CourseDTOVoter
+        arguments: [ @ilioscore.course.manager, @ilioscore.permission.manager ]
+        public: false
+        tags:
+            - { name: security.voter }

--- a/src/Ilios/AuthenticationBundle/Resources/config/entity_voters.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/entity_voters.yml
@@ -1,6 +1,6 @@
 services:
-    security.access.dto.course_voter:
-        class: Ilios\AuthenticationBundle\Voter\DTO\CourseDTOVoter
+    security.access.entity.course_voter:
+        class: Ilios\AuthenticationBundle\Voter\Entity\CourseEntityVoter
         parent: security.access.course_voter
         public: false
         tags:

--- a/src/Ilios/AuthenticationBundle/Resources/config/voters.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/voters.yml
@@ -56,8 +56,6 @@ services:
         class: Ilios\AuthenticationBundle\Voter\CourseVoter
         arguments: [ @ilioscore.course.manager, @ilioscore.permission.manager ]
         public: false
-        tags:
-             - { name: security.voter }
     security.access.curriculum_inventory_academic_level_voter:
         class: Ilios\AuthenticationBundle\Voter\CurriculumInventoryAcademicLevelVoter
         parent: security.access.curriculum_inventory_report_voter

--- a/src/Ilios/AuthenticationBundle/Voter/CompetencyVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/CompetencyVoter.php
@@ -58,7 +58,7 @@ class CompetencyVoter extends AbstractVoter
             case self::VIEW:
                 return (
                     $this->schoolsAreIdentical($competency->getSchool(), $user->getSchool())
-                    || $this->permissionManager->userHasReadPermissionToSchool($user, $competency->getSchool())
+                    || $this->permissionManager->userHasReadPermissionToSchool($user, $competency->getSchool()->getId())
                 );
                 break;
             case self::CREATE:
@@ -74,7 +74,7 @@ class CompetencyVoter extends AbstractVoter
                 return ($this->userHasRole($user, ['Developer'])
                     && (
                         $this->schoolsAreIdentical($competency->getSchool(), $user->getSchool())
-                        || $this->permissionManager->userHasWritePermissionToSchool($user, $competency->getSchool())
+                        || $this->permissionManager->userHasWritePermissionToSchool($user, $competency->getSchool()->getId())
                     )
                 );
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/CompetencyVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/CompetencyVoter.php
@@ -74,7 +74,10 @@ class CompetencyVoter extends AbstractVoter
                 return ($this->userHasRole($user, ['Developer'])
                     && (
                         $this->schoolsAreIdentical($competency->getSchool(), $user->getSchool())
-                        || $this->permissionManager->userHasWritePermissionToSchool($user, $competency->getSchool()->getId())
+                        || $this->permissionManager->userHasWritePermissionToSchool(
+                            $user,
+                            $competency->getSchool()->getId()
+                        )
                     )
                 );
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/CourseLearningMaterialVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/CourseLearningMaterialVoter.php
@@ -3,6 +3,7 @@
 namespace Ilios\AuthenticationBundle\Voter;
 
 use Ilios\CoreBundle\Entity\CourseLearningMaterialInterface;
+use Ilios\CoreBundle\Entity\CourseInterface;
 use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -49,7 +50,7 @@ class CourseLearningMaterialVoter extends CourseVoter
     /**
      * {@inheritdoc}
      */
-    protected function isWriteGranted($course, $user)
+    protected function isWriteGranted(CourseInterface $course, $user)
     {
         // prevent any sort of write operation (create/edit/delete) if the parent course is locked or archived.
         if ($course->isLocked() || $course->isArchived()) {

--- a/src/Ilios/AuthenticationBundle/Voter/CourseLearningMaterialVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/CourseLearningMaterialVoter.php
@@ -2,8 +2,8 @@
 
 namespace Ilios\AuthenticationBundle\Voter;
 
+use Ilios\CoreBundle\Entity\UserInterface;
 use Ilios\CoreBundle\Entity\CourseLearningMaterialInterface;
-use Ilios\CoreBundle\Entity\CourseInterface;
 use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -31,31 +31,38 @@ class CourseLearningMaterialVoter extends CourseVoter
      */
     protected function voteOnAttribute($attribute, $material, TokenInterface $token)
     {
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
         $course = $material->getCourse();
         if (! $course) {
             return false;
         }
-        // grant perms based on the owning course
-        $granted = parent::voteOnAttribute($attribute, $course, $token);
 
-        // prevent access if associated LM is in draft, and the current user has no elevated privileges.
-        if ($granted && self::VIEW === $attribute) {
-            $granted = $this->userHasRole($token->getUser(), ['Faculty', 'Course Director', 'Developer'])
-                || LearningMaterialStatusInterface::IN_DRAFT !== $material->getLearningMaterial()->getStatus()->getId();
+        switch ($attribute) {
+            case self::VIEW:
+                $granted =  $this->isViewGranted($course->getId(), $course->getSchool()->getId(), $user);
+                // prevent access if associated LM is in draft, and the current user has no elevated privileges.
+                if ($granted) {
+                    $granted = $this->userHasRole($token->getUser(), ['Faculty', 'Course Director', 'Developer'])
+                    || LearningMaterialStatusInterface::IN_DRAFT !== $material->getLearningMaterial()
+                            ->getStatus()->getId();
+                }
+
+                return $granted;
+                break;
+            case self::CREATE:
+            case self::EDIT:
+            case self::DELETE:
+                // prevent any sort of write operation (create/edit/delete) if the parent course is locked or archived.
+                if ($course->isLocked() || $course->isArchived()) {
+                    return false;
+                }
+                return $this->isWriteGranted($course->getId(), $course->getSchool()->getId(), $user);
+                break;
         }
-
-        return $granted;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function isWriteGranted(CourseInterface $course, $user)
-    {
-        // prevent any sort of write operation (create/edit/delete) if the parent course is locked or archived.
-        if ($course->isLocked() || $course->isArchived()) {
-            return false;
-        }
-        return parent::isWriteGranted($course, $user);
+        return false;
     }
 }

--- a/src/Ilios/AuthenticationBundle/Voter/CurriculumInventoryExportVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/CurriculumInventoryExportVoter.php
@@ -64,7 +64,7 @@ class CurriculumInventoryExportVoter extends AbstractVoter
                         $this->schoolsAreIdentical($user->getSchool(), $export->getReport()->getSchool())
                         || $this->permissionManager->userHasWritePermissionToSchool(
                             $user,
-                            $export->getReport()->getSchool()
+                            $export->getReport()->getSchool()->getId()
                         ))
                 );
             case self::VIEW:
@@ -81,7 +81,7 @@ class CurriculumInventoryExportVoter extends AbstractVoter
                         $this->schoolsAreIdentical($user->getSchool(), $export->getReport()->getSchool())
                         || $this->permissionManager->userHasReadPermissionToSchool(
                             $user,
-                            $export->getReport()->getSchool()
+                            $export->getReport()->getSchool()->getId()
                         ))
                 );
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/CurriculumInventoryInstitutionVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/CurriculumInventoryInstitutionVoter.php
@@ -71,7 +71,8 @@ class CurriculumInventoryInstitutionVoter extends AbstractVoter
                     && (
                         $this->schoolsAreIdentical($user->getSchool(), $institution->getSchool())
                         || $this->permissionManager->userHasReadPermissionToSchool(
-                            $user, $institution->getSchool()->getId()
+                            $user,
+                            $institution->getSchool()->getId()
                         )
                     )
                 );
@@ -90,7 +91,10 @@ class CurriculumInventoryInstitutionVoter extends AbstractVoter
                     $this->userHasRole($user, ['Course Director', 'Developer'])
                     && (
                         $this->schoolsAreIdentical($user->getSchool(), $institution->getSchool())
-                        || $this->permissionManager->userHasWritePermissionToSchool($user, $institution->getSchool()->getId())
+                        || $this->permissionManager->userHasWritePermissionToSchool(
+                            $user,
+                            $institution->getSchool()->getId()
+                        )
                     )
                 );
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/CurriculumInventoryInstitutionVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/CurriculumInventoryInstitutionVoter.php
@@ -70,7 +70,9 @@ class CurriculumInventoryInstitutionVoter extends AbstractVoter
                     $this->userHasRole($user, ['Course Director', 'Developer'])
                     && (
                         $this->schoolsAreIdentical($user->getSchool(), $institution->getSchool())
-                        || $this->permissionManager->userHasReadPermissionToSchool($user, $institution->getSchool())
+                        || $this->permissionManager->userHasReadPermissionToSchool(
+                            $user, $institution->getSchool()->getId()
+                        )
                     )
                 );
                 break;
@@ -88,7 +90,7 @@ class CurriculumInventoryInstitutionVoter extends AbstractVoter
                     $this->userHasRole($user, ['Course Director', 'Developer'])
                     && (
                         $this->schoolsAreIdentical($user->getSchool(), $institution->getSchool())
-                        || $this->permissionManager->userHasWritePermissionToSchool($user, $institution->getSchool())
+                        || $this->permissionManager->userHasWritePermissionToSchool($user, $institution->getSchool()->getId())
                     )
                 );
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/CurriculumInventoryReportVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/CurriculumInventoryReportVoter.php
@@ -86,7 +86,7 @@ class CurriculumInventoryReportVoter extends AbstractVoter
                 $this->schoolsAreIdentical($user->getSchool(), $report->getSchool())
                 || $this->permissionManager->userHasReadPermissionToSchool(
                     $user,
-                    $report->getSchool()
+                    $report->getSchool()->getId()
                 )
             )
         );
@@ -127,7 +127,7 @@ class CurriculumInventoryReportVoter extends AbstractVoter
                 $this->schoolsAreIdentical($user->getSchool(), $report->getSchool())
                 || $this->permissionManager->userHasWritePermissionToSchool(
                     $user,
-                    $report->getSchool()
+                    $report->getSchool()->getId()
                 ))
         );
     }

--- a/src/Ilios/AuthenticationBundle/Voter/DepartmentVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/DepartmentVoter.php
@@ -58,7 +58,7 @@ class DepartmentVoter extends AbstractVoter
             case self::VIEW:
                 return (
                     $this->schoolsAreIdentical($department->getSchool(), $user->getSchool())
-                    || $this->permissionManager->userHasReadPermissionToSchool($user, $department->getSchool())
+                    || $this->permissionManager->userHasReadPermissionToSchool($user, $department->getSchool()->getId())
                 );
                 break;
             case self::CREATE:
@@ -75,7 +75,7 @@ class DepartmentVoter extends AbstractVoter
                     $this->userHasRole($user, ['Developer'])
                     && (
                         $this->schoolsAreIdentical($department->getSchool(), $user->getSchool())
-                        || $this->permissionManager->userHasWritePermissionToSchool($user, $department->getSchool())
+                        || $this->permissionManager->userHasWritePermissionToSchool($user, $department->getSchool()->getId())
                     )
                 );
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/DepartmentVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/DepartmentVoter.php
@@ -75,7 +75,10 @@ class DepartmentVoter extends AbstractVoter
                     $this->userHasRole($user, ['Developer'])
                     && (
                         $this->schoolsAreIdentical($department->getSchool(), $user->getSchool())
-                        || $this->permissionManager->userHasWritePermissionToSchool($user, $department->getSchool()->getId())
+                        || $this->permissionManager->userHasWritePermissionToSchool(
+                            $user,
+                            $department->getSchool()->getId()
+                        )
                     )
                 );
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/Entity/CourseEntityVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/Entity/CourseEntityVoter.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Ilios\AuthenticationBundle\Voter\DTO;
+namespace Ilios\AuthenticationBundle\Voter\Entity;
 
-use Ilios\CoreBundle\Entity\DTO\CourseDTO;
 use Ilios\AuthenticationBundle\Voter\CourseVoter;
+use Ilios\CoreBundle\Entity\CourseInterface;
 use Ilios\CoreBundle\Entity\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
- * Class CourseDTOVoter
- * @package Ilios\AuthenticationBundle\Voter\ApiProxy\V1
+ * Class CourseEntityVoter
+ * @package Ilios\AuthenticationBundle\Voter\Entity
  */
-class CourseDTOVoter extends CourseVoter
+class CourseEntityVoter extends CourseVoter
 {
 
     /**
@@ -19,14 +19,14 @@ class CourseDTOVoter extends CourseVoter
      */
     protected function supports($attribute, $subject)
     {
-        return $subject instanceof CourseDTO && in_array($attribute, array(
+        return $subject instanceof CourseInterface && in_array($attribute, array(
             self::CREATE, self::VIEW, self::EDIT, self::DELETE
         ));
     }
 
     /**
      * @param string $attribute
-     * @param CourseDTO $course
+     * @param CourseInterface $course
      * @param TokenInterface $token
      * @return bool
      */
@@ -39,12 +39,12 @@ class CourseDTOVoter extends CourseVoter
 
         switch ($attribute) {
             case self::VIEW:
-                return $this->isViewGranted($course->id, $course->school, $user);
+                return $this->isViewGranted($course->getId(), $course->getSchool()->getId(), $user);
                 break;
             case self::CREATE:
             case self::EDIT:
             case self::DELETE:
-                return $this->isWriteGranted($course->id, $course->school, $user);
+                return $this->isWriteGranted($course->getId(), $course->getSchool()->getId(), $user);
                 break;
         }
         return false;

--- a/src/Ilios/AuthenticationBundle/Voter/InstructorGroupVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/InstructorGroupVoter.php
@@ -66,7 +66,7 @@ class InstructorGroupVoter extends AbstractVoter
                     $this->userHasRole($user, ['Course Director', 'Developer'])
                     && (
                         $this->schoolsAreIdentical($user->getSchool(), $group->getSchool())
-                        || $this->permissionManager->userHasWritePermissionToSchool($user, $group->getSchool())
+                        || $this->permissionManager->userHasWritePermissionToSchool($user, $group->getSchool()->getId())
                     )
                 );
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/LearnerGroupVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/LearnerGroupVoter.php
@@ -70,7 +70,7 @@ class LearnerGroupVoter extends AbstractVoter
                         )
                         || $this->permissionManager->userHasWritePermissionToSchool(
                             $user,
-                            $group->getSchool()
+                            $group->getSchool()->getId()
                         )
                     )
                     || $this->permissionManager->userHasWritePermissionToProgram(

--- a/src/Ilios/AuthenticationBundle/Voter/ObjectiveVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/ObjectiveVoter.php
@@ -112,7 +112,7 @@ class ObjectiveVoter extends AbstractVoter
                     $this->schoolsAreIdentical($programYear->getSchool(), $user->getSchool())
                     || $this->permissionManager->userHasWritePermissionToSchool(
                         $user,
-                        $programYear->getSchool()
+                        $programYear->getSchool()->getId()
                     )
                     || $this->stewardManager->schoolIsStewardingProgramYear($user, $programYear)
                 )
@@ -145,7 +145,7 @@ class ObjectiveVoter extends AbstractVoter
             $this->userHasRole($user, ['Faculty', 'Course Director', 'Developer'])
             && (
                 $this->schoolsAreIdentical($course->getSchool(), $user->getSchool())
-                || $this->permissionManager->userHasWritePermissionToSchool($user, $course->getSchool())
+                || $this->permissionManager->userHasWritePermissionToSchool($user, $course->getSchool()->getId())
             )
             || $this->permissionManager->userHasWritePermissionToCourse($user, $course)
         );
@@ -172,7 +172,7 @@ class ObjectiveVoter extends AbstractVoter
             $this->userHasRole($user, ['Faculty', 'Course Director', 'Developer'])
             && (
                 $this->schoolsAreIdentical($course->getSchool(), $user->getSchool())
-                || $this->permissionManager->userHasWritePermissionToSchool($user, $course->getSchool())
+                || $this->permissionManager->userHasWritePermissionToSchool($user, $course->getSchool()->getId())
             )
             || $this->permissionManager->userHasWritePermissionToCourse($user, $course)
         );

--- a/src/Ilios/AuthenticationBundle/Voter/ProgramVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/ProgramVoter.php
@@ -71,7 +71,7 @@ class ProgramVoter extends AbstractVoter
                             $this->schoolsAreIdentical($program->getSchool(), $user->getSchool())
                             || $this->permissionManager->userHasWritePermissionToSchool(
                                 $user,
-                                $program->getSchool()
+                                $program->getSchool()->getId()
                             )
                         )
                     )

--- a/src/Ilios/AuthenticationBundle/Voter/ProgramYearStewardVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/ProgramYearStewardVoter.php
@@ -70,7 +70,7 @@ class ProgramYearStewardVoter extends AbstractVoter
                             )
                             || $this->permissionManager->userHasReadPermissionToSchool(
                                 $user,
-                                $steward->getProgramOwningSchool()
+                                $steward->getProgramOwningSchool()->getId()
                             )
                             || $this->schoolsAreIdentical($steward->getSchool(), $user->getSchool())
                         )
@@ -103,7 +103,7 @@ class ProgramYearStewardVoter extends AbstractVoter
                             )
                             || $this->permissionManager->userHasWritePermissionToSchool(
                                 $user,
-                                $steward->getProgramOwningSchool()
+                                $steward->getProgramOwningSchool()->getId()
                             )
                             || $this->schoolsAreIdentical($steward->getSchool(), $user->getSchool())
                         )

--- a/src/Ilios/AuthenticationBundle/Voter/ProgramYearVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/ProgramYearVoter.php
@@ -108,7 +108,7 @@ class ProgramYearVoter extends AbstractVoter
                     $this->schoolsAreIdentical($programYear->getSchool(), $user->getSchool())
                     || $this->permissionManager->userHasWritePermissionToSchool(
                         $user,
-                        $programYear->getSchool()
+                        $programYear->getSchool()->getId()
                     )
                     || $this->stewardManager->schoolIsStewardingProgramYear($user, $programYear)
                 )

--- a/src/Ilios/AuthenticationBundle/Voter/SchoolVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/SchoolVoter.php
@@ -58,7 +58,7 @@ class SchoolVoter extends AbstractVoter
                 // 4. the given user is a learner,instructor or director in courses of the given school.
                 return (
                     $this->userHasRole($user, ['Developer'])
-                    || $this->permissionManager->userHasReadPermissionToSchool($user, $school)
+                    || $this->permissionManager->userHasReadPermissionToSchool($user, $school->getId())
                     || $this->permissionManager->userHasReadPermissionToCoursesInSchool($user, $school)
                     || $user->getAllSchools()->contains($school)
                 );
@@ -79,7 +79,7 @@ class SchoolVoter extends AbstractVoter
                     $this->userHasRole($user, ['Developer'])
                     && (
                         $this->schoolsAreIdentical($school, $user->getSchool())
-                        || $this->permissionManager->userHasWritePermissionToSchool($user, $school)
+                        || $this->permissionManager->userHasWritePermissionToSchool($user, $school->getId())
                     )
                 );
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/SchooleventVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/SchooleventVoter.php
@@ -63,11 +63,14 @@ class SchooleventVoter extends AbstractVoter
                 $eventOwningSchool = $this->schoolManager->findSchoolBy(['id' => $event->school]);
                 if ($this->userHasRole($user, ['Faculty', 'Course Director', 'Developer'])) {
                     return $this->schoolsAreIdentical($eventOwningSchool, $user->getSchool())
-                    || $this->permissionManager->userHasReadPermissionToSchool($user, $eventOwningSchool);
+                    || $this->permissionManager->userHasReadPermissionToSchool($user, $eventOwningSchool->getId());
                 } else {
                     return ((
                             $this->schoolsAreIdentical($eventOwningSchool, $user->getSchool())
-                            || $this->permissionManager->userHasReadPermissionToSchool($user, $eventOwningSchool)
+                            || $this->permissionManager->userHasReadPermissionToSchool(
+                                $user,
+                                $eventOwningSchool->getId()
+                            )
                         ) && $event->isPublished);
                 }
                 break;

--- a/src/Ilios/AuthenticationBundle/Voter/SessionTypeVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/SessionTypeVoter.php
@@ -71,7 +71,7 @@ class SessionTypeVoter extends AbstractVoter
                         $this->schoolsAreIdentical($sessionType->getSchool(), $user->getSchool())
                         || $this->permissionManager->userHasWritePermissionToSchool(
                             $user,
-                            $sessionType->getSchool()
+                            $sessionType->getSchool()->getId()
                         )
                     )
                 );

--- a/src/Ilios/AuthenticationBundle/Voter/SessionVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/SessionVoter.php
@@ -3,7 +3,7 @@
 namespace Ilios\AuthenticationBundle\Voter;
 
 use Ilios\CoreBundle\Entity\SessionInterface;
-use Ilios\CoreBundle\Entity\CourseInterface;
+use Ilios\CoreBundle\Entity\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
@@ -30,23 +30,30 @@ class SessionVoter extends CourseVoter
      */
     protected function voteOnAttribute($attribute, $session, TokenInterface $token)
     {
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
         $course = $session->getCourse();
         if (! $course) {
             return false;
         }
-        // grant perms based on the owning course
-        return parent::voteOnAttribute($attribute, $course, $token);
-    }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function isWriteGranted(CourseInterface $course, $user)
-    {
-        // prevent any sort of write operation (create/edit/delete) if the parent course is locked or archived.
-        if ($course->isLocked() || $course->isArchived()) {
-            return false;
+        switch ($attribute) {
+            case self::VIEW:
+                return $this->isViewGranted($course->getId(), $course->getSchool()->getId(), $user);
+                break;
+            case self::CREATE:
+            case self::EDIT:
+            case self::DELETE:
+                // prevent any sort of write operation (create/edit/delete) if the parent course is locked or archived.
+                if ($course->isLocked() || $course->isArchived()) {
+                    return false;
+                }
+                return $this->isWriteGranted($course->getId(), $course->getSchool()->getId(), $user);
+                break;
         }
-        return parent::isWriteGranted($course, $user);
+        return false;
     }
 }

--- a/src/Ilios/AuthenticationBundle/Voter/SessionVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/SessionVoter.php
@@ -3,6 +3,7 @@
 namespace Ilios\AuthenticationBundle\Voter;
 
 use Ilios\CoreBundle\Entity\SessionInterface;
+use Ilios\CoreBundle\Entity\CourseInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
@@ -40,7 +41,7 @@ class SessionVoter extends CourseVoter
     /**
      * {@inheritdoc}
      */
-    protected function isWriteGranted($course, $user)
+    protected function isWriteGranted(CourseInterface $course, $user)
     {
         // prevent any sort of write operation (create/edit/delete) if the parent course is locked or archived.
         if ($course->isLocked() || $course->isArchived()) {

--- a/src/Ilios/AuthenticationBundle/Voter/TopicVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/TopicVoter.php
@@ -60,7 +60,7 @@ class TopicVoter extends AbstractVoter
             case self::VIEW:
                 return (
                     $this->schoolsAreIdentical($topic->getSchool(), $user->getSchool())
-                    || $this->permissionManager->userHasReadPermissionToSchool($user, $topic->getSchool())
+                    || $this->permissionManager->userHasReadPermissionToSchool($user, $topic->getSchool()->getId())
                 );
                 break;
             case self::CREATE:
@@ -79,7 +79,7 @@ class TopicVoter extends AbstractVoter
                         $this->schoolsAreIdentical($topic->getSchool(), $user->getSchool())
                         || $this->permissionManager->userHasWritePermissionToSchool(
                             $user,
-                            $topic->getSchool()
+                            $topic->getSchool()->getId()
                         )
                     )
                 );

--- a/src/Ilios/CoreBundle/Controller/CourseController.php
+++ b/src/Ilios/CoreBundle/Controller/CourseController.php
@@ -39,7 +39,7 @@ class CourseController extends FOSRestController
      *        "description"="Course identifier."
      *     }
      *   },
-     *   output="Ilios\CoreBundle\Entity\Course",
+     *   output="Ilios\CoreBundle\Entity\DTO\CourseDTO",
      *   statusCodes={
      *     200 = "Course.",
      *     404 = "Not Found."
@@ -54,7 +54,11 @@ class CourseController extends FOSRestController
      */
     public function getAction($id)
     {
-        $course = $this->getOr404($id);
+        $course = $this->getCourseHandler()->findCourseDTOBy(['id' => $id]);
+
+        if (!$course) {
+            throw new NotFoundHttpException(sprintf('The resource \'%s\' was not found.', $id));
+        }
 
         $authChecker = $this->get('security.authorization_checker');
         if (! $authChecker->isGranted('view', $course)) {
@@ -73,7 +77,7 @@ class CourseController extends FOSRestController
      *   section = "Course",
      *   description = "Get all Course.",
      *   resource = true,
-     *   output="Ilios\CoreBundle\Entity\Course",
+     *   output="Ilios\CoreBundle\Entity\DTO\CourseDTO",
      *   statusCodes = {
      *     200 = "List of all Course",
      *     204 = "No content. Nothing to list."
@@ -144,7 +148,7 @@ class CourseController extends FOSRestController
                 );
         } else {
             $result = $this->getCourseHandler()
-                ->findCoursesBy(
+                ->findCourseDTOsBy(
                     $criteria,
                     $orderBy,
                     $limit,

--- a/src/Ilios/CoreBundle/Entity/DTO/CourseDTO.php
+++ b/src/Ilios/CoreBundle/Entity/DTO/CourseDTO.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Ilios\CoreBundle\Entity\DTO;
+
+use JMS\Serializer\Annotation as JMS;
+
+/**
+ * Class CourseDTO
+ * Data transfer object for a course
+ * @package Ilios\CoreBundle\Entity\DTO
+
+ */
+class CourseDTO
+{
+    /**
+     * @var int
+     * @JMS\Type("integer")
+     */
+    public $id;
+
+    /**
+     * @var string
+     * @JMS\Type("string")
+     */
+    public $title;
+
+    /**
+     * @var int
+     * @JMS\Type("integer")
+     */
+    public $level;
+
+    /**
+     * @var int
+     * @JMS\Type("integer")
+     */
+    public $year;
+
+    /**
+     * @var \DateTime
+     * @JMS\Type("DateTime<'c'>")
+     * @JMS\SerializedName("startDate")
+     */
+    public $startDate;
+
+    /**
+     * @var \DateTime
+     * @JMS\Type("DateTime<'c'>")
+     * @JMS\SerializedName("endDate")
+     */
+    public $endDate;
+
+    /**
+     * @var string
+     * @JMS\Type("string")
+     * @JMS\SerializedName("externalId")
+     */
+    public $externalId;
+
+    /**
+     * @var boolean
+     * @JMS\Type("boolean")
+     */
+    public $locked;
+
+    /**
+     * @var boolean
+     * @JMS\Type("boolean")
+     */
+    public $archived;
+
+    /**
+     * @var boolean
+     * @JMS\Type("boolean")
+     * @JMS\SerializedName("publishedAsTbd")
+     */
+    public $publishedAsTbd;
+
+    /**
+     * @var boolean
+     * @JMS\Type("boolean")
+     */
+    public $published;
+
+    /**
+     * @var int
+     * @JMS\Type("string")
+     * @JMS\SerializedName("clerkshipType")
+     */
+    public $clerkshipType;
+
+    /**
+     * @var int
+     * @JMS\Type("string")
+     * @JMS\SerializedName("school")
+     */
+    public $school;
+
+    /**
+     * @var int[]
+     * @JMS\Type("array<string>")
+     */
+    public $directors;
+
+    /**
+     * @var int[]
+     * @JMS\Type("array<string>")
+     */
+    public $cohorts;
+
+    /**
+     * @deprecated
+     * @var int[]
+     * @JMS\Type("array<string>")
+     */
+    public $topics;
+
+    /**
+     * @var int[]
+     * @JMS\Type("array<string>")
+     */
+    public $terms;
+
+    /**
+     * @var int[]
+     * @JMS\Type("array<string>")
+     */
+    public $objectives;
+
+    /**
+     * @var int[]
+     * @JMS\Type("array<string>")
+     * @JMS\SerializedName("meshDescriptors")
+     */
+    public $meshDescriptors;
+
+    /**
+     * @var int[]
+     * @JMS\Type("array<string>")
+     * @JMS\SerializedName("learningMaterials")
+     */
+    public $learningMaterials;
+
+    /**
+     * @var int[]
+     * @JMS\Type("array<string>")
+     */
+    public $sessions;
+
+    public function __construct(
+        $id,
+        $title,
+        $level,
+        $year,
+        $startDate,
+        $endDate,
+        $externalId,
+        $locked,
+        $archived,
+        $publishedAsTbd,
+        $published
+    ){
+        $this->id = $id;
+        $this->title = $title;
+        $this->level = $level;
+        $this->year = $year;
+        $this->startDate = $startDate;
+        $this->endDate = $endDate;
+        $this->externalId = $externalId;
+        $this->locked = $locked;
+        $this->archived = $archived;
+        $this->publishedAsTbd = $publishedAsTbd;
+        $this->published = $published;
+
+        $this->directors = [];
+        $this->cohorts = [];
+        $this->topics = [];
+        $this->terms = [];
+        $this->objectives = [];
+        $this->meshDescriptors = [];
+        $this->learningMaterials = [];
+        $this->sessions = [];
+
+    }
+
+}

--- a/src/Ilios/CoreBundle/Entity/DTO/CourseDTO.php
+++ b/src/Ilios/CoreBundle/Entity/DTO/CourseDTO.php
@@ -159,7 +159,7 @@ class CourseDTO
         $archived,
         $publishedAsTbd,
         $published
-    ){
+    ) {
         $this->id = $id;
         $this->title = $title;
         $this->level = $level;
@@ -182,5 +182,4 @@ class CourseDTO
         $this->sessions = [];
 
     }
-
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/CourseManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/CourseManager.php
@@ -25,6 +25,18 @@ class CourseManager extends AbstractManager implements CourseManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function findCourseDTOBy(
+        array $criteria,
+        array $orderBy = null
+    ) {
+        $results = $this->getRepository()->findDTOsBy($criteria, $orderBy, 1);
+
+        return empty($results)?false:$results[0];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findCoursesBy(
         array $criteria,
         array $orderBy = null,
@@ -32,6 +44,18 @@ class CourseManager extends AbstractManager implements CourseManagerInterface
         $offset = null
     ) {
         return $this->getRepository()->findBy($criteria, $orderBy, $limit, $offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findCourseDTOsBy(
+        array $criteria,
+        array $orderBy = null,
+        $limit = null,
+        $offset = null
+    ) {
+        return $this->getRepository()->findDTOsBy($criteria, $orderBy, $limit, $offset);
     }
 
     /**
@@ -97,8 +121,8 @@ class CourseManager extends AbstractManager implements CourseManagerInterface
     /**
      * @inheritdoc
      */
-    public function isUserInstructingInCourse(UserInterface $user, CourseInterface $course)
+    public function isUserInstructingInCourse(UserInterface $user, $courseId)
     {
-        return $this->getRepository()->isUserInstructingInCourse($user, $course);
+        return $this->getRepository()->isUserInstructingInCourse($user, $courseId);
     }
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/CourseManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/CourseManagerInterface.php
@@ -3,6 +3,7 @@
 namespace Ilios\CoreBundle\Entity\Manager;
 
 use Ilios\CoreBundle\Entity\CourseInterface;
+use Ilios\CoreBundle\Entity\DTO\CourseDTO;
 use Ilios\CoreBundle\Entity\UserInterface;
 
 /**
@@ -25,12 +26,38 @@ interface CourseManagerInterface extends ManagerInterface
     /**
      * @param array $criteria
      * @param array $orderBy
+     *
+     * @return CourseDTO
+     */
+    public function findCourseDTOBy(
+        array $criteria,
+        array $orderBy = null
+    );
+
+    /**
+     * @param array $criteria
+     * @param array $orderBy
      * @param integer $limit
      * @param integer $offset
      *
      * @return CourseInterface[]
      */
     public function findCoursesBy(
+        array $criteria,
+        array $orderBy = null,
+        $limit = null,
+        $offset = null
+    );
+
+    /**
+     * @param array $criteria
+     * @param array $orderBy
+     * @param integer $limit
+     * @param integer $offset
+     *
+     * @return CourseDTO[]
+     */
+    public function findCourseDTOsBy(
         array $criteria,
         array $orderBy = null,
         $limit = null,
@@ -93,8 +120,8 @@ interface CourseManagerInterface extends ManagerInterface
      * Checks if a given user is assigned as instructor to ILMs or offerings in a given course.
      *
      * @param UserInterface $user
-     * @param CourseInterface $course
+     * @param int $courseId
      * @return boolean TRUE if the user instructs at least one offering or ILM, FALSE otherwise.
      */
-    public function isUserInstructingInCourse(UserInterface $user, CourseInterface $course);
+    public function isUserInstructingInCourse(UserInterface $user, $courseId);
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
@@ -163,7 +163,7 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
         }
 
         foreach ($school->getCourses() as $course) {
-            if ($this->userHasReadPermissionToCourse($user, $course)) {
+            if ($this->userHasReadPermissionToCourse($user, $course->getId())) {
                 return true;
             }
         }
@@ -182,7 +182,7 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
         }
 
         foreach ($cohort->getCourses() as $course) {
-            if ($this->userHasReadPermissionToCourse($user, $course)) {
+            if ($this->userHasReadPermissionToCourse($user, $course->getId())) {
                 return true;
             }
         }

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
@@ -108,9 +108,9 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
     /**
      * {@inheritdoc}
      */
-    public function userHasReadPermissionToSchool(UserInterface $user, SchoolInterface $school = null)
+    public function userHasReadPermissionToSchool(UserInterface $user, $schoolId = null)
     {
-        return $school && $this->userHasPermission($user, self::CAN_READ, 'school', $school->getId());
+        return $schoolId && $this->userHasPermission($user, self::CAN_READ, 'school', $schoolId);
     }
 
     /**
@@ -148,9 +148,9 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
     /**
      * {@inheritdoc}
      */
-    public function userHasWritePermissionToSchool(UserInterface $user, SchoolInterface $school = null)
+    public function userHasWritePermissionToSchool(UserInterface $user, $schoolId = null)
     {
-        return $school && $this->userHasPermission($user, self::CAN_WRITE, 'school', $school->getId());
+        return $schoolId && $this->userHasPermission($user, self::CAN_WRITE, 'school', $schoolId);
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManager.php
@@ -92,9 +92,9 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
     /**
      * {@inheritdoc}
      */
-    public function userHasReadPermissionToCourse(UserInterface $user, CourseInterface $course = null)
+    public function userHasReadPermissionToCourse(UserInterface $user, $courseId = null)
     {
-        return $course && $this->userHasPermission($user, self::CAN_READ, 'course', $course->getId());
+        return $courseId && $this->userHasPermission($user, self::CAN_READ, 'course', $courseId);
     }
 
     /**
@@ -132,9 +132,9 @@ class PermissionManager extends AbstractManager implements PermissionManagerInte
     /**
      * {@inheritdoc}
      */
-    public function userHasWritePermissionToCourse(UserInterface $user, CourseInterface $course = null)
+    public function userHasWritePermissionToCourse(UserInterface $user, $courseId = null)
     {
-        return $course && $this->userHasPermission($user, self::CAN_WRITE, 'course', $course->getId());
+        return $courseId && $this->userHasPermission($user, self::CAN_WRITE, 'course', $courseId);
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
@@ -72,10 +72,10 @@ interface PermissionManagerInterface extends ManagerInterface
     /**
      * Checks if a given user has "read" permissions for a given course.
      * @param UserInterface $user
-     * @param CourseInterface|null $course
+     * @param null|$courseId
      * @return bool
      */
-    public function userHasReadPermissionToCourse(UserInterface $user, CourseInterface $course = null);
+    public function userHasReadPermissionToCourse(UserInterface $user, $courseId = null);
 
     /**
      * Checks if a given user has "read" permissions for a given program.
@@ -112,10 +112,10 @@ interface PermissionManagerInterface extends ManagerInterface
     /**
      * Checks if a given user has "write" permissions for a given course.
      * @param UserInterface $user
-     * @param CourseInterface|null $course
+     * @param int|null $courseId
      * @return bool
      */
-    public function userHasWritePermissionToCourse(UserInterface $user, CourseInterface $course = null);
+    public function userHasWritePermissionToCourse(UserInterface $user, $courseId = null);
 
     /**
      * Checks if a given user has "write" permissions for a given program.

--- a/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/PermissionManagerInterface.php
@@ -88,10 +88,10 @@ interface PermissionManagerInterface extends ManagerInterface
     /**
      * Checks if a given user has "read" permissions for a given school.
      * @param UserInterface $user
-     * @param SchoolInterface|null $school
+     * @param int|null $schoolId
      * @return bool
      */
-    public function userHasReadPermissionToSchool(UserInterface $user, SchoolInterface $school = null);
+    public function userHasReadPermissionToSchool(UserInterface $user, $schoolId = null);
     
     /**
      * Checks if a given user has "read" permissions for and in an array of schools.
@@ -128,10 +128,10 @@ interface PermissionManagerInterface extends ManagerInterface
     /**
      * Checks if a given user has "write" permissions for a given school.
      * @param UserInterface $user
-     * @param SchoolInterface|null $school
+     * @param int|null $schoolId
      * @return bool
      */
-    public function userHasWritePermissionToSchool(UserInterface $user, SchoolInterface $school = null);
+    public function userHasWritePermissionToSchool(UserInterface $user, $schoolId = null);
 
     /**
      * Checks if a given user has "read" permissions to any courses in a given school.

--- a/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
@@ -65,7 +65,8 @@ class CourseRepository extends EntityRepository
         $courseIds = array_keys($courseDTOs);
 
         $qb = $this->_em->createQueryBuilder()
-            ->select('s.id as schoolId, cl.id as clerkshipTypeId, c.id as courseId')->from('IliosCoreBundle:Course', 'c')
+            ->select('s.id as schoolId, cl.id as clerkshipTypeId, c.id as courseId')
+            ->from('IliosCoreBundle:Course', 'c')
             ->join('c.school', 's')
             ->leftJoin('c.clerkshipType', 'cl')
             ->where($qb->expr()->in('c.id', ':courseIds'))

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -807,6 +807,16 @@ class User implements UserInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function isDirectingCourse($courseId)
+    {
+        return $this->directedCourses->map(function (CourseInterface $course){
+            return $course->getId();
+        })->contains($courseId);
+    }
+
+    /**
      * @param Collection $learnerGroups
      */
     public function setLearnerGroups(Collection $learnerGroups)

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -811,7 +811,7 @@ class User implements UserInterface
      */
     public function isDirectingCourse($courseId)
     {
-        return $this->directedCourses->map(function (CourseInterface $course){
+        return $this->directedCourses->map(function (CourseInterface $course) {
             return $course->getId();
         })->contains($courseId);
     }

--- a/src/Ilios/CoreBundle/Entity/UserInterface.php
+++ b/src/Ilios/CoreBundle/Entity/UserInterface.php
@@ -201,6 +201,12 @@ interface UserInterface extends
     public function getDirectedCourses();
 
     /**
+     * @param int $courseId
+     * @return boolean
+     */
+    public function isDirectingCourse($courseId);
+
+    /**
      * @param Collection $userGroups
      */
     public function setLearnerGroups(Collection $userGroups);

--- a/src/Ilios/CoreBundle/Tests/Entity/Manager/PermissionManagerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/Manager/PermissionManagerTest.php
@@ -251,7 +251,7 @@ class PermissionManagerTest extends TestCase
             ->mock();
         $manager = new PermissionManager($registry, $class);
 
-        $this->assertTrue($manager->userHasWritePermissionToSchool($user, $school));
+        $this->assertTrue($manager->userHasWritePermissionToSchool($user, $school->getId()));
         $this->assertFalse($manager->userHasWritePermissionToSchool($user, null));
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/Manager/PermissionManagerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/Manager/PermissionManagerTest.php
@@ -110,7 +110,7 @@ class PermissionManagerTest extends TestCase
             ->mock();
         $manager = new PermissionManager($registry, $class);
 
-        $this->assertTrue($manager->userHasWritePermissionToCourse($user, $course));
+        $this->assertTrue($manager->userHasWritePermissionToCourse($user, $course->getId()));
         $this->assertFalse($manager->userHasWritePermissionToCourse($user, null));
     }
 
@@ -145,7 +145,7 @@ class PermissionManagerTest extends TestCase
             ->mock();
         $manager = new PermissionManager($registry, $class);
 
-        $this->assertTrue($manager->userHasReadPermissionToCourse($user, $course));
+        $this->assertTrue($manager->userHasReadPermissionToCourse($user, $course->getId()));
         $this->assertFalse($manager->userHasReadPermissionToCourse($user, null));
     }
 
@@ -286,7 +286,7 @@ class PermissionManagerTest extends TestCase
             ->mock();
         $manager = new PermissionManager($registry, $class);
 
-        $this->assertTrue($manager->userHasReadPermissionToSchool($user, $school));
+        $this->assertTrue($manager->userHasReadPermissionToSchool($user, $school->getId()));
         $this->assertFalse($manager->userHasReadPermissionToSchool($user, null));
     }
 


### PR DESCRIPTION
Using a data transfer object to pull courses from the API.  This is a substantial memory improvement over using entities and
serializing them.  5000 courses can now be queried in about 50mb of memory which is a hundred fold decrease in memory consumption.

I attempted to find some standard solutions we can apply across every endpoint, but may have over/under shot that goal.  Lets take the time to get this one right before we apply the pattern everywhere.