### PR TITLE
Cascade competency deletes correctly

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20160301211144.php
+++ b/app/Resources/DoctrineMigrations/Version20160301211144.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add cascade to set objective competency ID to null when a competency is deleted
+ */
+class Version20160301211144 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE objective DROP FOREIGN KEY FK_B996F101FB9F58C');
+        $this->addSql('ALTER TABLE objective ADD CONSTRAINT FK_B996F101FB9F58C FOREIGN KEY (competency_id) REFERENCES competency (competency_id) ON DELETE SET NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE objective DROP FOREIGN KEY FK_B996F101FB9F58C');
+        $this->addSql('ALTER TABLE objective ADD CONSTRAINT FK_B996F101FB9F58C FOREIGN KEY (competency_id) REFERENCES competency (competency_id)');
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/Objective.php
+++ b/src/Ilios/CoreBundle/Entity/Objective.php
@@ -68,7 +68,7 @@ class Objective implements ObjectiveInterface
      *
      * @ORM\ManyToOne(targetEntity="Competency", inversedBy="objectives")
      * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="competency_id", referencedColumnName="competency_id")
+     *   @ORM\JoinColumn(name="competency_id", referencedColumnName="competency_id", onDelete="SET NULL")
      * })
      *
      * @JMS\Expose


### PR DESCRIPTION
If a competency is deleted any objectives linked to it should have
their competency_id set to NULL.

@saschaben is this OK?  Or should we continue to prevent competencies from being remove at all if they are linked to any objectives? 