### PR TITLE
Clear YAML deprecations

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,32 +1,32 @@
 IliosAuthenticationBundle:
     resource: "@IliosAuthenticationBundle/Resources/config/routing.yml"
     prefix:   /auth
-    schemes:  [%forceProtocol%]
+    schemes:  ["%forceProtocol%"]
 
 NelmioApiDocBundle:
     resource: "@NelmioApiDocBundle/Resources/config/routing.yml"
     prefix:   /api/doc
-    schemes:  [%forceProtocol%]
+    schemes:  ["%forceProtocol%"]
 
 IliosCoreBundle:
     resource: "@IliosCoreBundle/Resources/config/routing.yml"
     prefix:   /api
-    schemes:  [%forceProtocol%]
+    schemes:  ["%forceProtocol%"]
     
 ilios_core_uploadfile:
     path: /upload
     defaults:  { _controller: IliosCoreBundle:Upload:upload }
-    schemes:  [%forceProtocol%]
+    schemes:  ["%forceProtocol%"]
 
 ilios_core_downloadlearningmaterial:
-    pattern:     /lm/{token}
+    path:     /lm/{token}
     defaults:
         _controller: IliosCoreBundle:Download:learningMaterial
     requirements:
         token: "^[a-zA-Z0-9]{64}$"
-    schemes:  [%forceProtocol%]
+    schemes:  ["%forceProtocol%"]
 
 ilios_web:
     resource: "@IliosWebBundle/Resources/config/routing.yml"
     prefix:   /
-    schemes:  [%forceProtocol%]
+    schemes:  ["%forceProtocol%"]

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-fixtures-bundle": "~2.3",
         "friendsofsymfony/rest-bundle": "~1.7",
         "tdn/php-types": "1.*",
-        "matthiasnoback/symfony-console-form": "^1.2",
+        "matthiasnoback/symfony-console-form": "^2.0",
         "dreamscapes/ldap-core": "^3.1",
         "eluceo/ical": "0.8.0",
         "exercise/htmlpurifier-bundle": "@stable"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cae1441913d5aa00829e0b6e6048f9b2",
