### PR TITLE
rm unique constraint from ci reports.

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20160608010345.php
+++ b/app/Resources/DoctrineMigrations/Version20160608010345.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Removes unique constraint from curriculum inventory reports table.
+ */
+class Version20160608010345 extends AbstractMigration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->addSql('DROP INDEX program_id_year ON curriculum_inventory_report');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->addSql('CREATE UNIQUE INDEX program_id_year ON curriculum_inventory_report (program_id, year)');
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/CurriculumInventoryReport.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventoryReport.php
@@ -18,9 +18,6 @@ use Ilios\CoreBundle\Traits\StringableIdEntity;
  * @package Ilios\CoreBundle\Entity
  *
  * @ORM\Table(name="curriculum_inventory_report",
- *   uniqueConstraints={
- *     @ORM\UniqueConstraint(name="program_id_year", columns={"program_id", "year"})
- *   },
  *   indexes={
  *     @ORM\Index(name="IDX_6E31899E3EB8070A", columns={"program_id"})
  *   }

--- a/src/Ilios/CoreBundle/Service/CurriculumInventory/Exporter.php
+++ b/src/Ilios/CoreBundle/Service/CurriculumInventory/Exporter.php
@@ -261,7 +261,7 @@ class Exporter
         //
         // ReportID
         //
-        $reportId = $report->getYear() . 'x' . $report->getProgram()->getId() . 'x' . time();
+        $reportId = $report->getYear() . 'x' . $report->getProgram()->getId() . 'x' . $report->getId() . 'x' . time();
         $reportIdNode = $dom->createElement('ReportID', $reportId);
         $reportIdNode->setAttribute('domain', "idd:{$this->institutionDomain}:cireport");
         $rootNode->appendChild($reportIdNode);


### PR DESCRIPTION
as discussed with @saschaben, there is no real need to enforce report uniqueness across academic year and associated programs. as long as the report id in the export itself is unique. 

so i ditched the unique constraint from the db schema and made the appropriate changes to the report exporter.