### PR TITLE
Log less information when there is a missing ship parameter

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
@@ -88,7 +88,22 @@ class ShibbolethAuthentication implements AuthenticationInterface
         $userId = $request->server->get($this->userIdAttribute);
         if (!$userId) {
             $msg =  "No '{$this->userIdAttribute}' found for authenticated user.";
-            $this->logger->error($msg, ['server vars' => var_export($_SERVER, true)]);
+            $logVars = [];
+
+            $shibProperties = [
+                'Shib-Session-ID',
+                'Shib-Authentication-Instant',
+                'Shib-Authentication-Method',
+                'Shib-Session-Index'
+            ];
+            foreach ($shibProperties as $key) {
+                $logVars[$key] = $request->server->get($key);
+            }
+
+            $logVars['HTTP_REFERER'] = $request->server->get('HTTP_REFERER');
+            $logVars['REMOTE_ADDR'] = $request->server->get('REMOTE_ADDR');
+
+            $this->logger->error($msg, ['server variables' => var_export($logVars, true)]);
             throw new \Exception($msg);
         }
         /* @var \Ilios\CoreBundle\Entity\AuthenticationInterface $authEntity */

--- a/tests/AuthenticationBundle/Service/ShibbolethAuthenticationTest.php
+++ b/tests/AuthenticationBundle/Service/ShibbolethAuthenticationTest.php
@@ -73,10 +73,17 @@ class ShibbolethAuthenticationTest extends TestCase
 
         $serverBag = m::mock('Symfony\Component\HttpFoundation\ServerBag')
             ->shouldReceive('get')->with('Shib-Application-ID')->andReturn(true)
+            ->shouldReceive('get')->with('Shib-Session-ID')->andReturn(true)
+            ->shouldReceive('get')->with('Shib-Authentication-Instant')->andReturn(true)
+            ->shouldReceive('get')->with('Shib-Authentication-Method')->andReturn(true)
+            ->shouldReceive('get')->with('Shib-Session-Index')->andReturn(true)
+            ->shouldReceive('get')->with('HTTP_REFERER')->andReturn(true)
+            ->shouldReceive('get')->with('REMOTE_ADDR')->andReturn(true)
             ->shouldReceive('get')->with('eppn')->andReturn(false)
             ->mock();
         $request = m::mock('Symfony\Component\HttpFoundation\Request');
         $request->server = $serverBag;
+        $logger->shouldReceive('error')->once();
         $this->setExpectedException('Exception');
         $obj->login($request);
     }


### PR DESCRIPTION
We were logging out the entire $_SERVER stack, but that is much more
information than we need to handle authentication issues.

Fixes #1471