### PR TITLE
apply correct strategy when changing sequence sort order

### DIFF
--- a/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceBlockController.php
+++ b/src/Ilios/CoreBundle/Controller/CurriculumInventorySequenceBlockController.php
@@ -403,7 +403,7 @@ class CurriculumInventorySequenceBlockController extends FOSRestController
 
         switch ($newValue) {
             case CurriculumInventorySequenceBlockInterface::ORDERED:
-                usort($children, [CurriculumInventorySequenceBlock::class, 'compareSequenceBlocksWithOrderedStrategy']);
+                usort($children, [CurriculumInventorySequenceBlock::class, 'compareSequenceBlocksWithDefaultStrategy']);
                 for ($i = 0, $n = count($children); $i < $n; $i++) {
                     $children[$i]->setOrderInSequence($i + 1);
                     $manager->update($children[$i]);


### PR DESCRIPTION
when switching the sort order of a block from parallel/unordered to ordered, we must re-sort nested blocks within.
this fix applies the correct strategy for sorting.