### PR TITLE
When and empty username is sent store it as null

### DIFF
--- a/src/Ilios/CoreBundle/Form/Type/AuthenticationType.php
+++ b/src/Ilios/CoreBundle/Form/Type/AuthenticationType.php
@@ -7,6 +7,7 @@ use Ilios\CoreBundle\Form\Type\AbstractType\SingleRelatedType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * Class AuthenticationType
@@ -24,7 +25,9 @@ class AuthenticationType extends AbstractType
             ->add('user', SingleRelatedType::class, [
                 'entityName' => "IliosCoreBundle:User"
             ])
-            ->add('username')
+            ->add('username', TextType::class, [
+                'empty_data'  => null
+            ])
             ->add('passwordBcrypt')
         ;
         $transformer = new RemoveMarkupTransformer();

--- a/tests/CoreBundle/Controller/AuthenticationControllerTest.php
+++ b/tests/CoreBundle/Controller/AuthenticationControllerTest.php
@@ -327,4 +327,28 @@ class AuthenticationControllerTest extends AbstractControllerTest
 
         $this->assertEquals(Codes::HTTP_CREATED, $response->getStatusCode(), $response->getContent());
     }
+
+    /**
+     * @group controllers_a
+     */
+    public function testPutAuthenticationWithNoUsernameOrPassword()
+    {
+        $data = $this->container->get('ilioscore.dataloader.authentication')
+            ->create();
+        unset($data['username']);
+        unset($data['password']);
+
+        $this->createJsonRequest(
+            'POST',
+            $this->getUrl('post_authentications'),
+            json_encode(['authentication' => $data]),
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+        $this->assertEquals(Codes::HTTP_CREATED, $response->getStatusCode(), $response->getContent());
+        $this->assertSame(
+            ['user' => $data['user']],
+            json_decode($response->getContent(), true)['authentications'][0]
+        );
+    }
 }


### PR DESCRIPTION
Empty values were getting converted into blank strings which then caused
duplicate key errors in the DB.  Instead they need to be stored as NULL.

Fixes #1590