### PR TITLE
Add active to competency, term, and vocabulary

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20160715212648.php
+++ b/app/Resources/DoctrineMigrations/Version20160715212648.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add active to Terms, Competencies, and Vocabularies
+ */
+class Version20160715212648 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE term ADD active TINYINT(1) NOT NULL');
+        $this->addSql('UPDATE term set active=true');
+
+        $this->addSql('ALTER TABLE competency ADD active TINYINT(1) NOT NULL');
+        $this->addSql('UPDATE competency set active=true');
+
+        $this->addSql('ALTER TABLE vocabulary ADD active TINYINT(1) NOT NULL');
+        $this->addSql('UPDATE vocabulary set active=true');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE term DROP active');
+        $this->addSql('ALTER TABLE competency DROP active');
+        $this->addSql('ALTER TABLE vocabulary DROP active');
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/Competency.php
+++ b/src/Ilios/CoreBundle/Entity/Competency.php
@@ -5,6 +5,7 @@ namespace Ilios\CoreBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Ilios\CoreBundle\Traits\ActivatableEntity;
 use Ilios\CoreBundle\Traits\StringableIdEntity;
 use JMS\Serializer\Annotation as JMS;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -31,6 +32,7 @@ class Competency implements CompetencyInterface
     use ProgramYearsEntity;
     use SchoolEntity;
     use StringableIdEntity;
+    use ActivatableEntity;
 
     /**
      * @var int
@@ -140,6 +142,19 @@ class Competency implements CompetencyInterface
     protected $programYears;
 
     /**
+     * @var boolean
+     *
+     * @ORM\Column(type="boolean")
+     *
+     * @Assert\NotNull()
+     * @Assert\Type(type="bool")
+     *
+     * @JMS\Expose
+     * @JMS\Type("boolean")
+     */
+    protected $active;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -148,6 +163,7 @@ class Competency implements CompetencyInterface
         $this->programYears = new ArrayCollection();
         $this->children = new ArrayCollection();
         $this->objectives = new ArrayCollection();
+        $this->active = true;
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/CompetencyInterface.php
+++ b/src/Ilios/CoreBundle/Entity/CompetencyInterface.php
@@ -5,6 +5,7 @@ namespace Ilios\CoreBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
+use Ilios\CoreBundle\Traits\ActivatableEntityInterface;
 use Ilios\CoreBundle\Traits\IdentifiableEntityInterface;
 
 use Ilios\CoreBundle\Entity\AamcPcrsInterface;
@@ -23,7 +24,8 @@ interface CompetencyInterface extends
     TitledEntityInterface,
     ProgramYearsEntityInterface,
     SchoolEntityInterface,
