### PR TITLE
Add CAS as an auth provider

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -165,3 +165,5 @@ ilios_authentication:
     shibboleth_authentication_user_id_attribute: "%shibboleth_authentication_user_id_attribute%"
     cas_authentication_server: "%cas_authentication_server%"
     cas_authentication_version: "%cas_authentication_version%"
+    cas_authentication_verify_ssl: "%cas_authentication_verify_ssl%"
+    cas_authentication_certificate_path: "%cas_authentication_certificate_path%"

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -163,3 +163,5 @@ ilios_authentication:
     shibboleth_authentication_login_path: "%shibboleth_authentication_login_path%"
     shibboleth_authentication_logout_path: "%shibboleth_authentication_logout_path%"
     shibboleth_authentication_user_id_attribute: "%shibboleth_authentication_user_id_attribute%"
+    cas_authentication_server: "%cas_authentication_server%"
+    cas_authentication_version: "%cas_authentication_version%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -43,3 +43,7 @@ parameters:
     timezone: 'America/Los_Angeles'
     forceProtocol: https
     keep_frontend_updated: true
+    cas_authentication_server: null
+    cas_authentication_version: 3
+    cas_authentication_verify_ssl: true
+    cas_authentication_certificate_path: null

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -36,3 +36,8 @@ parameters:
     shibboleth_authentication_user_id_attribute: null
     forceProtocol: http
     keep_frontend_updated: true
+    cas_authentication_server: null
+    cas_authentication_version: null
+    cas_authentication_certificate_path: null
+    cas_authentication_certificate_path: null
+

--- a/src/Ilios/AuthenticationBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/AuthenticationBundle/DependencyInjection/Configuration.php
@@ -34,6 +34,14 @@ class Configuration implements ConfigurationInterface
                 ->enumNode('cas_authentication_version')
                     ->values(array(null, 1, 2, 3))
                 ->end()
+                ->booleanNode('cas_authentication_verify_ssl')->defaultValue(true)->end()
+                ->scalarNode('cas_authentication_certificate_path')
+                    ->defaultValue(null)
+                    ->validate()
+                    ->ifTrue(function ($value) {
+                        return !is_null($value) && !\is_readable($value);
+                    })->thenInvalid('Unable to find certificate at %s or it is not readable')->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Ilios/AuthenticationBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/AuthenticationBundle/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->enumNode('type')
                     ->isRequired()
-                    ->values(array('form', 'shibboleth', 'ldap'))
+                    ->values(array('form', 'shibboleth', 'ldap', 'cas'))
                 ->end()
                 ->scalarNode('legacy_salt')->defaultValue(null)->end()
                 ->scalarNode('ldap_authentication_host')->defaultValue(null)->end()
@@ -30,6 +30,10 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('shibboleth_authentication_login_path')->defaultValue(null)->end()
                 ->scalarNode('shibboleth_authentication_logout_path')->defaultValue(null)->end()
                 ->scalarNode('shibboleth_authentication_user_id_attribute')->defaultValue(null)->end()
+                ->scalarNode('cas_authentication_server')->defaultValue(null)->end()
+                ->enumNode('cas_authentication_version')
+                    ->values(array(null, 1, 2, 3))
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Ilios/AuthenticationBundle/DependencyInjection/IliosAuthenticationExtension.php
+++ b/src/Ilios/AuthenticationBundle/DependencyInjection/IliosAuthenticationExtension.php
@@ -43,6 +43,8 @@ class IliosAuthenticationExtension extends Extension
         );
         $container->setParameter('ilios_authentication.cas.server', rtrim($config['cas_authentication_server'], '/'));
         $container->setParameter('ilios_authentication.cas.version', $config['cas_authentication_version']);
+        $container->setParameter('ilios_authentication.cas.verifySSL', $config['cas_authentication_verify_ssl']);
+        $container->setParameter('ilios_authentication.cas.certificatePath', $config['cas_authentication_certificate_path']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Ilios/AuthenticationBundle/DependencyInjection/IliosAuthenticationExtension.php
+++ b/src/Ilios/AuthenticationBundle/DependencyInjection/IliosAuthenticationExtension.php
@@ -41,7 +41,9 @@ class IliosAuthenticationExtension extends Extension
             'ilios_authentication.ldap.bind_template',
             $config['ldap_authentication_bind_template']
         );
