### PR TITLE
Add ancestry to courses and objectives

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20160915043119.php
+++ b/app/Resources/DoctrineMigrations/Version20160915043119.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add ancestors to courses and objectives
+ */
+class Version20160915043119 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE course ADD ancestor_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE course ADD CONSTRAINT FK_169E6FB9C671CEA1 FOREIGN KEY (ancestor_id) REFERENCES course (course_id)');
+        $this->addSql('CREATE INDEX IDX_169E6FB9C671CEA1 ON course (ancestor_id)');
+        $this->addSql('ALTER TABLE objective ADD ancestor_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE objective ADD CONSTRAINT FK_B996F101C671CEA1 FOREIGN KEY (ancestor_id) REFERENCES objective (objective_id)');
+        $this->addSql('CREATE INDEX IDX_B996F101C671CEA1 ON objective (ancestor_id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE course DROP FOREIGN KEY FK_169E6FB9C671CEA1');
+        $this->addSql('DROP INDEX IDX_169E6FB9C671CEA1 ON course');
+        $this->addSql('ALTER TABLE course DROP ancestor_id');
+        $this->addSql('ALTER TABLE objective DROP FOREIGN KEY FK_B996F101C671CEA1');
+        $this->addSql('DROP INDEX IDX_B996F101C671CEA1 ON objective');
+        $this->addSql('ALTER TABLE objective DROP ancestor_id');
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/Course.php
+++ b/src/Ilios/CoreBundle/Entity/Course.php
@@ -346,6 +346,29 @@ class Course implements CourseInterface
     protected $sessions;
 
     /**
+     * @var CourseInterface
+     *
+     * @ORM\ManyToOne(targetEntity="Course", inversedBy="descendants")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="ancestor_id", referencedColumnName="course_id")
+     * })
+     *
+     * @JMS\Expose
+     * @JMS\Type("string")
+     */
+    protected $ancestor;
+
+    /**
+     * @var CourseInterface
+     *
+     * @ORM\OneToMany(targetEntity="Course", mappedBy="ancestor")
+     *
+     * @JMS\Expose
+     * @JMS\Type("array<string>")
+     */
+    protected $descendants;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -357,6 +380,7 @@ class Course implements CourseInterface
         $this->meshDescriptors = new ArrayCollection();
         $this->learningMaterials = new ArrayCollection();
         $this->sessions = new ArrayCollection();
+        $this->descendants = new ArrayCollection();
         $this->publishedAsTbd = false;
         $this->published = false;
         $this->archived = false;
@@ -589,5 +613,49 @@ class Course implements CourseInterface
     public function getLearningMaterials()
     {
         return $this->learningMaterials;
+    }
+
+    /**
+     * @param CourseInterface $parent
+     */
+    public function setAncestor(CourseInterface $ancestor = null)
+    {
+        $this->ancestor = $ancestor;
+    }
+
+    /**
+     * @return CourseInterface
+     */
+    public function getAncestor()
+    {
+        return $this->ancestor;
+    }
+
+    /**
+     * @param Collection $descendants
+     */
+    public function setDescendants(Collection $descendants)
+    {
+        $this->descendants = new ArrayCollection();
+
+        foreach ($descendants as $descendant) {
+            $this->addDescendant($descendant);
+        }
+    }
+
+    /**
+     * @param CourseInterface $descendant
+     */
+    public function addDescendant(CourseInterface $descendant)
+    {
+        $this->descendants->add($descendant);
+    }
+
+    /**
+     * @return ArrayCollection|CourseInterface[]
+     */
+    public function getDescendants()
+    {
+        return $this->descendants;
     }
 }

--- a/src/Ilios/CoreBundle/Entity/CourseInterface.php
+++ b/src/Ilios/CoreBundle/Entity/CourseInterface.php
@@ -154,4 +154,29 @@ interface CourseInterface extends
      * @return ArrayCollection|CourseLearningMaterialInterface[]
      */
     public function getLearningMaterials();
