### PR TITLE
Add bulkCreateUsers API endpoint

### DIFF
--- a/src/Ilios/CliBundle/Command/UpdateFrontendCommand.php
+++ b/src/Ilios/CliBundle/Command/UpdateFrontendCommand.php
@@ -139,7 +139,7 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
      */
     public function isOptional()
     {
-        return true;
+        return false;
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/User.php
+++ b/src/Ilios/CoreBundle/Entity/User.php
@@ -285,6 +285,8 @@ class User implements UserInterface
      *   @ORM\JoinColumn(name="school_id", referencedColumnName="school_id", nullable=false)
      * })
      *
+     * @Assert\NotBlank()
+     *
      * @JMS\Expose
      * @JMS\Type("string")
      * @JMS\SerializedName("school")

--- a/src/Ilios/WebBundle/Controller/BulkUserCreationController.php
+++ b/src/Ilios/WebBundle/Controller/BulkUserCreationController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Ilios\WebBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use \SplFileObject;
+
+/**
+ * Class BulkUserCreationController
+ * @package Ilios\WebBundle\Controller
+ */
+class BulkUserCreationController extends Controller
+{
+    public function uploadAction(Request $request)
+    {
+        $schoolId = $request->request->get('school');
+
+        if (is_null($schoolId)) {
+            return new JsonResponse(array(
+                'errors' => 'No school parameter was found in the request'
+            ), JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $schoolManager = $this->container->get('ilioscore.school.manager');
+        $school = $schoolManager->findSchoolBy(['id'=>$schoolId]);
+        if (is_null($school)) {
+            return new JsonResponse(array(
+                'errors' => "The school {$schoolId} was not found"
+            ), JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $uploadedFile = $request->files->get('file');
+        if (is_null($uploadedFile)) {
+            return new JsonResponse(array(
+                'errors' => 'No file parameter was found in the request'
+            ), JsonResponse::HTTP_BAD_REQUEST);
+        }
+        if (!$uploadedFile->isValid()) {
+            return new JsonResponse(array('errors' => 'File failed to upload'), JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $userManager = $this->container->get('ilioscore.user.manager');
+        $validator = $this->get('validator');
+        $authChecker = $this->get('security.authorization_checker');
+
+        $file = $uploadedFile->openFile();
+        $file->setFlags(SplFileObject::READ_CSV);
+        $file->setCsvControl("\t");
+        
+        $results = [];
+
+        foreach ($file as $data) {
+            //drop blank lines
+            if (count($data) == 1 and is_null($data[0])) {
+                continue;
+            }
+            $result = $data;
+            if (count($data) >= 7) {
+                list($last, $first, $middel, $phone, $email, $campusId, $otherId) = $data;
+
+                $user = $userManager->createUser();
+                $user->setLastName($last);
+                $user->setFirstName($first);
+                $user->setMiddleName($middel);
+                $user->setPhone($phone);
+                $user->setEmail($email);
+                $user->setCampusId($campusId);
+                $user->setOtherId($otherId);
+                $user->setSchool($school);
+
+                if (! $authChecker->isGranted('create', $user)) {
+                    throw $this->createAccessDeniedException('Unauthorized access!');
+                }
+
+                $errors = $validator->validate($user);
+
+                if (count($errors) > 0) {
+                    $errorsString = (string) $errors;
+                    $result[] = 'error';
+                    $result[] = $errorsString;
+                } else {
+                    $userManager->updateUser($user);
+                    $result[] = 'success';
+                    $result[] = $user->getId();
+                }
+            } else {
+                $result[] = 'error';
+                $result[] = 'not enough fields';
+            }
+
+            $results[] = $result;
+        }
+
+        return new JsonResponse($results, JsonResponse::HTTP_OK);
+    }
+}

--- a/src/Ilios/WebBundle/Resources/config/routing.yml
+++ b/src/Ilios/WebBundle/Resources/config/routing.yml
@@ -19,6 +19,11 @@ ilios_web_directory_search:
     defaults:
         _controller: IliosWebBundle:Directory:search
     methods: [GET]
+ilios_web_bulk_user_creation:
+    path:     /application/bulkusercreation
+    defaults:
+        _controller: IliosWebBundle:BulkUserCreation:upload
+    methods: [POST]
 ilios_web_homepage:
     pattern:     /{url}
     defaults:

--- a/src/Ilios/WebBundle/Tests/Controller/BulkUserCreationControllerTest.php
+++ b/src/Ilios/WebBundle/Tests/Controller/BulkUserCreationControllerTest.php
@@ -1,0 +1,131 @@
+<?php
+namespace Ilios\WebBundle\Tests\Controller;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Filesystem\Filesystem;
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use FOS\RestBundle\Util\Codes;
+use Ilios\CoreBundle\Tests\Traits\JsonControllerTest;
+use \SplFileObject;
+
+/**
+ * Class ConfigControllerTest
+ * @package Ilios\WebBundle\Tests\Controller
+ */
+class BulkUserCreationControllerTest extends WebTestCase
+{
+    use JsonControllerTest;
+
+    protected $fakeTestFileDir;
+    protected $fakeTestFile;
+    protected $fs;
+
+    public function setUp()
+    {
+        $this->fs = new Filesystem();
+        $this->fakeTestFileDir = __DIR__ . '/FakeTestFiles';
+        if (!$this->fs->exists($this->fakeTestFileDir)) {
+            $this->fs->mkdir($this->fakeTestFileDir);
+        }
+
+        $line1 = ['Person', 'Test', 'M', '555-650-1234', 'test@example.com', '1234', '1234Other'];
+        $line2 = ['bad'];
+
+        $file = new SplFileObject($this->fakeTestFileDir . '/TESTFILE.txt', 'w');
+        $file->fputcsv($line1, "\t");
+        $file->fputcsv($line2, "\t");
+
+        $this->fs->copy(__FILE__, $this->fakeTestFileDir . '/TESTFILE.txt');
+        $this->fakeTestFile = new UploadedFile(
+            $this->fakeTestFileDir . '/TESTFILE.txt',
+            'TESTFILE.txt',
+            'text/plain',
+            filesize($this->fakeTestFileDir . '/TESTFILE.txt')
+        );
+
+        $this->loadFixtures([
+            'Ilios\CoreBundle\Tests\Fixture\LoadAuthenticationData',
+            'Ilios\CoreBundle\Tests\Fixture\LoadPermissionData',
+        ]);
+
+    }
+
+    public function tearDown()
+    {
+        $this->fs->remove($this->fakeTestFileDir);
+        unset($this->fs);
+        unset($this->fakeTestFile);
+    }
+
+    public function testUpload()
+    {
+        $client = $this->createClient();
+
+        $this->makeJsonRequest(
+            $client,
+            'POST',
+            '/application/bulkusercreation',
+            json_encode(['school' => 1]),
+            $this->getAuthenticatedUserToken(),
+            array('file' => $this->fakeTestFile)
+        );
+
+        $response = $client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_OK);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertSame(count($data), 2, 'Data returned for each line in the file');
+        $this->assertSame(
+            $data[0],
+            ['Person', 'Test', 'M', '555-650-1234', 'test@example.com', '1234', '1234Other', 'success', 5]
+        );
+        $this->assertSame($data[1], ['bad', 'error', 'not enough fields']);
+    }
+
+    public function testBadSchoolId()
+    {
+        $client = $this->createClient();
+
+        $this->makeJsonRequest(
+            $client,
+            'POST',
+            '/application/bulkusercreation',
+            json_encode(['school' => 23]),
+            $this->getAuthenticatedUserToken(),
+            array('file' => $this->fakeTestFile)
+        );
+
+        $response = $client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_BAD_REQUEST);
+
+        $this->assertEquals(
+            array('errors' => 'The school 23 was not found'),
+            json_decode($response->getContent(), true)
+        );
+    }
+
+    public function testMissingFile()
+    {
+        $client = $this->createClient();
+
+        $this->makeJsonRequest(
+            $client,
+            'POST',
+            '/application/bulkusercreation',
+            json_encode(['school' => 1]),
+            $this->getAuthenticatedUserToken()
+        );
+
+        $response = $client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_BAD_REQUEST);
+
+        $this->assertEquals(
+            array('errors' => 'No file parameter was found in the request'),
+            json_decode($response->getContent(), true)
+        );
+    }
+}


### PR DESCRIPTION
Takes a tab separated file with user information and creates accounts.
Returned a JSON object which contains the original data, the status of the request, and the new user id if applicable.

This is going to be REALLY slow for sets over 10-20 users because I'm saving each user one at a time instead of flushing them at the end.  I need to figure out how to save them in bulk and then pull out the user Ids for inclusion in the returned data.


Fixes #1375