-        
+        $container->setParameter('ilios_authentication.cas.server', rtrim($config['cas_authentication_server'], '/'));
+        $container->setParameter('ilios_authentication.cas.version', $config['cas_authentication_version']);
+
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('voters.yml');
@@ -65,6 +67,12 @@ class IliosAuthenticationExtension extends Extension
                 $container->setParameter(
                     'ilios_authentication.authenticatorservice',
                     'ilios_authentication.ldap.authentication'
+                );
+                break;
+            case 'cas':
+                $container->setParameter(
+                    'ilios_authentication.authenticatorservice',
+                    'ilios_authentication.cas.authentication'
                 );
                 break;
         }

--- a/src/Ilios/AuthenticationBundle/Resources/config/services.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/services.yml
@@ -23,9 +23,16 @@ services:
     ilios_authentication.ldap.authentication:
         class: Ilios\AuthenticationBundle\Service\LdapAuthentication
         arguments: ["@ilioscore.authentication.manager", "@ilios_authentication.jwt.manager", '%ilios_authentication.ldap.host%', '%ilios_authentication.ldap.port%', '%ilios_authentication.ldap.bind_template%']
+    ilios_authentication.cas.authentication:
+        class: Ilios\AuthenticationBundle\Service\CasAuthentication
+        arguments: ["@ilioscore.authentication.manager", "@ilios_authentication.jwt.manager", "@logger", "@router", '@ilios_authentication.cas.manager']
     ilios_authentication.authenticator_factory:
         class: Ilios\AuthenticationBundle\Service\AuthenticationFactory
         arguments: ['@service_container', '%ilios_authentication.authenticatorservice%']
     ilios_authentication.authenticator:
         class:   Ilios\AuthenticationBundle\Service\AuthenticationInterface
         factory: ["@ilios_authentication.authenticator_factory", createAuthenticationService]
+    ilios_authentication.cas.manager:
+            class: Ilios\AuthenticationBundle\Service\CasManager
+            arguments: ['%ilios_authentication.cas.server%', '%ilios_authentication.cas.version%']
+

--- a/src/Ilios/AuthenticationBundle/Resources/config/services.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/services.yml
@@ -34,5 +34,5 @@ services:
         factory: ["@ilios_authentication.authenticator_factory", createAuthenticationService]
     ilios_authentication.cas.manager:
             class: Ilios\AuthenticationBundle\Service\CasManager
-            arguments: ['%ilios_authentication.cas.server%', '%ilios_authentication.cas.version%']
+            arguments: ['%ilios_authentication.cas.server%', '%ilios_authentication.cas.version%', '%ilios_authentication.cas.verifySSL%', '%ilios_authentication.cas.certificatepath%']
 