+
+    /**
+     * @param CourseInterface $ancestor
+     */
+    public function setAncestor(CourseInterface $ancestor);
+
+    /**
+     * @return CourseInterface
+     */
+    public function getAncestor();
+
+    /**
+     * @param Collection $children
+     */
+    public function setDescendants(Collection $children);
+
+    /**
+     * @param CourseInterface $child
+     */
+    public function addDescendant(CourseInterface $child);
+
+    /**
+     * @return ArrayCollection|CourseInterface[]
+     */
+    public function getDescendants();
 }

--- a/src/Ilios/CoreBundle/Entity/DTO/CourseDTO.php
+++ b/src/Ilios/CoreBundle/Entity/DTO/CourseDTO.php
@@ -140,6 +140,18 @@ class CourseDTO
      */
     public $sessions;
 
+    /**
+     * @var int
+     * @JMS\Type("string")
+     */
+    public $ancestor;
+
+    /**
+     * @var int[]
+     * @JMS\Type("array<string>")
+     */
+    public $descendants;
+
     public function __construct(
         $id,
         $title,
@@ -172,5 +184,6 @@ class CourseDTO
         $this->meshDescriptors = [];
         $this->learningMaterials = [];
         $this->sessions = [];
+        $this->descendants = [];
     }
 }

--- a/src/Ilios/CoreBundle/Entity/Objective.php
+++ b/src/Ilios/CoreBundle/Entity/Objective.php
@@ -153,6 +153,29 @@ class Objective implements ObjectiveInterface
     protected $meshDescriptors;
 
     /**
+     * @var ObjectiveInterface
+     *
+     * @ORM\ManyToOne(targetEntity="Objective", inversedBy="descendants")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="ancestor_id", referencedColumnName="objective_id")
+     * })
+     *
+     * @JMS\Expose
+     * @JMS\Type("string")
+     */
+    protected $ancestor;
+
+    /**
+     * @var ObjectiveInterface
+     *
+     * @ORM\OneToMany(targetEntity="Objective", mappedBy="ancestor")
+     *
+     * @JMS\Expose
+     * @JMS\Type("array<string>")
+     */
+    protected $descendants;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -163,6 +186,7 @@ class Objective implements ObjectiveInterface
         $this->parents = new ArrayCollection();
         $this->children = new ArrayCollection();
         $this->meshDescriptors = new ArrayCollection();
+        $this->descendants = new ArrayCollection();
     }
 
     /**
@@ -298,5 +322,49 @@ class Objective implements ObjectiveInterface
             $this->programYears->add($programYear);
             $programYear->addObjective($this);
         }
+    }
+
+    /**
+     * @param ObjectiveInterface $parent
+     */
+    public function setAncestor(ObjectiveInterface $ancestor = null)
+    {
+        $this->ancestor = $ancestor;
+    }
+
+    /**
+     * @return ObjectiveInterface
+     */
+    public function getAncestor()
+    {
+        return $this->ancestor;
+    }
+
+    /**
+     * @param Collection $descendants
+     */
+    public function setDescendants(Collection $descendants)
+    {
+        $this->descendants = new ArrayCollection();
+
+        foreach ($descendants as $descendant) {
+            $this->addDescendant($descendant);
+        }
+    }
+
+    /**
+     * @param ObjectiveInterface $descendant
+     */
+    public function addDescendant(ObjectiveInterface $descendant)
+    {
+        $this->descendants->add($descendant);
+    }
+
+    /**
+     * @return ArrayCollection|ObjectiveInterface[]
+     */
+    public function getDescendants()
+    {
+        return $this->descendants;
     }
 }

--- a/src/Ilios/CoreBundle/Entity/ObjectiveInterface.php
+++ b/src/Ilios/CoreBundle/Entity/ObjectiveInterface.php
@@ -76,4 +76,29 @@ interface ObjectiveInterface extends
      * @return ArrayCollection|MeshDescriptorInterface[]
      */
     public function getMeshDescriptors();
