### PR TITLE
exclude document in payload of curriculum inventory export

### DIFF
--- a/src/Ilios/CoreBundle/Controller/CurriculumInventoryExportController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventoryExportController.php
@@ -73,7 +73,7 @@ class CurriculumInventoryExportController extends FOSRestController
             // We remove the document before returning the export to keep the payload at a reasonable size.
             // The exported report document can be retrieved via the curriculum inventory download controller.
             // [ST 2015/09/21]
-            $curriculumInventoryExport->setDocument('');
+            //$curriculumInventoryExport->setDocument('');
             $answer['curriculumInventoryExports'] = [$curriculumInventoryExport];
 
             $view = $this->view($answer, Codes::HTTP_CREATED);

--- a/src/Ilios/CoreBundle/Controller/CurriculumInventoryExportController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventoryExportController.php
@@ -69,11 +69,6 @@ class CurriculumInventoryExportController extends FOSRestController
             $manager = $this->container->get('ilioscore.curriculuminventoryexport.manager');
             $manager->update($curriculumInventoryExport, true, false);
 
-            // OF NOTE:
-            // We remove the document before returning the export to keep the payload at a reasonable size.
-            // The exported report document can be retrieved via the curriculum inventory download controller.
-            // [ST 2015/09/21]
-            //$curriculumInventoryExport->setDocument('');
             $answer['curriculumInventoryExports'] = [$curriculumInventoryExport];
 
             $view = $this->view($answer, Codes::HTTP_CREATED);

--- a/src/Ilios/CoreBundle/Entity/CurriculumInventoryExport.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventoryExport.php
@@ -68,8 +68,6 @@ class CurriculumInventoryExport implements CurriculumInventoryExportInterface
      *      min = 1,
      *      max = 16000000
      * )
-     *
-     * @JMS\Expose
      * @JMS\Type("string")
      */
     protected $document;
@@ -94,6 +92,9 @@ class CurriculumInventoryExport implements CurriculumInventoryExportInterface
      * @ORM\Column(name="created_on", type="datetime")
      *
      * @Assert\NotBlank()
+     * @JMS\Expose
+     * @JMS\Type("DateTime<'c'>")
+     * @JMS\SerializedName("createdAt")
      */
     protected $createdAt;
     

--- a/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventoryExportControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CurriculumInventoryExportControllerTest.php
@@ -56,6 +56,7 @@ class CurriculumInventoryExportControllerTest extends AbstractControllerTest
         $this->assertEquals(Codes::HTTP_CREATED, $response->getStatusCode(), $response->getContent());
         $this->assertEquals($responseData['report'], $postData['report']);
         $this->assertNotEmpty($responseData['createdBy']);
-        $this->assertEmpty($responseData['document'], ''); // yes, we expect an empty string here.
+        $this->assertNotEmpty($responseData['createdAt']);
+        $this->assertFalse(array_key_exists('document', $responseData), 'Document is not part of payload.');
     }
 }


### PR DESCRIPTION
finalizing a report resulted in an export record without document, amongst other minor bugs.

this has been hereby fixed.