### PR TITLE
Add newCourseTitle parameter to rollover

### DIFF
--- a/src/Ilios/CoreBundle/Controller/CourseController.php
+++ b/src/Ilios/CoreBundle/Controller/CourseController.php
@@ -377,6 +377,7 @@ class CourseController extends FOSRestController
         $options = [];
         $options['new-start-date'] = $request->get('newStartDate');
         $options['skip-offerings'] = $request->get('skipOfferings');
+        $options['new-course-title'] = $request->get('newCourseTitle');
 
         $rolloverCourse = $this->container->get('ilioscore.courserollover');
         $newCourse = $rolloverCourse->rolloverCourse($course->getId(), $year, $options);

--- a/src/Ilios/CoreBundle/Tests/Controller/CourseControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/CourseControllerTest.php
@@ -1078,4 +1078,37 @@ class CourseControllerTest extends AbstractControllerTest
         $this->assertEmpty($data[1]['offerings']);
 
     }
+
+    /**
+     * @group controllers_a
+     */
+    public function testRolloverCourseWithNewTitle()
+    {
+        $course = $this->container
+            ->get('ilioscore.dataloader.course')
+            ->getOne()
+        ;
+        $newCourseTitle = 'New (very cool) course title';
+
+        $this->createJsonRequest(
+            'POST',
+            $this->getUrl(
+                'api_course_rollover_v1',
+                [
+                    'id' => $course['id'],
+                    'year' => $course['year'],
+                    'newCourseTitle' => $newCourseTitle
+                ]
+            ),
+            null,
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_CREATED);
+        $data = json_decode($response->getContent(), true)['courses'];
+        $newCourse = $data[0];
+        $this->assertSame($course['year'], $newCourse['year']);
+        $this->assertSame($newCourseTitle, $newCourse['title']);
+    }
 }


### PR DESCRIPTION
Courses can be rolled over with a new title.

Fixes #1487