+
+    /**
+     * @param ObjectiveInterface $ancestor
+     */
+    public function setAncestor(ObjectiveInterface $ancestor);
+
+    /**
+     * @return ObjectiveInterface
+     */
+    public function getAncestor();
+
+    /**
+     * @param Collection $children
+     */
+    public function setDescendants(Collection $children);
+
+    /**
+     * @param ObjectiveInterface $child
+     */
+    public function addDescendant(ObjectiveInterface $child);
+
+    /**
+     * @return ArrayCollection|ObjectiveInterface[]
+     */
+    public function getDescendants();
 }

--- a/src/Ilios/CoreBundle/Form/Type/CourseType.php
+++ b/src/Ilios/CoreBundle/Form/Type/CourseType.php
@@ -65,6 +65,14 @@ class CourseType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])
+            ->add('ancestor', SingleRelatedType::class, [
+                'required' => false,
+                'entityName' => "IliosCoreBundle:Course"
+            ])
+            ->add('descendants', ManyRelatedType::class, [
+                'required' => false,
+                'entityName' => "IliosCoreBundle:Course"
+            ])
         ;
         $transformer = new RemoveMarkupTransformer();
         foreach (['title', 'externalId'] as $element) {

--- a/src/Ilios/CoreBundle/Form/Type/ObjectiveType.php
+++ b/src/Ilios/CoreBundle/Form/Type/ObjectiveType.php
@@ -51,6 +51,14 @@ class ObjectiveType extends AbstractType
                 'required' => false,
                 'entityName' => "IliosCoreBundle:MeshDescriptor"
             ])
+            ->add('ancestor', SingleRelatedType::class, [
+                'required' => false,
+                'entityName' => "IliosCoreBundle:Objective"
+            ])
+            ->add('descendants', ManyRelatedType::class, [
+                'required' => false,
+                'entityName' => "IliosCoreBundle:Objective"
+            ])
         ;
     }
 

--- a/tests/CoreBundle/Controller/CourseControllerTest.php
+++ b/tests/CoreBundle/Controller/CourseControllerTest.php
@@ -916,6 +916,58 @@ class CourseControllerTest extends AbstractControllerTest
     /**
      * @group controllers_a
      */
+    public function testFilterByAncestor()
+    {
+        $courses = $this->container->get('ilioscore.dataloader.course')->getAll();
+
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl('cget_courses', ['filters[ancestor]' => 3]),
+            null,
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_OK);
+        $data = json_decode($response->getContent(), true)['courses'];
+        $this->assertEquals(1, count($data), var_export($data, true));
+        $this->assertEquals(
+            $this->mockSerialize(
+                $courses[3]
+            ),
+            $data[0]
+        );
+    }
+
+    /**
+     * @group controllers_a
+     */
+    public function testFilterByAncestors()
+    {
+        $courses = $this->container->get('ilioscore.dataloader.course')->getAll();
+
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl('cget_courses', ['filters[ancestors]' => [3]]),
+            null,
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertJsonResponse($response, Codes::HTTP_OK);
+        $data = json_decode($response->getContent(), true)['courses'];
+        $this->assertEquals(1, count($data), var_export($data, true));
+        $this->assertEquals(
+            $this->mockSerialize(
+                $courses[3]
+            ),
+            $data[0]
+        );
+    }
+
+    /**
+     * @group controllers_a
+     */
     public function testRolloverCourse()
     {
         $course = $this->container

--- a/tests/CoreBundle/DataLoader/CourseData.php
+++ b/tests/CoreBundle/DataLoader/CourseData.php
@@ -28,7 +28,8 @@ class CourseData extends AbstractDataLoader
             'objectives' => ['2'],
             'meshDescriptors' => ["abc1"],
             'learningMaterials' => ['1', '2', '4'],
-            'sessions' => ['1', '2']
+            'sessions' => ['1', '2'],
+            'descendants' => []
         );
 
         $arr[] = array(
@@ -51,7 +52,8 @@ class CourseData extends AbstractDataLoader
             'objectives' => ['2', '4'],
             'meshDescriptors' => [],
             'learningMaterials' => [],
-            'sessions' => ['3', '5', '6', '7', '8']
+            'sessions' => ['3', '5', '6', '7', '8'],
+            'descendants' => []
         );
 
         $arr[] = array(
@@ -73,7 +75,8 @@ class CourseData extends AbstractDataLoader
             'objectives' => ['5'],
             'meshDescriptors' => [],
             'learningMaterials' => [],
-            'sessions' => []
+            'sessions' => [],
+            'descendants' => ['4']
         );
 
         $arr[] = array(
@@ -95,7 +98,9 @@ class CourseData extends AbstractDataLoader
             'objectives' => ['2'],
             'meshDescriptors' => [],
             'learningMaterials' => ["3"],
-            'sessions' => ["4"]
+            'sessions' => ["4"],
+            'ancestor' => '3',
+            'descendants' => []
         );
 
         return $arr;
