### PR TITLE
Increase the ICS feed window by removing course objectives

### DIFF
--- a/src/Ilios/WebBundle/Controller/IcsController.php
+++ b/src/Ilios/WebBundle/Controller/IcsController.php
@@ -15,7 +15,7 @@ use \Eluceo\iCal\Component as ICS;
 
 class IcsController extends Controller
 {
-    const LOOK_BACK = '-1 months';
+    const LOOK_BACK = '-4 months';
     const LOOK_FORWARD = '+2 months';
 
     public function indexAction(Request $request, $key)
@@ -113,9 +113,6 @@ class IcsController extends Controller
                     return $this->getTextForLearningMaterial(($learningMaterial->getLearningMaterial()));
                 })->toArray();
 
-        $courseObjectives = $session->getCourse()->getObjectives()->map(function (ObjectiveInterface $objective) {
-            return $this->purify($objective->getTitle());
-        })->toArray();
         $courseMaterials =
             $session->getCourse()->getLearningMaterials()
                 ->map(function (CourseLearningMaterialInterface $learningMaterial) {
@@ -132,8 +129,6 @@ class IcsController extends Controller
             implode($sessionObjectives, "\n"),
             "\nSession Learning Materials",
             implode("\n", $sessionMaterials),
-            "\nCourse Objectives",
-            implode($courseObjectives, "\n"),
             "\nCourse Learning Materials",
             implode("\n", $courseMaterials),
         ];


### PR DESCRIPTION
Google can only process a file that is less than 1mb in size.  In order
to expand the feed to our desired -4 months +2 months course objectives
have been removed.

Fixes #1230