### PR TITLE
removed the line referencing 'UCSF' from the email template

### DIFF
--- a/src/Ilios/CoreBundle/Resources/views/Email/teachingreminder.text.twig
+++ b/src/Ilios/CoreBundle/Resources/views/Email/teachingreminder.text.twig
@@ -43,6 +43,3 @@ The learning objectives listed for this course are:
 For a complete review of the session details and its associated learning materials, visit the session details on your Ilios Calendar at {{ base_url }}/courses/{{ offering.session.course.id }}.
 
 If you would like to edit the details of this session and do not have editing rights in Ilios for this course please contact the School of {{ offering.session.course.school.title }}'s Curriculum Coordinator at {{ offering.session.course.school.iliosAdministratorEmail }}.
-
-A description of most classrooms, including maps, can be found at: http://edtech.ucsf.edu/classroom-services/scheduling/classroom-features
-


### PR DESCRIPTION
fixes #1596 