-    "content-hash": "e685fd67d8f330bec56b9670d7f732df",
+    "hash": "b9f075595bb004ed962bf578a0dff75f",
+    "content-hash": "495bec35543525a6acc26b7022756d03",
     "packages": [
         {
             "name": "danielstjules/stringy",
@@ -1939,33 +1939,33 @@
         },
         {
             "name": "matthiasnoback/symfony-console-form",
-            "version": "v1.2.0",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matthiasnoback/symfony-console-form.git",
-                "reference": "2d2337827202eade7330a211b4665919f2887575"
+                "reference": "536c2a3cd973fd3354c892289b69432a9f64655d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matthiasnoback/symfony-console-form/zipball/2d2337827202eade7330a211b4665919f2887575",
-                "reference": "2d2337827202eade7330a211b4665919f2887575",
+                "url": "https://api.github.com/repos/matthiasnoback/symfony-console-form/zipball/536c2a3cd973fd3354c892289b69432a9f64655d",
+                "reference": "536c2a3cd973fd3354c892289b69432a9f64655d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "symfony/console": "~2.5",
-                "symfony/form": "~2.5"
+                "php": ">=5.5",
+                "symfony/console": "~2.8|~3.0",
+                "symfony/form": "~2.8|~3.0"
             },
             "require-dev": {
                 "beberlei/assert": "~2.1",
                 "behat/behat": "~3.0",
                 "fabpot/php-cs-fixer": "^1.10",
-                "symfony/console": "~2.5",
-                "symfony/finder": "~2.5",
-                "symfony/form": "~2.5",
-                "symfony/framework-bundle": "~2.5",
-                "symfony/validator": "~2.5",
-                "symfony/yaml": "~2.5"
+                "symfony/console": "~2.8|~3.0",
+                "symfony/finder": "~2.8|~3.0",
+                "symfony/form": "~2.8|~3.0",
+                "symfony/framework-bundle": "~2.8|~3.0",
+                "symfony/validator": "~2.8|~3.0",
+                "symfony/yaml": "~2.8|~3.0"
             },
             "type": "library",
             "autoload": {
@@ -1991,7 +1991,7 @@
                 "form",
                 "symfony"
             ],
-            "time": "2015-11-27 19:49:00"
+            "time": "2016-04-22 11:57:05"
         },
         {
             "name": "michelf/php-markdown",
@@ -3284,27 +3284,27 @@
         },
         {
             "name": "symfony/security-acl",
-            "version": "v2.8.0",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-acl.git",
-                "reference": "4a3f7327ad215242c78f6564ad4ea6d2db1b8347"
+                "reference": "053b49bf4aa333a392c83296855989bcf88ddad1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-acl/zipball/4a3f7327ad215242c78f6564ad4ea6d2db1b8347",
-                "reference": "4a3f7327ad215242c78f6564ad4ea6d2db1b8347",
+                "url": "https://api.github.com/repos/symfony/security-acl/zipball/053b49bf4aa333a392c83296855989bcf88ddad1",
+                "reference": "053b49bf4aa333a392c83296855989bcf88ddad1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
-                "symfony/security-core": "~2.4|~3.0.0"
+                "php": ">=5.5.9",
+                "symfony/security-core": "~2.8|~3.0"
             },
             "require-dev": {
                 "doctrine/common": "~2.2",
                 "doctrine/dbal": "~2.2",
                 "psr/log": "~1.0",
-                "symfony/phpunit-bridge": "~2.7|~3.0.0"
+                "symfony/phpunit-bridge": "~2.8|~3.0"
             },
             "suggest": {
                 "doctrine/dbal": "For using the built-in ACL implementation",
@@ -3314,7 +3314,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3341,7 +3341,7 @@
             ],
             "description": "Symfony Security Component - ACL (Access Control List)",
             "homepage": "https://symfony.com",
-            "time": "2015-12-28 09:39:09"
+            "time": "2015-12-28 09:39:46"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -3402,16 +3402,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v2.8.4",
+            "version": "v2.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "9e14f9f4869c19188a376eab61d9a1c1f1fee347"
+                "reference": "39ddd2383f4113cf67f8b28cde2c9d3fa340c3c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/9e14f9f4869c19188a376eab61d9a1c1f1fee347",
-                "reference": "9e14f9f4869c19188a376eab61d9a1c1f1fee347",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/39ddd2383f4113cf67f8b28cde2c9d3fa340c3c2",
+                "reference": "39ddd2383f4113cf67f8b28cde2c9d3fa340c3c2",
                 "shasum": ""
             },
             "require": {
@@ -3426,7 +3426,7 @@
                 "symfony/polyfill-php56": "~1.0",
                 "symfony/polyfill-php70": "~1.0",
                 "symfony/polyfill-util": "~1.0",
-                "symfony/security-acl": "~2.7",
+                "symfony/security-acl": "~2.7|~3.0.0",
                 "twig/twig": "~1.23|~2.0"
             },
             "conflict": {
@@ -3498,7 +3498,11 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Bridge\\": "src/Symfony/Bridge/",
+                    "Symfony\\Bridge\\Doctrine\\": "src/Symfony/Bridge/Doctrine/",
+                    "Symfony\\Bridge\\Monolog\\": "src/Symfony/Bridge/Monolog/",
+                    "Symfony\\Bridge\\ProxyManager\\": "src/Symfony/Bridge/ProxyManager/",
+                    "Symfony\\Bridge\\Swiftmailer\\": "src/Symfony/Bridge/Swiftmailer/",
+                    "Symfony\\Bridge\\Twig\\": "src/Symfony/Bridge/Twig/",
                     "Symfony\\Bundle\\": "src/Symfony/Bundle/",
                     "Symfony\\Component\\": "src/Symfony/Component/"
                 },
