### PR TITLE
generate LM d/l token explicitly.

### DIFF
--- a/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
+++ b/src/Ilios/CoreBundle/Controller/LearningMaterialController.php
@@ -226,6 +226,10 @@ class LearningMaterialController extends FOSRestController
             $manager = $this->container->get('ilioscore.learningmaterial.manager');
             $manager->update($learningMaterial, true, false);
 
+            // now generate the token and save again.
+            $learningMaterial->generateToken();
+            $manager->update($learningMaterial, true, true);
+
             $factory = $this->get('ilioscore.learningmaterial_decorator.factory');
 
             $answer['learningMaterials'] = [$factory->create($learningMaterial)];

--- a/src/Ilios/CoreBundle/Entity/LearningMaterial.php
+++ b/src/Ilios/CoreBundle/Entity/LearningMaterial.php
@@ -267,8 +267,6 @@ class LearningMaterial implements LearningMaterialInterface
         $this->uploadDate = new \DateTime();
         $this->sessionLearningMaterials = new ArrayCollection();
         $this->courseLearningMaterials = new ArrayCollection();
-        
-        $this->generateToken();
     }
 
     /**

--- a/src/Ilios/CoreBundle/Tests/Fixture/LoadLearningMaterialData.php
+++ b/src/Ilios/CoreBundle/Tests/Fixture/LoadLearningMaterialData.php
@@ -40,9 +40,7 @@ class LoadLearningMaterialData extends AbstractFixture implements
 
         foreach ($data as $arr) {
             $entity = new LearningMaterial();
-            if (array_key_exists('id', $arr)) {
-                $entity->setId($arr['id']);
-            }
+            $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
             $entity->setDescription($arr['description']);
             $entity->setOriginalAuthor($arr['originalAuthor']);
@@ -71,7 +69,7 @@ class LoadLearningMaterialData extends AbstractFixture implements
                 $entity->setRelativePath('fakefile' . $arr['id']);
                 $fs->copy(__FILE__, $path);
             }
-
+            $entity->generateToken();
             $manager->persist($entity);
             $this->addReference('learningMaterials' . $arr['id'], $entity);
         }


### PR DESCRIPTION
fixes a minor bug, where the token is generated prematurely (the LM's id is not present on record creation).