### PR TITLE
"atomic" ci report creation

### DIFF
--- a/src/Ilios/CoreBundle/Controller/CurriculumInventoryAcademicLevelController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventoryAcademicLevelController.php
@@ -151,7 +151,8 @@ class CurriculumInventoryAcademicLevelController extends FOSRestController
      *     201 = "Created CurriculumInventoryAcademicLevel.",
      *     400 = "Bad Request.",
      *     404 = "Not Found."
-     *   }
+     *   },
+     *   deprecated = true
      * )
      *
      * @Rest\View(statusCode=201, serializerEnableMaxDepthChecks=true)
@@ -199,7 +200,8 @@ class CurriculumInventoryAcademicLevelController extends FOSRestController
      *     201 = "Created CurriculumInventoryAcademicLevel.",
      *     400 = "Bad Request.",
      *     404 = "Not Found."
-     *   }
+     *   },
+     *   deprecated = true
      * )
      *
      * @Rest\View(serializerEnableMaxDepthChecks=true)
@@ -263,7 +265,8 @@ class CurriculumInventoryAcademicLevelController extends FOSRestController
      *     204 = "No content. Successfully deleted CurriculumInventoryAcademicLevel.",
      *     400 = "Bad Request.",
      *     404 = "Not found."
-     *   }
+     *   },
+     *   deprecated = true
      * )
      *
      * @Rest\View(statusCode=204)

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventoryReportController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventoryReportController.php
@@ -182,7 +182,7 @@ class CurriculumInventoryReportController extends FOSRestController
             $manager->update($curriculumInventoryReport, false, false);
 
             // create academic years and sequence while at it.
-            for($i = 1, $n = 10; $i <= $n; $i++) {
+            for ($i = 1, $n = 10; $i <= $n; $i++) {
                 $level = new CurriculumInventoryAcademicLevel();
                 $level->setLevel($i);
                 $level->setName('Year ' . $i); // @todo i18n 'Year'. [ST 2016/06/02]

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventoryReportController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventoryReportController.php
@@ -7,6 +7,8 @@ use FOS\RestBundle\Controller\Annotations\RouteResource;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\Util\Codes;
+use Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel;
+use Ilios\CoreBundle\Entity\CurriculumInventorySequence;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -139,11 +141,11 @@ class CurriculumInventoryReportController extends FOSRestController
     }
 
     /**
-     * Create a CurriculumInventoryReport.
+     * Create a CurriculumInventoryReport and its associated Academic Levels and Sequence.
      *
      * @ApiDoc(
      *   section = "CurriculumInventoryReport",
-     *   description = "Create a CurriculumInventoryReport.",
+     *   description = "Create a CurriculumInventoryReport and its associated Academic Levels and Sequence.",
      *   resource = true,
      *   input="Ilios\CoreBundle\Form\Type\CurriculumInventoryReportType",
      *   output="Ilios\CoreBundle\Entity\CurriculumInventoryReport",
@@ -165,6 +167,7 @@ class CurriculumInventoryReportController extends FOSRestController
         try {
             $handler = $this->container->get('ilioscore.curriculuminventoryreport.handler');
 
+            /* @var CurriculumInventoryReportInterface $curriculumInventoryReport */
             $curriculumInventoryReport = $handler->post($this->getPostData($request));
 
             $authChecker = $this->get('security.authorization_checker');
@@ -173,7 +176,24 @@ class CurriculumInventoryReportController extends FOSRestController
             }
 
             $manager = $this->container->get('ilioscore.curriculuminventoryreport.manager');