@@ -123,7 +128,8 @@ class CourseData extends AbstractDataLoader
             'objectives' => [1],
             'meshDescriptors' => [],
             'learningMaterials' => [],
-            'sessions' => []
+            'sessions' => [],
+            'descendants' => []
         ];
     }
 

--- a/tests/CoreBundle/DataLoader/ObjectiveData.php
+++ b/tests/CoreBundle/DataLoader/ObjectiveData.php
@@ -17,7 +17,8 @@ class ObjectiveData extends AbstractDataLoader
             'sessions' => [],
             'parents' => [],
             'children' => ['2'],
-            'meshDescriptors' => []
+            'meshDescriptors' => [],
+            'descendants' => []
         );
 
         $arr[] = array(
@@ -28,7 +29,8 @@ class ObjectiveData extends AbstractDataLoader
             'sessions' => [],
             'parents' => ['1'],
             'children' => ['3'],
-            'meshDescriptors' => []
+            'meshDescriptors' => [],
+            'descendants' => []
         );
 
         $arr[] = array(
@@ -39,7 +41,8 @@ class ObjectiveData extends AbstractDataLoader
             'sessions' => ['1'],
             'parents' => ['2'],
             'children' => [],
-            'meshDescriptors' => []
+            'meshDescriptors' => [],
+            'descendants' => []
         );
 
         $arr[] = array(
@@ -50,7 +53,8 @@ class ObjectiveData extends AbstractDataLoader
             'sessions' => [],
             'parents' => [],
             'children' => [],
-            'meshDescriptors' => []
+            'meshDescriptors' => [],
+            'descendants' => []
         );
 
         $arr[] = array(
@@ -61,7 +65,8 @@ class ObjectiveData extends AbstractDataLoader
             'sessions' => [],
             'parents' => [],
             'children' => [],
-            'meshDescriptors' => ["abc1"]
+            'meshDescriptors' => ["abc1"],
+            'descendants' => []
         );
 
         $arr[] = array(
@@ -72,7 +77,8 @@ class ObjectiveData extends AbstractDataLoader
             'sessions' => ["4"],
             'parents' => [],
             'children' => [],
-            'meshDescriptors' => ["abc1"]
+            'meshDescriptors' => ["abc1"],
+            'descendants' => ['7']
         );
 
         $arr[] = array(
@@ -83,7 +89,9 @@ class ObjectiveData extends AbstractDataLoader
             'sessions' => ["4"],
             'parents' => [],
             'children' => [],
-            'meshDescriptors' => ["abc3"]
+            'meshDescriptors' => ["abc3"],
+            'ancestor' => '6',
+            'descendants' => []
         );
 
         return $arr;
@@ -101,6 +109,7 @@ class ObjectiveData extends AbstractDataLoader
             'parents' => ['1'],
             'children' => [],
             'meshDescriptors' => [],
+            'descendants' => []
 
         );
     }

--- a/tests/CoreBundle/Entity/CourseTest.php
+++ b/tests/CoreBundle/Entity/CourseTest.php
@@ -71,6 +71,7 @@ class CourseTest extends EntityBase
         $this->assertEmpty($this->object->getLearningMaterials());
         $this->assertEmpty($this->object->getSessions());
         $this->assertEmpty($this->object->getTerms());
