### PR TITLE
Fix flakey end of the year tests

### DIFF
--- a/tests/CoreBundle/Classes/CourseRolloverTest.php
+++ b/tests/CoreBundle/Classes/CourseRolloverTest.php
@@ -487,22 +487,30 @@ class CourseRolloverTest extends \PHPUnit_Framework_TestCase
         $newCourse
             ->shouldReceive('setStartDate')->with(m::on(function (DateTime $newStart) use ($course, $newStartDate) {
                 $oldStart = $course->getStartDate();
+                $expectedStartWeek = (int) $oldStart->format('W') + 16;
+                if ($expectedStartWeek > 52) {
+                    $expectedStartWeek = $expectedStartWeek - 52;
+                }
                 return (
                     $newStart->format('c') === $newStartDate->format('c') &&
                     //day of the week is the same
                     $oldStart->format('w') === $newStart->format('w') &&
                     //Week of the year is two weeks later
-                    (int) $oldStart->format('W') + 16 ===  (int) $newStart->format('W')
+                    $expectedStartWeek ===  (int) $newStart->format('W')
                 );
             }))->once();
 
         $newCourse->shouldReceive('setEndDate')->with(m::on(function (DateTime $newEnd) use ($course) {
             $oldEnd = $course->getEndDate();
+            $expectedEndWeek = (int) $oldEnd->format('W') + 16;
+            if ($expectedEndWeek > 52) {
+                $expectedEndWeek = $expectedEndWeek - 52;
+            }
             return (
                 //day of the week is the same
                 $oldEnd->format('w') === $newEnd->format('w') &&
                 //Week of the year is two weeks laters
-                (int) $oldEnd->format('W') + 16 ===  (int) $newEnd->format('W')
+                $expectedEndWeek ===  (int) $newEnd->format('W')
             );
         }))->once();
 
@@ -515,11 +523,15 @@ class CourseRolloverTest extends \PHPUnit_Framework_TestCase
                 $newOffering->shouldIgnoreMissing();
                 $newOffering->shouldReceive('setStartDate')->with(m::on(function (DateTime $newStart) use ($offering) {
                     $oldStart = $offering->getStartDate();
+                    $expectedStartWeek = (int) $oldStart->format('W') + 16;
+                    if ($expectedStartWeek > 52) {
+                        $expectedStartWeek = $expectedStartWeek - 52;
+                    }
                     return (
                         //day of the week is the same
                         $oldStart->format('w') === $newStart->format('w') &&
                         //Week of the year is the same
-                        (int) $oldStart->format('W') + 16 ===  (int) $newStart->format('W')
+                        $expectedStartWeek ===  (int) $newStart->format('W')
                     );
                 }))->once();
                 $newOffering->shouldReceive('setEndDate')->with(m::on(function (DateTime $newEnd) use ($offering) {


### PR DESCRIPTION
Some tests were getting messed up as they rolled within 16 weeks of the
end of the year.