### PR TITLE
Require a frontend when starting up

### DIFF
--- a/src/Ilios/CliBundle/Command/UpdateFrontendCommand.php
+++ b/src/Ilios/CliBundle/Command/UpdateFrontendCommand.php
@@ -139,7 +139,7 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
      */
     public function isOptional()
     {
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
This was turned off when tests were failing because no frontend had been activated.