+        $this->assertEmpty($this->object->getDescendants());
     }
 
     /**
@@ -221,5 +222,31 @@ class CourseTest extends EntityBase
     public function testSetTerms()
     {
         $this->entityCollectionSetTest('term', 'Term');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Course::setAncestor
+     * @covers Ilios\CoreBundle\Entity\Course::getAncestor
+     */
+    public function testSetAncestor()
+    {
+        $this->entitySetTest('ancestor', 'Course');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Course::addDescendant
+     */
+    public function testAddDescendant()
+    {
+        $this->entityCollectionAddTest('descendant', 'Course');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Course::getDescendants
+     * @covers Ilios\CoreBundle\Entity\Course::setDescendants
+     */
+    public function testGetDescendants()
+    {
+        $this->entityCollectionSetTest('descendant', 'Course');
     }
 }

--- a/tests/CoreBundle/Entity/ObjectiveTest.php
+++ b/tests/CoreBundle/Entity/ObjectiveTest.php
@@ -32,6 +32,21 @@ class ObjectiveTest extends EntityBase
         $this->object->setTitle('test');
         $this->validate(0);
     }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Course::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertEmpty($this->object->getMeshDescriptors());
+        $this->assertEmpty($this->object->getSessions());
+        $this->assertEmpty($this->object->getCourses());
+        $this->assertEmpty($this->object->getProgramYears());
+        $this->assertEmpty($this->object->getDescendants());
+        $this->assertEmpty($this->object->getParents());
+        $this->assertEmpty($this->object->getChildren());
+    }
+
     /**
      * @covers Ilios\CoreBundle\Entity\Objective::setTitle
      * @covers Ilios\CoreBundle\Entity\Objective::getTitle
@@ -144,5 +159,31 @@ class ObjectiveTest extends EntityBase
     public function testGetParents()
     {
         $this->entityCollectionSetTest('parent', 'Objective');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Objective::setAncestor
+     * @covers Ilios\CoreBundle\Entity\Objective::getAncestor
+     */
+    public function testSetAncestor()
+    {
+        $this->entitySetTest('ancestor', 'Objective');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Objective::addDescendant
+     */
+    public function testAddDescendant()
+    {
+        $this->entityCollectionAddTest('descendant', 'Objective');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Objective::getDescendants
+     * @covers Ilios\CoreBundle\Entity\Objective::setDescendants
+     */
+    public function testGetDescendants()
+    {
+        $this->entityCollectionSetTest('descendant', 'Objective');
     }
 }

--- a/tests/CoreBundle/Fixture/LoadCourseData.php
+++ b/tests/CoreBundle/Fixture/LoadCourseData.php
@@ -42,6 +42,9 @@ class LoadCourseData extends AbstractFixture implements
             $entity->setPublishedAsTbd($arr['publishedAsTbd']);
             $entity->setPublished($arr['published']);
             $entity->setSchool($this->getReference('schools' . $arr['school']));
+            if (array_key_exists('ancestor', $arr)) {
+                $entity->setAncestor($this->getReference('courses' . $arr['ancestor']));
+            }
             if (isset($arr['clerkshipType'])) {
                 $entity->setClerkshipType($this->getReference('courseClerkshipTypes' . $arr['clerkshipType']));
             }

--- a/tests/CoreBundle/Fixture/LoadObjectiveData.php
+++ b/tests/CoreBundle/Fixture/LoadObjectiveData.php
@@ -41,6 +41,9 @@ class LoadObjectiveData extends AbstractFixture implements
             foreach ($arr['meshDescriptors'] as $id) {
                 $entity->addMeshDescriptor($this->getReference('meshDescriptors' . $id));
             }
+            if (array_key_exists('ancestor', $arr)) {
+                $entity->setAncestor($this->getReference('objectives' . $arr['ancestor']));
+            }
             $manager->persist($entity);
             $this->addReference('objectives' . $arr['id'], $entity);
         }


### PR DESCRIPTION
We will use the ancestor to track where courses and objectives come from
during rollovers and reporting.

Refs #729