### PR TITLE
Filter users by role and cohort

### DIFF
--- a/src/Ilios/CoreBundle/Controller/UserController.php
+++ b/src/Ilios/CoreBundle/Controller/UserController.php
@@ -126,13 +126,17 @@ class UserController extends FOSRestController
         $orderBy = $paramFetcher->get('order_by');
         $q = !is_null($paramFetcher->get('q')) ? $paramFetcher->get('q') : false;
         $criteria = !is_null($paramFetcher->get('filters')) ? $paramFetcher->get('filters') : [];
-        $criteria = array_map(function ($item) {
-            $item = $item == 'null' ? null : $item;
-            $item = $item == 'false' ? false : $item;
-            $item = $item == 'true' ? true : $item;
-
+        $deepTranspose = function ($item) use (&$deepTranspose) {
+            if (is_array($item)) {
+                $item = array_map($deepTranspose, $item);
+            } else {
+                $item = $item == 'null' ? null : $item;
+                $item = $item == 'false' ? false : $item;
+                $item = $item == 'true' ? true : $item;
+            }
             return $item;
-        }, $criteria);
+        };
+        $criteria = array_map($deepTranspose, $criteria);
 
         if ($q) {
             $result = $this->getUserHandler()->findUsersByQ(

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -706,7 +706,22 @@ class UserRepository extends EntityRepository
             $qb->setParameter(':roles', $ids);
         }
 
+        if (array_key_exists('cohorts', $criteria)) {
+            $ids = is_array($criteria['cohorts'])
+                ? $criteria['cohorts'] : [$criteria['cohorts']];
+            if (in_array(null, $ids)) {
+                $ids = array_diff($ids, [null]);
+                $qb->andWhere('u.cohorts IS EMPTY');
+            }
+            if (count($ids)) {
+                $qb->join('u.cohorts', 'c_cohorts');
+                $qb->andWhere($qb->expr()->in('c_cohorts.id', ':cohorts'));
+                $qb->setParameter(':cohorts', $ids);
+            }
+        }
+
         //cleanup all the possible relationship filters
+        unset($criteria['cohorts']);
         unset($criteria['roles']);
         unset($criteria['schools']);
         unset($criteria['instructedCourses']);

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -698,7 +698,16 @@ class UserRepository extends EntityRepository
             $qb->setParameter(':schools', $ids);
         }
 
+        if (array_key_exists('roles', $criteria)) {
+            $ids = is_array($criteria['roles'])
+                ? $criteria['roles'] : [$criteria['roles']];
+            $qb->join('u.roles', 'r_roles');
+            $qb->andWhere($qb->expr()->in('r_roles.id', ':roles'));
+            $qb->setParameter(':roles', $ids);
+        }
+
         //cleanup all the possible relationship filters
+        unset($criteria['roles']);
         unset($criteria['schools']);
         unset($criteria['instructedCourses']);
         unset($criteria['instructedSessions']);

--- a/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
@@ -1028,4 +1028,30 @@ class UserControllerTest extends AbstractControllerTest
             $data[2]
         );
     }
+
+    /**
+     * @group controllers_b
+     */
+    public function testFilterByRole()
+    {
+        $users = $this->container->get('ilioscore.dataloader.user')->getAll();
+
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl('cget_users', ['filters[roles]' => [2]]),
+            null,
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_OK);
+        $data = json_decode($response->getContent(), true)['users'];
+        $this->assertEquals(1, count($data), var_export($data, true));
+        $this->assertEquals(
+            $this->mockSerialize(
+                $users[2]
+            ),
+            $data[0]
+        );
+    }
 }

--- a/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/UserControllerTest.php
@@ -1054,4 +1054,68 @@ class UserControllerTest extends AbstractControllerTest
             $data[0]
         );
     }
+
+    /**
+     * @group controllers_b
+     */
+    public function testFilterByCohort()
+    {
+        $users = $this->container->get('ilioscore.dataloader.user')->getAll();
+
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl('cget_users', ['filters[cohorts]' => 1]),
+            null,
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_OK);
+        $data = json_decode($response->getContent(), true)['users'];
+        $this->assertEquals(2, count($data), var_export($data, true));
+        $this->assertEquals(
+            $this->mockSerialize(
+                $users[0]
+            ),
+            $data[0]
+        );
+        $this->assertEquals(
+            $this->mockSerialize(
+                $users[1]
+            ),
+            $data[1]
+        );
+    }
+
+    /**
+     * @group controllers_b
+     */
+    public function testFilterByNullCohort()
+    {
+        $users = $this->container->get('ilioscore.dataloader.user')->getAll();
+
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl('cget_users', ['filters[cohorts]' => 'null']),
+            null,
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_OK);
+        $data = json_decode($response->getContent(), true)['users'];
+        $this->assertEquals(2, count($data), var_export($data, true));
+        $this->assertEquals(
+            $this->mockSerialize(
+                $users[2]
+            ),
+            $data[0]
+        );
+        $this->assertEquals(
+            $this->mockSerialize(
+                $users[3]
+            ),
+            $data[1]
+        );
+    }
 }

--- a/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/UserData.php
@@ -95,7 +95,7 @@ class UserData extends AbstractDataLoader
             'instructedOfferings' => [],
             'programYears' => [],
             'alerts' => [],
-            'roles' => [],
+            'roles' => ['2'],
             'cohorts' => [],
             'reminders' => [],
             'pendingUserUpdates' => [],

--- a/src/Ilios/CoreBundle/Tests/DataLoader/UserRoleData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/UserRoleData.php
@@ -29,7 +29,7 @@ class UserRoleData extends AbstractDataLoader
         $arr = array();
 
         $arr[] = array(
-            'id' => 2,
+            'id' => 3,
             'title' => $this->faker->text(10)
         );
 

--- a/src/Ilios/CoreBundle/Tests/DataLoader/UserRoleData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/UserRoleData.php
@@ -14,6 +14,12 @@ class UserRoleData extends AbstractDataLoader
             'users' => ['1','2'],
         );
 
+        $arr[] = array(
+            'id' => 2,
+            'title' => 'Something Else',
+            'users' => ['3'],
+        );
+
 
         return $arr;
     }


### PR DESCRIPTION
User can be filtered by the cohorts they are in or if null is passed
then users with no cohorts will be returned.