-    LoggableEntityInterface
+    LoggableEntityInterface,
+    ActivatableEntityInterface
 {
     /**
      * @param CompetencyInterface $parent

--- a/src/Ilios/CoreBundle/Entity/DTO/TermDTO.php
+++ b/src/Ilios/CoreBundle/Entity/DTO/TermDTO.php
@@ -77,14 +77,22 @@ class TermDTO
      */
     public $aamcResourceTypes;
 
+    /**
+     * @var boolean
+     * @JMS\Type("boolean")
+     */
+    public $active;
+
     public function __construct(
         $id,
         $title,
-        $description
+        $description,
+        $active
     ) {
         $this->id = $id;
         $this->title = $title;
         $this->description = $description;
+        $this->active = $active;
 
         $this->children = [];
         $this->courses = [];

--- a/src/Ilios/CoreBundle/Entity/Repository/TermRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/TermRepository.php
@@ -54,7 +54,8 @@ class TermRepository extends EntityRepository
             $termDTOs[$arr['id']] = new TermDTO(
                 $arr['id'],
                 $arr['title'],
-                $arr['description']
+                $arr['description'],
+                $arr['active']
             );
         }
         $termIds = array_keys($termDTOs);

--- a/src/Ilios/CoreBundle/Entity/Term.php
+++ b/src/Ilios/CoreBundle/Entity/Term.php
@@ -5,6 +5,7 @@ namespace Ilios\CoreBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Ilios\CoreBundle\Traits\ActivatableEntity;
 use JMS\Serializer\Annotation as JMS;
 use Symfony\Component\Validator\Constraints as Assert;
 use Ilios\CoreBundle\Traits\CoursesEntity;
@@ -38,6 +39,7 @@ class Term implements TermInterface
     use SessionsEntity;
     use StringableIdEntity;
     use TitledEntity;
+    use ActivatableEntity;
 
     /**
      * @var int
@@ -176,6 +178,18 @@ class Term implements TermInterface
      */
     protected $aamcResourceTypes;
 
+    /**
+     * @var boolean
+     *
+     * @ORM\Column(type="boolean")
+     *
+     * @Assert\NotNull()
+     * @Assert\Type(type="bool")
+     *
+     * @JMS\Expose
+     * @JMS\Type("boolean")
+     */
+    protected $active;
 
     /**
      * Constructor
@@ -187,6 +201,7 @@ class Term implements TermInterface
         $this->programYears = new ArrayCollection();
         $this->sessions = new ArrayCollection();
         $this->children = new ArrayCollection();
+        $this->active = true;
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/TermInterface.php
+++ b/src/Ilios/CoreBundle/Entity/TermInterface.php
@@ -4,6 +4,7 @@ namespace Ilios\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Ilios\CoreBundle\Traits\ActivatableEntityInterface;
 use Ilios\CoreBundle\Traits\CoursesEntityInterface;
 use Ilios\CoreBundle\Traits\DescribableEntityInterface;
 use Ilios\CoreBundle\Traits\IdentifiableEntityInterface;
@@ -24,7 +25,8 @@ interface TermInterface extends
     LoggableEntityInterface,
     ProgramYearsEntityInterface,
     SessionsEntityInterface,
-    CoursesEntityInterface
+    CoursesEntityInterface,
+    ActivatableEntityInterface
 {
     /**
      * @param VocabularyInterface $vocabulary

--- a/src/Ilios/CoreBundle/Entity/Vocabulary.php
+++ b/src/Ilios/CoreBundle/Entity/Vocabulary.php
@@ -5,6 +5,7 @@ namespace Ilios\CoreBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Ilios\CoreBundle\Traits\ActivatableEntity;
 use Ilios\CoreBundle\Traits\CategorizableEntity;
 use JMS\Serializer\Annotation as JMS;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -34,6 +35,7 @@ class Vocabulary implements VocabularyInterface
     use StringableIdEntity;
     use TitledEntity;
     use CategorizableEntity;
+    use ActivatableEntity;
 
     /**
      * @var int
@@ -94,10 +96,24 @@ class Vocabulary implements VocabularyInterface
     protected $terms;
 
     /**
+     * @var boolean
+     *
+     * @ORM\Column(type="boolean")
+     *
+     * @Assert\NotNull()
+     * @Assert\Type(type="bool")
+     *
+     * @JMS\Expose
+     * @JMS\Type("boolean")
+     */
+    protected $active;
+
+    /**
      * Constructor.
      */
     public function __construct()
     {
         $this->terms = new ArrayCollection();
+        $this->active = true;
     }
 }

--- a/src/Ilios/CoreBundle/Entity/VocabularyInterface.php
+++ b/src/Ilios/CoreBundle/Entity/VocabularyInterface.php
@@ -4,6 +4,7 @@ namespace Ilios\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Ilios\CoreBundle\Traits\ActivatableEntityInterface;
 use Ilios\CoreBundle\Traits\CategorizableEntityInterface;
 use Ilios\CoreBundle\Traits\IdentifiableEntityInterface;
 use Ilios\CoreBundle\Traits\SchoolEntityInterface;
@@ -19,6 +20,7 @@ interface VocabularyInterface extends
     SchoolEntityInterface,
     StringableEntityInterface,
     TitledEntityInterface,
-    CategorizableEntityInterface
+    CategorizableEntityInterface,
+    ActivatableEntityInterface
 {
 }

