### PR TITLE
Stop allowing deprecations in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ php:
 - '5.5'
 - '5.6'
 env:
-  global:
-    - SYMFONY_DEPRECATIONS_HELPER=5000
   matrix:
   - TEST_PHPUNIT_CONTROLLERSA=true
   - TEST_PHPUNIT_CONTROLLERSB=true


### PR DESCRIPTION
We now have nothing blocking us from 3.0 so stop ignoring anything new
that pops up and consider it a failure.