### PR TITLE
Add authentication for users with different schools

### DIFF
--- a/src/Ilios/AuthenticationBundle/Resources/config/entity_voters.yml
+++ b/src/Ilios/AuthenticationBundle/Resources/config/entity_voters.yml
@@ -1,6 +1,7 @@
 services:
     security.access.entity.authentication_voter:
         class: Ilios\AuthenticationBundle\Voter\Entity\AuthenticationEntityVoter
+        arguments: [ "@ilioscore.permission.manager" ]
         public: false
         tags:
             - { name: security.voter }

--- a/src/Ilios/AuthenticationBundle/Voter/Entity/AuthenticationEntityVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/Entity/AuthenticationEntityVoter.php
@@ -4,6 +4,7 @@ namespace Ilios\AuthenticationBundle\Voter\Entity;
 
 use Ilios\CoreBundle\Entity\AuthenticationInterface;
 use Ilios\CoreBundle\Entity\UserInterface;
+use Ilios\CoreBundle\Entity\Manager\PermissionManager;
 use Ilios\AuthenticationBundle\Voter\AbstractVoter;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -13,6 +14,16 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  */
 class AuthenticationEntityVoter extends AbstractVoter
 {
+    /**
+     * @var PermissionManager
+     */
+    protected $permissionManager;
+
+    public function __construct(PermissionManager $permissionManager)
+    {
+        $this->permissionManager = $permissionManager;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Ilios/CoreBundle/Tests/Controller/AuthenticationControllerTest.php
+++ b/src/Ilios/CoreBundle/Tests/Controller/AuthenticationControllerTest.php
@@ -305,4 +305,26 @@ class AuthenticationControllerTest extends AbstractControllerTest
         $response = $this->client->getResponse();
         $this->assertJsonResponse($response, Codes::HTTP_OK);
     }
+
+    /**
+     * @group controllers_a
+     */
+    public function testPostAuthenticationForUserWithNonPrimarySchool()
+    {
+        $data = $this->container->get('ilioscore.dataloader.authentication')
+            ->create();
+        //user4 is in school 2
+        $data['user'] = 4;
+
+        $this->createJsonRequest(
+            'POST',
+            $this->getUrl('post_authentications'),
+            json_encode(['authentication' => $data]),
+            $this->getAuthenticatedUserToken()
+        );
+
+        $response = $this->client->getResponse();
+
+        $this->assertEquals(Codes::HTTP_CREATED, $response->getStatusCode(), $response->getContent());
+    }
 }


### PR DESCRIPTION
We were not injecting the permissionsManager so it wasn't possible to
add authentication records for users in a different primary school than
the requester.

Fixes #1546