### PR TITLE
Remove superfluous colon from token output

### DIFF
--- a/src/Ilios/CliBundle/Command/CreateUserTokenCommand.php
+++ b/src/Ilios/CliBundle/Command/CreateUserTokenCommand.php
@@ -76,6 +76,6 @@ class CreateUserTokenCommand extends Command
         $jwt = $this->jwtManager->createJwtFromUser($user, $input->getOption('ttl'));
         
         $output->writeln('Success!');
-        $output->writeln('Token: ' . $jwt);
+        $output->writeln('Token ' . $jwt);
     }
 }

--- a/src/Ilios/CliBundle/Tests/Command/CreateUserTokenCommandTest.php
+++ b/src/Ilios/CliBundle/Tests/Command/CreateUserTokenCommandTest.php
@@ -49,7 +49,7 @@ class CreateUserTokenCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Token: 123JWT/',
+            '/Token 123JWT/',
             $output
         );
     }
@@ -69,7 +69,7 @@ class CreateUserTokenCommandTest extends \PHPUnit_Framework_TestCase
         
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
-            '/Token: 123JWT/',
+            '/Token 123JWT/',
             $output
         );
     }


### PR DESCRIPTION
This isn't necessary and makes it harder to copy/paste the token into a
header.

Fixes #1506