@@ -3528,7 +3532,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2016-03-27 12:57:53"
+            "time": "2016-04-29 15:34:08"
         },
         {
             "name": "tdn/php-types",
@@ -4797,6 +4801,7 @@
                 "testing",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2014-05-14 17:42:22"
         },
         {
@@ -5354,16 +5359,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v2.8.4",
+            "version": "v2.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "a967db6a4cd5d276cf849d01b29dba559e149978"
+                "reference": "9d30940765450ccc58bc39f4bda30cc412101b4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/a967db6a4cd5d276cf849d01b29dba559e149978",
-                "reference": "a967db6a4cd5d276cf849d01b29dba559e149978",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/9d30940765450ccc58bc39f4bda30cc412101b4b",
+                "reference": "9d30940765450ccc58bc39f4bda30cc412101b4b",
                 "shasum": ""
             },
             "require": {
@@ -5405,7 +5410,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-03-23 13:45:24"
+            "time": "2016-04-05 16:36:54"
         }
     ],
     "aliases": [],

--- a/src/Ilios/AuthenticationBundle/Resources/config/dto_voters.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/dto_voters.yml
@@ -30,7 +30,7 @@ services:
             - { name: security.voter }
     security.access.dto.school_voter:
         class: Ilios\AuthenticationBundle\Voter\DTO\SchoolDTOVoter
-        arguments: [ @ilioscore.permission.manager, @ilioscore.school.manager ]
+        arguments: [ "@ilioscore.permission.manager", "@ilioscore.school.manager" ]
         public: false
         tags:
             - { name: security.voter }

--- a/src/Ilios/AuthenticationBundle/Resources/config/entity_voters.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/entity_voters.yml
@@ -24,13 +24,13 @@ services:
             - { name: security.voter }
     security.access.entity.program_year_voter:
         class: Ilios\AuthenticationBundle\Voter\Entity\ProgramYearEntityVoter
-        arguments: [ @ilioscore.permission.manager, @ilioscore.programyearsteward.manager ]
+        arguments: [ "@ilioscore.permission.manager", "@ilioscore.programyearsteward.manager" ]
         public: false
         tags:
             - { name: security.voter }
     security.access.entity.school_voter:
         class: Ilios\AuthenticationBundle\Voter\Entity\SchoolEntityVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
@@ -42,13 +42,13 @@ services:
             - { name: security.voter }
     security.access.entity.term_voter:
         class: Ilios\AuthenticationBundle\Voter\Entity\TermEntityVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
     security.access.entity.user_voter:
         class: Ilios\AuthenticationBundle\Voter\Entity\UserEntityVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }

--- a/src/Ilios/AuthenticationBundle/Resources/config/voters.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/voters.yml
@@ -36,7 +36,7 @@ services:
             - { name: security.voter }
     security.access.competency_voter:
         class: Ilios\AuthenticationBundle\Voter\CompetencyVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
@@ -53,7 +53,7 @@ services:
             - { name: security.voter }
     security.access.course_voter:
         class: Ilios\AuthenticationBundle\Voter\CourseVoter
