### PR TITLE
Prevent disabled users from logging in

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
@@ -77,13 +77,16 @@ class FormAuthentication implements AuthenticationInterface
             $authEntity = $this->authManager->findAuthenticationByUsername($username);
             if ($authEntity) {
                 $user = $authEntity->getUser();
-                $passwordValid = $this->encoder->isPasswordValid($user, $password);
-                if ($passwordValid) {
-                    $this->updateLegacyPassword($authEntity, $password);
-                    $jwt = $this->jwtManager->createJwtFromUser($user);
-                    
-                    return $this->createSuccessResponseFromJWT($jwt);
+                if ($user->isEnabled()) {
+                    $passwordValid = $this->encoder->isPasswordValid($user, $password);
+                    if ($passwordValid) {
+                        $this->updateLegacyPassword($authEntity, $password);
+                        $jwt = $this->jwtManager->createJwtFromUser($user);
+
+                        return $this->createSuccessResponseFromJWT($jwt);
+                    }
                 }
+
             }
             $errors[] = 'badCredentials';
         }

--- a/src/Ilios/AuthenticationBundle/Service/JsonWebTokenAuthenticator.php
+++ b/src/Ilios/AuthenticationBundle/Service/JsonWebTokenAuthenticator.php
@@ -81,6 +81,11 @@ class JsonWebTokenAuthenticator implements SimplePreAuthenticatorInterface, Auth
         }
         
         $user = $userProvider->loadUserByUsername($username);
+        if (!$user->isEnabled()) {
+            throw new BadCredentialsException(
+                'Invalid JSON Web Token: user is disabled'
+            );
+        }
         $authentication = $user->getAuthentication();
         if ($authentication) {
             $tokenNotValidBefore = $authentication->getInvalidateTokenIssuedBefore();

--- a/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
@@ -84,11 +84,13 @@ class LdapAuthentication implements AuthenticationInterface
             $authEntity = $this->authManager->findAuthenticationByUsername($username);
             if ($authEntity) {
                 $user = $authEntity->getUser();
-                $passwordValid = $this->checkLdapPassword($username, $password);
-                if ($passwordValid) {
-                    $jwt = $this->jwtManager->createJwtFromUser($user);
-                    
-                    return $this->createSuccessResponseFromJWT($jwt);
+                if ($user->isEnabled()) {
+                    $passwordValid = $this->checkLdapPassword($username, $password);
+                    if ($passwordValid) {
+                        $jwt = $this->jwtManager->createJwtFromUser($user);
+
+                        return $this->createSuccessResponseFromJWT($jwt);
+                    }
                 }
             }
             $errors[] = 'badCredentials';

--- a/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
@@ -47,7 +47,7 @@ class UserData extends AbstractDataLoader
             'firstName' => 'first',
             'email' => 'first@example.com',
             'phone' => $this->faker->phoneNumber,
-            'enabled' => false,
+            'enabled' => true,
             'campusId' => '2222@school.edu',
             'userSyncIgnore' => true,
             'icsFeedKey' => hash('sha256', '2'),

--- a/src/Ilios/CoreBundle/Tests/Traits/JsonControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Traits/JsonControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ilios\CoreBundle\Tests\Traits;
 
+use FOS\RestBundle\Util\Codes;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bundle\FrameworkBundle\Client;
 
@@ -60,6 +61,7 @@ trait JsonControllerTest
                 )
             );
             $response = $client->getResponse();
+            $this->assertJsonResponse($response, Codes::HTTP_OK);
             $response = json_decode($response->getContent(), true);
             $token = $response['jwt'];
         }


### PR DESCRIPTION
Modified the three supported authentication methods as a failsafe I
also modified the JWT token authenticator to ensure that even if a
disabled user gets a token it cannot be used to access the API.

Fixes #1332