--- a/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CompetencyType.php
@@ -39,6 +39,7 @@ class CompetencyType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:ProgramYear"
             ])
+            ->add('active', null, ['required' => true])
         ;
         $builder->get('title')->addViewTransformer(new RemoveMarkupTransformer());
     }

--- a/src/Ilios/CoreBundle/Form/Type/TermType.php
+++ b/src/Ilios/CoreBundle/Form/Type/TermType.php
@@ -49,6 +49,7 @@ class TermType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:AamcResourceType"
             ])
+            ->add('active', null, ['required' => true])
         ;
 
         $transformer = new RemoveMarkupTransformer();

--- a/src/Ilios/CoreBundle/Form/Type/VocabularyType.php
+++ b/src/Ilios/CoreBundle/Form/Type/VocabularyType.php
@@ -26,6 +26,7 @@ class VocabularyType extends AbstractType
                 'required' => true,
                 'entityName' => "IliosCoreBundle:School"
             ])
+            ->add('active', null, ['required' => true])
         ;
 
         $builder->get('title')->addViewTransformer(new RemoveMarkupTransformer());

--- a/src/Ilios/CoreBundle/Tests/DataLoader/CompetencyData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/CompetencyData.php
@@ -11,6 +11,7 @@ class CompetencyData extends AbstractDataLoader
         $arr[] = array(
             'id' => 1,
             'title' => $this->faker->text,
+            'active' => true,
             'school' => "1",
             'objectives' => [],
             'children' => ['3'],
@@ -21,6 +22,7 @@ class CompetencyData extends AbstractDataLoader
         $arr[] = array(
             'id' => 2,
             'title' => $this->faker->text,
+            'active' => false,
             'school' => "1",
             'objectives' => [],
             'children' => [],
@@ -31,6 +33,7 @@ class CompetencyData extends AbstractDataLoader
         $arr[] = array(
             'id' => 3,
             'title' => $this->faker->text,
+            'active' => true,
             'school' => "1",
             'objectives' => ['1'],
             'parent' => "1",
@@ -47,6 +50,7 @@ class CompetencyData extends AbstractDataLoader
         return [
             'id' => 4,
             'title' => $this->faker->text,
+            'active' => true,
             'school' => "1",
             'objectives' => [],
             'parent' => "1",

--- a/src/Ilios/CoreBundle/Tests/DataLoader/TermData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/TermData.php
@@ -17,6 +17,7 @@ class TermData extends AbstractDataLoader
             'programYears' => ["2"],
             'sessions' => ['2'],
             'aamcResourceTypes' => ['RE001'],
+            'active' => true,
         );
         $arr[] = array(
             'id' => 2,
@@ -29,6 +30,7 @@ class TermData extends AbstractDataLoader
             'programYears' => [],
             'sessions' => ['1'],
             'aamcResourceTypes' => ['RE001', 'RE002'],
+            'active' => true,
         );
         $arr[] = array(
             'id' => 3,
@@ -41,6 +43,7 @@ class TermData extends AbstractDataLoader
             'programYears' => [],
             'sessions' => ['3'],
             'aamcResourceTypes' => ['RE002'],
+            'active' => false,
         );
 
         $arr[] = array(
@@ -53,6 +56,7 @@ class TermData extends AbstractDataLoader
             'programYears' => ["2"],
             'sessions' => ['2'],
             'aamcResourceTypes' => [],
+            'active' => true,
         );
         $arr[] = array(
             'id' => 5,
@@ -64,6 +68,7 @@ class TermData extends AbstractDataLoader
             'programYears' => [],
             'sessions' => ['1'],
             'aamcResourceTypes' => [],
+            'active' => true,
         );
         $arr[] = array(
             'id' => 6,
@@ -75,6 +80,7 @@ class TermData extends AbstractDataLoader
             'programYears' => [],
             'sessions' => ['3'],
             'aamcResourceTypes' => [],
+            'active' => false,
         );
 
         return $arr;
@@ -92,6 +98,7 @@ class TermData extends AbstractDataLoader
             'programYears' => [],
             'sessions' => ['3'],
             'aamcResourceTypes' => [],
+            'active' => true,
         ];
     }
 

--- a/src/Ilios/CoreBundle/Tests/DataLoader/VocabularyData.php
+++ b/src/Ilios/CoreBundle/Tests/DataLoader/VocabularyData.php
@@ -10,12 +10,14 @@ class VocabularyData extends AbstractDataLoader
         $arr[] = array(
             'id' => 1,
             'title' => $this->faker->text(100),
+            'active' => true,
             'school' => '1',
             'terms' => ['1', '2', '3']
         );
         $arr[] = array(
             'id' => 2,
             'title' => $this->faker->text(100),
+            'active' => false,
             'school' => '2',
             'terms' => ['4', '5', '6']
         );
@@ -27,6 +29,7 @@ class VocabularyData extends AbstractDataLoader
         return [
             'id' => 3,
             'title' => $this->faker->text(100),
+            'active' => true,
             'school' => '2',
             'terms' => []
         ];

--- a/src/Ilios/CoreBundle/Tests/Fixture/LoadCompetencyData.php
+++ b/src/Ilios/CoreBundle/Tests/Fixture/LoadCompetencyData.php
@@ -32,6 +32,7 @@ class LoadCompetencyData extends AbstractFixture implements
             $entity = new Competency();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
+            $entity->setActive($arr['active']);
 
             foreach ($arr['aamcPcrses'] as $id) {
                 $entity->addAamcPcrs($this->getReference('aamcPcrs' . $id));

--- a/src/Ilios/CoreBundle/Tests/Fixture/LoadTermData.php
+++ b/src/Ilios/CoreBundle/Tests/Fixture/LoadTermData.php
@@ -33,6 +33,7 @@ class LoadTermData extends AbstractFixture implements
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
             $entity->setDescription($arr['description']);
+            $entity->setActive($arr['active']);
             $entity->setVocabulary($this->getReference('vocabularies' . $arr['vocabulary']));
             if (isset($arr['parent'])) {
                 $entity->setParent($this->getReference('terms' . $arr['parent']));

--- a/src/Ilios/CoreBundle/Tests/Fixture/LoadVocabularyData.php
+++ b/src/Ilios/CoreBundle/Tests/Fixture/LoadVocabularyData.php
@@ -32,6 +32,7 @@ class LoadVocabularyData extends AbstractFixture implements
             $entity = new Vocabulary();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
+            $entity->setActive($arr['active']);
             $entity->setSchool($this->getReference('schools' . $arr['school']));
             $manager->persist($entity);
             $this->addReference('vocabularies' . $arr['id'], $entity);

--- a/src/Ilios/CoreBundle/Traits/ActivatableEntity.php
+++ b/src/Ilios/CoreBundle/Traits/ActivatableEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Ilios\CoreBundle\Traits;
+
+/**
+ * Class ActivatableEntity
+ * @package Ilios\CoreBundle\Traits
+ */
+trait ActivatableEntity
+{
+    /**
+     * @return boolean
+     */
+    public function isActive()
+    {
+        return $this->active;
+    }
+
+    /**
+     * @param boolean $active
+     */
+    public function setActive($active)
+    {
+        $this->active = $active;
+    }
+}

--- a/src/Ilios/CoreBundle/Traits/ActivatableEntityInterface.php
+++ b/src/Ilios/CoreBundle/Traits/ActivatableEntityInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Ilios\CoreBundle\Traits;
+
+/**
+ * Interface ActivatableEntityInterface
+ * @package Ilios\CoreBundle\Traits
+ */
+interface ActivatableEntityInterface
+{
+    /**
+     * @return boolean
+     */
+    public function isActive();
+
+    /**
+     * @param boolean $active
+     */
+    public function setActive($active);
+}


### PR DESCRIPTION
This will allow some of these to be de-activated so they can be excluded
from selection while still remaining connected to existing collections
for archive purposes.

Fixes #1519