-            $manager->update($curriculumInventoryReport, true, false);
+            $levelManager = $this->container->get('ilioscore.curriculuminventoryacademiclevel.manager');
+            $sequenceManager = $this->container->get('ilioscore.curriculuminventorysequence.manager');
+
+            $manager->update($curriculumInventoryReport, false, false);
+
+            // create academic years and sequence while at it.
+            for($i = 1, $n = 10; $i <= $n; $i++) {
+                $level = new CurriculumInventoryAcademicLevel();
+                $level->setLevel($i);
+                $level->setName('Year ' . $i); // @todo i18n 'Year'. [ST 2016/06/02]
+                $curriculumInventoryReport->addAcademicLevel($level);
+                $level->setReport($curriculumInventoryReport);
+                $levelManager->update($level, false, false);
+            }
+            $sequence = new CurriculumInventorySequence();
+            $curriculumInventoryReport->setSequence($sequence);
+            $sequence->setReport($curriculumInventoryReport);
+            $sequenceManager->update($sequence, true, false); // flush here.
 
             $answer['curriculumInventoryReports'] = [$curriculumInventoryReport];
 

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceBlockController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceBlockController.php
@@ -151,7 +151,8 @@ class CurriculumInventorySequenceBlockController extends FOSRestController
      *     201 = "Created CurriculumInventorySequenceBlock.",
      *     400 = "Bad Request.",
      *     404 = "Not Found."
-     *   }
+     *   },
+     *   deprecated = true
      * )
      *
      * @Rest\View(statusCode=201, serializerEnableMaxDepthChecks=true)
@@ -264,7 +265,8 @@ class CurriculumInventorySequenceBlockController extends FOSRestController
      *     204 = "No content. Successfully deleted CurriculumInventorySequenceBlock.",
      *     400 = "Bad Request.",
      *     404 = "Not found."
-     *   }
+     *   },
+     *   deprecated = true
      * )
      *
      * @Rest\View(statusCode=204)

--- a/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventoryReportControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventoryReportControllerTest.php
@@ -99,6 +99,7 @@ class CurriculumInventoryReportControllerTest extends AbstractControllerTest
         $postData = $data;
         //unset any parameters which should not be POSTed
         unset($postData['id']);
+        unset($postData['sequence']);
         unset($postData['sequenceBlocks']);
         unset($postData['academicLevels']);
 
@@ -110,13 +111,14 @@ class CurriculumInventoryReportControllerTest extends AbstractControllerTest
         );
 
         $response = $this->client->getResponse();
-
+        $responseData = json_decode($response->getContent(), true)['curriculumInventoryReports'][0];
+        $this->assertEquals(10, count($responseData['academicLevels']), 'There should be 10 academic levels ids.');
+        $this->assertNotEmpty($responseData['sequence'], 'A sequence id should be present.');
+        // don't compare sequence and academic level ids.
+        $responseData['sequence'] = $data['sequence'];
+        $responseData['academicLevels'] = $data['academicLevels'];
         $this->assertEquals(Codes::HTTP_CREATED, $response->getStatusCode(), $response->getContent());
-        $this->assertEquals(
-            $data,
-            json_decode($response->getContent(), true)['curriculumInventoryReports'][0],
-            $response->getContent()
-        );
+        $this->assertEquals($data, $responseData, $response->getContent());
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/DataLoader/CurriculumInventoryReportData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/CurriculumInventoryReportData.php
@@ -59,6 +59,7 @@ class CurriculumInventoryReportData extends AbstractDataLoader
         return array(
             'id' => 4,
             'program' => '2',
+            'sequence' => null,
             'year' => (int) $this->faker->date('Y'),
             'name' => $this->faker->text(100),
             'description' => $this->faker->text(200),
@@ -66,6 +67,7 @@ class CurriculumInventoryReportData extends AbstractDataLoader
             'endDate' => $dt->format('c'),
             'sequenceBlocks' => [],
             'academicLevels' => [],
+
         );
     }
 


### PR DESCRIPTION
when a ci report gets created, it needs to spawn off academic levels and a sequence in the same go. 
so i augmented the post action on the ci report controller accordingly.

while at it, i flagged certain CRUD actions on the academic lvl and sequence controllers as deprecated as applicable. 

