### PR TITLE
Detect if a session exists before attempting to destroy it

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
@@ -120,8 +120,9 @@ class ShibbolethAuthentication implements AuthenticationInterface
     {
         $url = $request->getSchemeAndHttpHost();
         $logoutUrl = $url . $this->logoutPath;
-        session_unset();
-        session_destroy();
+        if (session_status() !== PHP_SESSION_NONE) {
+            session_destroy();
+        }
         return new JsonResponse(array(
             'status' => 'redirect',
             'logoutUrl' => $logoutUrl


### PR DESCRIPTION
This prevents cluttering up the logs with invalid attempts.

Fixes #1563