### PR TITLE
Align API docs with expectations

### DIFF
--- a/src/Ilios/CoreBundle/Entity/AlertChangeType.php
+++ b/src/Ilios/CoreBundle/Entity/AlertChangeType.php
@@ -46,7 +46,6 @@ class AlertChangeType implements AlertChangeTypeInterface
 
     /**
     * @ORM\Column(type="string", length=60)
-    * @todo should be on the TitledEntity Trait
     * @var string
     *
     * @Assert\NotBlank()

--- a/src/Ilios/CoreBundle/Entity/Competency.php
+++ b/src/Ilios/CoreBundle/Entity/Competency.php
@@ -31,7 +31,6 @@ class Competency implements CompetencyInterface
     use SchoolEntity;
 
     /**
-     * @deprecated To be removed in 3.1, replaced by ID by enabling trait.
      * @var int
      *
      * @ORM\Column(name="competency_id", type="integer")
@@ -47,7 +46,6 @@ class Competency implements CompetencyInterface
 
     /**
      * @ORM\Column(type="string", length=200, nullable=true)
-     * @todo should be on the TitledEntity Trait
      * @var string
      *
      * @Assert\Type(type="string")
@@ -68,6 +66,8 @@ class Competency implements CompetencyInterface
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="school_id", referencedColumnName="school_id")
      * })
+     *
+     * @Assert\NotNull()
      *
      * @JMS\Expose
      * @JMS\Type("string")

--- a/src/Ilios/CoreBundle/Entity/CurriculumInventoryInstitution.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventoryInstitution.php
@@ -171,6 +171,8 @@ class CurriculumInventoryInstitution implements CurriculumInventoryInstitutionIn
     /**
      * @var SchoolInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\OneToOne(targetEntity="School", inversedBy="curriculumInventoryInstitution")
      * @ORM\JoinColumn(name="school_id", referencedColumnName="school_id", unique=true, nullable=false)
      *

--- a/src/Ilios/CoreBundle/Entity/CurriculumInventorySequence.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventorySequence.php
@@ -41,6 +41,7 @@ class CurriculumInventorySequence implements CurriculumInventorySequenceInterfac
 
     /**
      * @var CurriculumInventoryReportInterface
+     * @Assert\NotNull()
      *
      * @ORM\OneToOne(targetEntity="CurriculumInventoryReport", inversedBy="sequence")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/CurriculumInventorySequenceBlock.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventorySequenceBlock.php
@@ -250,6 +250,7 @@ class CurriculumInventorySequenceBlock implements CurriculumInventorySequenceBlo
 
     /**
      * @var CurriculumInventoryReportInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="CurriculumInventoryReport", inversedBy="sequenceBlocks")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/CurriculumInventorySequenceBlockSession.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventorySequenceBlockSession.php
@@ -62,6 +62,7 @@ class CurriculumInventorySequenceBlockSession implements CurriculumInventorySequ
 
     /**
      * @var CurriculumInventorySequenceBlockInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="CurriculumInventorySequenceBlock", inversedBy="sessions")
      * @ORM\JoinColumns({
@@ -76,6 +77,7 @@ class CurriculumInventorySequenceBlockSession implements CurriculumInventorySequ
 
     /**
      * @var SessionInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="Session")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/Department.php
+++ b/src/Ilios/CoreBundle/Entity/Department.php
@@ -47,7 +47,6 @@ class Department implements DepartmentInterface
 
     /**
      * @ORM\Column(type="string", length=90)
-     * @todo should be on the TitledEntity Trait
      * @var string
      *
      * @Assert\NotBlank()
@@ -64,6 +63,7 @@ class Department implements DepartmentInterface
 
     /**
      * @var SchoolInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="School", inversedBy="departments")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/InstructorGroup.php
+++ b/src/Ilios/CoreBundle/Entity/InstructorGroup.php
@@ -63,8 +63,8 @@ class InstructorGroup implements InstructorGroupInterface
     protected $title;
 
     /**
-     * original annotation: ORM\Column(name="school_id", type="integer")
      * @var SchoolInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="School", inversedBy="instructorGroups")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/LearnerGroup.php
+++ b/src/Ilios/CoreBundle/Entity/LearnerGroup.php
@@ -79,6 +79,7 @@ class LearnerGroup implements LearnerGroupInterface
 
     /**
      * @var CohortInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="Cohort", inversedBy="learnerGroups")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/LearningMaterial.php
+++ b/src/Ilios/CoreBundle/Entity/LearningMaterial.php
@@ -107,6 +107,7 @@ class LearningMaterial implements LearningMaterialInterface
 
     /**
      * @var LearningMaterialUserRoleInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="LearningMaterialUserRole", inversedBy="learningMaterials")
      * @ORM\JoinColumns({
@@ -120,6 +121,7 @@ class LearningMaterial implements LearningMaterialInterface
 
     /**
      * @var LearningMaterialStatusInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="LearningMaterialStatus", inversedBy="learningMaterials")
      * @ORM\JoinColumns({
@@ -133,6 +135,7 @@ class LearningMaterial implements LearningMaterialInterface
 
     /**
      * @var UserInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="User", inversedBy="learningMaterials")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/Offering.php
+++ b/src/Ilios/CoreBundle/Entity/Offering.php
@@ -122,6 +122,7 @@ class Offering implements OfferingInterface
 
     /**
      * @var Session
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="Session", inversedBy="offerings")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/PendingUserUpdate.php
+++ b/src/Ilios/CoreBundle/Entity/PendingUserUpdate.php
@@ -91,6 +91,7 @@ class PendingUserUpdate implements PendingUserUpdateInterface
 
     /**
      * @var UserInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="User", inversedBy="pendingUserUpdates")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/Permission.php
+++ b/src/Ilios/CoreBundle/Entity/Permission.php
@@ -44,6 +44,7 @@ class Permission implements PermissionInterface
 
     /**
      * @var UserInterface
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="User", inversedBy="permissions")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/Program.php
+++ b/src/Ilios/CoreBundle/Entity/Program.php
@@ -36,7 +36,6 @@ class Program implements ProgramInterface
     use PublishableEntity;
 
     /**
-     * @deprecated Replace with trait in 3.x
      * @var int
      *
      * @ORM\Column(name="program_id", type="integer")
@@ -124,17 +123,19 @@ class Program implements ProgramInterface
     protected $published;
 
     /**
-    * @var SchoolInterface
-    *
-    * @ORM\ManyToOne(targetEntity="School", inversedBy="programs")
-    * @ORM\JoinColumns({
-    *   @ORM\JoinColumn(name="school_id", referencedColumnName="school_id", nullable=false)
-    * })
-    *
-    * @JMS\Expose
-    * @JMS\Type("string")
-    * @JMS\SerializedName("school")
-    */
+     * @var SchoolInterface
+     *
+     * @Assert\NotNull()
+     *
+     * @ORM\ManyToOne(targetEntity="School", inversedBy="programs")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="school_id", referencedColumnName="school_id", nullable=false)
+     * })
+     *
+     * @JMS\Expose
+     * @JMS\Type("string")
+     * @JMS\SerializedName("school")
+     */
     protected $school;
 
     /**

--- a/src/Ilios/CoreBundle/Entity/ProgramYear.php
+++ b/src/Ilios/CoreBundle/Entity/ProgramYear.php
@@ -120,6 +120,8 @@ class ProgramYear implements ProgramYearInterface
     /**
      * @var ProgramInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\ManyToOne(targetEntity="Program", inversedBy="programYears")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="program_id", referencedColumnName="program_id")

--- a/src/Ilios/CoreBundle/Entity/ProgramYearSteward.php
+++ b/src/Ilios/CoreBundle/Entity/ProgramYearSteward.php
@@ -66,6 +66,8 @@ class ProgramYearSteward implements ProgramYearStewardInterface
     /**
      * @var ProgramYearInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\ManyToOne(targetEntity="ProgramYear", inversedBy="stewards")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="program_year_id", referencedColumnName="program_year_id", onDelete="CASCADE",
@@ -75,11 +77,13 @@ class ProgramYearSteward implements ProgramYearStewardInterface
      * @JMS\Expose
      * @JMS\Type("string")
      * @JMS\SerializedName("programYear")
-     */
+     **/
     protected $programYear;
 
     /**
      * @var SchoolInterface
+     *
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="School", inversedBy="stewards")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/Report.php
+++ b/src/Ilios/CoreBundle/Entity/Report.php
@@ -139,6 +139,8 @@ class Report implements ReportInterface
     /**
      * @var UserInterface $user
      *
+     * @Assert\NotNull()
+     *
      * @ORM\ManyToOne(targetEntity="User", inversedBy="reports")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="user_id", referencedColumnName="user_id", onDelete="cascade", nullable=false)

--- a/src/Ilios/CoreBundle/Entity/Session.php
+++ b/src/Ilios/CoreBundle/Entity/Session.php
@@ -161,6 +161,8 @@ class Session implements SessionInterface
     /**
      * @var SessionTypeInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\ManyToOne(targetEntity="SessionType", inversedBy="sessions")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="session_type_id", referencedColumnName="session_type_id", nullable=false)
@@ -174,6 +176,8 @@ class Session implements SessionInterface
 
     /**
      * @var CourseInterface
+     *
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="Course", inversedBy="sessions")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/SessionDescription.php
+++ b/src/Ilios/CoreBundle/Entity/SessionDescription.php
@@ -43,6 +43,8 @@ class SessionDescription implements SessionDescriptionInterface
     /**
      * @var SessionInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\OneToOne(targetEntity="Session", inversedBy="sessionDescription")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(

--- a/src/Ilios/CoreBundle/Entity/SessionLearningMaterial.php
+++ b/src/Ilios/CoreBundle/Entity/SessionLearningMaterial.php
@@ -89,6 +89,8 @@ class SessionLearningMaterial implements SessionLearningMaterialInterface
     /**
      * @var SessionInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\ManyToOne(targetEntity="Session", inversedBy="learningMaterials")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="session_id", referencedColumnName="session_id", onDelete="CASCADE")
@@ -101,6 +103,8 @@ class SessionLearningMaterial implements SessionLearningMaterialInterface
 
     /**
      * @var LearningMaterialInterface
+     *
+     * @Assert\NotNull()
      *
      * @ORM\ManyToOne(targetEntity="LearningMaterial", inversedBy="sessionLearningMaterials")
      * @ORM\JoinColumns({

--- a/src/Ilios/CoreBundle/Entity/SessionType.php
+++ b/src/Ilios/CoreBundle/Entity/SessionType.php
@@ -104,6 +104,8 @@ class SessionType implements SessionTypeInterface
     /**
      * @var SchoolInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\ManyToOne(targetEntity="School", inversedBy="sessionTypes")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="school_id", referencedColumnName="school_id", nullable=false)

--- a/src/Ilios/CoreBundle/Entity/Term.php
+++ b/src/Ilios/CoreBundle/Entity/Term.php
@@ -144,6 +144,8 @@ class Term implements TermInterface
     /**
      * @var VocabularyInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\ManyToOne(targetEntity="Vocabulary", inversedBy="terms")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="vocabulary_id", referencedColumnName="vocabulary_id", nullable=false)

--- a/src/Ilios/CoreBundle/Entity/UserMadeReminder.php
+++ b/src/Ilios/CoreBundle/Entity/UserMadeReminder.php
@@ -101,6 +101,8 @@ class UserMadeReminder implements UserMadeReminderInterface
     /**
      * @var UserInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\ManyToOne(targetEntity="User", inversedBy="reminders")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="user_id", referencedColumnName="user_id", nullable=false)

--- a/src/Ilios/CoreBundle/Entity/Vocabulary.php
+++ b/src/Ilios/CoreBundle/Entity/Vocabulary.php
@@ -69,6 +69,8 @@ class Vocabulary implements VocabularyInterface
     /**
      * @var SchoolInterface
      *
+     * @Assert\NotNull()
+     *
      * @ORM\ManyToOne(targetEntity="School", inversedBy="vocabularies")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="school_id", referencedColumnName="school_id", nullable=false)

--- a/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
@@ -24,7 +24,7 @@ class CompetencyType extends AbstractType
         $builder
             ->add('title', null, ['required' => false, 'empty_data' => null])
             ->add('school', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:School"
             ])
             ->add('parent', SingleRelatedType::class, [

--- a/src/Ilios/CoreBundle/Form/Type/CourseLearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseLearningMaterialType.php
@@ -26,11 +26,11 @@ class CourseLearningMaterialType extends AbstractType
             ->add('required', null, ['required' => false])
             ->add('publicNotes', null, ['required' => false])
             ->add('course', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Course"
             ])
             ->add('learningMaterial', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:LearningMaterial"
             ])
             ->add('meshDescriptors', ManyRelatedType::class, [

--- a/src/Ilios/CoreBundle/Form/Type/CourseType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseType.php
@@ -23,7 +23,7 @@ class CourseType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('title', null, ['required' => false, 'empty_data' => null])
+            ->add('title')
             ->add('level')
             ->add('year')
             ->add('startDate', DateTimeType::class, array(

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryAcademicLevelType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryAcademicLevelType.php
@@ -25,7 +25,7 @@ class CurriculumInventoryAcademicLevelType extends AbstractType
             ->add('description', null, ['required' => false, 'empty_data' => null])
             ->add('level')
             ->add('report', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryExportType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryExportType.php
@@ -21,7 +21,7 @@ class CurriculumInventoryExportType extends AbstractType
     {
         $builder
             ->add('report', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
             ])
             ->add('document', null, [ 'required' => false ]);

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryInstitutionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventoryInstitutionType.php
@@ -36,7 +36,7 @@ class CurriculumInventoryInstitutionType extends AbstractType
         }
         $builder
             ->add('school', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:School"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockSessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockSessionType.php
@@ -22,11 +22,11 @@ class CurriculumInventorySequenceBlockSessionType extends AbstractType
         $builder
             ->add('countOfferingsOnce', null, ['required' => false])
             ->add('sequenceBlock', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:CurriculumInventorySequenceBlock"
             ])
             ->add('session', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Session"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceBlockType.php
@@ -50,7 +50,7 @@ class CurriculumInventorySequenceBlockType extends AbstractType
                 'entityName' => "IliosCoreBundle:CurriculumInventorySequenceBlock"
             ])
             ->add('report', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CurriculumInventorySequenceType.php
@@ -23,7 +23,7 @@ class CurriculumInventorySequenceType extends AbstractType
         $builder
             ->add('description', null, ['required' => false, 'empty_data' => null])
             ->add('report', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:CurriculumInventoryReport"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/DepartmentType.php
+++ b/src/Ilios/CoreBundle/Form/Type/DepartmentType.php
@@ -23,7 +23,7 @@ class DepartmentType extends AbstractType
         $builder
             ->add('title', null, ['empty_data' => null])
             ->add('school', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:School"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/InstructorGroupType.php
+++ b/src/Ilios/CoreBundle/Form/Type/InstructorGroupType.php
@@ -24,7 +24,7 @@ class InstructorGroupType extends AbstractType
         $builder
             ->add('title', null, ['empty_data' => null])
             ->add('school', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:School"
             ])
             ->add('learnerGroups', ManyRelatedType::class, [

--- a/src/Ilios/CoreBundle/Form/Type/LearnerGroupType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearnerGroupType.php
@@ -25,7 +25,7 @@ class LearnerGroupType extends AbstractType
             ->add('title', null, ['empty_data' => null])
             ->add('location', null, ['required' => false, 'empty_data' => null])
             ->add('cohort', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Cohort"
             ])
             ->add('parent', SingleRelatedType::class, [

--- a/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/LearningMaterialType.php
@@ -34,15 +34,15 @@ class LearningMaterialType extends AbstractType
             ->add('filesize')
             ->add('mimetype', null, ['empty_data' => null])
             ->add('userRole', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:LearningMaterialUserRole"
             ])
             ->add('status', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:LearningMaterialStatus"
             ])
             ->add('owningUser', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:User"
             ])
             ->add('citation', TextType::class, ['required' => false, 'empty_data' => null])

--- a/src/Ilios/CoreBundle/Form/Type/OfferingType.php
+++ b/src/Ilios/CoreBundle/Form/Type/OfferingType.php
@@ -32,7 +32,7 @@ class OfferingType extends AbstractType
                 'widget' => 'single_text',
             ))
             ->add('session', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Session"
             ])
             ->add('learnerGroups', ManyRelatedType::class, [

--- a/src/Ilios/CoreBundle/Form/Type/PendingUserUpdateType.php
+++ b/src/Ilios/CoreBundle/Form/Type/PendingUserUpdateType.php
@@ -25,7 +25,7 @@ class PendingUserUpdateType extends AbstractType
             ->add('property', null, ['empty_data' => null])
             ->add('value', null, ['empty_data' => null])
             ->add('user', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:User"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/PermissionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/PermissionType.php
@@ -27,7 +27,7 @@ class PermissionType extends AbstractType
             ->add('tableRowId', null)
             ->add('tableName', null)
             ->add('user', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:User"
             ]);
     }

--- a/src/Ilios/CoreBundle/Form/Type/ProgramType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramType.php
@@ -27,7 +27,7 @@ class ProgramType extends AbstractType
             ->add('publishedAsTbd', null, ['required' => false])
             ->add('published', null, ['required' => false])
             ->add('school', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:School"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/ProgramYearStewardType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramYearStewardType.php
@@ -25,11 +25,11 @@ class ProgramYearStewardType extends AbstractType
                 'entityName' => "IliosCoreBundle:Department"
             ])
             ->add('programYear', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:ProgramYear"
             ])
             ->add('school', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:School"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/ProgramYearType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ProgramYearType.php
@@ -27,7 +27,7 @@ class ProgramYearType extends AbstractType
             ->add('publishedAsTbd', null, ['required' => false])
             ->add('published', null, ['required' => false])
             ->add('program', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Program"
             ])
             ->add('cohort', SingleRelatedType::class, [

--- a/src/Ilios/CoreBundle/Form/Type/ReportType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ReportType.php
@@ -26,7 +26,7 @@ class ReportType extends AbstractType
             ->add('prepositionalObject', null, ['required' => false, 'empty_data' => null])
             ->add('prepositionalObjectTableRowId', null, ['required' => false, 'empty_data' => null])
             ->add('user', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:User"
             ])
             ->add('school', SingleRelatedType::class, [

--- a/src/Ilios/CoreBundle/Form/Type/SessionDescriptionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionDescriptionType.php
@@ -23,7 +23,7 @@ class SessionDescriptionType extends AbstractType
         $builder
             ->add('description', PurifiedTextareaType::class, ['required' => false])
             ->add('session', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Session"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/SessionLearningMaterialType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionLearningMaterialType.php
@@ -26,11 +26,11 @@ class SessionLearningMaterialType extends AbstractType
             ->add('required', null, ['required' => false])
             ->add('publicNotes', null, ['required' => false])
             ->add('session', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Session"
             ])
             ->add('learningMaterial', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:LearningMaterial"
             ])
             ->add('meshDescriptors', ManyRelatedType::class, [

--- a/src/Ilios/CoreBundle/Form/Type/SessionType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionType.php
@@ -29,11 +29,11 @@ class SessionType extends AbstractType
             ->add('publishedAsTbd', null, ['required' => false])
             ->add('published', null, ['required' => false])
             ->add('sessionType', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:SessionType"
             ])
             ->add('course', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Course"
             ])
             ->add(

--- a/src/Ilios/CoreBundle/Form/Type/SessionTypeType.php
+++ b/src/Ilios/CoreBundle/Form/Type/SessionTypeType.php
@@ -30,7 +30,7 @@ class SessionTypeType extends AbstractType
                 'entityName' => "IliosCoreBundle:AssessmentOption"
             ])
             ->add('school', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:School"
             ])
             ->add('aamcMethods', ManyRelatedType::class, [

--- a/src/Ilios/CoreBundle/Form/Type/TermType.php
+++ b/src/Ilios/CoreBundle/Form/Type/TermType.php
@@ -25,7 +25,7 @@ class TermType extends AbstractType
         $builder
             ->add('title', null, ['required' => false, 'empty_data' => null])
             ->add('vocabulary', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:Vocabulary"
             ])
             ->add('description', TextareaType::class, ['required' => false])

--- a/src/Ilios/CoreBundle/Form/Type/UserMadeReminderType.php
+++ b/src/Ilios/CoreBundle/Form/Type/UserMadeReminderType.php
@@ -28,7 +28,7 @@ class UserMadeReminderType extends AbstractType
             ))
             ->add('closed', null, ['required' => false])
             ->add('user', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:User"
             ])
         ;

--- a/src/Ilios/CoreBundle/Form/Type/VocabularyType.php
+++ b/src/Ilios/CoreBundle/Form/Type/VocabularyType.php
@@ -23,7 +23,7 @@ class VocabularyType extends AbstractType
         $builder
             ->add('title', null, ['required' => false, 'empty_data' => null])
             ->add('school', SingleRelatedType::class, [
-                'required' => false,
+                'required' => true,
                 'entityName' => "IliosCoreBundle:School"
             ])
         ;

--- a/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventoryInstitutionTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventoryInstitutionTest.php
@@ -33,6 +33,7 @@ class CurriculumInventoryInstitutionTest extends EntityBase
             'addressZipCode',
             'addressCountryCode'
         );
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
         $this->validateNotBlanks($notBlank);
 
         $this->object->setName('10lenMAX');
@@ -42,6 +43,24 @@ class CurriculumInventoryInstitutionTest extends EntityBase
         $this->object->setAddressStateOrProvince('CA');
         $this->object->setAddressZipcode('99999');
         $this->object->setAddressCountryCode('US');
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNull = array(
+            'school'
+        );
+        $this->object->setName('10lenMAX');
+        $this->object->setAamcCode('ddd');
+        $this->object->setAddressStreet('1123 A');
+        $this->object->setAddressCity('Irvine');
+        $this->object->setAddressStateOrProvince('CA');
+        $this->object->setAddressZipcode('99999');
+        $this->object->setAddressCountryCode('US');
+        $this->validateNotNulls($notNull);
+
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
         $this->validate(0);
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventorySequenceBlockTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventorySequenceBlockTest.php
@@ -9,8 +9,7 @@ use Mockery as m;
 /**
  * Tests for Entity CurriculumInventorySequenceBlock
  */
