### PR TITLE
Term children should not be saved with the term

### DIFF
--- a/src/Ilios/CoreBundle/Form/Type/TermType.php
+++ b/src/Ilios/CoreBundle/Form/Type/TermType.php
@@ -32,10 +32,6 @@ class TermType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Term"
             ])
-            ->add('children', ManyRelatedType::class, [
-                'required' => false,
-                'entityName' => "IliosCoreBundle:Term"
-            ])
             ->add('courses', ManyRelatedType::class, [
                 'required' => false,
                 'entityName' => "IliosCoreBundle:Course"

--- a/src/Ilios/CoreBundle/Tests/Controller/TermControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/TermControllerTest.php
@@ -151,6 +151,7 @@ class TermControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['children']);
 
         $this->createJsonRequest(
             'PUT',


### PR DESCRIPTION
We don’t allow saving of the many side in a one to many relationship
anywhere, and ember doesn’t send this data by default.