--- a/src/Ilios/AuthenticationBundle/Service/CasManager.php
+++ b/src/Ilios/AuthenticationBundle/Service/CasManager.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\Service;
+
+/**
+ * Class CasManager
+ * @package Ilios\AuthenticationBundle\Service
+ */
+class CasManager
+{
+    /**
+     * @var string
+     */
+    protected $casServer;
+
+    /**
+     * @var string
+     */
+    protected $casVersion;
+
+    /**
+     * Constructor
+     *
+     * @param string $casServer
+     * @param string $casVersion
+     */
+    public function __construct(
+        $casServer,
+        $casVersion
+    ) {
+        $this->casServer = $casServer;
+        $this->casVersion = $casVersion;
+    }
+
+    public function getLoginUrl()
+    {
+        $logoutUrl = $this->casServer . '/login';
+        return $logoutUrl;
+    }
+
+    public function getLogoutUrl()
+    {
+        $logoutUrl = $this->casServer . '/logout';
+        return $logoutUrl;
+    }
+
+    /**
+     * Use a ticket to authenticate a user and get a userId
+     *
+     * @param string $service
+     * @param string $ticket
+     *
+     * @return string $userId
+     */
+    public function getUserId($service, $ticket)
+    {
+        $url = $this->getUrl($service, $ticket);
+        $root = $this->connect($url);
+
+        if ($root->getElementsByTagName("authenticationSuccess")->length != 0) {
+            // authentication succeeded, extract the user name
+            $elements = $root->getElementsByTagName("authenticationSuccess");
+            if ($elements->item(0)->getElementsByTagName("user")->length > 0) {
+                return $elements->item(0)->getElementsByTagName("user")->item(0)->nodeValue;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Use a ticket to authenticate a user and get a userId
+     *
+     * @param string $service
+     * @param string $ticket
+     *
+     * @return string $userId
+     */
+    protected function getUrl($service, $ticket)
+    {
+        $validate = '';
+        switch ($this->casVersion) {
+            case 1:
+                $validate = 'validate';
+                break;
+            case 2:
+                $validate = 'serviceValidate';
+                break;
+            case 3:
+                $validate = 'p3/serviceValidate';
+                break;
+        }
+        $url = $this->casServer . '/' .
+            $validate .
+            '?service=' . $service .
+            '&ticket=' . $ticket;
+
+        return $url;
+    }
+
+    /**
+     * Get the XML response from the CAS server
+     *
+     * @param string $url
+     *
+     * @return \DOMElement
+     *
+     * @throws \Exception
+     */
+    protected function connect($url)
+    {
+        $ch = curl_init($url);
+
+        //@todo Setup SSL validation for CURL at this point
+        //if this code is still here this is a MAJOR flaw and should
+        //be called out or not merged or fixed IMMEDIATLY
+        //JRJ is an idiot if you are reading this message.
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+
+        // return the CURL output into a variable
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+        $response = curl_exec($ch);
+        if ($response === false) {
+            throw new \Exception(
+                'CURL error #' . curl_errno($ch) . ': ' . curl_error($ch)
+            );
+        }
+        curl_close($ch);
+
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->encoding = "utf-8";
+
+        if (!($dom->loadXML($response))) {
+            throw new \Exception(
+                'Ticket not validated - bad response from server: ' . var_export($response, true)
+            );
+        }
+
+        if (!($root = $dom->documentElement)) {
+            throw new \Exception(
+                'Ticket not validated - bad XML: ' . var_export($response, true)
+            );
+        }
+        if ($root->localName != 'serviceResponse') {
+            throw new \Exception(
+                'Ticket not validated - bad xml:' . var_export($response, true)
+            );
+        }
+
+        return $root;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -39,4 +39,33 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'type'
         );
     }
+
+    public function testInvalidCasCertificatePath()
+    {
+        $this->assertConfigurationIsInvalid(
+            array(
+                array('type' => 'form', 'cas_authentication_certificate_path' => '')
+            ),
+            'Unable to find certificate at'
+        );
+    }
+
+    public function testValidCasCertificatePath()
+    {
+        $this->assertConfigurationIsValid(
+            array(
+                array('type' => 'form', 'cas_authentication_certificate_path' => __FILE__)
+            )
+        );
+    }
+
+    public function testInvalidCasVersion()
+    {
+        $this->assertConfigurationIsInvalid(
+            array(
+                array('type' => 'form', 'cas_authentication_version' => '99')
+            ),
+            'cas_authentication_version'
+        );
+    }
 }

--- a/src/Ilios/AuthenticationBundle/Tests/DependencyInjection/IliosAuthenticationExtensionTest.php
+++ b/src/Ilios/AuthenticationBundle/Tests/DependencyInjection/IliosAuthenticationExtensionTest.php
@@ -23,6 +23,11 @@ class IliosAuthenticationExtensionTest extends AbstractExtensionTestCase
         $shibbLoginPath = 'shibboleth_authentication_login_path';
         $shibbLogoutPath = 'shibboleth_authentication_logout_path';
         $shibbUserIdAttribute = 'shibboleth_authentication_user_id_attribute';
+        $casSuthenticationServer = 'cas_authentication_server';
+        $casSuthenticationVersion = 1;
+        $casSuthenticationVerifySSL = false;
+        $casSuthenticationCertificatePath = __FILE__;
+
 
         $this->load(array(
             'legacy_salt' => $legacySalt,
@@ -32,6 +37,10 @@ class IliosAuthenticationExtensionTest extends AbstractExtensionTestCase
             'shibboleth_authentication_login_path' => $shibbLoginPath,
             'shibboleth_authentication_logout_path' => $shibbLogoutPath,
             'shibboleth_authentication_user_id_attribute' => $shibbUserIdAttribute,
+            'cas_authentication_server' => $casSuthenticationServer,
+            'cas_authentication_version' => $casSuthenticationVersion,
+            'cas_authentication_verify_ssl' => $casSuthenticationVerifySSL,
+            'cas_authentication_certificate_path' => $casSuthenticationCertificatePath,
         ));
         $parameters = array(
             'ilios_authentication.legacy_salt' => $legacySalt,
@@ -41,6 +50,10 @@ class IliosAuthenticationExtensionTest extends AbstractExtensionTestCase
             'ilios_authentication.shibboleth.login_path' => $shibbLoginPath,
             'ilios_authentication.shibboleth.logout_path' => $shibbLogoutPath,
             'ilios_authentication.shibboleth.user_id_attribute' => $shibbUserIdAttribute,
+            'ilios_authentication.cas.server' => $casSuthenticationServer,
+            'ilios_authentication.cas.version' => $casSuthenticationVersion,
+            'ilios_authentication.cas.verifySSL' => $casSuthenticationVerifySSL,
+            'ilios_authentication.cas.certificatePath' => $casSuthenticationCertificatePath,
         );
         foreach ($parameters as $name => $value) {
             $this->assertContainerBuilderHasParameter($name, $value);
@@ -53,8 +66,10 @@ class IliosAuthenticationExtensionTest extends AbstractExtensionTestCase
             'ilios_authentication.form.authentication',
             'ilios_authentication.shibboleth.authentication',
             'ilios_authentication.ldap.authentication',
+            'ilios_authentication.cas.authentication',
             'ilios_authentication.authenticator_factory',
-            'ilios_authentication.authenticator'
+            'ilios_authentication.authenticator',
+            'ilios_authentication.cas.manager',
         );
         foreach ($services as $service) {
             $this->assertContainerBuilderHasService($service);
@@ -71,6 +86,10 @@ class IliosAuthenticationExtensionTest extends AbstractExtensionTestCase
             'shibboleth_authentication_login_path' => 'login_path',
             'shibboleth_authentication_logout_path' => 'logout_path',
             'shibboleth_authentication_user_id_attribute' => 'user_id',
+            'cas_authentication_server' => null,
+            'cas_authentication_version' => null,
+            'cas_authentication_verify_ssl' => true,
+            'cas_authentication_certificate_path' => null,
         ));
         $parameters = array(
             'ilios_authentication.authenticatorservice' => 'ilios_authentication.shibboleth.authentication',
@@ -90,9 +109,36 @@ class IliosAuthenticationExtensionTest extends AbstractExtensionTestCase
             'shibboleth_authentication_login_path' => 'login_path',
             'shibboleth_authentication_logout_path' => 'logout_path',
             'shibboleth_authentication_user_id_attribute' => 'user_id',
+            'cas_authentication_server' => null,
+            'cas_authentication_version' => null,
+            'cas_authentication_verify_ssl' => true,
+            'cas_authentication_certificate_path' => null,
         ));
         $parameters = array(
             'ilios_authentication.authenticatorservice' => 'ilios_authentication.ldap.authentication',
+        );
+        foreach ($parameters as $name => $value) {
+            $this->assertContainerBuilderHasParameter($name, $value);
+        }
+    }
+
+    public function testCasAuthConfig()
+    {
+        $this->load(array(
+            'legacy_salt' => 'salt',
+            'type' => 'cas',
+            'ldap_authentication_host' => 'host',
+            'ldap_authentication_port' => 'port',
+            'shibboleth_authentication_login_path' => 'login_path',
+            'shibboleth_authentication_logout_path' => 'logout_path',
+            'shibboleth_authentication_user_id_attribute' => 'user_id',
+            'cas_authentication_server' => 'server',
+            'cas_authentication_version' => 3,
+            'cas_authentication_verify_ssl' => false,
+            'cas_authentication_certificate_path' => null,
+        ));
+        $parameters = array(
+            'ilios_authentication.authenticatorservice' => 'ilios_authentication.cas.authentication',
         );
         foreach ($parameters as $name => $value) {
             $this->assertContainerBuilderHasParameter($name, $value);

--- a/src/Ilios/WebBundle/Controller/ConfigController.php
+++ b/src/Ilios/WebBundle/Controller/ConfigController.php
@@ -4,6 +4,8 @@ namespace Ilios\WebBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use phpCAS;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Class ConfigController
@@ -21,6 +23,11 @@ class ConfigController extends Controller
             $loginPath = $this->container->getParameter('ilios_authentication.shibboleth.login_path');
             $url = $this->get('request')->getSchemeAndHttpHost();
             $configuration['loginUrl'] = $url . $loginPath;
+        }
+        if ($authenticationType === 'cas') {
+            $cas = $this->container->get('ilios_authentication.cas.manager');
+
+            $configuration['casLoginUrl'] = $cas->getLoginUrl();
         }
         $configuration['locale'] = $this->container->getParameter('locale');
 

--- a/src/Ilios/WebBundle/Service/WebIndexFromJson.php
+++ b/src/Ilios/WebBundle/Service/WebIndexFromJson.php
@@ -11,7 +11,7 @@ class WebIndexFromJson
      * @var string
      */
     const DEFAULT_TEMPLATE_NAME = 'webindex.html.twig';
-    const API_VERSION = 'v1.6';
+    const API_VERSION = 'v1.7';
     const AWS_BUCKER = 'https://s3-us-west-2.amazonaws.com/frontend-json-config/';
 
     const PRODUCTION = 'prod';


### PR DESCRIPTION
This is a pretty simplistic implementation of CAS which basically just
validates a ticket that the frontend has provided.  All of the
redirecting will need to happen there.

todo:
- [x] Implement SSL validation and certificate support
- [x] Validate my assumptions about how CAS works with an expert.


Fixes #1522
