### PR TITLE
Allow an empty password to be passed to authentication POST

### DIFF
--- a/src/Ilios/CoreBundle/Controller/AuthenticationController.php
+++ b/src/Ilios/CoreBundle/Controller/AuthenticationController.php
@@ -59,10 +59,11 @@ class AuthenticationController extends FOSRestController
                     $encoder = $this->container->get('security.password_encoder');
                     $encodedPassword = $encoder->encodePassword($user, $data['password']);
                     $data['passwordBcrypt'] = $encodedPassword;
-                    unset($data['password']);
                 }
 
             }
+            //unset the password here in case it is NULL and didn't satisy the above condition
+            unset($data['password']);
 
             $authentication = $handler->post($data);
 

--- a/src/Ilios/CoreBundle/Tests/Controller/AuthenticationControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/AuthenticationControllerTest.php
@@ -53,6 +53,27 @@ class AuthenticationControllerTest extends AbstractControllerTest
     /**
      * @group controllers_a
      */
+    public function testPostAuthenticationWithEmptyPassword()
+    {
+        $data = $this->container->get('ilioscore.dataloader.authentication')
+            ->create();
+        $data['password'] = null;
+
+        $this->createJsonRequest(
+            'POST',
+            $this->getUrl('post_authentications'),
+            json_encode(['authentication' => $data]),
+            $this->getAuthenticatedUserToken()
+        );
+
+        $response = $this->client->getResponse();
+
+        $this->assertEquals(Codes::HTTP_CREATED, $response->getStatusCode(), $response->getContent());
+    }
+
+    /**
+     * @group controllers_a
+     */
     public function testPostBadAuthentication()
     {
         $invalidAuthentication = $this->container


### PR DESCRIPTION
If we sent password=null to authentication it would blow up, even
though this is a valid thing to do when creating accounts that will
work on shibboleth and ldap providers.