### PR TITLE
Improved composer install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,7 +60,7 @@ sudo -u apache git checkout tags/v3.0.0
 ```   
 5. Run the following command to build the packages and its dependencies.  This step assumes you have PHP 5.6+ and Composer installed on your system:
 ```bash
-sudo -u apache composer install
+sudo -u apache SYMFONY_ENV=prod composer install --no-dev --optimize-autoloader
 ```  
 This will install the required PHP Symfony packages and their dependencies.  When the process nears completion, you will be prompted with the following configuration setting options.  You should set them as noted:
 ```bash

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,7 +17,7 @@ _NOTE:_ The steps below assume that file ownership of the deployed codebase belo
 
  ```bash
 cd YOUR_ILIOS_APPLICATION_ROOT
-sudo -u apache composer install --no-dev
+sudo -u apache SYMFONY_ENV=prod composer install --no-dev --optimize-autoloader
 ```
 
 3. Execute any pending database migrations.


### PR DESCRIPTION
Adding the `SYMFONY_ENV` ensures that symfony’s cache clear command (which
runs at the end of composer install) gets the correct environment and
doesn't blow up on missing packages.

The `—optimize-autoloader` flag is recommended by symfony for production
installs.

Fixes #1549