-class
-CurriculumInventorySequenceBlockTest extends EntityBase
+class CurriculumInventorySequenceBlockTest extends EntityBase
 {
     /**
      * @var CurriculumInventorySequenceBlock
@@ -37,6 +36,7 @@ CurriculumInventorySequenceBlockTest extends EntityBase
             'endDate',
             'duration'
         );
+        $this->object->setReport(m::mock('Ilios\CoreBundle\Entity\CurriculumInventoryReportInterface'));
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('test title for the block max 200');
@@ -47,6 +47,25 @@ CurriculumInventorySequenceBlockTest extends EntityBase
         $this->object->setStartDate(new \DateTime());
         $this->object->setEndDate(new \DateTime());
         $this->object->setDuration(60);
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNulls = array(
+            'report'
+        );
+        $this->object->setTitle('test title for the block max 200');
+        $this->object->setChildSequenceOrder(1);
+        $this->object->setOrderInSequence(2);
+        $this->object->setMinimum(1);
+        $this->object->setMaximum(521);
+        $this->object->setStartDate(new \DateTime());
+        $this->object->setEndDate(new \DateTime());
+        $this->object->setDuration(60);
+        $this->validateNotNulls($notNulls);
+
+        $this->object->setReport(m::mock('Ilios\CoreBundle\Entity\CurriculumInventoryReportInterface'));
         $this->validate(0);
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventorySequenceBlockTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/CurriculumInventorySequenceBlockTest.php
@@ -9,7 +9,8 @@ use Mockery as m;
 /**
  * Tests for Entity CurriculumInventorySequenceBlock
  */
-class CurriculumInventorySequenceBlockTest extends EntityBase
+class
+CurriculumInventorySequenceBlockTest extends EntityBase
 {
     /**
      * @var CurriculumInventorySequenceBlock

--- a/src/Ilios/CoreBundle/Tests/Entity/DepartmentTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/DepartmentTest.php
@@ -27,9 +27,23 @@ class DepartmentTest extends EntityBase
         $notBlank = array(
             'title'
         );
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('test');
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNull = array(
+            'school'
+        );
+        $this->object->setTitle('test');
+        $this->validateNotNulls($notNull);
+
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
+
         $this->validate(0);
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/InstructorGroupTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/InstructorGroupTest.php
@@ -27,11 +27,27 @@ class InstructorGroupTest extends EntityBase
         $notBlank = array(
             'title'
         );
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('test');
         $this->validate(0);
     }
+
+    public function testNotNullValidation()
+    {
+        $notNulls = array(
+            'school'
+        );
+        $this->object->setTitle('test');
+
+        $this->validateNotNulls($notNulls);
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
+
+
+        $this->validate(0);
+    }
+
     /**
      * @covers Ilios\CoreBundle\Entity\InstructorGroup::__construct
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/LearnerGroupTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/LearnerGroupTest.php
@@ -31,9 +31,24 @@ class LearnerGroupTest extends EntityBase
         $notBlank = array(
             'title'
         );
+        $this->object->setCohort(m::mock('Ilios\CoreBundle\Entity\CohortInterface'));
+
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('test');
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNulls = array(
+            'cohort'
+        );
+        $this->object->setTitle('test');
+        $this->validateNotNulls($notNulls);
+
+        $this->object->setCohort(m::mock('Ilios\CoreBundle\Entity\CohortInterface'));
+
         $this->validate(0);
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/LearningMaterialTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/LearningMaterialTest.php
@@ -30,9 +30,31 @@ class LearningMaterialTest extends EntityBase
         $notBlank = array(
             'title'
         );
+        $this->object->setUserRole(m::mock('Ilios\CoreBundle\Entity\LearningMaterialUserRoleInterface'));
+        $this->object->setStatus(m::mock('Ilios\CoreBundle\Entity\LearningMaterialStatusInterface'));
+        $this->object->setOwningUser(m::mock('Ilios\CoreBundle\Entity\UserInterface'));
+
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('test');
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNulls = array(
+            'userRole',
+            'status',
+            'owningUser'
+        );
+        $this->object->setTitle('test');
+
+        $this->validateNotNulls($notNulls);
+
+        $this->object->setUserRole(m::mock('Ilios\CoreBundle\Entity\LearningMaterialUserRoleInterface'));
+        $this->object->setStatus(m::mock('Ilios\CoreBundle\Entity\LearningMaterialStatusInterface'));
+        $this->object->setOwningUser(m::mock('Ilios\CoreBundle\Entity\UserInterface'));
+
         $this->validate(0);
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/OfferingTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/OfferingTest.php
@@ -32,6 +32,8 @@ class OfferingTest extends EntityBase
             'startDate',
             'endDate'
         );
+        $this->object->setSession(m::mock('Ilios\CoreBundle\Entity\SessionInterface'));
+
         $this->validateNotBlanks($notBlank);
 
         $this->object->setRoom('RCF 112');
@@ -39,6 +41,23 @@ class OfferingTest extends EntityBase
         $this->object->setEndDate(new \DateTime());
         $this->validate(0);
     }
+
+    public function testNotNullValidation()
+    {
+        $notNulls = array(
+            'session'
+        );
+
+        $this->object->setRoom('RCF 112');
+        $this->object->setStartDate(new \DateTime());
+        $this->object->setEndDate(new \DateTime());
+
+        $this->validateNotNulls($notNulls);
+        $this->object->setSession(m::mock('Ilios\CoreBundle\Entity\SessionInterface'));
+
+        $this->validate(0);
+    }
+
     /**
      * @covers Ilios\CoreBundle\Entity\Offering::__construct
      */

--- a/src/Ilios/CoreBundle/Tests/Entity/ProgramTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/ProgramTest.php
@@ -28,10 +28,27 @@ class ProgramTest extends EntityBase
             'title',
             'duration'
         );
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
+
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('DVc');
         $this->object->setDuration(30);
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNull = array(
+            'school'
+        );
+        $this->object->setTitle('DVc');
+        $this->object->setDuration(30);
+
+        $this->validateNotNulls($notNull);
+
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
+
         $this->validate(0);
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/ProgramYearTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/ProgramYearTest.php
@@ -29,9 +29,25 @@ class ProgramYearTest extends EntityBase
         $notBlank = array(
             'startYear',
         );
+        $this->object->setProgram(m::mock('Ilios\CoreBundle\Entity\ProgramInterface'));
+
         $this->validateNotBlanks($notBlank);
 
         $this->object->setStartYear(3);
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNull = array(
+            'program',
+        );
+        $this->object->setStartYear(3);
+
+        $this->validateNotNulls($notNull);
+        $this->object->setProgram(m::mock('Ilios\CoreBundle\Entity\ProgramInterface'));
+
+
         $this->validate(0);
     }
 

