### PR TITLE
Only include used levels in CI export

### DIFF
--- a/src/Ilios/CoreBundle/Entity/CurriculumInventoryAcademicLevelInterface.php
+++ b/src/Ilios/CoreBundle/Entity/CurriculumInventoryAcademicLevelInterface.php
@@ -5,8 +5,7 @@ namespace Ilios\CoreBundle\Entity;
 use Ilios\CoreBundle\Traits\DescribableEntityInterface;
 use Ilios\CoreBundle\Traits\IdentifiableEntityInterface;
 use Ilios\CoreBundle\Traits\NameableEntityInterface;
-
-use Ilios\CoreBundle\Entity\CurriculumInventoryReportInterface;
+use Doctrine\Common\Collections\Collection;
 
 /**
  * Interface CurriculumInventoryAcademicLevelInterface
@@ -36,4 +35,19 @@ interface CurriculumInventoryAcademicLevelInterface extends
      * @return CurriculumInventoryReportInterface
      */
     public function getReport();
+
+    /**
+     * @param Collection $sequenceBlocks
+     */
+    public function setSequenceBlocks(Collection $sequenceBlocks = null);
+
+    /**
+     * @param CurriculumInventorySequenceBlockInterface $sequenceBlock
+     */
+    public function addSequenceBlock(CurriculumInventorySequenceBlockInterface $sequenceBlock);
+
+    /**
+     * @return ArrayCollection|CurriculumInventorySequenceBlockInterface[]
+     */
+    public function getSequenceBlocks();
 }

--- a/src/Ilios/CoreBundle/Service/CurriculumInventory/Exporter.php
+++ b/src/Ilios/CoreBundle/Service/CurriculumInventory/Exporter.php
@@ -494,7 +494,10 @@ class Exporter
         //
         // Academic Levels
         //
-        $levels = $report->getAcademicLevels();
+        $levels = $report->getAcademicLevels()->filter(function (CurriculumInventoryAcademicLevelInterface $level) {
+            return $level->getSequenceBlocks()->count() > 0;
+        });
+
         $academicLevelsNode = $dom->createElement('AcademicLevels');
         $rootNode->appendChild($academicLevelsNode);
         $levelsInProgramNode = $dom->createElement('LevelsInProgram', $levels->count());


### PR DESCRIPTION
We pre-create a bunch of academic levels for a report, but we should
only include those levels which have a sequence block associated with
them in the final report.

Fixes #1584