### PR TITLE
Replace SecureRandom with random_bytes

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20150916173024.php
+++ b/app/Resources/DoctrineMigrations/Version20150916173024.php
@@ -4,7 +4,6 @@ namespace Ilios\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
-use Symfony\Component\Security\Core\Util\SecureRandom;
 
 /**
  * Add icsf_feed_key to user table to use in calendar feed
@@ -26,10 +25,8 @@ class Version20150916173024 extends AbstractMigration
         $sql = 'SELECT user_id FROM `user`';
         $rows = $this->connection->executeQuery($sql)->fetchAll();
         if (count($rows)) {
-            $generator = new SecureRandom();
-            
-            $updates = array_map(function ($arr) use ($generator) {
-                $random = $generator->nextBytes(128);
+            $updates = array_map(function ($arr) {
+                $random = random_bytes(128);
                 $key = $arr['user_id'] . microtime() . '_' . $random;
                 $key = hash('sha256', $key);
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "dreamscapes/ldap-core": "^3.1",
         "eluceo/ical": "0.8.0",
         "exercise/htmlpurifier-bundle": "@stable",
-        "ocramius/proxy-manager": "^1.0"
+        "ocramius/proxy-manager": "^1.0",
+        "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
         "sensio/generator-bundle": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f3c36fdd56b8aae654884f62a2659c78",
-    "content-hash": "c8e6ea626a7b9ec19252426384893593",
+    "hash": "0bd310c994a501b059f1c5c019a612c1",
+    "content-hash": "8962b27339a7f87470a2d84c695e4a00",
     "packages": [
         {
             "name": "danielstjules/stringy",


### PR DESCRIPTION
Symfony has deprecated the SecureRandom class in favor of the built in
php function.  In order to maintain compatibility with PHP < 7 we need
the compat library as well.

Fixes #1530