--- a/src/Ilios/CoreBundle/Tests/Entity/SessionTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/SessionTest.php
@@ -29,7 +29,24 @@ class SessionTest extends EntityBase
         $notBlank = array(
 
         );
+        $this->object->setSessionType(m::mock('Ilios\CoreBundle\Entity\SessionTypeInterface'));
+        $this->object->setCourse(m::mock('Ilios\CoreBundle\Entity\CourseInterface'));
+
         $this->validateNotBlanks($notBlank);
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNull = array(
+            'sessionType',
+            'course'
+        );
+        $this->validateNotNulls($notNull);
+
+        $this->object->setSessionType(m::mock('Ilios\CoreBundle\Entity\SessionTypeInterface'));
+        $this->object->setCourse(m::mock('Ilios\CoreBundle\Entity\CourseInterface'));
+
         $this->validate(0);
     }
     /**

--- a/src/Ilios/CoreBundle/Tests/Entity/SessionTypeTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/SessionTypeTest.php
@@ -27,9 +27,26 @@ class SessionTypeTest extends EntityBase
         $notBlank = array(
             'title'
         );
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
+
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('test');
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNull = array(
+            'school'
+        );
+        $this->object->setTitle('test');
+
+        $this->validateNotNulls($notNull);
+
+        $this->object->setSchool(m::mock('Ilios\CoreBundle\Entity\SchoolInterface'));
+
+
         $this->validate(0);
     }
     /**

--- a/src/Ilios/CoreBundle/Tests/Entity/UserMadeReminderTest.php
+++ b/src/Ilios/CoreBundle/Tests/Entity/UserMadeReminderTest.php
@@ -27,9 +27,24 @@ class UserMadeReminderTest extends EntityBase
         $notBlank = array(
             'dueDate'
         );
+        $this->object->setUser(m::mock('Ilios\CoreBundle\Entity\UserInterface'));
+
         $this->validateNotBlanks($notBlank);
 
         $this->object->setDueDate(new \DateTime());
+        $this->validate(0);
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNulls = array(
+            'user'
+        );
+        $this->object->setDueDate(new \DateTime());
+
+        $this->validateNotNulls($notNulls);
+
+        $this->object->setUser(m::mock('Ilios\CoreBundle\Entity\UserInterface'));
         $this->validate(0);
     }
     


### PR DESCRIPTION
We had some mis-documented ‘required’ fields in the API due to relationships and carelessness.  These are now resolved.

Fixes #1433