### PR TITLE
When a course objective is removed unlink session objectives

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Course.php
+++ b/src/Ilios/CoreBundle/Entity/Course.php
@@ -692,4 +692,32 @@ class Course implements CourseInterface
             $administrator->removeAdministeredCourse($this);
         }
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function addObjective(ObjectiveInterface $objective)
+    {
+        if (!$this->objectives->contains($objective)) {
+            $this->objectives->add($objective);
+            $objective->addCourse($this);
+        }
+    }
+
+    /**
+     * When and objective is remove from a course it needs to remove any relationships
+     * to children that belong to sessions in that course
+     */
+    public function removeObjective(ObjectiveInterface $objective)
+    {
+        if ($this->objectives->contains($objective)) {
+            $this->objectives->removeElement($objective);
+            $objective->removeCourse($this);
+            foreach ($this->getSessions() as $session) {
+                foreach ($session->getObjectives() as $sessionObjective) {
+                    $sessionObjective->removeParent($objective);
+                }
+            }
+        }
+    }
 }

--- a/tests/CoreBundle/Controller/SessionControllerTest.php
+++ b/tests/CoreBundle/Controller/SessionControllerTest.php
@@ -1108,12 +1108,18 @@ class SessionControllerTest extends AbstractControllerTest
             unset($arr['updatedAt']);
             return $arr;
         }, json_decode($response->getContent(), true)['sessions']);
-        $this->assertEquals(1, count($data), var_export($data, true));
+        $this->assertEquals(2, count($data), var_export($data, true));
         $this->assertEquals(
             $this->mockSerialize(
                 $sessions[0]
             ),
             $data[0]
+        );
+        $this->assertEquals(
+            $this->mockSerialize(
+                $sessions[3]
+            ),
+            $data[1]
         );
     }
 

--- a/tests/CoreBundle/Controller/SessionTypeControllerTest.php
+++ b/tests/CoreBundle/Controller/SessionTypeControllerTest.php
@@ -432,12 +432,18 @@ class SessionTypeControllerTest extends AbstractControllerTest
 
         $this->assertJsonResponse($response, Codes::HTTP_OK);
         $data = json_decode($response->getContent(), true)['sessionTypes'];
-        $this->assertEquals(1, count($data), var_export($data, true));
+        $this->assertEquals(2, count($data), var_export($data, true));
         $this->assertEquals(
             $this->mockSerialize(
                 $sessionTypes[0]
             ),
             $data[0]
+        );
+        $this->assertEquals(
+            $this->mockSerialize(
+                $sessionTypes[1]
+            ),
+            $data[1]
         );
     }
 

--- a/tests/CoreBundle/DataLoader/ObjectiveData.php
+++ b/tests/CoreBundle/DataLoader/ObjectiveData.php
@@ -28,7 +28,7 @@ class ObjectiveData extends AbstractDataLoader
             'programYears' => ['1'],
             'sessions' => ['1'],
             'parents' => ['1'],
-            'children' => ['3'],
+            'children' => ['3', '6'],
             'meshDescriptors' => ['abc1'],
             'descendants' => ['3']
         );
@@ -76,7 +76,7 @@ class ObjectiveData extends AbstractDataLoader
             'courses' => [],
             'programYears' => [],
             'sessions' => ["4"],
-            'parents' => [],
+            'parents' => ['2'],
             'children' => [],
             'meshDescriptors' => ["abc1"],
             'descendants' => ['7']

--- a/tests/CoreBundle/Entity/CourseTest.php
+++ b/tests/CoreBundle/Entity/CourseTest.php
@@ -363,4 +363,46 @@ class CourseTest extends EntityBase
     {
         $this->entityCollectionSetTest('administrator', 'User', false, false, 'addAdministeredCourse');
     }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Course::addObjective
+     */
+    public function testAddObjective()
+    {
+        $this->entityCollectionAddTest('objective', 'Objective', false, false, 'addCourse');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Course::removeObjective
+     */
+    public function testRemoveObjective()
+    {
+        $this->entityCollectionRemoveTest('objective', 'Objective', false, false, false, 'removeCourse');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Course::getObjectives
+     */
+    public function testGetObjectives()
+    {
+        $this->entityCollectionSetTest('objective', 'Objective', false, false, 'addCourse');
+    }
+
+    /**
+     * @covers Ilios\CoreBundle\Entity\Course::removeObjective
+     */
+    public function testRemoveObjectiveWithSessionChildren()
+    {
+        $sessionObjective = m::mock('Ilios\CoreBundle\Entity\Objective');
+        $session = m::mock('Ilios\CoreBundle\Entity\Session');
+        $this->object->addSession($session);
+        $courseObjective = m::mock('Ilios\CoreBundle\Entity\Objective');
+        $courseObjective->shouldReceive('addCourse')->with($this->object)->once();
+        $courseObjective->shouldReceive('removeCourse')->with($this->object)->once();
+
+        $session->shouldReceive('getObjectives')->andReturn([$sessionObjective])->once();
+        $sessionObjective->shouldReceive('removeParent')->with($courseObjective)->once();
+        $this->object->addObjective($courseObjective);
+        $this->object->removeObjective($courseObjective);
+    }
 }


### PR DESCRIPTION
The link between course objectives and session objectives is not
something the DB can remove on its own, we have to look for an remove
this ourselves.

Fixes #1597