### PR TITLE
disable profiler in test env.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -24,6 +24,9 @@ framework:
     http_method_override: true
     serializer:
         enabled: false
+    profiler:
+        enabled: false
+        collect: false
 
 # Twig Configuration
 twig:

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -7,7 +7,7 @@ framework:
     session:
         storage_id: session.storage.mock_file
     profiler:
-        collect: false
+        enabled: true
 
 web_profiler:
     toolbar: false

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -37,7 +37,6 @@ monolog:
 
 liip_functional_test:
     cache_sqlite_db: true
-    #query_count.max_query_count: 50
 
 swiftmailer:
     disable_delivery: true

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -37,7 +37,7 @@ monolog:
 
 liip_functional_test:
     cache_sqlite_db: true
-    query_count.max_query_count: 50
+    #query_count.max_query_count: 50
 
 swiftmailer:
     disable_delivery: true


### PR DESCRIPTION
i yanked the Liip profiler and query counter in all environments, and only enabled the profiler in test env.
based on this recommendation: http://symfony.com/doc/current/cookbook/testing/profiling.html#speeding-up-tests-by-not-collecting-profiler-data

we were getting warnings in travis:

![selection_095](https://cloud.githubusercontent.com/assets/1410427/12991466/3d7076dc-d0c4-11e5-88e7-b4e72678c2a3.png)

see: https://github.com/liip/LiipFunctionalTestBundle#query-counter