-        arguments: [ @ilioscore.course.manager, @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.course.manager", "@ilioscore.permission.manager" ]
         public: false
     security.access.curriculum_inventory_academic_level_voter:
         class: Ilios\AuthenticationBundle\Voter\CurriculumInventoryAcademicLevelVoter
@@ -63,19 +63,19 @@ services:
             - { name: security.voter }
     security.access.curriculum_inventory_export_voter:
         class: Ilios\AuthenticationBundle\Voter\CurriculumInventoryExportVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
     security.access.curriculum_inventory_institution_voter:
         class: Ilios\AuthenticationBundle\Voter\CurriculumInventoryInstitutionVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
     security.access.curriculum_inventory_report_voter:
         class: Ilios\AuthenticationBundle\Voter\CurriculumInventoryReportVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
@@ -99,7 +99,7 @@ services:
             - { name: security.voter }
     security.access.department_voter:
         class: Ilios\AuthenticationBundle\Voter\DepartmentVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
@@ -116,7 +116,7 @@ services:
             - { name: security.voter }
     security.access.instructor_group_voter:
         class: Ilios\AuthenticationBundle\Voter\InstructorGroupVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
@@ -142,7 +142,7 @@ services:
             - { name: security.voter }
     security.access.objective_voter:
         class: Ilios\AuthenticationBundle\Voter\ObjectiveVoter
-        arguments: [ @ilioscore.permission.manager, @ilioscore.programyearsteward.manager ]
+        arguments: [ "@ilioscore.permission.manager", "@ilioscore.programyearsteward.manager" ]
         public: false
         tags:
             - { name: security.voter }
@@ -154,7 +154,7 @@ services:
             - { name: security.voter }
     security.access.pending_user_update_voter:
         class: Ilios\AuthenticationBundle\Voter\PendingUserUpdateVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
@@ -165,13 +165,13 @@ services:
             - { name: security.voter }
     security.access.program_voter:
         class: Ilios\AuthenticationBundle\Voter\ProgramVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
     security.access.program_year_steward_voter:
         class: Ilios\AuthenticationBundle\Voter\ProgramYearStewardVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
@@ -182,7 +182,7 @@ services:
             - { name: security.voter }
     security.access.school_event_voter:
         class: Ilios\AuthenticationBundle\Voter\SchooleventVoter
-        arguments: [ @ilioscore.permission.manager, @ilioscore.school.manager ]
+        arguments: [ "@ilioscore.permission.manager", "@ilioscore.school.manager" ]
         public: false
         tags:
             - { name: security.voter }
@@ -200,19 +200,19 @@ services:
             - { name: security.voter }
     security.access.session_type_voter:
         class: Ilios\AuthenticationBundle\Voter\SessionTypeVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
     security.access.temporary_filesystem_voter:
         class: Ilios\AuthenticationBundle\Voter\TemporaryFileSystemVoter
-        arguments: [ @ilioscore.permission.manager ]
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }
     security.access.userevent_voter:
         class: Ilios\AuthenticationBundle\Voter\UsereventVoter
-        arguments: [ @ilioscore.user.manager ]
+        arguments: [ "@ilioscore.user.manager" ]
         public: false
         tags:
             - { name: security.voter }

--- a/src/Ilios/CoreBundle/Resources/config/routing.yml
+++ b/src/Ilios/CoreBundle/Resources/config/routing.yml
@@ -369,7 +369,7 @@ api_vocabulary_v1:
     defaults: {_format:json}
 
 api_bad_request:
-    pattern:     /{url}
+    path:     /{url}
     defaults:
         url: null
         _controller: IliosCoreBundle:BadRequest:index

--- a/src/Ilios/WebBundle/Resources/config/routing.yml
+++ b/src/Ilios/WebBundle/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 ilios_web_ics:
-    pattern:     /ics/{key}
+    path:     /ics/{key}
     defaults:
         _controller: IliosWebBundle:Ics:index
     requirements:
@@ -10,7 +10,7 @@ ilios_web_config:
         _controller: IliosWebBundle:Config:index
     methods: [GET]
 ilios_web_errors:
-    pattern:     /errors
+    path:     /errors
     defaults:
         _controller: IliosWebBundle:Error:error
     methods:  [POST]
@@ -20,7 +20,7 @@ ilios_web_directory_search:
         _controller: IliosWebBundle:Directory:search
     methods: [GET]
 ilios_web_homepage:
-    pattern:     /{url}
+    path:     /{url}
     defaults:
         url: null
         _controller: IliosWebBundle:Index:index


### PR DESCRIPTION
Replaced patters with path in routes.
Unquotes variables are deprecated and being removed in 3.0.

Fixes #1401

Updating composer libs fixes #1400