### PR TITLE
Allow access to app_dev.php by proxies

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -10,7 +10,6 @@ use Symfony\Component\Debug\Debug;
 // This check prevents access to debug front controllers that are deployed by accident to production servers.
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
-    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
     || !(in_array(@$_SERVER['REMOTE_ADDR'], array(
             '10.10.10.1',
             '127.0.0.1',


### PR DESCRIPTION
This is needed for development with ember-cli and since we indicate in
our instructions that app_dev.php should be removed in production and
running proxies on localhost isn’t really something anyone does anymore
I think it is safe to remove this protection.