### PR TITLE
Don't set the session if we are unsetting the ILM session

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Session.php
+++ b/src/Ilios/CoreBundle/Entity/Session.php
@@ -404,7 +404,9 @@ class Session implements SessionInterface
     public function setIlmSession(IlmSessionInterface $ilmSession = null)
     {
         $this->ilmSession = $ilmSession;
-        $ilmSession->setSession($this);
+        if ($ilmSession) {
+            $ilmSession->setSession($this);
+        }
     }
 
     /**


### PR DESCRIPTION
When ILM is removed from a session we send NULL to this method.  We
should not then turn around and attempt to set the session on that NULL
values.

Fixes #1564