### PR TITLE
Enforce permission for archivable and lockable entities

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,4 +1,6 @@
 security:
+    access_decision_manager:
+      strategy: unanimous
     firewalls:
         api_docs:
             pattern:   ^/api/doc

--- a/src/Ilios/AuthenticationBundle/Service/JsonWebTokenManager.php
+++ b/src/Ilios/AuthenticationBundle/Service/JsonWebTokenManager.php
@@ -70,6 +70,18 @@ class JsonWebTokenManager
      */
     public function createJwtFromUser(UserInterface $user, $timeToLive = 'PT8H')
     {
+        return $this->createJwtFromUserId($user->getId(), $timeToLive);
+    }
+
+    /**
+     * Build a token from a userId
+     * @param  integer $userId
+     * @param string $timeToLive PHP DateInterval notation for the length of time the token shoud be valid
+     *
+     * @return string
+     */
+    public function createJwtFromUserId($userId, $timeToLive = 'PT8H')
+    {
         $requestedInterval = new \DateInterval($timeToLive);
         $maximumInterval = new \DateInterval('P364D');
         $interval = $requestedInterval > $maximumInterval?$maximumInterval:$requestedInterval;
@@ -82,7 +94,7 @@ class JsonWebTokenManager
             'aud' => self::TOKEN_AUD,
             'iat' => $now->format('U'),
             'exp' => $expires->format('U'),
-            'user_id' => $user->getId()
+            'user_id' => $userId
         );
 
         return JWT::encode($arr, $this->jwtKey);

--- a/src/Ilios/CoreBundle/Controller/CourseController.php
+++ b/src/Ilios/CoreBundle/Controller/CourseController.php
@@ -366,7 +366,7 @@ class CourseController extends FOSRestController
 
         $authChecker = $this->get('security.authorization_checker');
 
-        if (! $authChecker->isGranted(['modify'], $course)) {
+        if (! $authChecker->isGranted(['edit'], $course)) {
             throw $this->createAccessDeniedException('Unauthorized access!');
         }
 

--- a/tests/CoreBundle/Controller/CourseControllerTest.php
+++ b/tests/CoreBundle/Controller/CourseControllerTest.php
@@ -1255,4 +1255,33 @@ class CourseControllerTest extends AbstractControllerTest
         $this->assertEquals($newIlmData[0]['hours'], $ilms[0]['hours']);
         $this->assertEquals($newIlmData[1]['hours'], $ilms[1]['hours']);
     }
+
+    /**
+     * @group controllers_a
+     */
+    public function testRejectUnpriviledged()
+    {
+        $subject = $this->container
+            ->get('ilioscore.dataloader.course')
+            ->getOne()
+        ;
+        //unset any parameters which should not be POSTed
+        $id = $subject['id'];
+        unset($subject['id']);
+        unset($subject['learningMaterials']);
+        unset($subject['sessions']);
+        $userId = 3;
+
+        $this->canNot($userId, 'POST', $this->getUrl('post_courses'), json_encode(['course' => $subject]));
+        $this->canNot($userId, 'PUT', $this->getUrl('put_courses', ['id' => $id]), json_encode(['course' => $subject]));
+        $this->canNot($userId, 'PUT', $this->getUrl('put_courses', ['id' => $id * 10000]), json_encode(['course' => $subject]));
+        $this->canNot($userId, 'DELETE', $this->getUrl('delete_courses', ['id' => $id]));
+        $rolloverData = [
+            'id' => $id,
+            'year' => 2019,
+            'newStartDate' => 'false',
+            'skipOfferings' => 'false',
+        ];
+        $this->canNot($userId, 'POST', $this->getUrl('api_course_rollover_v1', $rolloverData));
+    }
 }

--- a/tests/CoreBundle/Controller/ProgramControllerTest.php
+++ b/tests/CoreBundle/Controller/ProgramControllerTest.php
@@ -472,7 +472,7 @@ class ProgramControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @group controllers_b_a
+     * @group controllers_b
      */
     public function testFilterBySchools()
     {
@@ -501,5 +501,27 @@ class ProgramControllerTest extends AbstractControllerTest
             ),
             $data[1]
         );
+    }
+
+    /**
+     * @group controllers_b
+     */
+    public function testRejectUnpriviledged()
+    {
+        $subject = $this->container
+            ->get('ilioscore.dataloader.program')
+            ->getOne()
+        ;
+        //unset any parameters which should not be POSTed
+        $id = $subject['id'];
+        unset($subject['id']);
+        unset($subject['programYears']);
+        unset($subject['curriculumInventoryReports']);
+        $userId = 3;
+
+        $this->canNot($userId, 'POST', $this->getUrl('post_programs'), json_encode(['program' => $subject]));
+        $this->canNot($userId, 'PUT', $this->getUrl('put_programs', ['id' => $id]), json_encode(['program' => $subject]));
+        $this->canNot($userId, 'PUT', $this->getUrl('put_programs', ['id' => $id * 10000]), json_encode(['program' => $subject]));
+        $this->canNot($userId, 'DELETE', $this->getUrl('delete_programs', ['id' => $id]));
     }
 }

--- a/tests/CoreBundle/Controller/ProgramYearControllerTest.php
+++ b/tests/CoreBundle/Controller/ProgramYearControllerTest.php
@@ -399,4 +399,25 @@ class ProgramYearControllerTest extends AbstractControllerTest
             $data[1]
         );
     }
+
+    /**
+     * @group controllers_b
+     */
+    public function testRejectUnpriviledged()
+    {
+        $subject = $this->container
+            ->get('ilioscore.dataloader.programyear')
+            ->getOne()
+        ;
+        //unset any parameters which should not be POSTed
+        $id = $subject['id'];
+        unset($subject['id']);
+        unset($subject['stewards']);
+        $userId = 3;
+
+        $this->canNot($userId, 'POST', $this->getUrl('post_programyears'), json_encode(['programYear' => $subject]));
+        $this->canNot($userId, 'PUT', $this->getUrl('put_programyears', ['id' => $id]), json_encode(['programYear' => $subject]));
+        $this->canNot($userId, 'PUT', $this->getUrl('put_programyears', ['id' => $id * 10000]), json_encode(['programYear' => $subject]));
+        $this->canNot($userId, 'DELETE', $this->getUrl('delete_programyears', ['id' => $id]));
+    }
 }


### PR DESCRIPTION
We were using a 'modify' keyword as well as doing voter lookup by
allowing a single yes voter to grant permissions.  Instead we need to
check with all voters and ensure we are looking for both 'delete' and
'modify' permissions.

Fixes #1576