### PR TITLE
Doctrine event listener cleanup

### DIFF
--- a/src/Ilios/CoreBundle/EventListener/LogEntityChanges.php
+++ b/src/Ilios/CoreBundle/EventListener/LogEntityChanges.php
@@ -7,19 +7,15 @@ use Ilios\CoreBundle\Entity\LoggableEntityInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
- * LogEntityChanges event listener
- * Listen for every change to an entity and log it
+ * Doctrine event listener.
+ * Listen for every change to an entity and log it.
+ *
+ * Class LogEntityChanges
+ * @package Ilios\CoreBundle\EventListener
  */
 class LogEntityChanges
 {
     use ContainerAwareTrait;
-
-    public function getSubscribedEvents()
-    {
-        return [
-            'onFlush'
-        ];
-    }
 
     /**
     * Get all the entities that have changed and create log entries for them

--- a/src/Ilios/CoreBundle/EventListener/TimestampListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TimestampListener.php
@@ -2,22 +2,14 @@
 
 namespace Ilios\CoreBundle\EventListener;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 
 use Ilios\CoreBundle\Traits\TimestampableEntityInterface;
 
-class TimestampListener implements EventSubscriber
+class TimestampListener
 {
-    public function getSubscribedEvents()
-    {
-        return [
-            'onFlush'
-        ];
-    }
-
-    public function onFlush(OnFlushEventArgs $eventArgs)
-    {
+     public function onFlush(OnFlushEventArgs $eventArgs)
+     {
         $entityManager = $eventArgs->getEntityManager();
         $uow = $entityManager->getUnitOfWork();
         $entities = array_merge(

--- a/src/Ilios/CoreBundle/EventListener/TimestampListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TimestampListener.php
@@ -3,9 +3,14 @@
 namespace Ilios\CoreBundle\EventListener;
 
 use Doctrine\ORM\Event\OnFlushEventArgs;
-
 use Ilios\CoreBundle\Traits\TimestampableEntityInterface;
 
+/**
+ * Event listener that updates timestamp-properties of eligible entities during insertion/update.
+ *
+ * Class TimestampListener
+ * @package Ilios\CoreBundle\EventListener
+ */
 class TimestampListener
 {
      public function onFlush(OnFlushEventArgs $eventArgs)

--- a/src/Ilios/CoreBundle/EventListener/TimestampListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TimestampListener.php
@@ -6,15 +6,15 @@ use Doctrine\ORM\Event\OnFlushEventArgs;
 use Ilios\CoreBundle\Traits\TimestampableEntityInterface;
 
 /**
- * Event listener that updates timestamp-properties of eligible entities during insertion/update.
+ * Doctrine event listener that updates timestamp-properties of eligible entities during insertion/update.
  *
  * Class TimestampListener
  * @package Ilios\CoreBundle\EventListener
  */
 class TimestampListener
 {
-     public function onFlush(OnFlushEventArgs $eventArgs)
-     {
+    public function onFlush(OnFlushEventArgs $eventArgs)
+    {
         $entityManager = $eventArgs->getEntityManager();
         $uow = $entityManager->getUnitOfWork();
         $entities = array_merge(

--- a/src/Ilios/CoreBundle/EventListener/UpdateOfferingTimestamp.php
+++ b/src/Ilios/CoreBundle/EventListener/UpdateOfferingTimestamp.php
@@ -9,10 +9,10 @@ use Ilios\CoreBundle\Entity\Offering;
  * Doctrine event listener.
  *
  * To correctly set the offering last_updated timestamp we have to listen for updates to the offering as well as
- * all the related entities
+ * all the related entities.
  *
  * The Doctrine built in LifeCycle Callbacks were not able to handle this correctly,
- * or else I was never able to write them correctly
+ * or else I was never able to write them correctly.
  *
  * Class UpdateOfferingTimestamp
  * @package Ilios\CoreBundle\EventListener
@@ -21,10 +21,10 @@ class UpdateOfferingTimestamp
 {
     /**
     * Grab all of the entities that have a relationship with offering and update the offering
-    * they are associated with
+    * they are associated with.
     *
-    * We have to do this operation usign onFlush so we can catch inserts, updated
-    * and deletes for all associations
+    * We have to do this operation using onFlush so we can catch inserts, updated
+    * and deletes for all associations.
     *
     * @param OnFlushEventArgs $eventArgs
     */

--- a/src/Ilios/CoreBundle/EventListener/UpdateOfferingTimestamp.php
+++ b/src/Ilios/CoreBundle/EventListener/UpdateOfferingTimestamp.php
@@ -6,22 +6,19 @@ use Doctrine\ORM\Event\OnFlushEventArgs;
 use Ilios\CoreBundle\Entity\Offering;
 
 /**
- * UpdateOfferingTimestamp event listener
+ * Doctrine event listener.
+ *
  * To correctly set the offering last_updated timestamp we have to listen for updates to the offering as well as
  * all the related entities
  *
  * The Doctrine built in LifeCycle Callbacks were not able to handle this correctly,
  * or else I was never able to write them correctly
- * */
+ *
+ * Class UpdateOfferingTimestamp
+ * @package Ilios\CoreBundle\EventListener
+ */
 class UpdateOfferingTimestamp
 {
-    public function getSubscribedEvents()
-    {
-        return [
-            'onFlush'
-        ];
-    }
-
     /**
     * Grab all of the entities that have a relationship with offering and update the offering
     * they are associated with

--- a/src/Ilios/CoreBundle/EventListener/UpdateOfferingTimestamp.php
+++ b/src/Ilios/CoreBundle/EventListener/UpdateOfferingTimestamp.php
@@ -1,7 +1,6 @@
 <?php
 namespace Ilios\CoreBundle\EventListener;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 
 use Ilios\CoreBundle\Entity\Offering;

--- a/src/Ilios/CoreBundle/EventListener/UpdateSessionTimestamp.php
+++ b/src/Ilios/CoreBundle/EventListener/UpdateSessionTimestamp.php
@@ -2,26 +2,22 @@
 namespace Ilios\CoreBundle\EventListener;
 
 use Doctrine\ORM\Event\OnFlushEventArgs;
-
 use Ilios\CoreBundle\Entity\Session;
 
 /**
- * UpdateSessionTimestamp event listener
+ * Doctrine event listener.
+ *
  * To correctly set the session last_updated timestamp we have to listen for updates to the session as well as
  * all the related entities
  *
  * The Doctrine built in LifeCycle Callbacks were not able to handle this correctly,
  * or else I was never able to write them correctly
- * */
+ *
+ * Class UpdateSessionTimestamp
+ * @package Ilios\CoreBundle\EventListener
+ */
 class UpdateSessionTimestamp
 {
-    public function getSubscribedEvents()
-    {
-        return [
-            'onFlush'
-        ];
-    }
-
     /**
     * Grab all of the entities that have a relationship with session and update the session
     * they are associated with

--- a/src/Ilios/CoreBundle/EventListener/UpdateSessionTimestamp.php
+++ b/src/Ilios/CoreBundle/EventListener/UpdateSessionTimestamp.php
@@ -8,10 +8,10 @@ use Ilios\CoreBundle\Entity\Session;
  * Doctrine event listener.
  *
  * To correctly set the session last_updated timestamp we have to listen for updates to the session as well as
- * all the related entities
+ * all the related entities.
  *
  * The Doctrine built in LifeCycle Callbacks were not able to handle this correctly,
- * or else I was never able to write them correctly
+ * or else I was never able to write them correctly.
  *
  * Class UpdateSessionTimestamp
  * @package Ilios\CoreBundle\EventListener
@@ -20,10 +20,10 @@ class UpdateSessionTimestamp
 {
     /**
     * Grab all of the entities that have a relationship with session and update the session
-    * they are associated with
+    * they are associated with.
     *
-    * We have to do this operation usign onFlush so we can catch inserts, updated
-    * and deletes for all associations
+    * We have to do this operation using onFlush so we can catch inserts, updated
+    * and deletes for all associations.
     *
     * @param OnFlushEventArgs $eventArgs
     */

--- a/src/Ilios/CoreBundle/EventListener/UpdateSessionTimestamp.php
+++ b/src/Ilios/CoreBundle/EventListener/UpdateSessionTimestamp.php
@@ -1,7 +1,6 @@
 <?php
 namespace Ilios\CoreBundle\EventListener;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 
 use Ilios\CoreBundle\Entity\Session;

--- a/src/Ilios/CoreBundle/Tests/EventListener/ContainerInjectorTest.php
+++ b/src/Ilios/CoreBundle/Tests/EventListener/ContainerInjectorTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ilios\CoreBundle\Tests\EventListner;
+namespace Ilios\CoreBundle\Tests\EventListener;
 
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Mockery as m;


### PR DESCRIPTION
Fixed a few minor things.
Most notably, I dropped everything event-subscriber related, since we are using event listeners exclusively.