### PR TITLE
prefixed Ilios namespace with slash.

### DIFF
--- a/tests/AuthenticationBundle/Voter/AamcResourceTypeVoterTest.php
+++ b/tests/AuthenticationBundle/Voter/AamcResourceTypeVoterTest.php
@@ -29,7 +29,7 @@ class AamcResourceTypeVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnViewProvider
-     * @covers Ilios\AuthenticationBundle\Voter\AamcResourceTypeVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\AamcResourceTypeVoter::vote
      */
     public function testVoteOnView($token, AamcResourceTypeInterface $object, $expectedOutcome, $message)
     {
@@ -39,7 +39,7 @@ class AamcResourceTypeVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnCreateProvider
-     * @covers Ilios\AuthenticationBundle\Voter\AamcResourceTypeVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\AamcResourceTypeVoter::vote
      * @no
      */
     public function testVoteOnCreate($token, AamcResourceTypeInterface $object, $expectedOutcome, $message)
@@ -50,7 +50,7 @@ class AamcResourceTypeVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnEditProvider
-     * @covers Ilios\AuthenticationBundle\Voter\AamcResourceTypeVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\AamcResourceTypeVoter::vote
      */
     public function testVoteOnEdit($token, AamcResourceTypeInterface $object, $expectedOutcome, $message)
     {
@@ -60,7 +60,7 @@ class AamcResourceTypeVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnDeleteProvider
-     * @covers Ilios\AuthenticationBundle\Voter\AamcResourceTypeVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\AamcResourceTypeVoter::vote
      */
     public function testVoteOnDelete($token, AamcResourceTypeInterface $object, $expectedOutcome, $message)
     {

--- a/tests/AuthenticationBundle/Voter/DTO/SchoolDTOVoterTest.php
+++ b/tests/AuthenticationBundle/Voter/DTO/SchoolDTOVoterTest.php
@@ -29,7 +29,7 @@ class SchoolDTOVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnViewAccessProvider
-     * @covers Ilios\AuthenticationBundle\Voter\DTO\SchoolDTOVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\DTO\SchoolDTOVoter::vote
      */
     public function testVoteOnViewAccess($token, SchoolDTO $object, $expectedOutcome, $message)
     {

--- a/tests/AuthenticationBundle/Voter/Entity/SchoolEntityVoterTest.php
+++ b/tests/AuthenticationBundle/Voter/Entity/SchoolEntityVoterTest.php
@@ -34,7 +34,7 @@ class SchoolEntityVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnViewAccessProvider
-     * @covers Ilios\AuthenticationBundle\Voter\Entity\SchoolEntityVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\Entity\SchoolEntityVoter::vote
      */
     public function testVoteOnViewAccess($token, SchoolInterface $object, $expectedOutcome, $message)
     {

--- a/tests/AuthenticationBundle/Voter/UsereventVoterTest.php
+++ b/tests/AuthenticationBundle/Voter/UsereventVoterTest.php
@@ -28,7 +28,7 @@ class UsereventVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnViewAccessAsDeveloperProvider
-     * @covers Ilios\AuthenticationBundle\Voter\UsereventVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\UsereventVoter::vote
      */
     public function testVoteOnViewAccessAsDeveloper($token, UserEvent $object, $expectedOutcome, $message)
     {
@@ -37,7 +37,7 @@ class UsereventVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnViewAccessAsFacultyProvider
-     * @covers Ilios\AuthenticationBundle\Voter\UsereventVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\UsereventVoter::vote
      */
     public function testVoteOnViewAccessAsFaculty($token, UserEvent $object, $expectedOutcome, $message)
     {
@@ -46,7 +46,7 @@ class UsereventVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnViewAccessAsDirectorProvider
-     * @covers Ilios\AuthenticationBundle\Voter\UsereventVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\UsereventVoter::vote
      */
     public function testVoteOnViewAccessAsDirector($token, UserEvent $object, $expectedOutcome, $message)
     {
@@ -55,7 +55,7 @@ class UsereventVoterTest extends AbstractVoterTestCase
 
     /**
      * @dataProvider testVoteOnViewAccessAsStudentProvider
-     * @covers Ilios\AuthenticationBundle\Voter\UsereventVoter::vote
+     * @covers \Ilios\AuthenticationBundle\Voter\UsereventVoter::vote
      */
     public function testVoteOnViewAccessAsStudent($token, UserEvent $object, $expectedOutcome, $message)
     {

--- a/tests/CliBundle/Command/AuditLogExportCommandTest.php
+++ b/tests/CliBundle/Command/AuditLogExportCommandTest.php
@@ -47,7 +47,7 @@ class AuditLogExportCommandTest extends WebTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\InstallFirstUserCommand::execute
+     * @covers \Ilios\CliBundle\Command\InstallFirstUserCommand::execute
      */
     public function testExecuteWithDefaultRange()
     {
@@ -61,7 +61,7 @@ class AuditLogExportCommandTest extends WebTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\InstallFirstUserCommand::execute
+     * @covers \Ilios\CliBundle\Command\InstallFirstUserCommand::execute
      */
     public function testExecuteWithCustomRange()
     {
@@ -77,7 +77,7 @@ class AuditLogExportCommandTest extends WebTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\InstallFirstUserCommand::execute
+     * @covers \Ilios\CliBundle\Command\InstallFirstUserCommand::execute
      */
     public function testExecuteWithDeletion()
     {

--- a/tests/CliBundle/Command/SendChangeAlertsCommandTest.php
+++ b/tests/CliBundle/Command/SendChangeAlertsCommandTest.php
@@ -97,7 +97,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
      * @dataProvider testExecuteProvider
      *
      * @param AlertInterface $alert
@@ -179,7 +179,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
      * @dataProvider testExecuteProvider
      *
      * @param AlertInterface $alert
@@ -205,7 +205,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
      */
     public function testExecuteNoPendingAlerts()
     {
@@ -216,7 +216,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
         $this->assertEquals('No undispatched offering alerts found.', trim($output));
     }
     /**
-     * @covers Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
      * @dataProvider testExecuteNoRecipientsConfiguredProvider
      *
      * @param AlertInterface $alert
@@ -239,7 +239,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
      * @dataProvider testExecuteRecipientWithoutEmailProvider
      *
      * @param AlertInterface $alert
@@ -262,7 +262,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendChangeAlertsCommand::execute
      * @dataProvider testExecuteDeletedOfferingProvider
      *
      * @param AlertInterface $alert

--- a/tests/CliBundle/Command/SendTeachingRemindersCommandTest.php
+++ b/tests/CliBundle/Command/SendTeachingRemindersCommandTest.php
@@ -91,7 +91,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteDryRun()
     {
@@ -165,7 +165,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteDryRunWithNoResult()
     {
@@ -185,7 +185,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteDryRunWithSenderName()
     {
@@ -208,7 +208,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteDryRunWithCustomSubject()
     {
@@ -229,7 +229,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecute()
     {
@@ -247,7 +247,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteWithMissingInput()
     {
@@ -262,7 +262,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
+     * @covers \Ilios\CliBundle\Command\SendTeachingRemindersCommand::execute
      */
     public function testExecuteWithInvalidInput()
     {

--- a/tests/CoreBundle/Controller/CurriculumInventoryDownloadControllerTest.php
+++ b/tests/CoreBundle/Controller/CurriculumInventoryDownloadControllerTest.php
@@ -32,7 +32,7 @@ class CurriculumInventoryDownloadControllerTest extends WebTestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Controller\CurriculumInventoryDownloadController::getAction
+     * @covers \Ilios\CoreBundle\Controller\CurriculumInventoryDownloadController::getAction
      * @group controllers_a
      */
     public function testGetCurriculumInventoryDownload()

--- a/tests/CoreBundle/Controller/CurriculumInventoryExportControllerTest.php
+++ b/tests/CoreBundle/Controller/CurriculumInventoryExportControllerTest.php
@@ -36,7 +36,7 @@ class CurriculumInventoryExportControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\Controller\CurriculumInventoryExportController::postAction
+     * @covers \Ilios\CoreBundle\Controller\CurriculumInventoryExportController::postAction
      * @group controllers_a
      */
     public function testPostCurriculumInventoryExport()

--- a/tests/CoreBundle/Controller/PermissionControllerTest.php
+++ b/tests/CoreBundle/Controller/PermissionControllerTest.php
@@ -31,7 +31,7 @@ class PermissionControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\Controller\PermissionController::getAction
+     * @covers \Ilios\CoreBundle\Controller\PermissionController::getAction
      * @group controllers_b
      */
     public function testGetPermission()
@@ -61,7 +61,7 @@ class PermissionControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\Controller\PermissionController::cgetAction
+     * @covers \Ilios\CoreBundle\Controller\PermissionController::cgetAction
      * @group controllers_b
      */
     public function testGetAllPermissions()
@@ -81,7 +81,7 @@ class PermissionControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\Controller\PermissionController::postAction
+     * @covers \Ilios\CoreBundle\Controller\PermissionController::postAction
      * @group controllers_b
      */
     public function testPostPermission()
@@ -110,7 +110,7 @@ class PermissionControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\Controller\PermissionController::postAction
+     * @covers \Ilios\CoreBundle\Controller\PermissionController::postAction
      * @group controllers_b
      */
     public function testPostBadPermission()
@@ -132,7 +132,7 @@ class PermissionControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\Controller\PermissionController::putAction
+     * @covers \Ilios\CoreBundle\Controller\PermissionController::putAction
      * @group controllers_b
      */
     public function testPutPermission()
@@ -164,7 +164,7 @@ class PermissionControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\Controller\PermissionController::deleteAction
+     * @covers \Ilios\CoreBundle\Controller\PermissionController::deleteAction
      * @group controllers
      */
     public function testDeletePermission()
@@ -201,7 +201,7 @@ class PermissionControllerTest extends AbstractControllerTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\Controller\PermissionController::getAction
+     * @covers \Ilios\CoreBundle\Controller\PermissionController::getAction
      * @group controllers
      */
     public function testPermissionNotFound()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadAamcMethodDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadAamcMethodDataTest.php
@@ -29,7 +29,7 @@ class LoadAamcMethodDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadAamcMethodData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadAamcMethodData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadAamcPcrsDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadAamcPcrsDataTest.php
@@ -29,7 +29,7 @@ class LoadAamcPcrsDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadAamcPcrsData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadAamcPcrsData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadAamcResourceTypeTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadAamcResourceTypeTest.php
@@ -29,7 +29,7 @@ class LoadAamcResourceTypeDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadAamcResourceTypeData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadAamcResourceTypeData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadAlertChangeTypeDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadAlertChangeTypeDataTest.php
@@ -29,7 +29,7 @@ class LoadAlertChangeTypeDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadAlertChangeTypeData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadAlertChangeTypeData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadAssessmentOptionDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadAssessmentOptionDataTest.php
@@ -29,7 +29,7 @@ class LoadAssessmentOptionDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadAssessmentOptionData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadAssessmentOptionData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadCompetencyAamcPcrsDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadCompetencyAamcPcrsDataTest.php
@@ -29,7 +29,7 @@ class LoadCompetencyAmcPcrsDataTest extends AbstractDataFixtureTest
         ];
     }
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadCompetencyAamcPcrsData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadCompetencyAamcPcrsData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadCompetencyDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadCompetencyDataTest.php
@@ -29,7 +29,7 @@ class LoadCompetencyDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadCompetencyData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadCompetencyData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadCourseClerkshipTypeDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadCourseClerkshipTypeDataTest.php
@@ -29,7 +29,7 @@ class LoadCourseClerkshipTypeDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadCourseClerkshipTypeData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadCourseClerkshipTypeData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadCurriculumInventoryInstitutionDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadCurriculumInventoryInstitutionDataTest.php
@@ -29,7 +29,7 @@ class LoadCurriculumInventoryInstitutionDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadCurriculumInventoryInstitutionData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadCurriculumInventoryInstitutionData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadDepartmentDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadDepartmentDataTest.php
@@ -29,7 +29,7 @@ class LoadDepartmentDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadDepartmentData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadDepartmentData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadLearningMaterialStatusDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadLearningMaterialStatusDataTest.php
@@ -29,7 +29,7 @@ class LoadLearningMaterialStatusDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadLearningMaterialStatusData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadLearningMaterialStatusData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadLearningMaterialUserRoleDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadLearningMaterialUserRoleDataTest.php
@@ -29,7 +29,7 @@ class LoadLearningMaterialUserRoleDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadLearningMaterialUserRoleData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadLearningMaterialUserRoleData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshConceptDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshConceptDataTest.php
@@ -29,7 +29,7 @@ class LoadMeshConceptDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshConceptData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshConceptData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshConceptSemanticTypeDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshConceptSemanticTypeDataTest.php
@@ -30,7 +30,7 @@ class LoadMeshConceptSemanticTypeDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshConceptSemanticTypeData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshConceptSemanticTypeData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshConceptTermDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshConceptTermDataTest.php
@@ -30,7 +30,7 @@ class LoadMeshConceptTermDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshConceptTermData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshConceptTermData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshDescriptorConceptDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshDescriptorConceptDataTest.php
@@ -30,7 +30,7 @@ class LoadMeshDescriptorConceptDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshDescriptorConceptData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshDescriptorConceptData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshDescriptorDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshDescriptorDataTest.php
@@ -29,7 +29,7 @@ class LoadMeshDescriptorDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshDescriptorData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshDescriptorData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshDescriptorQualifierDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshDescriptorQualifierDataTest.php
@@ -30,7 +30,7 @@ class LoadMeshDescriptorQualifierDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshDescriptorQualifierData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshDescriptorQualifierData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshPreviousIndexingDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshPreviousIndexingDataTest.php
@@ -29,7 +29,7 @@ class LoadMeshPreviousIndexingDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshPreviousIndexingData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshPreviousIndexingData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshQualifierDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshQualifierDataTest.php
@@ -29,7 +29,7 @@ class LoadMeshQualifierDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshQualifierData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshQualifierData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshSemanticTypeDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshSemanticTypeDataTest.php
@@ -29,7 +29,7 @@ class LoadMeshSemanticTypeDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshSemanticTypeData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshSemanticTypeData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshTermDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshTermDataTest.php
@@ -29,7 +29,7 @@ class LoadMeshTermDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshTermData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshTermData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadMeshTreeDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadMeshTreeDataTest.php
@@ -29,7 +29,7 @@ class LoadMeshTreeDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadMeshTreeData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadMeshTreeData::load
      * @group mesh_data_import
      */
     public function testLoad()

--- a/tests/CoreBundle/DataFixtures/ORM/LoadSchoolDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadSchoolDataTest.php
@@ -29,7 +29,7 @@ class LoadSchoolDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadSchoolData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadSchoolData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadSessionTypeAamcMethodDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadSessionTypeAamcMethodDataTest.php
@@ -30,7 +30,7 @@ class LoadSessionTypeAamcMethodDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadSessionTypeAamcMethodData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadSessionTypeAamcMethodData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadSessionTypeDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadSessionTypeDataTest.php
@@ -29,7 +29,7 @@ class LoadSessionTypeDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadSessionTypeData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadSessionTypeData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadTermDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadTermDataTest.php
@@ -29,7 +29,7 @@ class LoadTermDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadTermData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadTermData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadUserRoleDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadUserRoleDataTest.php
@@ -29,7 +29,7 @@ class LoadUserRoleDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadUserRoleData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadUserRoleData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/DataFixtures/ORM/LoadVocabularyDataTest.php
+++ b/tests/CoreBundle/DataFixtures/ORM/LoadVocabularyDataTest.php
@@ -29,7 +29,7 @@ class LoadVocabularyDataTest extends AbstractDataFixtureTest
     }
 
     /**
-     * @covers Ilios\CoreBundle\DataFixtures\ORM\LoadVocabularyData::load
+     * @covers \Ilios\CoreBundle\DataFixtures\ORM\LoadVocabularyData::load
      */
     public function testLoad()
     {

--- a/tests/CoreBundle/Entity/AamcMethodTest.php
+++ b/tests/CoreBundle/Entity/AamcMethodTest.php
@@ -36,7 +36,7 @@ class AamcMethodTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcMethod::__construct
+     * @covers \Ilios\CoreBundle\Entity\AamcMethod::__construct
      */
     public function testConstructor()
     {
@@ -44,8 +44,8 @@ class AamcMethodTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcMethod::setDescription
-     * @covers Ilios\CoreBundle\Entity\AamcMethod::getDescription
+     * @covers \Ilios\CoreBundle\Entity\AamcMethod::setDescription
+     * @covers \Ilios\CoreBundle\Entity\AamcMethod::getDescription
      */
     public function testSetDescription()
     {
@@ -53,7 +53,7 @@ class AamcMethodTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcMethod::addSessionType
+     * @covers \Ilios\CoreBundle\Entity\AamcMethod::addSessionType
      */
     public function testAddSessionType()
     {
@@ -61,7 +61,7 @@ class AamcMethodTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcMethod::removeSessionType
+     * @covers \Ilios\CoreBundle\Entity\AamcMethod::removeSessionType
      */
     public function testRemoveSessionType()
     {
@@ -69,7 +69,7 @@ class AamcMethodTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcMethod::getSessionTypes
+     * @covers \Ilios\CoreBundle\Entity\AamcMethod::getSessionTypes
      */
     public function testGetSessionTypes()
     {

--- a/tests/CoreBundle/Entity/AamcPcrsTest.php
+++ b/tests/CoreBundle/Entity/AamcPcrsTest.php
@@ -36,7 +36,7 @@ class AamcPcrsTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcPcrs::__construct
+     * @covers \Ilios\CoreBundle\Entity\AamcPcrs::__construct
      */
     public function testConstructor()
     {
@@ -44,9 +44,9 @@ class AamcPcrsTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcPcrs::setDescription
-     * @covers Ilios\CoreBundle\Entity\AamcPcrs::getDescription
-     * @covers Ilios\CoreBundle\Entity\AamcPcrs::getDescription
+     * @covers \Ilios\CoreBundle\Entity\AamcPcrs::setDescription
+     * @covers \Ilios\CoreBundle\Entity\AamcPcrs::getDescription
+     * @covers \Ilios\CoreBundle\Entity\AamcPcrs::getDescription
      */
     public function testSetDescription()
     {
@@ -54,7 +54,7 @@ class AamcPcrsTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcPcrs::addCompetency
+     * @covers \Ilios\CoreBundle\Entity\AamcPcrs::addCompetency
      */
     public function testAddCompetency()
     {
@@ -62,7 +62,7 @@ class AamcPcrsTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcPcrs::getCompetencies
+     * @covers \Ilios\CoreBundle\Entity\AamcPcrs::getCompetencies
      */
     public function testGetCompetencies()
     {
@@ -76,7 +76,7 @@ class AamcPcrsTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcPcrs::removeCompetency
+     * @covers \Ilios\CoreBundle\Entity\AamcPcrs::removeCompetency
      */
     public function testRemoveCompetency()
     {

--- a/tests/CoreBundle/Entity/AamcResourceTypeTest.php
+++ b/tests/CoreBundle/Entity/AamcResourceTypeTest.php
@@ -38,7 +38,7 @@ class AamcResourceTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcResourceType::__construct
+     * @covers \Ilios\CoreBundle\Entity\AamcResourceType::__construct
      */
     public function testConstructor()
     {
@@ -46,8 +46,8 @@ class AamcResourceTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcResourceType::setTitle
-     * @covers Ilios\CoreBundle\Entity\AamcResourceType::getTitle
+     * @covers \Ilios\CoreBundle\Entity\AamcResourceType::setTitle
+     * @covers \Ilios\CoreBundle\Entity\AamcResourceType::getTitle
      */
     public function testSetTitle()
     {
@@ -55,8 +55,8 @@ class AamcResourceTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcResourceType::setDescription
-     * @covers Ilios\CoreBundle\Entity\AamcResourceType::getDescription
+     * @covers \Ilios\CoreBundle\Entity\AamcResourceType::setDescription
+     * @covers \Ilios\CoreBundle\Entity\AamcResourceType::getDescription
      */
     public function testSetDescription()
     {
@@ -64,7 +64,7 @@ class AamcResourceTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcResourceType::addTerm
+     * @covers \Ilios\CoreBundle\Entity\AamcResourceType::addTerm
      */
     public function testAddTerm()
     {
@@ -72,7 +72,7 @@ class AamcResourceTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcResourceType::removeTerm
+     * @covers \Ilios\CoreBundle\Entity\AamcResourceType::removeTerm
      */
     public function testRemoveTerm()
     {
@@ -80,7 +80,7 @@ class AamcResourceTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AamcResourceType::getTerms
+     * @covers \Ilios\CoreBundle\Entity\AamcResourceType::getTerms
      */
     public function testGetTerms()
     {

--- a/tests/CoreBundle/Entity/AlertChangeTypeTest.php
+++ b/tests/CoreBundle/Entity/AlertChangeTypeTest.php
@@ -33,7 +33,7 @@ class AlertChangeTypeTest extends EntityBase
         $this->validate(0);
     }
     /**
-     * @covers Ilios\CoreBundle\Entity\AlertChangeType::__construct
+     * @covers \Ilios\CoreBundle\Entity\AlertChangeType::__construct
      */
     public function testConstructor()
     {
@@ -41,8 +41,8 @@ class AlertChangeTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AlertChangeType::setTitle
-     * @covers Ilios\CoreBundle\Entity\AlertChangeType::getTitle
+     * @covers \Ilios\CoreBundle\Entity\AlertChangeType::setTitle
+     * @covers \Ilios\CoreBundle\Entity\AlertChangeType::getTitle
      */
     public function testSetTitle()
     {
@@ -50,7 +50,7 @@ class AlertChangeTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AlertChangeType::addAlert
+     * @covers \Ilios\CoreBundle\Entity\AlertChangeType::addAlert
      */
     public function testAddAlert()
     {
@@ -58,7 +58,7 @@ class AlertChangeTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AlertChangeType::removeAlert
+     * @covers \Ilios\CoreBundle\Entity\AlertChangeType::removeAlert
      */
     public function testRemoveAlert()
     {
@@ -66,7 +66,7 @@ class AlertChangeTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AlertChangeType::getAlerts
+     * @covers \Ilios\CoreBundle\Entity\AlertChangeType::getAlerts
      */
     public function testGetAlerts()
     {

--- a/tests/CoreBundle/Entity/AlertTest.php
+++ b/tests/CoreBundle/Entity/AlertTest.php
@@ -36,7 +36,7 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::__construct
+     * @covers \Ilios\CoreBundle\Entity\Alert::__construct
      */
     public function testConstructor()
     {
@@ -46,8 +46,8 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::setTableName
-     * @covers Ilios\CoreBundle\Entity\Alert::getTableName
+     * @covers \Ilios\CoreBundle\Entity\Alert::setTableName
+     * @covers \Ilios\CoreBundle\Entity\Alert::getTableName
      */
     public function testSetTableName()
     {
@@ -55,8 +55,8 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::setAdditionalText
-     * @covers Ilios\CoreBundle\Entity\Alert::getAdditionalText
+     * @covers \Ilios\CoreBundle\Entity\Alert::setAdditionalText
+     * @covers \Ilios\CoreBundle\Entity\Alert::getAdditionalText
      */
     public function testSetAdditionalText()
     {
@@ -64,8 +64,8 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::setDispatched
-     * @covers Ilios\CoreBundle\Entity\Alert::isDispatched
+     * @covers \Ilios\CoreBundle\Entity\Alert::setDispatched
+     * @covers \Ilios\CoreBundle\Entity\Alert::isDispatched
      */
     public function testSetDispatched()
     {
@@ -73,7 +73,7 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::addChangeType
+     * @covers \Ilios\CoreBundle\Entity\Alert::addChangeType
      */
     public function testAddChangeType()
     {
@@ -81,7 +81,7 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::removeChangeType
+     * @covers \Ilios\CoreBundle\Entity\Alert::removeChangeType
      */
     public function testRemoveChangeType()
     {
@@ -89,8 +89,8 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::getChangeTypes
-     * @covers Ilios\CoreBundle\Entity\Alert::setChangeTypes
+     * @covers \Ilios\CoreBundle\Entity\Alert::getChangeTypes
+     * @covers \Ilios\CoreBundle\Entity\Alert::setChangeTypes
      */
     public function testGetChangeTypes()
     {
@@ -98,7 +98,7 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::addInstigator
+     * @covers \Ilios\CoreBundle\Entity\Alert::addInstigator
      */
     public function testAddInstigator()
     {
@@ -106,7 +106,7 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::removeInstigator
+     * @covers \Ilios\CoreBundle\Entity\Alert::removeInstigator
      */
     public function testRemoveInstigator()
     {
@@ -114,8 +114,8 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::getInstigators
-     * @covers Ilios\CoreBundle\Entity\Alert::setInstigators
+     * @covers \Ilios\CoreBundle\Entity\Alert::getInstigators
+     * @covers \Ilios\CoreBundle\Entity\Alert::setInstigators
      */
     public function testGetInstigators()
     {
@@ -123,7 +123,7 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::addRecipient
+     * @covers \Ilios\CoreBundle\Entity\Alert::addRecipient
      */
     public function testAddRecipient()
     {
@@ -131,7 +131,7 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::removeRecipient
+     * @covers \Ilios\CoreBundle\Entity\Alert::removeRecipient
      */
     public function testRemoveRecipient()
     {
@@ -139,8 +139,8 @@ class AlertTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Alert::getRecipients
-     * @covers Ilios\CoreBundle\Entity\Alert::setRecipients
+     * @covers \Ilios\CoreBundle\Entity\Alert::getRecipients
+     * @covers \Ilios\CoreBundle\Entity\Alert::setRecipients
      */
     public function testGetRecipients()
     {

--- a/tests/CoreBundle/Entity/AssessmentOptionTest.php
+++ b/tests/CoreBundle/Entity/AssessmentOptionTest.php
@@ -35,7 +35,7 @@ class AssessmentOptionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AssessmentOption::__construct
+     * @covers \Ilios\CoreBundle\Entity\AssessmentOption::__construct
      */
     public function testConstructor()
     {
@@ -43,8 +43,8 @@ class AssessmentOptionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AssessmentOption::setName
-     * @covers Ilios\CoreBundle\Entity\AssessmentOption::getName
+     * @covers \Ilios\CoreBundle\Entity\AssessmentOption::setName
+     * @covers \Ilios\CoreBundle\Entity\AssessmentOption::getName
      */
     public function testSetName()
     {
@@ -52,7 +52,7 @@ class AssessmentOptionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AssessmentOption::addSessionType
+     * @covers \Ilios\CoreBundle\Entity\AssessmentOption::addSessionType
      */
     public function testAddSessionType()
     {
@@ -60,7 +60,7 @@ class AssessmentOptionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AssessmentOption::removeSessionType
+     * @covers \Ilios\CoreBundle\Entity\AssessmentOption::removeSessionType
      */
     public function testRemoveSessionType()
     {
@@ -68,7 +68,7 @@ class AssessmentOptionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AssessmentOption::getSessionTypes
+     * @covers \Ilios\CoreBundle\Entity\AssessmentOption::getSessionTypes
      */
     public function testGetSessionTypes()
     {

--- a/tests/CoreBundle/Entity/AuditLogTest.php
+++ b/tests/CoreBundle/Entity/AuditLogTest.php
@@ -40,7 +40,7 @@ class AuditLogTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AuditLog::__construct
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::__construct
      */
     public function testConstructor()
     {
@@ -48,8 +48,8 @@ class AuditLogTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AuditLog::setAction
-     * @covers Ilios\CoreBundle\Entity\AuditLog::getAction
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::setAction
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::getAction
      */
     public function testSetAction()
     {
@@ -57,8 +57,8 @@ class AuditLogTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AuditLog::setObjectId
-     * @covers Ilios\CoreBundle\Entity\AuditLog::getObjectId
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::setObjectId
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::getObjectId
      */
     public function testSetObjectId()
     {
@@ -66,8 +66,8 @@ class AuditLogTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AuditLog::setObjectId
-     * @covers Ilios\CoreBundle\Entity\AuditLog::getObjectId
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::setObjectId
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::getObjectId
      */
     public function testSetObjectIdForcesInt()
     {
@@ -76,8 +76,8 @@ class AuditLogTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AuditLog::setObjectClass
-     * @covers Ilios\CoreBundle\Entity\AuditLog::getObjectClass
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::setObjectClass
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::getObjectClass
      */
     public function testSetObjectClass()
     {
@@ -85,8 +85,8 @@ class AuditLogTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AuditLog::setValuesChanged
-     * @covers Ilios\CoreBundle\Entity\AuditLog::getValuesChanged
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::setValuesChanged
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::getValuesChanged
      */
     public function testSetValuesChanged()
     {
@@ -94,8 +94,8 @@ class AuditLogTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\AuditLog::setUser
-     * @covers Ilios\CoreBundle\Entity\AuditLog::getUser
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::setUser
+     * @covers \Ilios\CoreBundle\Entity\AuditLog::getUser
      */
     public function testSetUser()
     {
@@ -103,8 +103,8 @@ class AuditLogTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::setCreatedAt
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::getCreatedAt
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::setCreatedAt
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::getCreatedAt
      */
     public function testSetCreatedAt()
     {

--- a/tests/CoreBundle/Entity/AuthenticationTest.php
+++ b/tests/CoreBundle/Entity/AuthenticationTest.php
@@ -23,8 +23,8 @@ class AuthenticationTest extends EntityBase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\Authentication::setUsername
-     * @covers Ilios\CoreBundle\Entity\Authentication::getUsername
+     * @covers \Ilios\CoreBundle\Entity\Authentication::setUsername
+     * @covers \Ilios\CoreBundle\Entity\Authentication::getUsername
      */
     public function testSetUsername()
     {
@@ -32,7 +32,7 @@ class AuthenticationTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Authentication::setPasswordSha256
+     * @covers \Ilios\CoreBundle\Entity\Authentication::setPasswordSha256
      */
     public function testSetPasswordSha256()
     {
@@ -40,8 +40,8 @@ class AuthenticationTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Authentication::setUser
-     * @covers Ilios\CoreBundle\Entity\Authentication::getUser
+     * @covers \Ilios\CoreBundle\Entity\Authentication::setUser
+     * @covers \Ilios\CoreBundle\Entity\Authentication::getUser
      */
     public function testSetUser()
     {
@@ -49,8 +49,8 @@ class AuthenticationTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Authentication::setInvalidateTokenIssuedBefore
-     * @covers Ilios\CoreBundle\Entity\Authentication::getInvalidateTokenIssuedBefore
+     * @covers \Ilios\CoreBundle\Entity\Authentication::setInvalidateTokenIssuedBefore
+     * @covers \Ilios\CoreBundle\Entity\Authentication::getInvalidateTokenIssuedBefore
      */
     public function testSetInvalidateTokenIssuedBefore()
     {

--- a/tests/CoreBundle/Entity/CohortTest.php
+++ b/tests/CoreBundle/Entity/CohortTest.php
@@ -37,7 +37,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::__construct
+     * @covers \Ilios\CoreBundle\Entity\Cohort::__construct
      */
     public function testConstructor()
     {
@@ -47,8 +47,8 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::setTitle
-     * @covers Ilios\CoreBundle\Entity\Cohort::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Cohort::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Cohort::getTitle
      */
     public function testSetTitle()
     {
@@ -56,8 +56,8 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::setProgramYear
-     * @covers Ilios\CoreBundle\Entity\Cohort::getProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Cohort::setProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Cohort::getProgramYear
      */
     public function testSetProgramYear()
     {
@@ -65,7 +65,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::addCourse
+     * @covers \Ilios\CoreBundle\Entity\Cohort::addCourse
      */
     public function testAddCourse()
     {
@@ -73,7 +73,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::removeCourse
+     * @covers \Ilios\CoreBundle\Entity\Cohort::removeCourse
      */
     public function testRemoveCourse()
     {
@@ -81,7 +81,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::getCourses
+     * @covers \Ilios\CoreBundle\Entity\Cohort::getCourses
      */
     public function testGetCourses()
     {
@@ -89,7 +89,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::addUser
+     * @covers \Ilios\CoreBundle\Entity\Cohort::addUser
      */
     public function testAddUser()
     {
@@ -97,7 +97,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::removeUser
+     * @covers \Ilios\CoreBundle\Entity\Cohort::removeUser
      */
     public function testRemoveUser()
     {
@@ -105,7 +105,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::getUsers
+     * @covers \Ilios\CoreBundle\Entity\Cohort::getUsers
      */
     public function testGetUsers()
     {
@@ -113,7 +113,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::addLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\Cohort::addLearnerGroup
      */
     public function testAddLearnerGroup()
     {
@@ -121,7 +121,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::removeLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\Cohort::removeLearnerGroup
      */
     public function testRemoveLearnerGroup()
     {
@@ -129,7 +129,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::getLearnerGroups
+     * @covers \Ilios\CoreBundle\Entity\Cohort::getLearnerGroups
      */
     public function testGetLearnerGroups()
     {
@@ -137,7 +137,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::getProgram
+     * @covers \Ilios\CoreBundle\Entity\Cohort::getProgram
      */
     public function testGetProgram()
     {
@@ -158,7 +158,7 @@ class CohortTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Cohort::getSchool
+     * @covers \Ilios\CoreBundle\Entity\Cohort::getSchool
      */
     public function testGetSchool()
     {

--- a/tests/CoreBundle/Entity/CompetencyTest.php
+++ b/tests/CoreBundle/Entity/CompetencyTest.php
@@ -23,7 +23,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::__construct
+     * @covers \Ilios\CoreBundle\Entity\Competency::__construct
      */
     public function testConstructor()
     {
@@ -34,8 +34,8 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::setTitle
-     * @covers Ilios\CoreBundle\Entity\Competency::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Competency::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Competency::getTitle
      */
     public function testSetTitle()
     {
@@ -43,8 +43,8 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::setSchool
-     * @covers Ilios\CoreBundle\Entity\Competency::getSchool
+     * @covers \Ilios\CoreBundle\Entity\Competency::setSchool
+     * @covers \Ilios\CoreBundle\Entity\Competency::getSchool
      */
     public function testSetSchool()
     {
@@ -52,8 +52,8 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::setParent
-     * @covers Ilios\CoreBundle\Entity\Competency::getParent
+     * @covers \Ilios\CoreBundle\Entity\Competency::setParent
+     * @covers \Ilios\CoreBundle\Entity\Competency::getParent
      */
     public function testSetParent()
     {
@@ -61,7 +61,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::setParent
+     * @covers \Ilios\CoreBundle\Entity\Competency::setParent
      */
     public function testRemoveParent()
     {
@@ -73,7 +73,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::addAamcPcrs
+     * @covers \Ilios\CoreBundle\Entity\Competency::addAamcPcrs
      */
     public function testAddPcrs()
     {
@@ -81,7 +81,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::removeAamcPcrs
+     * @covers \Ilios\CoreBundle\Entity\Competency::removeAamcPcrs
      */
     public function testRemovePcrs()
     {
@@ -96,8 +96,8 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::getAamcPcrses
-     * @covers Ilios\CoreBundle\Entity\Competency::setAamcPcrses
+     * @covers \Ilios\CoreBundle\Entity\Competency::getAamcPcrses
+     * @covers \Ilios\CoreBundle\Entity\Competency::setAamcPcrses
      */
     public function testGetPcrses()
     {
@@ -105,7 +105,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::addProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Competency::addProgramYear
      */
     public function testAddProgramYear()
     {
@@ -113,7 +113,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::removeProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Competency::removeProgramYear
      */
     public function testRemoveProgramYear()
     {
@@ -121,7 +121,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::getProgramYears
+     * @covers \Ilios\CoreBundle\Entity\Competency::getProgramYears
      */
     public function testGetProgramYears()
     {
@@ -129,7 +129,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::addObjective
+     * @covers \Ilios\CoreBundle\Entity\Competency::addObjective
      */
     public function testAddObjective()
     {
@@ -137,7 +137,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::removeObjective
+     * @covers \Ilios\CoreBundle\Entity\Competency::removeObjective
      */
     public function testRemoveObjective()
     {
@@ -145,7 +145,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::getObjectives
+     * @covers \Ilios\CoreBundle\Entity\Competency::getObjectives
      */
     public function testGetObjectives()
     {
@@ -153,7 +153,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::addChild
+     * @covers \Ilios\CoreBundle\Entity\Competency::addChild
      */
     public function testAddChild()
     {
@@ -161,7 +161,7 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::removeChild
+     * @covers \Ilios\CoreBundle\Entity\Competency::removeChild
      */
     public function testRemoveChild()
     {
@@ -169,8 +169,8 @@ class CompetencyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Competency::getChildren
-     * @covers Ilios\CoreBundle\Entity\Competency::setChildren
+     * @covers \Ilios\CoreBundle\Entity\Competency::getChildren
+     * @covers \Ilios\CoreBundle\Entity\Competency::setChildren
      */
     public function testGetChildren()
     {

--- a/tests/CoreBundle/Entity/CourseClerkshipTypeTest.php
+++ b/tests/CoreBundle/Entity/CourseClerkshipTypeTest.php
@@ -34,7 +34,7 @@ class CourseClerkshipTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseClerkshipType::__construct
+     * @covers \Ilios\CoreBundle\Entity\CourseClerkshipType::__construct
      */
     public function testConstructor()
     {
@@ -42,8 +42,8 @@ class CourseClerkshipTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseClerkshipType::setTitle
-     * @covers Ilios\CoreBundle\Entity\CourseClerkshipType::getTitle
+     * @covers \Ilios\CoreBundle\Entity\CourseClerkshipType::setTitle
+     * @covers \Ilios\CoreBundle\Entity\CourseClerkshipType::getTitle
      */
     public function testSetTitle()
     {
@@ -51,7 +51,7 @@ class CourseClerkshipTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseClerkshipType::addCourse
+     * @covers \Ilios\CoreBundle\Entity\CourseClerkshipType::addCourse
      */
     public function testAddCourse()
     {
@@ -59,7 +59,7 @@ class CourseClerkshipTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseClerkshipType::removeCourse
+     * @covers \Ilios\CoreBundle\Entity\CourseClerkshipType::removeCourse
      */
     public function testRemoveCourse()
     {
@@ -67,7 +67,7 @@ class CourseClerkshipTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseClerkshipType::getCourses
+     * @covers \Ilios\CoreBundle\Entity\CourseClerkshipType::getCourses
      */
     public function testGetCourses()
     {

--- a/tests/CoreBundle/Entity/CourseLearningMaterialTest.php
+++ b/tests/CoreBundle/Entity/CourseLearningMaterialTest.php
@@ -23,7 +23,7 @@ class CourseLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::__construct
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::__construct
      */
     public function testConstructor()
     {
@@ -32,8 +32,8 @@ class CourseLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::setNotes
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::getNotes
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::setNotes
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::getNotes
      */
     public function testSetNotes()
     {
@@ -41,8 +41,8 @@ class CourseLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::setRequired
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::isRequired
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::setRequired
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::isRequired
      */
     public function testSetRequired()
     {
@@ -50,8 +50,8 @@ class CourseLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::setPublicNotes
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::hasPublicNotes
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::setPublicNotes
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::hasPublicNotes
      */
     public function testSetPublicNotes()
     {
@@ -59,8 +59,8 @@ class CourseLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::setCourse
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::getCourse
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::setCourse
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::getCourse
      */
     public function testSetCourse()
     {
@@ -68,8 +68,8 @@ class CourseLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::setLearningMaterial
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::getLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::setLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::getLearningMaterial
      */
     public function testSetLearningMaterial()
     {
@@ -77,7 +77,7 @@ class CourseLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::addMeshDescriptor
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::addMeshDescriptor
      */
     public function testAddMeshDescriptor()
     {
@@ -85,7 +85,7 @@ class CourseLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::removeMeshDescriptor
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::removeMeshDescriptor
      */
     public function testRemoveMeshDescriptor()
     {
@@ -93,7 +93,7 @@ class CourseLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CourseLearningMaterial::getMeshDescriptors
+     * @covers \Ilios\CoreBundle\Entity\CourseLearningMaterial::getMeshDescriptors
      */
     public function testGetMeshDescriptors()
     {

--- a/tests/CoreBundle/Entity/CourseTest.php
+++ b/tests/CoreBundle/Entity/CourseTest.php
@@ -60,7 +60,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::__construct
+     * @covers \Ilios\CoreBundle\Entity\Course::__construct
      */
     public function testConstructor()
     {
@@ -76,8 +76,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setTitle
-     * @covers Ilios\CoreBundle\Entity\Course::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Course::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Course::getTitle
      */
     public function testSetTitle()
     {
@@ -85,8 +85,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setLevel
-     * @covers Ilios\CoreBundle\Entity\Course::getLevel
+     * @covers \Ilios\CoreBundle\Entity\Course::setLevel
+     * @covers \Ilios\CoreBundle\Entity\Course::getLevel
      */
     public function testSetCourseLevel()
     {
@@ -94,8 +94,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setYear
-     * @covers Ilios\CoreBundle\Entity\Course::getYear
+     * @covers \Ilios\CoreBundle\Entity\Course::setYear
+     * @covers \Ilios\CoreBundle\Entity\Course::getYear
      */
     public function testSetYear()
     {
@@ -103,8 +103,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setStartDate
-     * @covers Ilios\CoreBundle\Entity\Course::getStartDate
+     * @covers \Ilios\CoreBundle\Entity\Course::setStartDate
+     * @covers \Ilios\CoreBundle\Entity\Course::getStartDate
      */
     public function testSetStartDate()
     {
@@ -112,8 +112,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setEndDate
-     * @covers Ilios\CoreBundle\Entity\Course::getEndDate
+     * @covers \Ilios\CoreBundle\Entity\Course::setEndDate
+     * @covers \Ilios\CoreBundle\Entity\Course::getEndDate
      */
     public function testSetEndDate()
     {
@@ -121,8 +121,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setId
-     * @covers Ilios\CoreBundle\Entity\Course::getId
+     * @covers \Ilios\CoreBundle\Entity\Course::setId
+     * @covers \Ilios\CoreBundle\Entity\Course::getId
      */
     public function testSetExternalId()
     {
@@ -130,8 +130,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setLocked
-     * @covers Ilios\CoreBundle\Entity\Course::isLocked
+     * @covers \Ilios\CoreBundle\Entity\Course::setLocked
+     * @covers \Ilios\CoreBundle\Entity\Course::isLocked
      */
     public function testSetLocked()
     {
@@ -139,8 +139,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setArchived
-     * @covers Ilios\CoreBundle\Entity\Course::isArchived
+     * @covers \Ilios\CoreBundle\Entity\Course::setArchived
+     * @covers \Ilios\CoreBundle\Entity\Course::isArchived
      */
     public function testSetArchived()
     {
@@ -148,8 +148,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setPublishedAsTbd
-     * @covers Ilios\CoreBundle\Entity\Course::isPublishedAsTbd
+     * @covers \Ilios\CoreBundle\Entity\Course::setPublishedAsTbd
+     * @covers \Ilios\CoreBundle\Entity\Course::isPublishedAsTbd
      */
     public function testSetPublishedAsTbd()
     {
@@ -157,8 +157,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setPublished
-     * @covers Ilios\CoreBundle\Entity\Course::isPublished
+     * @covers \Ilios\CoreBundle\Entity\Course::setPublished
+     * @covers \Ilios\CoreBundle\Entity\Course::isPublished
      */
     public function testSetPublished()
     {
@@ -166,8 +166,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setSchool
-     * @covers Ilios\CoreBundle\Entity\Course::getSchool
+     * @covers \Ilios\CoreBundle\Entity\Course::setSchool
+     * @covers \Ilios\CoreBundle\Entity\Course::getSchool
      */
     public function testSetSchool()
     {
@@ -175,8 +175,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setClerkshipType
-     * @covers Ilios\CoreBundle\Entity\Course::getClerkshipType
+     * @covers \Ilios\CoreBundle\Entity\Course::setClerkshipType
+     * @covers \Ilios\CoreBundle\Entity\Course::getClerkshipType
      */
     public function testSetClerkshipType()
     {
@@ -184,7 +184,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::addDirector
+     * @covers \Ilios\CoreBundle\Entity\Course::addDirector
      */
     public function testAddDirector()
     {
@@ -192,7 +192,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::removeDirector
+     * @covers \Ilios\CoreBundle\Entity\Course::removeDirector
      */
     public function testRemoveDirector()
     {
@@ -200,7 +200,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::getDirectors
+     * @covers \Ilios\CoreBundle\Entity\Course::getDirectors
      */
     public function testGetDirectors()
     {
@@ -208,7 +208,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::addCohort
+     * @covers \Ilios\CoreBundle\Entity\Course::addCohort
      */
     public function testAddCohort()
     {
@@ -216,7 +216,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::removeCohort
+     * @covers \Ilios\CoreBundle\Entity\Course::removeCohort
      */
     public function testRemoveCohort()
     {
@@ -224,7 +224,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::getCohorts
+     * @covers \Ilios\CoreBundle\Entity\Course::getCohorts
      */
     public function testGetCohorts()
     {
@@ -232,7 +232,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::addLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\Course::addLearningMaterial
      */
     public function testAddLearningMaterial()
     {
@@ -240,7 +240,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::removeLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\Course::removeLearningMaterial
      */
     public function testRemoveLearningMaterial()
     {
@@ -248,8 +248,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setLearningMaterials
-     * @covers Ilios\CoreBundle\Entity\Course::getLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\Course::setLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\Course::getLearningMaterials
      */
     public function testGetLearningMaterials()
     {
@@ -257,7 +257,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::addTerm
+     * @covers \Ilios\CoreBundle\Entity\Course::addTerm
      */
     public function testAddTerm()
     {
@@ -265,7 +265,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::removeTerm
+     * @covers \Ilios\CoreBundle\Entity\Course::removeTerm
      */
     public function testRemoveTerm()
     {
@@ -273,8 +273,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::getTerms
-     * @covers Ilios\CoreBundle\Entity\Course::setTerms
+     * @covers \Ilios\CoreBundle\Entity\Course::getTerms
+     * @covers \Ilios\CoreBundle\Entity\Course::setTerms
      */
     public function testSetTerms()
     {
@@ -282,8 +282,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::setAncestor
-     * @covers Ilios\CoreBundle\Entity\Course::getAncestor
+     * @covers \Ilios\CoreBundle\Entity\Course::setAncestor
+     * @covers \Ilios\CoreBundle\Entity\Course::getAncestor
      */
     public function testSetAncestor()
     {
@@ -291,7 +291,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::addDescendant
+     * @covers \Ilios\CoreBundle\Entity\Course::addDescendant
      */
     public function testAddDescendant()
     {
@@ -299,7 +299,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::removeDescendant
+     * @covers \Ilios\CoreBundle\Entity\Course::removeDescendant
      */
     public function testRemoveDescendant()
     {
@@ -307,8 +307,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::getDescendants
-     * @covers Ilios\CoreBundle\Entity\Course::setDescendants
+     * @covers \Ilios\CoreBundle\Entity\Course::getDescendants
+     * @covers \Ilios\CoreBundle\Entity\Course::setDescendants
      */
     public function testGetDescendants()
     {
@@ -316,7 +316,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::addSession
+     * @covers \Ilios\CoreBundle\Entity\Course::addSession
      */
     public function testAddSession()
     {
@@ -324,7 +324,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::removeSession
+     * @covers \Ilios\CoreBundle\Entity\Course::removeSession
      */
     public function testRemoveSession()
     {
@@ -332,7 +332,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::getSessions
+     * @covers \Ilios\CoreBundle\Entity\Course::getSessions
      */
     public function testGetSessions()
     {
@@ -340,7 +340,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::addAdministrator
+     * @covers \Ilios\CoreBundle\Entity\Course::addAdministrator
      */
     public function testAddAdministrator()
     {
@@ -348,7 +348,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::removeAdministrator
+     * @covers \Ilios\CoreBundle\Entity\Course::removeAdministrator
      */
     public function testRemoveAdministrator()
     {
@@ -356,8 +356,8 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::getAdministrators
-     * @covers Ilios\CoreBundle\Entity\Course::setAdministrators
+     * @covers \Ilios\CoreBundle\Entity\Course::getAdministrators
+     * @covers \Ilios\CoreBundle\Entity\Course::setAdministrators
      */
     public function testSetAdministrators()
     {
@@ -365,7 +365,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::addObjective
+     * @covers \Ilios\CoreBundle\Entity\Course::addObjective
      */
     public function testAddObjective()
     {
@@ -373,7 +373,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::removeObjective
+     * @covers \Ilios\CoreBundle\Entity\Course::removeObjective
      */
     public function testRemoveObjective()
     {
@@ -381,7 +381,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::getObjectives
+     * @covers \Ilios\CoreBundle\Entity\Course::getObjectives
      */
     public function testGetObjectives()
     {
@@ -389,7 +389,7 @@ class CourseTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::removeObjective
+     * @covers \Ilios\CoreBundle\Entity\Course::removeObjective
      */
     public function testRemoveObjectiveWithSessionChildren()
     {

--- a/tests/CoreBundle/Entity/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/CoreBundle/Entity/CurriculumInventoryAcademicLevelTest.php
@@ -36,7 +36,7 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::__construct
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::__construct
      */
     public function testConstructor()
     {
@@ -44,8 +44,8 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::setLevel
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getLevel
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::setLevel
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getLevel
      */
     public function testSetLevel()
     {
@@ -53,8 +53,8 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::setName
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getName
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::setName
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getName
      */
     public function testSetName()
     {
@@ -62,8 +62,8 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::setDescription
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getDescription
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::setDescription
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getDescription
      */
     public function testSetDescription()
     {
@@ -71,8 +71,8 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::setReport
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getReport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::setReport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getReport
      */
     public function testSetReport()
     {
@@ -80,7 +80,7 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::addSequenceBlock
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::addSequenceBlock
      */
     public function testAddSequenceBlock()
     {
@@ -88,7 +88,7 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::removeSequenceBlock
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::removeSequenceBlock
      */
     public function testRemoveSequenceBlock()
     {
@@ -96,7 +96,7 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getSequenceBlocks
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryAcademicLevel::getSequenceBlocks
      */
     public function testGetSequenceBlocks()
     {

--- a/tests/CoreBundle/Entity/CurriculumInventoryExportTest.php
+++ b/tests/CoreBundle/Entity/CurriculumInventoryExportTest.php
@@ -34,7 +34,7 @@ class CurriculumInventoryExportTest extends EntityBase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::__construct
+     * @covers \Ilios\CoreBundle\Entity\Session::__construct
      */
     public function testConstructor()
     {
@@ -42,8 +42,8 @@ class CurriculumInventoryExportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryExport::setDocument
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryExport::getDocument
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryExport::setDocument
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryExport::getDocument
      */
     public function testSetDocument()
     {
@@ -51,8 +51,8 @@ class CurriculumInventoryExportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryExport::setReport
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryExport::getReport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryExport::setReport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryExport::getReport
      */
     public function testSetReport()
     {
@@ -60,8 +60,8 @@ class CurriculumInventoryExportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryExport::setCreatedBy
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryExport::getCreatedBy
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryExport::setCreatedBy
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryExport::getCreatedBy
      */
     public function testSetCreatedBy()
     {

--- a/tests/CoreBundle/Entity/CurriculumInventoryInstitutionTest.php
+++ b/tests/CoreBundle/Entity/CurriculumInventoryInstitutionTest.php
@@ -66,8 +66,8 @@ class CurriculumInventoryInstitutionTest extends EntityBase
 
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setName
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getName
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setName
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getName
      */
     public function testSetName()
     {
@@ -75,8 +75,8 @@ class CurriculumInventoryInstitutionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAamcCode
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAamcCode
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAamcCode
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAamcCode
      */
     public function testSetAamcCode()
     {
@@ -84,8 +84,8 @@ class CurriculumInventoryInstitutionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressStreet
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressStreet
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressStreet
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressStreet
      */
     public function testSetAddressStreet()
     {
@@ -93,8 +93,8 @@ class CurriculumInventoryInstitutionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressCity
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressCity
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressCity
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressCity
      */
     public function testSetAddressCity()
     {
@@ -102,8 +102,8 @@ class CurriculumInventoryInstitutionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressStateOrProvince
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressStateOrProvince
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressStateOrProvince
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressStateOrProvince
      */
     public function testSetAddressStateOrProvince()
     {
@@ -111,8 +111,8 @@ class CurriculumInventoryInstitutionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressZipcode
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressZipcode
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressZipcode
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressZipcode
      */
     public function testSetAddressZipcode()
     {
@@ -120,8 +120,8 @@ class CurriculumInventoryInstitutionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressCountryCode
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressCountryCode
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setAddressCountryCode
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getAddressCountryCode
      */
     public function testSetAddressCountryCode()
     {
@@ -129,8 +129,8 @@ class CurriculumInventoryInstitutionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setSchool
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getSchool
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::setSchool
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryInstitution::getSchool
      */
     public function testSetSchool()
     {

--- a/tests/CoreBundle/Entity/CurriculumInventoryReportTest.php
+++ b/tests/CoreBundle/Entity/CurriculumInventoryReportTest.php
@@ -40,7 +40,7 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::__construct
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::__construct
      */
     public function testConstructor()
     {
@@ -49,8 +49,8 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setYear
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getYear
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::setYear
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getYear
      */
     public function testSetYear()
     {
@@ -58,8 +58,8 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setName
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getName
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::setName
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getName
      */
     public function testSetName()
     {
@@ -67,8 +67,8 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setDescription
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getDescription
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::setDescription
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getDescription
      */
     public function testSetDescription()
     {
@@ -76,8 +76,8 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setStartDate
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getStartDate
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::setStartDate
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getStartDate
      */
     public function testSetStartDate()
     {
@@ -85,8 +85,8 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setEndDate
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getEndDate
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::setEndDate
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getEndDate
      */
     public function testSetEndDate()
     {
@@ -94,8 +94,8 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setExport
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getExport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::setExport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getExport
      */
     public function testSetExport()
     {
@@ -103,8 +103,8 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setSequence
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getSequence
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::setSequence
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getSequence
      */
     public function testSetSequence()
     {
@@ -112,8 +112,8 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setProgram
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getProgram
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::setProgram
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getProgram
      */
     public function testSetProgram()
     {
@@ -121,7 +121,7 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getSchool
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getSchool
      */
     public function testGetSchool()
     {
@@ -142,7 +142,7 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::addSequenceBlock
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::addSequenceBlock
      */
     public function testAddSequenceBlock()
     {
@@ -150,7 +150,7 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::removeSequenceBlock
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::removeSequenceBlock
      */
     public function testRemoveSequenceBlock()
     {
@@ -158,7 +158,7 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getSequenceBlocks
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getSequenceBlocks
      */
     public function testGetSequenceBlocks()
     {
@@ -166,7 +166,7 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::addAcademicLevel
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::addAcademicLevel
      */
     public function testAddAcademicLevel()
     {
@@ -174,7 +174,7 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::removeAcademicLevel
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::removeAcademicLevel
      */
     public function testRemoveAcademicLevel()
     {
@@ -182,8 +182,8 @@ class CurriculumInventoryReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::getAcademicLevels
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventoryReport::setAcademicLevels
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::getAcademicLevels
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventoryReport::setAcademicLevels
      */
     public function testGetAcademicLevels()
     {

--- a/tests/CoreBundle/Entity/CurriculumInventorySequenceBlockTest.php
+++ b/tests/CoreBundle/Entity/CurriculumInventorySequenceBlockTest.php
@@ -68,7 +68,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::__construct
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::__construct
      */
     public function testConstructor()
     {
@@ -77,8 +77,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setRequired
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getRequired
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setRequired
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getRequired
      */
     public function testSetRequired()
     {
@@ -86,8 +86,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setChildSequenceOrder
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getChildSequenceOrder
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setChildSequenceOrder
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getChildSequenceOrder
      */
     public function testSetChildSequenceOrder()
     {
@@ -95,8 +95,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setOrderInSequence
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getOrderInSequence
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setOrderInSequence
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getOrderInSequence
      */
     public function testSetOrderInSequence()
     {
@@ -104,8 +104,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setMinimum
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getMinimum
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setMinimum
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getMinimum
      */
     public function testSetMinimum()
     {
@@ -113,8 +113,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setMaximum
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getMaximum
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setMaximum
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getMaximum
      */
     public function testSetMaximum()
     {
@@ -122,8 +122,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setTrack
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::hasTrack
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setTrack
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::hasTrack
      */
     public function testSetTrack()
     {
@@ -131,8 +131,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setDescription
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getDescription
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setDescription
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getDescription
      */
     public function testSetDescription()
     {
@@ -140,8 +140,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setTitle
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getTitle
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setTitle
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getTitle
      */
     public function testSetTitle()
     {
@@ -149,8 +149,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setStartDate
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getStartDate
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setStartDate
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getStartDate
      */
     public function testSetStartDate()
     {
@@ -158,8 +158,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setEndDate
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getEndDate
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setEndDate
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getEndDate
      */
     public function testSetEndDate()
     {
@@ -167,8 +167,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setDuration
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getDuration
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setDuration
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getDuration
      */
     public function testSetDuration()
     {
@@ -176,8 +176,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setAcademicLevel
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getAcademicLevel
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setAcademicLevel
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getAcademicLevel
      */
     public function testSetAcademicLevel()
     {
@@ -185,8 +185,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setCourse
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getCourse
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setCourse
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getCourse
      */
     public function testSetCourse()
     {
@@ -194,8 +194,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setParent
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getParent
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setParent
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getParent
      */
     public function testSetParent()
     {
@@ -203,8 +203,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setReport
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getReport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setReport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getReport
      */
     public function testSetReport()
     {
@@ -212,7 +212,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::compareSequenceBlocksWithOrderedStrategy
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::compareSequenceBlocksWithOrderedStrategy
      * @dataProvider testCompareSequenceBlocksWithOrderedStrategyProvider
      *
      * @param CurriculumInventorySequenceBlockInterface $blockA
@@ -263,7 +263,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::compareSequenceBlocksWithDefaultStrategy
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::compareSequenceBlocksWithDefaultStrategy
      * @dataProvider testCompareSequenceBlocksWithDefaultStrategyProvider
      *
      * @param CurriculumInventorySequenceBlockInterface $blockA
@@ -342,7 +342,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::addChild
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::addChild
      */
     public function testAddChild()
     {
@@ -350,7 +350,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::removeChild
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::removeChild
      */
     public function testRemoveChild()
     {
@@ -358,8 +358,8 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getChildren
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setChildren
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getChildren
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::setChildren
      */
     public function testGetChildren()
     {
@@ -367,7 +367,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::addSession
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::addSession
      */
     public function testAddSession()
     {
@@ -375,7 +375,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::removeSession
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::removeSession
      */
     public function testRemoveSession()
     {
@@ -383,7 +383,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getSessions
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequenceBlock::getSessions
      */
     public function testGetSessions()
     {

--- a/tests/CoreBundle/Entity/CurriculumInventorySequenceTest.php
+++ b/tests/CoreBundle/Entity/CurriculumInventorySequenceTest.php
@@ -23,8 +23,8 @@ class CurriculumInventorySequenceTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequence::setDescription
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequence::getDescription
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequence::setDescription
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequence::getDescription
      */
     public function testSetDescription()
     {
@@ -32,8 +32,8 @@ class CurriculumInventorySequenceTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequence::setReport
-     * @covers Ilios\CoreBundle\Entity\CurriculumInventorySequence::getReport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequence::setReport
+     * @covers \Ilios\CoreBundle\Entity\CurriculumInventorySequence::getReport
      */
     public function testSetReport()
     {

--- a/tests/CoreBundle/Entity/DepartmentTest.php
+++ b/tests/CoreBundle/Entity/DepartmentTest.php
@@ -48,7 +48,7 @@ class DepartmentTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Department::__construct
+     * @covers \Ilios\CoreBundle\Entity\Department::__construct
      */
     public function testConstructor()
     {
@@ -56,8 +56,8 @@ class DepartmentTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Department::setTitle
-     * @covers Ilios\CoreBundle\Entity\Department::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Department::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Department::getTitle
      */
     public function testSetTitle()
     {
@@ -65,8 +65,8 @@ class DepartmentTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Department::setSchool
-     * @covers Ilios\CoreBundle\Entity\Department::getSchool
+     * @covers \Ilios\CoreBundle\Entity\Department::setSchool
+     * @covers \Ilios\CoreBundle\Entity\Department::getSchool
      */
     public function testSetSchool()
     {
@@ -74,7 +74,7 @@ class DepartmentTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addSteward
+     * @covers \Ilios\CoreBundle\Entity\School::addSteward
      */
     public function testAddSteward()
     {
@@ -82,7 +82,7 @@ class DepartmentTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeSteward
+     * @covers \Ilios\CoreBundle\Entity\School::removeSteward
      */
     public function testRemoveSteward()
     {
@@ -90,7 +90,7 @@ class DepartmentTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getStewards
+     * @covers \Ilios\CoreBundle\Entity\School::getStewards
      */
     public function testGetSteward()
     {

--- a/tests/CoreBundle/Entity/IlmSessionTest.php
+++ b/tests/CoreBundle/Entity/IlmSessionTest.php
@@ -51,7 +51,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::__construct
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::__construct
      */
     public function testConstructor()
     {
@@ -62,8 +62,8 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::setHours
-     * @covers Ilios\CoreBundle\Entity\IlmSession::getHours
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::setHours
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::getHours
      */
     public function testSetHours()
     {
@@ -71,8 +71,8 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::setDueDate
-     * @covers Ilios\CoreBundle\Entity\IlmSession::getDueDate
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::setDueDate
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::getDueDate
      */
     public function testSetDueDate()
     {
@@ -80,7 +80,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::addLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::addLearnerGroup
      */
     public function testAddLearnerGroup()
     {
@@ -88,7 +88,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::removeLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::removeLearnerGroup
      */
     public function testRemoveLearnerGroup()
     {
@@ -96,7 +96,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::getLearnerGroups
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::getLearnerGroups
      */
     public function testGetLearnerGroups()
     {
@@ -104,7 +104,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::addInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::addInstructorGroup
      */
     public function testAddInstructorGroup()
     {
@@ -112,7 +112,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::removeInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::removeInstructorGroup
      */
     public function testRemoveInstructorGroup()
     {
@@ -120,7 +120,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::getInstructorGroups
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::getInstructorGroups
      */
     public function testGetInstructorGroups()
     {
@@ -128,7 +128,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::addInstructor
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::addInstructor
      */
     public function testAddInstructor()
     {
@@ -136,7 +136,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::removeInstructor
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::removeInstructor
      */
     public function testRemoveInstructor()
     {
@@ -144,7 +144,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::getInstructors
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::getInstructors
      */
     public function testGetInstructors()
     {
@@ -152,7 +152,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::addLearner
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::addLearner
      */
     public function testAddLearner()
     {
@@ -160,7 +160,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::removeLearner
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::removeLearner
      */
     public function testRemoveLearner()
     {
@@ -168,7 +168,7 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::getLearners
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::getLearners
      */
     public function testGetLearners()
     {
@@ -176,8 +176,8 @@ class IlmSessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IlmSession::setSession
-     * @covers Ilios\CoreBundle\Entity\IlmSession::getSession
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::setSession
+     * @covers \Ilios\CoreBundle\Entity\IlmSession::getSession
      */
     public function testSetSession()
     {

--- a/tests/CoreBundle/Entity/IngestionExceptionTest.php
+++ b/tests/CoreBundle/Entity/IngestionExceptionTest.php
@@ -25,8 +25,8 @@ class IngestionExceptionTest extends EntityBase
     // not sure about this one -- there is the ID field which is NotBlank() but I recall this failing
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IngestionException::setUser
-     * @covers Ilios\CoreBundle\Entity\IngestionException::getUser
+     * @covers \Ilios\CoreBundle\Entity\IngestionException::setUser
+     * @covers \Ilios\CoreBundle\Entity\IngestionException::getUser
      */
     public function testSetUser()
     {
@@ -34,8 +34,8 @@ class IngestionExceptionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\IngestionException::setUid
-     * @covers Ilios\CoreBundle\Entity\IngestionException::getUid
+     * @covers \Ilios\CoreBundle\Entity\IngestionException::setUid
+     * @covers \Ilios\CoreBundle\Entity\IngestionException::getUid
      */
     public function testSetTitle()
     {

--- a/tests/CoreBundle/Entity/InstructorGroupTest.php
+++ b/tests/CoreBundle/Entity/InstructorGroupTest.php
@@ -49,7 +49,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::__construct
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::__construct
      */
     public function testConstructor()
     {
@@ -60,7 +60,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::addLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::addLearnerGroup
      */
     public function testAddLearnerGroup()
     {
@@ -68,7 +68,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::removeLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::removeLearnerGroup
      */
     public function testRemoveLearnerGroup()
     {
@@ -76,7 +76,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::getLearnerGroups
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::getLearnerGroups
      */
     public function testGetLearnerGroups()
     {
@@ -84,7 +84,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::addIlmSession
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::addIlmSession
      */
     public function testAddIlmSession()
     {
@@ -92,7 +92,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::removeIlmSession
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::removeIlmSession
      */
     public function testRemoveIlmSession()
     {
@@ -100,7 +100,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::getIlmSessions
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::getIlmSessions
      */
     public function testGetIlmSessions()
     {
@@ -108,7 +108,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::addUser
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::addUser
      */
     public function testAddUser()
     {
@@ -116,7 +116,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::removeUser
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::removeUser
      */
     public function testRemoveUser()
     {
@@ -124,7 +124,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::getUsers
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::getUsers
      */
     public function testGetUsers()
     {
@@ -132,7 +132,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::addOffering
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::addOffering
      */
     public function testAddOffering()
     {
@@ -140,7 +140,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::removeOffering
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::removeOffering
      */
     public function testRemoveOffering()
     {
@@ -148,7 +148,7 @@ class InstructorGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\InstructorGroup::getOfferings
+     * @covers \Ilios\CoreBundle\Entity\InstructorGroup::getOfferings
      */
     public function testGetOfferings()
     {

--- a/tests/CoreBundle/Entity/LearnerGroupTest.php
+++ b/tests/CoreBundle/Entity/LearnerGroupTest.php
@@ -53,7 +53,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::__construct
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::__construct
      */
     public function testConstructor()
     {
@@ -66,8 +66,8 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::setTitle
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getTitle
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::setTitle
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getTitle
      */
     public function testSetTitle()
     {
@@ -75,8 +75,8 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::setLocation
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getLocation
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::setLocation
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getLocation
      */
     public function testSetLocation()
     {
@@ -84,8 +84,8 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::setCohort
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getCohort
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::setCohort
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getCohort
      */
     public function testSetCohort()
     {
@@ -93,7 +93,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::addIlmSession
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::addIlmSession
      */
     public function testAddIlmSession()
     {
@@ -101,7 +101,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::removeIlmSession
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::removeIlmSession
      */
     public function testRemoveIlmSession()
     {
@@ -109,7 +109,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getIlmSessions
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getIlmSessions
      */
     public function getGetIlmSessions()
     {
@@ -117,7 +117,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::addOffering
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::addOffering
      */
     public function testAddOffering()
     {
@@ -125,7 +125,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::removeOffering
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::removeOffering
      */
     public function testRemoveOffering()
     {
@@ -133,7 +133,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getOfferings
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getOfferings
      */
     public function getGetOfferings()
     {
@@ -141,7 +141,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::addInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::addInstructorGroup
      */
     public function testAddInstructorGroup()
     {
@@ -149,7 +149,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::removeInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::removeInstructorGroup
      */
     public function testRemoveInstructorGroup()
     {
@@ -157,7 +157,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getInstructorGroups
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getInstructorGroups
      */
     public function getGetInstructorGroups()
     {
@@ -165,7 +165,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::addUser
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::addUser
      */
     public function testAddUser()
     {
@@ -173,7 +173,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::removeUser
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::removeUser
      */
     public function testRemoveUser()
     {
@@ -181,7 +181,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getUsers
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getUsers
      */
     public function getGetUsers()
     {
@@ -189,7 +189,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::addInstructor
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::addInstructor
      */
     public function testAddInstructor()
     {
@@ -197,7 +197,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::removeInstructor
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::removeInstructor
      */
     public function testRemoveInstructor()
     {
@@ -205,7 +205,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getInstructors
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getInstructors
      */
     public function getGetInstructors()
     {
@@ -213,7 +213,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getProgramYear
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getProgramYear
      */
     public function testGetProgramYear()
     {
@@ -234,7 +234,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getProgram
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getProgram
      */
     public function testGetProgram()
     {
@@ -264,7 +264,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getSchool
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getSchool
      */
     public function testGetSchool()
     {
@@ -305,7 +305,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::addChild
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::addChild
      */
     public function testAddChild()
     {
@@ -313,7 +313,7 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::removeChild
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::removeChild
      */
     public function testRemoveChild()
     {
@@ -321,8 +321,8 @@ class LearnerGroupTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::getChildren
-     * @covers Ilios\CoreBundle\Entity\LearnerGroup::setChildren
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::getChildren
+     * @covers \Ilios\CoreBundle\Entity\LearnerGroup::setChildren
      */
     public function testGetChildren()
     {

--- a/tests/CoreBundle/Entity/LearningMaterialStatusTest.php
+++ b/tests/CoreBundle/Entity/LearningMaterialStatusTest.php
@@ -34,7 +34,7 @@ class LearningMaterialStatusTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialStatus::__construct
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialStatus::__construct
      */
     public function testConstructor()
     {
@@ -42,8 +42,8 @@ class LearningMaterialStatusTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialStatus::setTitle
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialStatus::getTitle
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialStatus::setTitle
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialStatus::getTitle
      */
     public function testSetTitle()
     {
@@ -51,7 +51,7 @@ class LearningMaterialStatusTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialStatus::addLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialStatus::addLearningMaterial
      */
     public function testAddLearningMaterial()
     {
@@ -59,7 +59,7 @@ class LearningMaterialStatusTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialStatus::removeLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialStatus::removeLearningMaterial
      */
     public function testRemoveLearningMaterial()
     {
@@ -67,7 +67,7 @@ class LearningMaterialStatusTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialStatus::getLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialStatus::getLearningMaterials
      */
     public function testGetLearningMaterials()
     {

--- a/tests/CoreBundle/Entity/LearningMaterialTest.php
+++ b/tests/CoreBundle/Entity/LearningMaterialTest.php
@@ -58,7 +58,7 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::__construct
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::__construct
      */
     public function testConstructor()
     {
@@ -67,8 +67,8 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::setTitle
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::getTitle
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::setTitle
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::getTitle
      */
     public function testSetTitle()
     {
@@ -76,8 +76,8 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::setDescription
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::getDescription
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::setDescription
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::getDescription
      */
     public function testSetDescription()
     {
@@ -85,8 +85,8 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::setOriginalAuthor
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::getOriginalAuthor
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::setOriginalAuthor
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::getOriginalAuthor
      */
     public function testSetOriginalAuthor()
     {
@@ -94,7 +94,7 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::getOwningSchool
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::getOwningSchool
      */
     public function testGetOwningSchool()
     {
@@ -117,7 +117,7 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::addCourseLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::addCourseLearningMaterial
      */
     public function testAddCourseLearningMaterial()
     {
@@ -125,7 +125,7 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::removeCourseLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::removeCourseLearningMaterial
      */
     public function testRemoveCourseLearningMaterial()
     {
@@ -133,8 +133,8 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::getCourseLearningMaterials
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::setCourseLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::getCourseLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::setCourseLearningMaterials
      */
     public function getGetCourseLearningMaterials()
     {
@@ -142,7 +142,7 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::addSessionLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::addSessionLearningMaterial
      */
     public function testAddSessionLearningMaterial()
     {
@@ -150,7 +150,7 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::removeSessionLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::removeSessionLearningMaterial
      */
     public function testRemoveSessionLearningMaterial()
     {
@@ -158,8 +158,8 @@ class LearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::getSessionLearningMaterials
-     * @covers Ilios\CoreBundle\Entity\LearningMaterial::setSessionLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::getSessionLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterial::setSessionLearningMaterials
      */
     public function getGetSessionLearningMaterials()
     {

--- a/tests/CoreBundle/Entity/LearningMaterialUserRoleTest.php
+++ b/tests/CoreBundle/Entity/LearningMaterialUserRoleTest.php
@@ -34,7 +34,7 @@ class LearningMaterialUserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialUserRole::__construct
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialUserRole::__construct
      */
     public function testConstructor()
     {
@@ -42,8 +42,8 @@ class LearningMaterialUserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialUserRole::setTitle
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialUserRole::getTitle
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialUserRole::setTitle
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialUserRole::getTitle
      */
     public function testSetTitle()
     {
@@ -51,7 +51,7 @@ class LearningMaterialUserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialUserRole::addLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialUserRole::addLearningMaterial
      */
     public function testAddLearningMaterial()
     {
@@ -59,7 +59,7 @@ class LearningMaterialUserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialUserRole::removeLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialUserRole::removeLearningMaterial
      */
     public function testRemoveLearningMaterial()
     {
@@ -67,7 +67,7 @@ class LearningMaterialUserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\LearningMaterialUserRole::getLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\LearningMaterialUserRole::getLearningMaterials
      */
     public function testGetLearningMaterials()
     {

--- a/tests/CoreBundle/Entity/Manager/CourseManagerTest.php
+++ b/tests/CoreBundle/Entity/Manager/CourseManagerTest.php
@@ -19,7 +19,7 @@ class CourseManagerTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\CourseManager::delete
+     * @covers \Ilios\CoreBundle\Entity\Manager\CourseManager::delete
      */
     public function testDeleteCourse()
     {

--- a/tests/CoreBundle/Entity/Manager/OfferingManagerTest.php
+++ b/tests/CoreBundle/Entity/Manager/OfferingManagerTest.php
@@ -22,7 +22,7 @@ class OfferingManagerTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\OfferingManager::delete
+     * @covers \Ilios\CoreBundle\Entity\Manager\OfferingManager::delete
      */
     public function testDeleteOffering()
     {
@@ -45,7 +45,7 @@ class OfferingManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\OfferingManager::getOfferingsForTeachingReminders
+     * @covers \Ilios\CoreBundle\Entity\Manager\OfferingManager::getOfferingsForTeachingReminders
      */
     public function testGetOfferingsForTeachingReminders()
     {

--- a/tests/CoreBundle/Entity/Manager/PermissionManagerTest.php
+++ b/tests/CoreBundle/Entity/Manager/PermissionManagerTest.php
@@ -25,7 +25,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasPermission
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasPermission
      */
     public function testUserHasPermission()
     {
@@ -77,7 +77,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasWritePermissionToCourse
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasWritePermissionToCourse
      */
     public function testUserHasWritePermissionToCourse()
     {
@@ -112,7 +112,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToCourse
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToCourse
      */
     public function testUserHasReadPermissionToCourse()
     {
@@ -147,7 +147,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasWritePermissionToProgram
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasWritePermissionToProgram
      */
     public function testUserHasWritePermissionToProgram()
     {
@@ -182,7 +182,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToProgram
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToProgram
      */
     public function testUserHasReadPermissionToProgram()
     {
@@ -218,7 +218,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
 
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasWritePermissionToSchool
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasWritePermissionToSchool
      */
     public function testUserHasWritePermissionToSchool()
     {
@@ -253,7 +253,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToSchool
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToSchool
      */
     public function testUserHasReadPermissionToSchool()
     {
@@ -288,7 +288,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasWritePermissionToSchools
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasWritePermissionToSchools
      */
     public function testUserHasWritePermissionToSchools()
     {
@@ -333,7 +333,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToSchools
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToSchools
      */
     public function testUserHasReadPermissionToSchools()
     {
@@ -378,7 +378,7 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToCoursesInSchool
+     * @covers \Ilios\CoreBundle\Entity\Manager\PermissionManager::userHasReadPermissionToCoursesInSchool
      */
     public function testUserHasReadPermissionToCoursesBySchool()
     {

--- a/tests/CoreBundle/Entity/Manager/SchoolManagerTest.php
+++ b/tests/CoreBundle/Entity/Manager/SchoolManagerTest.php
@@ -19,7 +19,7 @@ class SchoolManagerTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\Manager\SchoolManager::delete
+     * @covers \Ilios\CoreBundle\Entity\Manager\SchoolManager::delete
      */
     public function testDeleteSchool()
     {

--- a/tests/CoreBundle/Entity/MeshConceptTest.php
+++ b/tests/CoreBundle/Entity/MeshConceptTest.php
@@ -36,7 +36,7 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::__construct
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::__construct
      */
     public function testConstructor()
     {
@@ -48,8 +48,8 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::setName
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::getName
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::setName
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::getName
      */
     public function testSetName()
     {
@@ -57,8 +57,8 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::setUmlsUid
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::getUmlsUid
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::setUmlsUid
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::getUmlsUid
      */
     public function testSetUmlsUid()
     {
@@ -66,8 +66,8 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::setPreferred
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::getPreferred
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::setPreferred
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::getPreferred
      */
     public function testSetPreferred()
     {
@@ -75,8 +75,8 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::setScopeNote
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::getScopeNote
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::setScopeNote
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::getScopeNote
      */
     public function testSetScopeNote()
     {
@@ -84,7 +84,7 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::setCasn1Name
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::setCasn1Name
      */
     public function testSetCasn1Name()
     {
@@ -92,8 +92,8 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::setRegistryNumber
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::getRegistryNumber
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::setRegistryNumber
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::getRegistryNumber
      */
     public function testSetRegistryNumber()
     {
@@ -101,7 +101,7 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::addSemanticType
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::addSemanticType
      */
     public function testAddSemanticType()
     {
@@ -109,7 +109,7 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::removeSemanticType
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::removeSemanticType
      */
     public function testRemoveSemanticType()
     {
@@ -117,8 +117,8 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::setSemanticTypes
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::getSemanticTypes
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::setSemanticTypes
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::getSemanticTypes
      */
     public function testGetSemanticTypes()
     {
@@ -126,7 +126,7 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::addTerm
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::addTerm
      */
     public function testAddTerm()
     {
@@ -134,7 +134,7 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::removeTerm
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::removeTerm
      */
     public function testRemoveTerm()
     {
@@ -142,8 +142,8 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::setTerms
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::getTerms
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::setTerms
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::getTerms
      */
     public function testGetTerms()
     {
@@ -151,7 +151,7 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::addDescriptor
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::addDescriptor
      */
     public function testAddDescriptor()
     {
@@ -159,7 +159,7 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::removeDescriptor
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::removeDescriptor
      */
     public function testRemoveDescriptor()
     {
@@ -167,8 +167,8 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::setDescriptors
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::getDescriptors
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::setDescriptors
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::getDescriptors
      */
     public function testGetDescriptors()
     {
@@ -176,7 +176,7 @@ class MeshConceptTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshConcept::stampUpdate
+     * @covers \Ilios\CoreBundle\Entity\MeshConcept::stampUpdate
      */
     public function testStampUpdate()
     {

--- a/tests/CoreBundle/Entity/MeshDescriptorTest.php
+++ b/tests/CoreBundle/Entity/MeshDescriptorTest.php
@@ -33,7 +33,7 @@ class MeshDescriptorTest extends EntityBase
         $this->validate(0);
     }
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::__construct
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::__construct
      */
     public function testConstructor()
     {
@@ -51,8 +51,8 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::setName
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getName
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::setName
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getName
      */
     public function testSetName()
     {
@@ -60,8 +60,8 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::setAnnotation
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getAnnotation
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::setAnnotation
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getAnnotation
      */
     public function testSetAnnotation()
     {
@@ -69,7 +69,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::addCourse
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::addCourse
      */
     public function testAddCourse()
     {
@@ -77,7 +77,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::removeCourse
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::removeCourse
      */
     public function testRemoveCourse()
     {
@@ -85,7 +85,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getCourses
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getCourses
      */
     public function testGetCourses()
     {
@@ -93,7 +93,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::addObjective
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::addObjective
      */
     public function testAddObjective()
     {
@@ -101,7 +101,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::removeObjective
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::removeObjective
      */
     public function testRemoveObjective()
     {
@@ -109,8 +109,8 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::setObjectives
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getObjectives
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::setObjectives
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getObjectives
      */
     public function testGetObjectives()
     {
@@ -118,7 +118,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::addSession
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::addSession
      */
     public function testAddSession()
     {
@@ -126,7 +126,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::removeSession
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::removeSession
      */
     public function testRemoveSession()
     {
@@ -134,7 +134,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getSessions
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getSessions
      */
     public function testGetSessions()
     {
@@ -142,7 +142,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::addConcept
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::addConcept
      */
     public function testAddConcept()
     {
@@ -150,7 +150,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::removeConcept
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::removeConcept
      */
     public function testRemoveConcept()
     {
@@ -158,7 +158,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getConcepts
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getConcepts
      */
     public function testGetConcepts()
     {
@@ -166,7 +166,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::addQualifier
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::addQualifier
      */
     public function testAddQualifier()
     {
@@ -174,7 +174,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::removeQualifier
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::removeQualifier
      */
     public function testRemoveQualifier()
     {
@@ -182,8 +182,8 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getQualifiers
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::setQualifiers
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getQualifiers
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::setQualifiers
      */
     public function testGetQualifiers()
     {
@@ -191,7 +191,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::addTree
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::addTree
      */
     public function testAddTree()
     {
@@ -199,7 +199,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::removeTree
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::removeTree
      */
     public function testRemoveTree()
     {
@@ -207,8 +207,8 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getTrees
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::setTrees
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getTrees
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::setTrees
      */
     public function testGetTrees()
     {
@@ -216,7 +216,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::addSessionLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::addSessionLearningMaterial
      */
     public function testAddSessionLearningMaterial()
     {
@@ -230,7 +230,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::removeSessionLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::removeSessionLearningMaterial
      */
     public function testRemoveSessionLearningMaterial()
     {
@@ -245,8 +245,8 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getSessionLearningMaterials
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::setSessionLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getSessionLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::setSessionLearningMaterials
      */
     public function testGetSessionLearningMaterials()
     {
@@ -260,7 +260,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::addCourseLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::addCourseLearningMaterial
      */
     public function testAddCourseLearningMaterial()
     {
@@ -274,7 +274,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::removeCourseLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::removeCourseLearningMaterial
      */
     public function testRemoveCourseLearningMaterial()
     {
@@ -289,8 +289,8 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::getCourseLearningMaterials
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::setCourseLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::getCourseLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::setCourseLearningMaterials
      */
     public function testGetCourseLearningMaterials()
     {
@@ -304,7 +304,7 @@ class MeshDescriptorTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshDescriptor::stampUpdate
+     * @covers \Ilios\CoreBundle\Entity\MeshDescriptor::stampUpdate
      */
     public function testStampUpdate()
     {

--- a/tests/CoreBundle/Entity/MeshPreviousIndexingTest.php
+++ b/tests/CoreBundle/Entity/MeshPreviousIndexingTest.php
@@ -35,8 +35,8 @@ class MeshPreviousIndexingTest extends EntityBase
         $this->validate(0);
     }
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshPreviousIndexing::setPreviousIndexing
-     * @covers Ilios\CoreBundle\Entity\MeshPreviousIndexing::getPreviousIndexing
+     * @covers \Ilios\CoreBundle\Entity\MeshPreviousIndexing::setPreviousIndexing
+     * @covers \Ilios\CoreBundle\Entity\MeshPreviousIndexing::getPreviousIndexing
      */
     public function testSetPreviousIndexing()
     {
@@ -44,8 +44,8 @@ class MeshPreviousIndexingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshPreviousIndexing::getDescriptor
-     * @covers Ilios\CoreBundle\Entity\MeshPreviousIndexing::setDescriptor
+     * @covers \Ilios\CoreBundle\Entity\MeshPreviousIndexing::getDescriptor
+     * @covers \Ilios\CoreBundle\Entity\MeshPreviousIndexing::setDescriptor
      */
     public function testSetDescriptor()
     {

--- a/tests/CoreBundle/Entity/MeshQualifierTest.php
+++ b/tests/CoreBundle/Entity/MeshQualifierTest.php
@@ -33,7 +33,7 @@ class MeshQualifierTest extends EntityBase
         $this->validate(0);
     }
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshQualifier::__construct
+     * @covers \Ilios\CoreBundle\Entity\MeshQualifier::__construct
      */
     public function testConstructor()
     {
@@ -45,8 +45,8 @@ class MeshQualifierTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshQualifier::setName
-     * @covers Ilios\CoreBundle\Entity\MeshQualifier::getName
+     * @covers \Ilios\CoreBundle\Entity\MeshQualifier::setName
+     * @covers \Ilios\CoreBundle\Entity\MeshQualifier::getName
      */
     public function testSetName()
     {
@@ -54,7 +54,7 @@ class MeshQualifierTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshQualifier::stampUpdate
+     * @covers \Ilios\CoreBundle\Entity\MeshQualifier::stampUpdate
      */
     public function testStampUpdate()
     {
@@ -67,7 +67,7 @@ class MeshQualifierTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshQualifier::addDescriptor
+     * @covers \Ilios\CoreBundle\Entity\MeshQualifier::addDescriptor
      */
     public function testAddDescriptor()
     {
@@ -75,7 +75,7 @@ class MeshQualifierTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshQualifier::removeDescriptor
+     * @covers \Ilios\CoreBundle\Entity\MeshQualifier::removeDescriptor
      */
     public function testRemoveDescriptor()
     {
@@ -83,8 +83,8 @@ class MeshQualifierTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshQualifier::getDescriptors
-     * @covers Ilios\CoreBundle\Entity\MeshQualifier::setDescriptors
+     * @covers \Ilios\CoreBundle\Entity\MeshQualifier::getDescriptors
+     * @covers \Ilios\CoreBundle\Entity\MeshQualifier::setDescriptors
      */
     public function getGetDescriptors()
     {

--- a/tests/CoreBundle/Entity/MeshSemanticTypeTest.php
+++ b/tests/CoreBundle/Entity/MeshSemanticTypeTest.php
@@ -35,7 +35,7 @@ class MeshSemanticTypeTest extends EntityBase
 
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshSemanticType::__construct
+     * @covers \Ilios\CoreBundle\Entity\MeshSemanticType::__construct
      */
     public function testConstructor()
     {
@@ -47,8 +47,8 @@ class MeshSemanticTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshSemanticType::setName
-     * @covers Ilios\CoreBundle\Entity\MeshSemanticType::getName
+     * @covers \Ilios\CoreBundle\Entity\MeshSemanticType::setName
+     * @covers \Ilios\CoreBundle\Entity\MeshSemanticType::getName
      */
     public function testSetName()
     {
@@ -56,7 +56,7 @@ class MeshSemanticTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshSemanticType::stampUpdate
+     * @covers \Ilios\CoreBundle\Entity\MeshSemanticType::stampUpdate
      */
     public function testStampUpdate()
     {
@@ -69,7 +69,7 @@ class MeshSemanticTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshSemanticType::addConcept
+     * @covers \Ilios\CoreBundle\Entity\MeshSemanticType::addConcept
      */
     public function testAddConcept()
     {
@@ -77,7 +77,7 @@ class MeshSemanticTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshSemanticType::removeConcept
+     * @covers \Ilios\CoreBundle\Entity\MeshSemanticType::removeConcept
      */
     public function testRemoveConcept()
     {
@@ -85,7 +85,7 @@ class MeshSemanticTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshSemanticType::getConcepts
+     * @covers \Ilios\CoreBundle\Entity\MeshSemanticType::getConcepts
      */
     public function getGetConcepts()
     {

--- a/tests/CoreBundle/Entity/MeshTermTest.php
+++ b/tests/CoreBundle/Entity/MeshTermTest.php
@@ -37,7 +37,7 @@ class MeshTermTest extends EntityBase
 
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::__construct
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::__construct
      */
     public function testConstructor()
     {
@@ -49,8 +49,8 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::setName
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::getName
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::setName
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::getName
      */
     public function testSetName()
     {
@@ -58,8 +58,8 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::setLexicalTag
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::getLexicalTag
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::setLexicalTag
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::getLexicalTag
      */
     public function testSetLexicalTag()
     {
@@ -67,8 +67,8 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::setConceptPreferred
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::isConceptPreferred
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::setConceptPreferred
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::isConceptPreferred
      */
     public function testSetConceptPreferred()
     {
@@ -76,8 +76,8 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::setRecordPreferred
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::isRecordPreferred
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::setRecordPreferred
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::isRecordPreferred
      */
     public function testSetRecordPreferred()
     {
@@ -85,8 +85,8 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::setPermuted
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::isPermuted
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::setPermuted
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::isPermuted
      */
     public function testSetPermuted()
     {
@@ -94,8 +94,8 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::setPrintable
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::isPrintable
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::setPrintable
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::isPrintable
      */
     public function testSetPrintable()
     {
@@ -103,7 +103,7 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::stampUpdate
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::stampUpdate
      */
     public function testStampUpdate()
     {
@@ -116,7 +116,7 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::addConcept
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::addConcept
      */
     public function testAddConcept()
     {
@@ -124,7 +124,7 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::removeConcept
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::removeConcept
      */
     public function testRemoveConcept()
     {
@@ -132,7 +132,7 @@ class MeshTermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTerm::getConcepts
+     * @covers \Ilios\CoreBundle\Entity\MeshTerm::getConcepts
      */
     public function getGetConcepts()
     {

--- a/tests/CoreBundle/Entity/MeshTreeTest.php
+++ b/tests/CoreBundle/Entity/MeshTreeTest.php
@@ -34,8 +34,8 @@ class MeshTreeTest extends EntityBase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTree::setTreeNumber
-     * @covers Ilios\CoreBundle\Entity\MeshTree::getTreeNumber
+     * @covers \Ilios\CoreBundle\Entity\MeshTree::setTreeNumber
+     * @covers \Ilios\CoreBundle\Entity\MeshTree::getTreeNumber
      */
     public function testSetTreeNumber()
     {
@@ -43,8 +43,8 @@ class MeshTreeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\MeshTree::getDescriptor
-     * @covers Ilios\CoreBundle\Entity\MeshTree::setDescriptor
+     * @covers \Ilios\CoreBundle\Entity\MeshTree::getDescriptor
+     * @covers \Ilios\CoreBundle\Entity\MeshTree::setDescriptor
      */
     public function testSetDescriptor()
     {

--- a/tests/CoreBundle/Entity/ObjectiveTest.php
+++ b/tests/CoreBundle/Entity/ObjectiveTest.php
@@ -34,7 +34,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Course::__construct
+     * @covers \Ilios\CoreBundle\Entity\Course::__construct
      */
     public function testConstructor()
     {
@@ -48,8 +48,8 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::setTitle
-     * @covers Ilios\CoreBundle\Entity\Objective::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Objective::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Objective::getTitle
      */
     public function testSetTitle()
     {
@@ -57,8 +57,8 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::setCompetency
-     * @covers Ilios\CoreBundle\Entity\Objective::getCompetency
+     * @covers \Ilios\CoreBundle\Entity\Objective::setCompetency
+     * @covers \Ilios\CoreBundle\Entity\Objective::getCompetency
      */
     public function testSetCompetency()
     {
@@ -66,7 +66,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::addCourse
+     * @covers \Ilios\CoreBundle\Entity\Objective::addCourse
      */
     public function testAddCourse()
     {
@@ -74,7 +74,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::removeCourse
+     * @covers \Ilios\CoreBundle\Entity\Objective::removeCourse
      */
     public function testRemoveCourse()
     {
@@ -82,7 +82,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::getCourses
+     * @covers \Ilios\CoreBundle\Entity\Objective::getCourses
      */
     public function testGetCourses()
     {
@@ -90,7 +90,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::addProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Objective::addProgramYear
      */
     public function testAddProgramYear()
     {
@@ -98,7 +98,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::removeProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Objective::removeProgramYear
      */
     public function testRemoveProgramYear()
     {
@@ -106,7 +106,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::getProgramYears
+     * @covers \Ilios\CoreBundle\Entity\Objective::getProgramYears
      */
     public function testGetProgramYears()
     {
@@ -114,7 +114,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::addSession
+     * @covers \Ilios\CoreBundle\Entity\Objective::addSession
      */
     public function testAddSession()
     {
@@ -122,7 +122,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::removeSession
+     * @covers \Ilios\CoreBundle\Entity\Objective::removeSession
      */
     public function testRemoveSession()
     {
@@ -130,7 +130,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::getSessions
+     * @covers \Ilios\CoreBundle\Entity\Objective::getSessions
      */
     public function testGetSessions()
     {
@@ -138,7 +138,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::addChild
+     * @covers \Ilios\CoreBundle\Entity\Objective::addChild
      */
     public function testAddChild()
     {
@@ -146,7 +146,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::removeChild
+     * @covers \Ilios\CoreBundle\Entity\Objective::removeChild
      */
     public function testRemoveChild()
     {
@@ -154,8 +154,8 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::getChildren
-     * @covers Ilios\CoreBundle\Entity\Objective::setChildren
+     * @covers \Ilios\CoreBundle\Entity\Objective::getChildren
+     * @covers \Ilios\CoreBundle\Entity\Objective::setChildren
      */
     public function testGetChildren()
     {
@@ -163,7 +163,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::addMeshDescriptor
+     * @covers \Ilios\CoreBundle\Entity\Objective::addMeshDescriptor
      */
     public function testAddMeshDescriptor()
     {
@@ -171,7 +171,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::removeMeshDescriptor
+     * @covers \Ilios\CoreBundle\Entity\Objective::removeMeshDescriptor
      */
     public function testRemoveMeshDescriptor()
     {
@@ -179,7 +179,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::getMeshDescriptors
+     * @covers \Ilios\CoreBundle\Entity\Objective::getMeshDescriptors
      */
     public function testGetMeshDescriptors()
     {
@@ -187,7 +187,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::addParent
+     * @covers \Ilios\CoreBundle\Entity\Objective::addParent
      */
     public function testAddParent()
     {
@@ -195,7 +195,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::removeParent
+     * @covers \Ilios\CoreBundle\Entity\Objective::removeParent
      */
     public function testRemoveParent()
     {
@@ -203,8 +203,8 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::getParents
-     * @covers Ilios\CoreBundle\Entity\Objective::setParents
+     * @covers \Ilios\CoreBundle\Entity\Objective::getParents
+     * @covers \Ilios\CoreBundle\Entity\Objective::setParents
      */
     public function testGetParents()
     {
@@ -212,8 +212,8 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::setAncestor
-     * @covers Ilios\CoreBundle\Entity\Objective::getAncestor
+     * @covers \Ilios\CoreBundle\Entity\Objective::setAncestor
+     * @covers \Ilios\CoreBundle\Entity\Objective::getAncestor
      */
     public function testSetAncestor()
     {
@@ -221,7 +221,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::addDescendant
+     * @covers \Ilios\CoreBundle\Entity\Objective::addDescendant
      */
     public function testAddDescendant()
     {
@@ -229,7 +229,7 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::removeDescendant
+     * @covers \Ilios\CoreBundle\Entity\Objective::removeDescendant
      */
     public function testRemoveDescendant()
     {
@@ -237,8 +237,8 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Objective::getDescendants
-     * @covers Ilios\CoreBundle\Entity\Objective::setDescendants
+     * @covers \Ilios\CoreBundle\Entity\Objective::getDescendants
+     * @covers \Ilios\CoreBundle\Entity\Objective::setDescendants
      */
     public function testGetDescendants()
     {

--- a/tests/CoreBundle/Entity/OfferingTest.php
+++ b/tests/CoreBundle/Entity/OfferingTest.php
@@ -59,7 +59,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::__construct
+     * @covers \Ilios\CoreBundle\Entity\Offering::__construct
      */
     public function testConstructor()
     {
@@ -71,8 +71,8 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::setRoom
-     * @covers Ilios\CoreBundle\Entity\Offering::getRoom
+     * @covers \Ilios\CoreBundle\Entity\Offering::setRoom
+     * @covers \Ilios\CoreBundle\Entity\Offering::getRoom
      */
     public function testSetRoom()
     {
@@ -80,8 +80,8 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::setSite
-     * @covers Ilios\CoreBundle\Entity\Offering::getSite
+     * @covers \Ilios\CoreBundle\Entity\Offering::setSite
+     * @covers \Ilios\CoreBundle\Entity\Offering::getSite
      */
     public function testSetSite()
     {
@@ -89,8 +89,8 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::setStartDate
-     * @covers Ilios\CoreBundle\Entity\Offering::getStartDate
+     * @covers \Ilios\CoreBundle\Entity\Offering::setStartDate
+     * @covers \Ilios\CoreBundle\Entity\Offering::getStartDate
      */
     public function testSetStartDate()
     {
@@ -98,8 +98,8 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::setEndDate
-     * @covers Ilios\CoreBundle\Entity\Offering::getEndDate
+     * @covers \Ilios\CoreBundle\Entity\Offering::setEndDate
+     * @covers \Ilios\CoreBundle\Entity\Offering::getEndDate
      */
     public function testSetEndDate()
     {
@@ -107,8 +107,8 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::setSession
-     * @covers Ilios\CoreBundle\Entity\Offering::getSession
+     * @covers \Ilios\CoreBundle\Entity\Offering::setSession
+     * @covers \Ilios\CoreBundle\Entity\Offering::getSession
      */
     public function testSetSession()
     {
@@ -116,7 +116,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::addLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\Offering::addLearnerGroup
      */
     public function testAddLearnerGroup()
     {
@@ -124,7 +124,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::removeLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\Offering::removeLearnerGroup
      */
     public function testRemoveLearnerGroup()
     {
@@ -132,7 +132,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::setLearnerGroups
+     * @covers \Ilios\CoreBundle\Entity\Offering::setLearnerGroups
      */
     public function testSetLearnerGroup()
     {
@@ -140,7 +140,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::addInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\Offering::addInstructorGroup
      */
     public function testAddInstructorGroup()
     {
@@ -148,7 +148,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::removeInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\Offering::removeInstructorGroup
      */
     public function testRemoveInstructorGroup()
     {
@@ -156,7 +156,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::setInstructorGroups
+     * @covers \Ilios\CoreBundle\Entity\Offering::setInstructorGroups
      */
     public function testSetInstructorGroup()
     {
@@ -164,7 +164,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::addLearner
+     * @covers \Ilios\CoreBundle\Entity\Offering::addLearner
      */
     public function testAddLearner()
     {
@@ -172,7 +172,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::removeLearner
+     * @covers \Ilios\CoreBundle\Entity\Offering::removeLearner
      */
     public function testRemoveLearner()
     {
@@ -180,7 +180,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::setLearners
+     * @covers \Ilios\CoreBundle\Entity\Offering::setLearners
      */
     public function testSetLearner()
     {
@@ -188,7 +188,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::addInstructor
+     * @covers \Ilios\CoreBundle\Entity\Offering::addInstructor
      */
     public function testAddInstructor()
     {
@@ -196,7 +196,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::removeInstructor
+     * @covers \Ilios\CoreBundle\Entity\Offering::removeInstructor
      */
     public function testRemoveInstructor()
     {
@@ -204,7 +204,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::setInstructors
+     * @covers \Ilios\CoreBundle\Entity\Offering::setInstructors
      */
     public function testSetInstructor()
     {
@@ -212,7 +212,7 @@ class OfferingTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Offering::getSchool
+     * @covers \Ilios\CoreBundle\Entity\Offering::getSchool
      */
     public function testGetSchool()
     {

--- a/tests/CoreBundle/Entity/PendingUserUpdateTest.php
+++ b/tests/CoreBundle/Entity/PendingUserUpdateTest.php
@@ -55,8 +55,8 @@ class PendingUserUpdateTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\PendingUserUpdate::setType
-     * @covers Ilios\CoreBundle\Entity\PendingUserUpdate::getType
+     * @covers \Ilios\CoreBundle\Entity\PendingUserUpdate::setType
+     * @covers \Ilios\CoreBundle\Entity\PendingUserUpdate::getType
      */
     public function testSetType()
     {
@@ -64,8 +64,8 @@ class PendingUserUpdateTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\PendingUserUpdate::setProperty
-     * @covers Ilios\CoreBundle\Entity\PendingUserUpdate::getProperty
+     * @covers \Ilios\CoreBundle\Entity\PendingUserUpdate::setProperty
+     * @covers \Ilios\CoreBundle\Entity\PendingUserUpdate::getProperty
      */
     public function testSetProperty()
     {
@@ -73,8 +73,8 @@ class PendingUserUpdateTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\PendingUserUpdate::setValue
-     * @covers Ilios\CoreBundle\Entity\PendingUserUpdate::getValue
+     * @covers \Ilios\CoreBundle\Entity\PendingUserUpdate::setValue
+     * @covers \Ilios\CoreBundle\Entity\PendingUserUpdate::getValue
      */
     public function testSetValue()
     {
@@ -82,8 +82,8 @@ class PendingUserUpdateTest extends EntityBase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\PendingUserUpdate::setUser
-     * @covers Ilios\CoreBundle\Entity\PendingUserUpdate::getUser
+     * @covers \Ilios\CoreBundle\Entity\PendingUserUpdate::setUser
+     * @covers \Ilios\CoreBundle\Entity\PendingUserUpdate::getUser
      */
     public function testSetUser()
     {

--- a/tests/CoreBundle/Entity/PermissionTest.php
+++ b/tests/CoreBundle/Entity/PermissionTest.php
@@ -26,8 +26,8 @@ class PermissionTest extends EntityBase
     // NotBlank() tests
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Permission::setCanRead
-     * @covers Ilios\CoreBundle\Entity\Permission::hasCanRead
+     * @covers \Ilios\CoreBundle\Entity\Permission::setCanRead
+     * @covers \Ilios\CoreBundle\Entity\Permission::hasCanRead
      */
     public function testSetCanRead()
     {
@@ -35,8 +35,8 @@ class PermissionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Permission::setCanWrite
-     * @covers Ilios\CoreBundle\Entity\Permission::hasCanWrite
+     * @covers \Ilios\CoreBundle\Entity\Permission::setCanWrite
+     * @covers \Ilios\CoreBundle\Entity\Permission::hasCanWrite
      */
     public function testSetCanWrite()
     {
@@ -44,8 +44,8 @@ class PermissionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Permission::setTableName
-     * @covers Ilios\CoreBundle\Entity\Permission::getTableName
+     * @covers \Ilios\CoreBundle\Entity\Permission::setTableName
+     * @covers \Ilios\CoreBundle\Entity\Permission::getTableName
      */
     public function testSetTableName()
     {
@@ -53,8 +53,8 @@ class PermissionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Permission::setUser
-     * @covers Ilios\CoreBundle\Entity\Permission::getUser
+     * @covers \Ilios\CoreBundle\Entity\Permission::setUser
+     * @covers \Ilios\CoreBundle\Entity\Permission::getUser
      */
     public function testSetUser()
     {

--- a/tests/CoreBundle/Entity/ProgramTest.php
+++ b/tests/CoreBundle/Entity/ProgramTest.php
@@ -53,7 +53,7 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::__construct
+     * @covers \Ilios\CoreBundle\Entity\Program::__construct
      */
     public function testConstructor()
     {
@@ -63,8 +63,8 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::setTitle
-     * @covers Ilios\CoreBundle\Entity\Program::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Program::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Program::getTitle
      */
     public function testSetTitle()
     {
@@ -72,8 +72,8 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::setShortTitle
-     * @covers Ilios\CoreBundle\Entity\Program::getShortTitle
+     * @covers \Ilios\CoreBundle\Entity\Program::setShortTitle
+     * @covers \Ilios\CoreBundle\Entity\Program::getShortTitle
      */
     public function testSetShortTitle()
     {
@@ -81,8 +81,8 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::setDuration
-     * @covers Ilios\CoreBundle\Entity\Program::getDuration
+     * @covers \Ilios\CoreBundle\Entity\Program::setDuration
+     * @covers \Ilios\CoreBundle\Entity\Program::getDuration
      */
     public function testSetDuration()
     {
@@ -90,8 +90,8 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::setPublishedAsTbd
-     * @covers Ilios\CoreBundle\Entity\Program::isPublishedAsTbd
+     * @covers \Ilios\CoreBundle\Entity\Program::setPublishedAsTbd
+     * @covers \Ilios\CoreBundle\Entity\Program::isPublishedAsTbd
      */
     public function testSetPublishedAsTbd()
     {
@@ -99,8 +99,8 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::setPublished
-     * @covers Ilios\CoreBundle\Entity\Program::isPublished
+     * @covers \Ilios\CoreBundle\Entity\Program::setPublished
+     * @covers \Ilios\CoreBundle\Entity\Program::isPublished
      */
     public function testSetPublished()
     {
@@ -108,8 +108,8 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::setSchool
-     * @covers Ilios\CoreBundle\Entity\Program::getSchool
+     * @covers \Ilios\CoreBundle\Entity\Program::setSchool
+     * @covers \Ilios\CoreBundle\Entity\Program::getSchool
      */
     public function testSetSchool()
     {
@@ -117,7 +117,7 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::addProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Program::addProgramYear
      */
     public function testAddProgramYear()
     {
@@ -125,7 +125,7 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::removeProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Program::removeProgramYear
      */
     public function testRemoveProgramYear()
     {
@@ -133,7 +133,7 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::getProgramYears
+     * @covers \Ilios\CoreBundle\Entity\Program::getProgramYears
      */
     public function testGetProgramYears()
     {
@@ -141,7 +141,7 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::addCurriculumInventoryReport
+     * @covers \Ilios\CoreBundle\Entity\Program::addCurriculumInventoryReport
      */
     public function testAddCurriculumInventoryReport()
     {
@@ -149,7 +149,7 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::removeCurriculumInventoryReport
+     * @covers \Ilios\CoreBundle\Entity\Program::removeCurriculumInventoryReport
      */
     public function testRemoveCurriculumInventoryReport()
     {
@@ -157,8 +157,8 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::getCurriculumInventoryReports
-     * @covers Ilios\CoreBundle\Entity\Program::setCurriculumInventoryReports
+     * @covers \Ilios\CoreBundle\Entity\Program::getCurriculumInventoryReports
+     * @covers \Ilios\CoreBundle\Entity\Program::setCurriculumInventoryReports
      */
     public function testGetCurriculumInventoryReports()
     {
@@ -166,7 +166,7 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::addDirector
+     * @covers \Ilios\CoreBundle\Entity\Program::addDirector
      */
     public function testAddDirector()
     {
@@ -174,7 +174,7 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::removeDirector
+     * @covers \Ilios\CoreBundle\Entity\Program::removeDirector
      */
     public function testRemoveDirector()
     {
@@ -182,7 +182,7 @@ class ProgramTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Program::getDirectors
+     * @covers \Ilios\CoreBundle\Entity\Program::getDirectors
      */
     public function testGetDirectors()
     {

--- a/tests/CoreBundle/Entity/ProgramYearStewardTest.php
+++ b/tests/CoreBundle/Entity/ProgramYearStewardTest.php
@@ -26,8 +26,8 @@ class ProgramYearStewardTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYearSteward::setDepartment
-     * @covers Ilios\CoreBundle\Entity\ProgramYearSteward::getDepartment
+     * @covers \Ilios\CoreBundle\Entity\ProgramYearSteward::setDepartment
+     * @covers \Ilios\CoreBundle\Entity\ProgramYearSteward::getDepartment
      */
     public function testSetDepartment()
     {
@@ -35,8 +35,8 @@ class ProgramYearStewardTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYearSteward::setProgramYear
-     * @covers Ilios\CoreBundle\Entity\ProgramYearSteward::getProgramYear
+     * @covers \Ilios\CoreBundle\Entity\ProgramYearSteward::setProgramYear
+     * @covers \Ilios\CoreBundle\Entity\ProgramYearSteward::getProgramYear
      */
     public function testSetProgramYear()
     {
@@ -44,8 +44,8 @@ class ProgramYearStewardTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYearSteward::setSchool
-     * @covers Ilios\CoreBundle\Entity\ProgramYearSteward::getSchool
+     * @covers \Ilios\CoreBundle\Entity\ProgramYearSteward::setSchool
+     * @covers \Ilios\CoreBundle\Entity\ProgramYearSteward::getSchool
      */
     public function testSetSchool()
     {
@@ -53,7 +53,7 @@ class ProgramYearStewardTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYearSteward::getSchool
+     * @covers \Ilios\CoreBundle\Entity\ProgramYearSteward::getSchool
      */
     public function testGetSchool()
     {
@@ -61,7 +61,7 @@ class ProgramYearStewardTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYearSteward::getProgram
+     * @covers \Ilios\CoreBundle\Entity\ProgramYearSteward::getProgram
      */
     public function testGetProgram()
     {
@@ -82,7 +82,7 @@ class ProgramYearStewardTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYearSteward::getProgramOwningSchool
+     * @covers \Ilios\CoreBundle\Entity\ProgramYearSteward::getProgramOwningSchool
      */
     public function testGetProgramOwningSchool()
     {

--- a/tests/CoreBundle/Entity/ProgramYearTest.php
+++ b/tests/CoreBundle/Entity/ProgramYearTest.php
@@ -52,7 +52,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::__construct
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::__construct
      */
     public function testConstructor()
     {
@@ -64,8 +64,8 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::setStartYear
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::getStartYear
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::setStartYear
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::getStartYear
      */
     public function testSetStartYear()
     {
@@ -73,8 +73,8 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::setLocked
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::isLocked
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::setLocked
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::isLocked
      */
     public function testSetLocked()
     {
@@ -82,8 +82,8 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::setArchived
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::isArchived
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::setArchived
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::isArchived
      */
     public function testSetArchived()
     {
@@ -91,8 +91,8 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::setPublishedAsTbd
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::isPublishedAsTbd
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::setPublishedAsTbd
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::isPublishedAsTbd
      */
     public function testSetPublishedAsTbd()
     {
@@ -100,8 +100,8 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::setPublished
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::isPublished
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::setPublished
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::isPublished
      */
     public function testSetPublished()
     {
@@ -109,8 +109,8 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::setProgram
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::getProgram
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::setProgram
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::getProgram
      */
     public function testSetProgram()
     {
@@ -118,7 +118,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::addDirector
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::addDirector
      */
     public function testAddDirector()
     {
@@ -126,7 +126,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::removeDirector
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::removeDirector
      */
     public function testRemoveDirector()
     {
@@ -134,7 +134,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::getDirectors
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::getDirectors
      */
     public function testGetDirectors()
     {
@@ -142,7 +142,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::addSteward
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::addSteward
      */
     public function testAddSteward()
     {
@@ -150,7 +150,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::removeSteward
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::removeSteward
      */
     public function testRemoveSteward()
     {
@@ -158,7 +158,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::getStewards
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::getStewards
      */
     public function testGetSteward()
     {
@@ -166,7 +166,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::getSchool
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::getSchool
      */
     public function testGetSchool()
     {
@@ -187,7 +187,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::addTerm
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::addTerm
      */
     public function testAddTerm()
     {
@@ -195,7 +195,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::removeTerm
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::removeTerm
      */
     public function testRemoveTerm()
     {
@@ -203,8 +203,8 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::getTerms
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::setTerms
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::getTerms
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::setTerms
      */
     public function testSetTerms()
     {
@@ -212,7 +212,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::addObjective
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::addObjective
      */
     public function testAddObjective()
     {
@@ -220,7 +220,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::removeObjective
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::removeObjective
      */
     public function testRemoveObjective()
     {
@@ -228,8 +228,8 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::getObjectives
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::setObjectives
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::getObjectives
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::setObjectives
      */
     public function testSetObjectives()
     {
@@ -237,7 +237,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::addCompetency
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::addCompetency
      */
     public function testAddCompetency()
     {
@@ -245,7 +245,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::getCompetencies
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::getCompetencies
      */
     public function testGetCompetencies()
     {
@@ -258,7 +258,7 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::removeCompetency
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::removeCompetency
      */
     public function testRemoveCompetency()
     {
@@ -272,8 +272,8 @@ class ProgramYearTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\ProgramYear::setCohort
-     * @covers Ilios\CoreBundle\Entity\PendingCohortUpdate::getCohort
+     * @covers \Ilios\CoreBundle\Entity\ProgramYear::setCohort
+     * @covers \Ilios\CoreBundle\Entity\PendingCohortUpdate::getCohort
      */
     public function testSetCohort()
     {

--- a/tests/CoreBundle/Entity/ReportTest.php
+++ b/tests/CoreBundle/Entity/ReportTest.php
@@ -23,7 +23,7 @@ class ReportTest extends EntityBase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::__construct
+     * @covers \Ilios\CoreBundle\Entity\Session::__construct
      */
     public function testConstructor()
     {
@@ -31,8 +31,8 @@ class ReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Report::setSubject
-     * @covers Ilios\CoreBundle\Entity\Report::getSubject
+     * @covers \Ilios\CoreBundle\Entity\Report::setSubject
+     * @covers \Ilios\CoreBundle\Entity\Report::getSubject
      */
     public function testSetSubject()
     {
@@ -40,8 +40,8 @@ class ReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Report::setPrepositionalObject
-     * @covers Ilios\CoreBundle\Entity\Report::getPrepositionalObject
+     * @covers \Ilios\CoreBundle\Entity\Report::setPrepositionalObject
+     * @covers \Ilios\CoreBundle\Entity\Report::getPrepositionalObject
      */
     public function testSetPrepositionalObject()
     {
@@ -49,8 +49,8 @@ class ReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Report::setPrepositionalObjectTableRowId
-     * @covers Ilios\CoreBundle\Entity\Report::getPrepositionalObjectTableRowId
+     * @covers \Ilios\CoreBundle\Entity\Report::setPrepositionalObjectTableRowId
+     * @covers \Ilios\CoreBundle\Entity\Report::getPrepositionalObjectTableRowId
      */
     public function testSetPrepositionalObjectTableRowId()
     {
@@ -58,8 +58,8 @@ class ReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Report::setTitle
-     * @covers Ilios\CoreBundle\Entity\Report::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Report::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Report::getTitle
      */
     public function testSetTitle()
     {
@@ -67,8 +67,8 @@ class ReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Report::setUser
-     * @covers Ilios\CoreBundle\Entity\Report::getUser
+     * @covers \Ilios\CoreBundle\Entity\Report::setUser
+     * @covers \Ilios\CoreBundle\Entity\Report::getUser
      */
     public function testSetUser()
     {
@@ -76,8 +76,8 @@ class ReportTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Report::setSchool
-     * @covers Ilios\CoreBundle\Entity\Report::getSchool
+     * @covers \Ilios\CoreBundle\Entity\Report::setSchool
+     * @covers \Ilios\CoreBundle\Entity\Report::getSchool
      */
     public function testSetSchool()
     {

--- a/tests/CoreBundle/Entity/SchoolTest.php
+++ b/tests/CoreBundle/Entity/SchoolTest.php
@@ -36,7 +36,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::__construct
+     * @covers \Ilios\CoreBundle\Entity\School::__construct
      */
     public function testConstructor()
     {
@@ -52,8 +52,8 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::setTemplatePrefix
-     * @covers Ilios\CoreBundle\Entity\School::getTemplatePrefix
+     * @covers \Ilios\CoreBundle\Entity\School::setTemplatePrefix
+     * @covers \Ilios\CoreBundle\Entity\School::getTemplatePrefix
      */
     public function testSetTemplatePrefix()
     {
@@ -61,8 +61,8 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::setTitle
-     * @covers Ilios\CoreBundle\Entity\School::getTitle
+     * @covers \Ilios\CoreBundle\Entity\School::setTitle
+     * @covers \Ilios\CoreBundle\Entity\School::getTitle
      */
     public function testSetTitle()
     {
@@ -70,8 +70,8 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::setIliosAdministratorEmail
-     * @covers Ilios\CoreBundle\Entity\School::getIliosAdministratorEmail
+     * @covers \Ilios\CoreBundle\Entity\School::setIliosAdministratorEmail
+     * @covers \Ilios\CoreBundle\Entity\School::getIliosAdministratorEmail
      */
     public function testSetIliosAdministratorEmail()
     {
@@ -79,8 +79,8 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::setChangeAlertRecipients
-     * @covers Ilios\CoreBundle\Entity\School::getChangeAlertRecipients
+     * @covers \Ilios\CoreBundle\Entity\School::setChangeAlertRecipients
+     * @covers \Ilios\CoreBundle\Entity\School::getChangeAlertRecipients
      */
     public function testSetChangeAlertRecipients()
     {
@@ -88,8 +88,8 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::setCurriculumInventoryInstitution
-     * @covers Ilios\CoreBundle\Entity\School::getCurriculumInventoryInstitution
+     * @covers \Ilios\CoreBundle\Entity\School::setCurriculumInventoryInstitution
+     * @covers \Ilios\CoreBundle\Entity\School::getCurriculumInventoryInstitution
      */
     public function testSetCurriculumInventoryInstitution()
     {
@@ -97,7 +97,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addAlert
+     * @covers \Ilios\CoreBundle\Entity\School::addAlert
      */
     public function testAddAlert()
     {
@@ -105,7 +105,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeAlert
+     * @covers \Ilios\CoreBundle\Entity\School::removeAlert
      */
     public function testRemoveAlert()
     {
@@ -113,7 +113,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getAlerts
+     * @covers \Ilios\CoreBundle\Entity\School::getAlerts
      */
     public function testGetAlerts()
     {
@@ -121,7 +121,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addCompetency
+     * @covers \Ilios\CoreBundle\Entity\School::addCompetency
      */
     public function testAddCompetency()
     {
@@ -129,7 +129,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getCompetencies
+     * @covers \Ilios\CoreBundle\Entity\School::getCompetencies
      */
     public function testGetCompetencies()
     {
@@ -142,7 +142,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeCompetency
+     * @covers \Ilios\CoreBundle\Entity\School::removeCompetency
      */
     public function testRemoveCompetency()
     {
@@ -156,7 +156,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addCourse
+     * @covers \Ilios\CoreBundle\Entity\School::addCourse
      */
     public function testAddCourse()
     {
@@ -164,7 +164,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeCourse
+     * @covers \Ilios\CoreBundle\Entity\School::removeCourse
      */
     public function testRemoveCourse()
     {
@@ -172,7 +172,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getCourses
+     * @covers \Ilios\CoreBundle\Entity\School::getCourses
      */
     public function testGetCourses()
     {
@@ -180,7 +180,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addProgram
+     * @covers \Ilios\CoreBundle\Entity\School::addProgram
      */
     public function testAddProgram()
     {
@@ -188,7 +188,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeProgram
+     * @covers \Ilios\CoreBundle\Entity\School::removeProgram
      */
     public function testRemoveProgram()
     {
@@ -196,7 +196,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getPrograms
+     * @covers \Ilios\CoreBundle\Entity\School::getPrograms
      */
     public function testGetPrograms()
     {
@@ -204,7 +204,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addDepartment
+     * @covers \Ilios\CoreBundle\Entity\School::addDepartment
      */
     public function testAddDepartment()
     {
@@ -212,7 +212,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeDepartment
+     * @covers \Ilios\CoreBundle\Entity\School::removeDepartment
      */
     public function testRemoveDepartment()
     {
@@ -220,8 +220,8 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getDepartments
-     * @covers Ilios\CoreBundle\Entity\School::setDepartments
+     * @covers \Ilios\CoreBundle\Entity\School::getDepartments
+     * @covers \Ilios\CoreBundle\Entity\School::setDepartments
      */
     public function testGetDepartments()
     {
@@ -229,7 +229,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addSteward
+     * @covers \Ilios\CoreBundle\Entity\School::addSteward
      */
     public function testAddSteward()
     {
@@ -237,7 +237,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeSteward
+     * @covers \Ilios\CoreBundle\Entity\School::removeSteward
      */
     public function testRemoveSteward()
     {
@@ -245,7 +245,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getStewards
+     * @covers \Ilios\CoreBundle\Entity\School::getStewards
      */
     public function testGetSteward()
     {
@@ -253,7 +253,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addVocabulary
+     * @covers \Ilios\CoreBundle\Entity\School::addVocabulary
      */
     public function testAddVocabulary()
     {
@@ -261,7 +261,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeVocabulary
+     * @covers \Ilios\CoreBundle\Entity\School::removeVocabulary
      */
     public function testRemoveVocabulary()
     {
@@ -269,8 +269,8 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getVocabularies
-     * @covers Ilios\CoreBundle\Entity\School::setVocabularies
+     * @covers \Ilios\CoreBundle\Entity\School::getVocabularies
+     * @covers \Ilios\CoreBundle\Entity\School::setVocabularies
      */
     public function testGetVocabularies()
     {
@@ -278,7 +278,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\School::addInstructorGroup
      */
     public function testAddInstructorGroup()
     {
@@ -286,7 +286,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\School::removeInstructorGroup
      */
     public function testRemoveInstructorGroup()
     {
@@ -294,7 +294,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::setInstructorGroups
+     * @covers \Ilios\CoreBundle\Entity\School::setInstructorGroups
      */
     public function testSetInstructorGroup()
     {
@@ -302,7 +302,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addSessionType
+     * @covers \Ilios\CoreBundle\Entity\School::addSessionType
      */
     public function testAddSessionType()
     {
@@ -310,7 +310,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeSessionType
+     * @covers \Ilios\CoreBundle\Entity\School::removeSessionType
      */
     public function testRemoveSessionType()
     {
@@ -318,7 +318,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::setSessionTypes
+     * @covers \Ilios\CoreBundle\Entity\School::setSessionTypes
      */
     public function testSetSessionType()
     {
@@ -326,7 +326,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addDirector
+     * @covers \Ilios\CoreBundle\Entity\School::addDirector
      */
     public function testAddDirector()
     {
@@ -334,7 +334,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeDirector
+     * @covers \Ilios\CoreBundle\Entity\School::removeDirector
      */
     public function testRemoveDirector()
     {
@@ -342,7 +342,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getDirectors
+     * @covers \Ilios\CoreBundle\Entity\School::getDirectors
      */
     public function testGetDirectors()
     {
@@ -350,7 +350,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::addAdministrator
+     * @covers \Ilios\CoreBundle\Entity\School::addAdministrator
      */
     public function testAddAdministrator()
     {
@@ -358,7 +358,7 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::removeAdministrator
+     * @covers \Ilios\CoreBundle\Entity\School::removeAdministrator
      */
     public function testRemoveAdministrator()
     {
@@ -366,8 +366,8 @@ class SchoolTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\School::getAdministrators
-     * @covers Ilios\CoreBundle\Entity\School::setAdministrators
+     * @covers \Ilios\CoreBundle\Entity\School::getAdministrators
+     * @covers \Ilios\CoreBundle\Entity\School::setAdministrators
      */
     public function testSetAdministrators()
     {

--- a/tests/CoreBundle/Entity/SessionDescriptionTest.php
+++ b/tests/CoreBundle/Entity/SessionDescriptionTest.php
@@ -23,8 +23,8 @@ class SessionDescriptionTest extends EntityBase
     }
    
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionDescription::setDescription
-     * @covers Ilios\CoreBundle\Entity\SessionDescription::getDescription
+     * @covers \Ilios\CoreBundle\Entity\SessionDescription::setDescription
+     * @covers \Ilios\CoreBundle\Entity\SessionDescription::getDescription
      */
     public function testSetDescription()
     {
@@ -32,8 +32,8 @@ class SessionDescriptionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionDescription::setSession
-     * @covers Ilios\CoreBundle\Entity\SessionDescription::getSession
+     * @covers \Ilios\CoreBundle\Entity\SessionDescription::setSession
+     * @covers \Ilios\CoreBundle\Entity\SessionDescription::getSession
      */
     public function testSetSession()
     {

--- a/tests/CoreBundle/Entity/SessionLearningMaterialTest.php
+++ b/tests/CoreBundle/Entity/SessionLearningMaterialTest.php
@@ -23,7 +23,7 @@ class SessionLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::__construct
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::__construct
      */
     public function testConstructor()
     {
@@ -31,8 +31,8 @@ class SessionLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::setNotes
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::getNotes
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::setNotes
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::getNotes
      */
     public function testSetNotes()
     {
@@ -40,8 +40,8 @@ class SessionLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::setRequired
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::isRequired
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::setRequired
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::isRequired
      */
     public function testSetRequired()
     {
@@ -49,8 +49,8 @@ class SessionLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::setPublicNotes
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::hasPublicNotes
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::setPublicNotes
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::hasPublicNotes
      */
     public function testSetNotesArePublic()
     {
@@ -58,8 +58,8 @@ class SessionLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::setSession
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::getSession
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::setSession
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::getSession
      */
     public function testSetSession()
     {
@@ -67,8 +67,8 @@ class SessionLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::setLearningMaterial
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::getLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::setLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::getLearningMaterial
      */
     public function testSetLearningMaterial()
     {
@@ -76,7 +76,7 @@ class SessionLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::addMeshDescriptor
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::addMeshDescriptor
      */
     public function testAddMeshDescriptor()
     {
@@ -84,7 +84,7 @@ class SessionLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::removeMeshDescriptor
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::removeMeshDescriptor
      */
     public function testRemoveMeshDescriptor()
     {
@@ -92,7 +92,7 @@ class SessionLearningMaterialTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionLearningMaterial::getMeshDescriptors
+     * @covers \Ilios\CoreBundle\Entity\SessionLearningMaterial::getMeshDescriptors
      */
     public function testGetMeshDescriptors()
     {

--- a/tests/CoreBundle/Entity/SessionTest.php
+++ b/tests/CoreBundle/Entity/SessionTest.php
@@ -50,7 +50,7 @@ class SessionTest extends EntityBase
         $this->validate(0);
     }
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::__construct
+     * @covers \Ilios\CoreBundle\Entity\Session::__construct
      */
     public function testConstructor()
     {
@@ -62,8 +62,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setTitle
-     * @covers Ilios\CoreBundle\Entity\Session::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Session::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Session::getTitle
      */
     public function testSetTitle()
     {
@@ -71,8 +71,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setAttireRequired
-     * @covers Ilios\CoreBundle\Entity\Session::isAttireRequired
+     * @covers \Ilios\CoreBundle\Entity\Session::setAttireRequired
+     * @covers \Ilios\CoreBundle\Entity\Session::isAttireRequired
      */
     public function testSetAttireRequired()
     {
@@ -80,8 +80,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setEquipmentRequired
-     * @covers Ilios\CoreBundle\Entity\Session::isEquipmentRequired
+     * @covers \Ilios\CoreBundle\Entity\Session::setEquipmentRequired
+     * @covers \Ilios\CoreBundle\Entity\Session::isEquipmentRequired
      */
     public function testSetEquipmentRequired()
     {
@@ -89,8 +89,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setSupplemental
-     * @covers Ilios\CoreBundle\Entity\Session::isSupplemental
+     * @covers \Ilios\CoreBundle\Entity\Session::setSupplemental
+     * @covers \Ilios\CoreBundle\Entity\Session::isSupplemental
      */
     public function testSetSupplemental()
     {
@@ -98,8 +98,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setPublishedAsTbd
-     * @covers Ilios\CoreBundle\Entity\Session::isPublishedAsTbd
+     * @covers \Ilios\CoreBundle\Entity\Session::setPublishedAsTbd
+     * @covers \Ilios\CoreBundle\Entity\Session::isPublishedAsTbd
      */
     public function testSetPublishedAsTbd()
     {
@@ -107,8 +107,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setPublished
-     * @covers Ilios\CoreBundle\Entity\Session::isPublished
+     * @covers \Ilios\CoreBundle\Entity\Session::setPublished
+     * @covers \Ilios\CoreBundle\Entity\Session::isPublished
      */
     public function testSetPublished()
     {
@@ -116,8 +116,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setSessionType
-     * @covers Ilios\CoreBundle\Entity\Session::getSessionType
+     * @covers \Ilios\CoreBundle\Entity\Session::setSessionType
+     * @covers \Ilios\CoreBundle\Entity\Session::getSessionType
      */
     public function testSetSessionType()
     {
@@ -125,8 +125,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setCourse
-     * @covers Ilios\CoreBundle\Entity\Session::getCourse
+     * @covers \Ilios\CoreBundle\Entity\Session::setCourse
+     * @covers \Ilios\CoreBundle\Entity\Session::getCourse
      */
     public function testSetCourse()
     {
@@ -134,8 +134,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setIlmSession
-     * @covers Ilios\CoreBundle\Entity\Session::getIlmSession
+     * @covers \Ilios\CoreBundle\Entity\Session::setIlmSession
+     * @covers \Ilios\CoreBundle\Entity\Session::getIlmSession
      */
     public function testSetIlmSession()
     {
@@ -148,7 +148,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::addLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\Session::addLearningMaterial
      */
     public function testAddLearningMaterial()
     {
@@ -156,7 +156,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::removeLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\Session::removeLearningMaterial
      */
     public function testRemoveLearningMaterial()
     {
@@ -164,8 +164,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setLearningMaterials
-     * @covers Ilios\CoreBundle\Entity\Session::getLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\Session::setLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\Session::getLearningMaterials
      */
     public function testGetLearningMaterials()
     {
@@ -173,7 +173,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::stampUpdate
+     * @covers \Ilios\CoreBundle\Entity\Session::stampUpdate
      */
     public function testStampUpdate()
     {
@@ -186,7 +186,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::getSchool
+     * @covers \Ilios\CoreBundle\Entity\Session::getSchool
      */
     public function testGetSchool()
     {
@@ -207,7 +207,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::addTerm
+     * @covers \Ilios\CoreBundle\Entity\Session::addTerm
      */
     public function testAddTerm()
     {
@@ -215,7 +215,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::removeTerm
+     * @covers \Ilios\CoreBundle\Entity\Session::removeTerm
      */
     public function testRemoveTerm()
     {
@@ -223,8 +223,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::getTerms
-     * @covers Ilios\CoreBundle\Entity\Session::setTerms
+     * @covers \Ilios\CoreBundle\Entity\Session::getTerms
+     * @covers \Ilios\CoreBundle\Entity\Session::setTerms
      */
     public function testSetTerms()
     {
@@ -232,7 +232,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::addObjective
+     * @covers \Ilios\CoreBundle\Entity\Session::addObjective
      */
     public function testAddObjective()
     {
@@ -240,7 +240,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::removeObjective
+     * @covers \Ilios\CoreBundle\Entity\Session::removeObjective
      */
     public function testRemoveObjective()
     {
@@ -248,8 +248,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::getObjectives
-     * @covers Ilios\CoreBundle\Entity\Session::setObjectives
+     * @covers \Ilios\CoreBundle\Entity\Session::getObjectives
+     * @covers \Ilios\CoreBundle\Entity\Session::setObjectives
      */
     public function testSetObjectives()
     {
@@ -257,7 +257,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::addMeshDescriptor
+     * @covers \Ilios\CoreBundle\Entity\Session::addMeshDescriptor
      */
     public function testAddMeshDescriptor()
     {
@@ -265,7 +265,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::removeMeshDescriptor
+     * @covers \Ilios\CoreBundle\Entity\Session::removeMeshDescriptor
      */
     public function testRemoveMeshDescriptor()
     {
@@ -273,8 +273,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::getMeshDescriptors
-     * @covers Ilios\CoreBundle\Entity\Session::setMeshDescriptors
+     * @covers \Ilios\CoreBundle\Entity\Session::getMeshDescriptors
+     * @covers \Ilios\CoreBundle\Entity\Session::setMeshDescriptors
      */
     public function testSetMeshDescriptors()
     {
@@ -282,8 +282,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setSessionDescription
-     * @covers Ilios\CoreBundle\Entity\Session::getSessionDescription
+     * @covers \Ilios\CoreBundle\Entity\Session::setSessionDescription
+     * @covers \Ilios\CoreBundle\Entity\Session::getSessionDescription
      */
     public function testSetSessionDescription()
     {
@@ -296,7 +296,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::addSequenceBlock
+     * @covers \Ilios\CoreBundle\Entity\Session::addSequenceBlock
      */
     public function testAddSequenceBlock()
     {
@@ -304,7 +304,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::removeSequenceBlock
+     * @covers \Ilios\CoreBundle\Entity\Session::removeSequenceBlock
      */
     public function testRemoveSequenceBlock()
     {
@@ -312,8 +312,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::setSequenceBlocks
-     * @covers Ilios\CoreBundle\Entity\Session::getSequenceBlocks
+     * @covers \Ilios\CoreBundle\Entity\Session::setSequenceBlocks
+     * @covers \Ilios\CoreBundle\Entity\Session::getSequenceBlocks
      */
     public function testGetSequenceBlocks()
     {
@@ -321,7 +321,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::addOffering
+     * @covers \Ilios\CoreBundle\Entity\Session::addOffering
      */
     public function testAddOffering()
     {
@@ -329,7 +329,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::removeOffering
+     * @covers \Ilios\CoreBundle\Entity\Session::removeOffering
      */
     public function testRemoveOffering()
     {
@@ -337,8 +337,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::getOfferings
-     * @covers Ilios\CoreBundle\Entity\Session::setOfferings
+     * @covers \Ilios\CoreBundle\Entity\Session::getOfferings
+     * @covers \Ilios\CoreBundle\Entity\Session::setOfferings
      */
     public function testSetOfferings()
     {
@@ -346,7 +346,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::addAdministrator
+     * @covers \Ilios\CoreBundle\Entity\Session::addAdministrator
      */
     public function testAddAdministrator()
     {
@@ -354,7 +354,7 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::removeAdministrator
+     * @covers \Ilios\CoreBundle\Entity\Session::removeAdministrator
      */
     public function testRemoveAdministrator()
     {
@@ -362,8 +362,8 @@ class SessionTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::getAdministrators
-     * @covers Ilios\CoreBundle\Entity\Session::setAdministrators
+     * @covers \Ilios\CoreBundle\Entity\Session::getAdministrators
+     * @covers \Ilios\CoreBundle\Entity\Session::setAdministrators
      */
     public function testSetAdministrators()
     {

--- a/tests/CoreBundle/Entity/SessionTypeTest.php
+++ b/tests/CoreBundle/Entity/SessionTypeTest.php
@@ -50,7 +50,7 @@ class SessionTypeTest extends EntityBase
         $this->validate(0);
     }
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::__construct
+     * @covers \Ilios\CoreBundle\Entity\SessionType::__construct
      */
     public function testConstructor()
     {
@@ -59,8 +59,8 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::setTitle
-     * @covers Ilios\CoreBundle\Entity\SessionType::getTitle
+     * @covers \Ilios\CoreBundle\Entity\SessionType::setTitle
+     * @covers \Ilios\CoreBundle\Entity\SessionType::getTitle
      */
     public function testSetTitle()
     {
@@ -68,8 +68,8 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::setSessionTypeCssClass
-     * @covers Ilios\CoreBundle\Entity\SessionType::getSessionTypeCssClass
+     * @covers \Ilios\CoreBundle\Entity\SessionType::setSessionTypeCssClass
+     * @covers \Ilios\CoreBundle\Entity\SessionType::getSessionTypeCssClass
      */
     public function testSetSessionTypeCssClass()
     {
@@ -77,8 +77,8 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::setAssessment
-     * @covers Ilios\CoreBundle\Entity\SessionType::isAssessment
+     * @covers \Ilios\CoreBundle\Entity\SessionType::setAssessment
+     * @covers \Ilios\CoreBundle\Entity\SessionType::isAssessment
      */
     public function testIsAssessment()
     {
@@ -86,8 +86,8 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::setAssessmentOption
-     * @covers Ilios\CoreBundle\Entity\SessionType::getAssessmentOption
+     * @covers \Ilios\CoreBundle\Entity\SessionType::setAssessmentOption
+     * @covers \Ilios\CoreBundle\Entity\SessionType::getAssessmentOption
      */
     public function testSetAssessmentOption()
     {
@@ -95,7 +95,7 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::addAamcMethod
+     * @covers \Ilios\CoreBundle\Entity\SessionType::addAamcMethod
      */
     public function testAddAamcMethod()
     {
@@ -103,7 +103,7 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::removeAamcMethod
+     * @covers \Ilios\CoreBundle\Entity\SessionType::removeAamcMethod
      */
     public function testRemoveAamcMethod()
     {
@@ -111,8 +111,8 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::setAamcMethods
-     * @covers Ilios\CoreBundle\Entity\SessionType::getAamcMethods
+     * @covers \Ilios\CoreBundle\Entity\SessionType::setAamcMethods
+     * @covers \Ilios\CoreBundle\Entity\SessionType::getAamcMethods
      */
     public function testSetAamcMethods()
     {
@@ -120,7 +120,7 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::addSession
+     * @covers \Ilios\CoreBundle\Entity\SessionType::addSession
      */
     public function testAddSession()
     {
@@ -128,7 +128,7 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::removeSession
+     * @covers \Ilios\CoreBundle\Entity\SessionType::removeSession
      */
     public function testRemoveSession()
     {
@@ -136,7 +136,7 @@ class SessionTypeTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\SessionType::setSessions
+     * @covers \Ilios\CoreBundle\Entity\SessionType::setSessions
      */
     public function testSetSessions()
     {

--- a/tests/CoreBundle/Entity/TermTest.php
+++ b/tests/CoreBundle/Entity/TermTest.php
@@ -23,7 +23,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::__construct
+     * @covers \Ilios\CoreBundle\Entity\Term::__construct
      */
     public function testConstructor()
     {
@@ -35,8 +35,8 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::setTitle
-     * @covers Ilios\CoreBundle\Entity\Term::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Term::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Term::getTitle
      */
     public function testSetTitle()
     {
@@ -44,8 +44,8 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::setDescription
-     * @covers Ilios\CoreBundle\Entity\Term::getDescription
+     * @covers \Ilios\CoreBundle\Entity\Term::setDescription
+     * @covers \Ilios\CoreBundle\Entity\Term::getDescription
      */
     public function testSetDescription()
     {
@@ -53,8 +53,8 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::setVocabulary
-     * @covers Ilios\CoreBundle\Entity\Term::getVocabulary
+     * @covers \Ilios\CoreBundle\Entity\Term::setVocabulary
+     * @covers \Ilios\CoreBundle\Entity\Term::getVocabulary
      */
     public function testSetVocabulary()
     {
@@ -62,8 +62,8 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::setParent
-     * @covers Ilios\CoreBundle\Entity\Term::getParent
+     * @covers \Ilios\CoreBundle\Entity\Term::setParent
+     * @covers \Ilios\CoreBundle\Entity\Term::getParent
      */
     public function testSetParent()
     {
@@ -71,7 +71,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::addCourse
+     * @covers \Ilios\CoreBundle\Entity\Term::addCourse
      */
     public function testAddCourse()
     {
@@ -79,7 +79,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::removeCourse
+     * @covers \Ilios\CoreBundle\Entity\Term::removeCourse
      */
     public function testRemoveCourse()
     {
@@ -87,7 +87,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::getCourses
+     * @covers \Ilios\CoreBundle\Entity\Term::getCourses
      */
     public function testGetCourses()
     {
@@ -95,7 +95,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::addProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Term::addProgramYear
      */
     public function testAddProgramYear()
     {
@@ -103,7 +103,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::removeProgramYear
+     * @covers \Ilios\CoreBundle\Entity\Term::removeProgramYear
      */
     public function testRemoveProgramYear()
     {
@@ -111,7 +111,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::getProgramYears
+     * @covers \Ilios\CoreBundle\Entity\Term::getProgramYears
      */
     public function testGetProgramYears()
     {
@@ -119,7 +119,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::addSession
+     * @covers \Ilios\CoreBundle\Entity\Term::addSession
      */
     public function testAddSession()
     {
@@ -127,7 +127,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::removeSession
+     * @covers \Ilios\CoreBundle\Entity\Term::removeSession
      */
     public function testRemoveSession()
     {
@@ -135,7 +135,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::getSessions
+     * @covers \Ilios\CoreBundle\Entity\Term::getSessions
      */
     public function testGetSessions()
     {
@@ -143,7 +143,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::addAamcResourceType
+     * @covers \Ilios\CoreBundle\Entity\Term::addAamcResourceType
      */
     public function testAddAamcResourceTypes()
     {
@@ -151,7 +151,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::removeAamcResourceType
+     * @covers \Ilios\CoreBundle\Entity\Term::removeAamcResourceType
      */
     public function testRemoveAamcResourceTypes()
     {
@@ -159,8 +159,8 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::getAamcResourceTypes
-     * @covers Ilios\CoreBundle\Entity\Term::setAamcResourceTypes
+     * @covers \Ilios\CoreBundle\Entity\Term::getAamcResourceTypes
+     * @covers \Ilios\CoreBundle\Entity\Term::setAamcResourceTypes
      */
     public function testGetAamcResourceTypes()
     {
@@ -168,7 +168,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::addChild
+     * @covers \Ilios\CoreBundle\Entity\Term::addChild
      */
     public function testAddChild()
     {
@@ -176,7 +176,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::removeChild
+     * @covers \Ilios\CoreBundle\Entity\Term::removeChild
      */
     public function testRemoveChild()
     {
@@ -184,7 +184,7 @@ class TermTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Term::getChildren
+     * @covers \Ilios\CoreBundle\Entity\Term::getChildren
      */
     public function testGetChildren()
     {

--- a/tests/CoreBundle/Entity/UserMadeReminderTest.php
+++ b/tests/CoreBundle/Entity/UserMadeReminderTest.php
@@ -49,7 +49,7 @@ class UserMadeReminderTest extends EntityBase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\Session::__construct
+     * @covers \Ilios\CoreBundle\Entity\Session::__construct
      */
     public function testConstructor()
     {
@@ -57,8 +57,8 @@ class UserMadeReminderTest extends EntityBase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::setNote
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::getNote
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::setNote
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::getNote
      */
     public function testSetNote()
     {
@@ -66,8 +66,8 @@ class UserMadeReminderTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::setDueDate
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::getDueDate
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::setDueDate
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::getDueDate
      */
     public function testSetDueDate()
     {
@@ -75,8 +75,8 @@ class UserMadeReminderTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::setClosed
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::isClosed
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::setClosed
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::isClosed
      */
     public function testSetClosed()
     {
@@ -84,8 +84,8 @@ class UserMadeReminderTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::setUser
-     * @covers Ilios\CoreBundle\Entity\UserMadeReminder::getUser
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::setUser
+     * @covers \Ilios\CoreBundle\Entity\UserMadeReminder::getUser
      */
     public function testSetUser()
     {

--- a/tests/CoreBundle/Entity/UserRoleTest.php
+++ b/tests/CoreBundle/Entity/UserRoleTest.php
@@ -34,7 +34,7 @@ class UserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\UserRole::__construct
+     * @covers \Ilios\CoreBundle\Entity\UserRole::__construct
      */
     public function testConstructor()
     {
@@ -42,8 +42,8 @@ class UserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\UserRole::setTitle
-     * @covers Ilios\CoreBundle\Entity\UserRole::getTitle
+     * @covers \Ilios\CoreBundle\Entity\UserRole::setTitle
+     * @covers \Ilios\CoreBundle\Entity\UserRole::getTitle
      */
     public function testSetTitle()
     {
@@ -51,7 +51,7 @@ class UserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\UserRole::addUser
+     * @covers \Ilios\CoreBundle\Entity\UserRole::addUser
      */
     public function testAddUser()
     {
@@ -59,7 +59,7 @@ class UserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\UserRole::removeUser
+     * @covers \Ilios\CoreBundle\Entity\UserRole::removeUser
      */
     public function testRemoveUser()
     {
@@ -67,7 +67,7 @@ class UserRoleTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\UserRole::getUsers
+     * @covers \Ilios\CoreBundle\Entity\UserRole::getUsers
      */
     public function testGetUsers()
     {

--- a/tests/CoreBundle/Entity/UserTest.php
+++ b/tests/CoreBundle/Entity/UserTest.php
@@ -40,7 +40,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::__construct
+     * @covers \Ilios\CoreBundle\Entity\User::__construct
      */
     public function testConstructor()
     {
@@ -67,8 +67,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setLastName
-     * @covers Ilios\CoreBundle\Entity\User::getLastName
+     * @covers \Ilios\CoreBundle\Entity\User::setLastName
+     * @covers \Ilios\CoreBundle\Entity\User::getLastName
      */
     public function testSetLastName()
     {
@@ -76,8 +76,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setFirstName
-     * @covers Ilios\CoreBundle\Entity\User::getFirstName
+     * @covers \Ilios\CoreBundle\Entity\User::setFirstName
+     * @covers \Ilios\CoreBundle\Entity\User::getFirstName
      */
     public function testSetFirstName()
     {
@@ -85,8 +85,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setMiddleName
-     * @covers Ilios\CoreBundle\Entity\User::getMiddleName
+     * @covers \Ilios\CoreBundle\Entity\User::setMiddleName
+     * @covers \Ilios\CoreBundle\Entity\User::getMiddleName
      */
     public function testSetMiddleName()
     {
@@ -94,8 +94,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setPhone
-     * @covers Ilios\CoreBundle\Entity\User::getPhone
+     * @covers \Ilios\CoreBundle\Entity\User::setPhone
+     * @covers \Ilios\CoreBundle\Entity\User::getPhone
      */
     public function testSetPhone()
     {
@@ -103,8 +103,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setEmail
-     * @covers Ilios\CoreBundle\Entity\User::getEmail
+     * @covers \Ilios\CoreBundle\Entity\User::setEmail
+     * @covers \Ilios\CoreBundle\Entity\User::getEmail
      */
     public function testSetEmail()
     {
@@ -112,8 +112,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setAddedViaIlios
-     * @covers Ilios\CoreBundle\Entity\User::isAddedViaIlios
+     * @covers \Ilios\CoreBundle\Entity\User::setAddedViaIlios
+     * @covers \Ilios\CoreBundle\Entity\User::isAddedViaIlios
      */
     public function testSetAddedViaIlios()
     {
@@ -121,8 +121,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setEnabled
-     * @covers Ilios\CoreBundle\Entity\User::isEnabled
+     * @covers \Ilios\CoreBundle\Entity\User::setEnabled
+     * @covers \Ilios\CoreBundle\Entity\User::isEnabled
      */
     public function testSetEnabled()
     {
@@ -130,8 +130,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setCampusId
-     * @covers Ilios\CoreBundle\Entity\User::getCampusId
+     * @covers \Ilios\CoreBundle\Entity\User::setCampusId
+     * @covers \Ilios\CoreBundle\Entity\User::getCampusId
      */
     public function testSetCampusId()
     {
@@ -139,8 +139,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setOtherId
-     * @covers Ilios\CoreBundle\Entity\User::getOtherId
+     * @covers \Ilios\CoreBundle\Entity\User::setOtherId
+     * @covers \Ilios\CoreBundle\Entity\User::getOtherId
      */
     public function testSetOtherId()
     {
@@ -148,8 +148,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setExamined
-     * @covers Ilios\CoreBundle\Entity\User::isExamined
+     * @covers \Ilios\CoreBundle\Entity\User::setExamined
+     * @covers \Ilios\CoreBundle\Entity\User::isExamined
      */
     public function testSetExamined()
     {
@@ -157,8 +157,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setUserSyncIgnore
-     * @covers Ilios\CoreBundle\Entity\User::isUserSyncIgnore
+     * @covers \Ilios\CoreBundle\Entity\User::setUserSyncIgnore
+     * @covers \Ilios\CoreBundle\Entity\User::isUserSyncIgnore
      */
     public function testSetUserSyncIgnore()
     {
@@ -166,8 +166,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setIcsFeedKey
-     * @covers Ilios\CoreBundle\Entity\User::generateIcsFeedKey
+     * @covers \Ilios\CoreBundle\Entity\User::setIcsFeedKey
+     * @covers \Ilios\CoreBundle\Entity\User::generateIcsFeedKey
      */
     public function testSetIcsFeedKey()
     {
@@ -175,8 +175,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setSchool
-     * @covers Ilios\CoreBundle\Entity\User::getSchool
+     * @covers \Ilios\CoreBundle\Entity\User::setSchool
+     * @covers \Ilios\CoreBundle\Entity\User::getSchool
      */
     public function testSetSchool()
     {
@@ -184,7 +184,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addReminder
+     * @covers \Ilios\CoreBundle\Entity\User::addReminder
      */
     public function testAddReminder()
     {
@@ -192,7 +192,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeReminder
+     * @covers \Ilios\CoreBundle\Entity\User::removeReminder
      */
     public function testRemoveReminder()
     {
@@ -200,8 +200,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setReminders
-     * @covers Ilios\CoreBundle\Entity\User::getReminders
+     * @covers \Ilios\CoreBundle\Entity\User::setReminders
+     * @covers \Ilios\CoreBundle\Entity\User::getReminders
      */
     public function testSetReminders()
     {
@@ -209,7 +209,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addAuditLog
+     * @covers \Ilios\CoreBundle\Entity\User::addAuditLog
      */
     public function testAddAuditLog()
     {
@@ -217,7 +217,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeAuditLog
+     * @covers \Ilios\CoreBundle\Entity\User::removeAuditLog
      */
     public function testRemoveAuditLog()
     {
@@ -225,8 +225,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setAuditLogs
-     * @covers Ilios\CoreBundle\Entity\User::getAuditLogs
+     * @covers \Ilios\CoreBundle\Entity\User::setAuditLogs
+     * @covers \Ilios\CoreBundle\Entity\User::getAuditLogs
      */
     public function testSetAuditLogs()
     {
@@ -234,7 +234,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addPermission
+     * @covers \Ilios\CoreBundle\Entity\User::addPermission
      */
     public function testAddPermission()
     {
@@ -242,7 +242,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removePermission
+     * @covers \Ilios\CoreBundle\Entity\User::removePermission
      */
     public function testRemovePermission()
     {
@@ -250,8 +250,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setPermissions
-     * @covers Ilios\CoreBundle\Entity\User::getPermissions
+     * @covers \Ilios\CoreBundle\Entity\User::setPermissions
+     * @covers \Ilios\CoreBundle\Entity\User::getPermissions
      */
     public function testSetPermissions()
     {
@@ -259,7 +259,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addDirectedCourse
+     * @covers \Ilios\CoreBundle\Entity\User::addDirectedCourse
      */
     public function testAddDirectedCourse()
     {
@@ -267,7 +267,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeDirectedCourse
+     * @covers \Ilios\CoreBundle\Entity\User::removeDirectedCourse
      */
     public function testRemoveDirectedCourse()
     {
@@ -275,8 +275,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getDirectedCourses
-     * @covers Ilios\CoreBundle\Entity\User::setDirectedCourses
+     * @covers \Ilios\CoreBundle\Entity\User::getDirectedCourses
+     * @covers \Ilios\CoreBundle\Entity\User::setDirectedCourses
      */
     public function testGetDirectedCourses()
     {
@@ -284,7 +284,7 @@ class UserTest extends EntityBase
     }
     
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addAdministeredSession
+     * @covers \Ilios\CoreBundle\Entity\User::addAdministeredSession
      */
     public function testAddAdministeredSession()
     {
@@ -292,7 +292,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeAdministeredSession
+     * @covers \Ilios\CoreBundle\Entity\User::removeAdministeredSession
      */
     public function testRemoveAdministeredSession()
     {
@@ -300,8 +300,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getAdministeredSessions
-     * @covers Ilios\CoreBundle\Entity\User::setAdministeredSessions
+     * @covers \Ilios\CoreBundle\Entity\User::getAdministeredSessions
+     * @covers \Ilios\CoreBundle\Entity\User::setAdministeredSessions
      */
     public function testGetAdministeredSessions()
     {
@@ -309,7 +309,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\User::addLearnerGroup
      */
     public function testAddLearnerGroup()
     {
@@ -317,7 +317,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\User::removeLearnerGroup
      */
     public function testRemoveLearnerGroup()
     {
@@ -325,7 +325,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getLearnerGroups
+     * @covers \Ilios\CoreBundle\Entity\User::getLearnerGroups
      */
     public function testSetLearnerGroups()
     {
@@ -333,7 +333,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addInstructedLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\User::addInstructedLearnerGroup
      */
     public function testAddInstructedLearnerGroup()
     {
@@ -341,7 +341,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeInstructedLearnerGroup
+     * @covers \Ilios\CoreBundle\Entity\User::removeInstructedLearnerGroup
      */
     public function testRemoveInstructedLearnerGroup()
     {
@@ -356,8 +356,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getInstructedLearnerGroups
-     * @covers Ilios\CoreBundle\Entity\User::setInstructedLearnerGroups
+     * @covers \Ilios\CoreBundle\Entity\User::getInstructedLearnerGroups
+     * @covers \Ilios\CoreBundle\Entity\User::setInstructedLearnerGroups
      */
     public function testGetInstructedLearnerGroups()
     {
@@ -365,7 +365,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\User::addInstructorGroup
      */
     public function testAddInstructorGroup()
     {
@@ -373,7 +373,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeInstructorGroup
+     * @covers \Ilios\CoreBundle\Entity\User::removeInstructorGroup
      */
     public function testRemoveInstructorGroup()
     {
@@ -381,7 +381,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getInstructorGroups
+     * @covers \Ilios\CoreBundle\Entity\User::getInstructorGroups
      */
     public function testSetInstructorGroups()
     {
@@ -389,7 +389,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addOffering
+     * @covers \Ilios\CoreBundle\Entity\User::addOffering
      */
     public function testAddOffering()
     {
@@ -397,7 +397,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeOffering
+     * @covers \Ilios\CoreBundle\Entity\User::removeOffering
      */
     public function testRemoveOffering()
     {
@@ -405,7 +405,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getOfferings
+     * @covers \Ilios\CoreBundle\Entity\User::getOfferings
      */
     public function testSetOfferings()
     {
@@ -413,7 +413,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addProgramYear
+     * @covers \Ilios\CoreBundle\Entity\User::addProgramYear
      */
     public function testAddProgramYear()
     {
@@ -421,7 +421,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeProgramYear
+     * @covers \Ilios\CoreBundle\Entity\User::removeProgramYear
      */
     public function testRemoveProgramYear()
     {
@@ -429,7 +429,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getProgramYears
+     * @covers \Ilios\CoreBundle\Entity\User::getProgramYears
      */
     public function testSetProgramYears()
     {
@@ -437,7 +437,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addAlert
+     * @covers \Ilios\CoreBundle\Entity\User::addAlert
      */
     public function testAddAlert()
     {
@@ -445,7 +445,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeAlert
+     * @covers \Ilios\CoreBundle\Entity\User::removeAlert
      */
     public function testRemoveAlert()
     {
@@ -453,7 +453,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getAlerts
+     * @covers \Ilios\CoreBundle\Entity\User::getAlerts
      */
     public function testSetAlerts()
     {
@@ -461,7 +461,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addRole
+     * @covers \Ilios\CoreBundle\Entity\User::addRole
      */
     public function testAddRole()
     {
@@ -469,7 +469,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeRole
+     * @covers \Ilios\CoreBundle\Entity\User::removeRole
      */
     public function testRemoveRole()
     {
@@ -477,8 +477,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getRoles
-     * @covers Ilios\CoreBundle\Entity\User::setRoles
+     * @covers \Ilios\CoreBundle\Entity\User::getRoles
+     * @covers \Ilios\CoreBundle\Entity\User::setRoles
      */
     public function testSetRoles()
     {
@@ -486,7 +486,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\User::addLearningMaterial
      */
     public function testAddLearningMaterial()
     {
@@ -494,7 +494,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeLearningMaterial
+     * @covers \Ilios\CoreBundle\Entity\User::removeLearningMaterial
      */
     public function testRemoveLearningMaterial()
     {
@@ -502,7 +502,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getLearningMaterials
+     * @covers \Ilios\CoreBundle\Entity\User::getLearningMaterials
      */
     public function testSetLearningMaterials()
     {
@@ -510,7 +510,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addReport
+     * @covers \Ilios\CoreBundle\Entity\User::addReport
      */
     public function testAddReport()
     {
@@ -518,7 +518,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeReport
+     * @covers \Ilios\CoreBundle\Entity\User::removeReport
      */
     public function testRemoveReport()
     {
@@ -526,8 +526,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getReports
-     * @covers Ilios\CoreBundle\Entity\User::setReports
+     * @covers \Ilios\CoreBundle\Entity\User::getReports
+     * @covers \Ilios\CoreBundle\Entity\User::setReports
      */
     public function testSetReports()
     {
@@ -535,7 +535,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addCohort
+     * @covers \Ilios\CoreBundle\Entity\User::addCohort
      */
     public function testAddCohort()
     {
@@ -543,7 +543,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeCohort
+     * @covers \Ilios\CoreBundle\Entity\User::removeCohort
      */
     public function testRemoveCohort()
     {
@@ -551,8 +551,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getCohorts
-     * @covers Ilios\CoreBundle\Entity\User::setCohorts
+     * @covers \Ilios\CoreBundle\Entity\User::getCohorts
+     * @covers \Ilios\CoreBundle\Entity\User::setCohorts
      */
     public function testSetCohorts()
     {
@@ -568,7 +568,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addInstructedOffering
+     * @covers \Ilios\CoreBundle\Entity\User::addInstructedOffering
      */
     public function testAddInstructedOffering()
     {
@@ -576,7 +576,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeInstructedOffering
+     * @covers \Ilios\CoreBundle\Entity\User::removeInstructedOffering
      */
     public function testRemoveInstructedOffering()
     {
@@ -584,8 +584,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getInstructedOfferings
-     * @covers Ilios\CoreBundle\Entity\User::setInstructedOfferings
+     * @covers \Ilios\CoreBundle\Entity\User::getInstructedOfferings
+     * @covers \Ilios\CoreBundle\Entity\User::setInstructedOfferings
      */
     public function testSetInstructedOffering()
     {
@@ -593,7 +593,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addInstructorIlmSession
+     * @covers \Ilios\CoreBundle\Entity\User::addInstructorIlmSession
      */
     public function testAddInstructorIlmSessions()
     {
@@ -601,7 +601,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeInstructorIlmSession
+     * @covers \Ilios\CoreBundle\Entity\User::removeInstructorIlmSession
      */
     public function testRemoveInstructorIlmSessions()
     {
@@ -616,8 +616,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getInstructorIlmSessions
-     * @covers Ilios\CoreBundle\Entity\User::setInstructorIlmSessions
+     * @covers \Ilios\CoreBundle\Entity\User::getInstructorIlmSessions
+     * @covers \Ilios\CoreBundle\Entity\User::setInstructorIlmSessions
      */
     public function testGetInstructorIlmSessions()
     {
@@ -625,7 +625,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addLearnerIlmSession
+     * @covers \Ilios\CoreBundle\Entity\User::addLearnerIlmSession
      */
     public function testAddLearnerIlmSessions()
     {
@@ -633,7 +633,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeLearnerIlmSession
+     * @covers \Ilios\CoreBundle\Entity\User::removeLearnerIlmSession
      */
     public function testRemoveLearnerIlmSessions()
     {
@@ -648,8 +648,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getLearnerIlmSessions
-     * @covers Ilios\CoreBundle\Entity\User::setLearnerIlmSessions
+     * @covers \Ilios\CoreBundle\Entity\User::getLearnerIlmSessions
+     * @covers \Ilios\CoreBundle\Entity\User::setLearnerIlmSessions
      */
     public function testGetLearnerIlmSessions()
     {
@@ -657,8 +657,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::setPrimaryCohort
-     * @covers Ilios\CoreBundle\Entity\User::getPrimaryCohort
+     * @covers \Ilios\CoreBundle\Entity\User::setPrimaryCohort
+     * @covers \Ilios\CoreBundle\Entity\User::getPrimaryCohort
      */
     public function testSetPrimaryCohort()
     {
@@ -673,7 +673,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addPendingUserUpdate
+     * @covers \Ilios\CoreBundle\Entity\User::addPendingUserUpdate
      */
     public function testAddPendingUserUpdates()
     {
@@ -681,7 +681,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removePendingUserUpdate
+     * @covers \Ilios\CoreBundle\Entity\User::removePendingUserUpdate
      */
     public function testRemovePendingUserUpdates()
     {
@@ -689,8 +689,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getPendingUserUpdates
-     * @covers Ilios\CoreBundle\Entity\User::setPendingUserUpdates
+     * @covers \Ilios\CoreBundle\Entity\User::getPendingUserUpdates
+     * @covers \Ilios\CoreBundle\Entity\User::setPendingUserUpdates
      */
     public function testGetPendingUserUpdates()
     {
@@ -698,7 +698,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addDirectedSchool
+     * @covers \Ilios\CoreBundle\Entity\User::addDirectedSchool
      */
     public function testAddDirectedSchool()
     {
@@ -706,7 +706,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeDirectedSchool
+     * @covers \Ilios\CoreBundle\Entity\User::removeDirectedSchool
      */
     public function testRemoveDirectedSchool()
     {
@@ -714,8 +714,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getDirectedSchools
-     * @covers Ilios\CoreBundle\Entity\User::setDirectedSchools
+     * @covers \Ilios\CoreBundle\Entity\User::getDirectedSchools
+     * @covers \Ilios\CoreBundle\Entity\User::setDirectedSchools
      */
     public function testGetDirectedSchools()
     {
@@ -723,7 +723,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addAdministeredCourse
+     * @covers \Ilios\CoreBundle\Entity\User::addAdministeredCourse
      */
     public function testAddAdministeredCourse()
     {
@@ -731,7 +731,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeAdministeredCourse
+     * @covers \Ilios\CoreBundle\Entity\User::removeAdministeredCourse
      */
     public function testRemoveAdministeredCourse()
     {
@@ -739,8 +739,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getAdministeredCourses
-     * @covers Ilios\CoreBundle\Entity\User::setAdministeredCourses
+     * @covers \Ilios\CoreBundle\Entity\User::getAdministeredCourses
+     * @covers \Ilios\CoreBundle\Entity\User::setAdministeredCourses
      */
     public function testGetAdministeredCourses()
     {
@@ -748,7 +748,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addAdministeredSchool
+     * @covers \Ilios\CoreBundle\Entity\User::addAdministeredSchool
      */
     public function testAddAdministeredSchool()
     {
@@ -756,7 +756,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeAdministeredSchool
+     * @covers \Ilios\CoreBundle\Entity\User::removeAdministeredSchool
      */
     public function testRemoveAdministeredSchool()
     {
@@ -764,8 +764,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getAdministeredSchools
-     * @covers Ilios\CoreBundle\Entity\User::setAdministeredSchools
+     * @covers \Ilios\CoreBundle\Entity\User::getAdministeredSchools
+     * @covers \Ilios\CoreBundle\Entity\User::setAdministeredSchools
      */
     public function testGetAdministeredSchools()
     {
@@ -773,7 +773,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::addDirectedProgram
+     * @covers \Ilios\CoreBundle\Entity\User::addDirectedProgram
      */
     public function testAddDirectedProgram()
     {
@@ -781,7 +781,7 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::removeDirectedProgram
+     * @covers \Ilios\CoreBundle\Entity\User::removeDirectedProgram
      */
     public function testRemoveDirectedProgram()
     {
@@ -789,8 +789,8 @@ class UserTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\User::getDirectedPrograms
-     * @covers Ilios\CoreBundle\Entity\User::setDirectedPrograms
+     * @covers \Ilios\CoreBundle\Entity\User::getDirectedPrograms
+     * @covers \Ilios\CoreBundle\Entity\User::setDirectedPrograms
      */
     public function testGetDirectedPrograms()
     {

--- a/tests/CoreBundle/Entity/VocabularyTest.php
+++ b/tests/CoreBundle/Entity/VocabularyTest.php
@@ -23,7 +23,7 @@ class VocabularyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Vocabulary::__construct
+     * @covers \Ilios\CoreBundle\Entity\Vocabulary::__construct
      */
     public function testConstructor()
     {
@@ -31,8 +31,8 @@ class VocabularyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Vocabulary::setTitle
-     * @covers Ilios\CoreBundle\Entity\Vocabulary::getTitle
+     * @covers \Ilios\CoreBundle\Entity\Vocabulary::setTitle
+     * @covers \Ilios\CoreBundle\Entity\Vocabulary::getTitle
      */
     public function testSetTitle()
     {
@@ -40,8 +40,8 @@ class VocabularyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Vocabulary::setSchool
-     * @covers Ilios\CoreBundle\Entity\Vocabulary::getSchool
+     * @covers \Ilios\CoreBundle\Entity\Vocabulary::setSchool
+     * @covers \Ilios\CoreBundle\Entity\Vocabulary::getSchool
      */
     public function testSetSchool()
     {
@@ -49,7 +49,7 @@ class VocabularyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Vocabulary::addTerm
+     * @covers \Ilios\CoreBundle\Entity\Vocabulary::addTerm
      */
     public function testAddTerm()
     {
@@ -57,7 +57,7 @@ class VocabularyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Vocabulary::removeTerm
+     * @covers \Ilios\CoreBundle\Entity\Vocabulary::removeTerm
      */
     public function testRemoveTerm()
     {
@@ -65,7 +65,7 @@ class VocabularyTest extends EntityBase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Entity\Vocabulary::getTerms
+     * @covers \Ilios\CoreBundle\Entity\Vocabulary::getTerms
      */
     public function testGetTerm()
     {

--- a/tests/CoreBundle/Form/DataTransformer/RemoveMarkupTransformerTest.php
+++ b/tests/CoreBundle/Form/DataTransformer/RemoveMarkupTransformerTest.php
@@ -26,7 +26,7 @@ class RemoveMarkupTransformerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer::reverseTransform
+     * @covers \Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer::reverseTransform
      */
     public function testReverseTransformNotString()
     {
@@ -43,7 +43,7 @@ class RemoveMarkupTransformerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer::reverseTransform
+     * @covers \Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer::reverseTransform
      */
     public function testReverseTransform()
     {
@@ -53,7 +53,7 @@ class RemoveMarkupTransformerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer::Transform
+     * @covers \Ilios\CoreBundle\Form\DataTransformer\RemoveMarkupTransformer::Transform
      */
     public function testTransform()
     {

--- a/tests/CoreBundle/Service/CurriculumInventory/ExporterTest.php
+++ b/tests/CoreBundle/Service/CurriculumInventory/ExporterTest.php
@@ -15,7 +15,7 @@ class ExporterTest extends TestCase
 {
 
     /**
-     * @covers Ilios\CoreBundle\Service\CurriculumInventory\Exporter::__construct
+     * @covers \Ilios\CoreBundle\Service\CurriculumInventory\Exporter::__construct
      */
     public function testConstructor()
     {

--- a/tests/CoreBundle/Service/DirectoryTest.php
+++ b/tests/CoreBundle/Service/DirectoryTest.php
@@ -14,7 +14,7 @@ class DirectoryTest extends TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Service\Directory::__construct
+     * @covers \Ilios\CoreBundle\Service\Directory::__construct
      */
     public function testConstructor()
     {
@@ -24,7 +24,7 @@ class DirectoryTest extends TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Service\Directory::findByCampusId
+     * @covers \Ilios\CoreBundle\Service\Directory::findByCampusId
      */
     public function testFindByCampusId()
     {
@@ -37,7 +37,7 @@ class DirectoryTest extends TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Service\Directory::findByCampusId
+     * @covers \Ilios\CoreBundle\Service\Directory::findByCampusId
      */
     public function testFindByCampusIds()
     {
@@ -50,7 +50,7 @@ class DirectoryTest extends TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Service\Directory::findByCampusId
+     * @covers \Ilios\CoreBundle\Service\Directory::findByCampusId
      */
     public function testFindByCampusIdsOnlyUseUnique()
     {
@@ -64,7 +64,7 @@ class DirectoryTest extends TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Service\Directory::find
+     * @covers \Ilios\CoreBundle\Service\Directory::find
      */
     public function testFind()
     {
@@ -78,7 +78,7 @@ class DirectoryTest extends TestCase
     }
 
     /**
-     * @covers Ilios\CoreBundle\Service\Directory::findByLdapFilter
+     * @covers \Ilios\CoreBundle\Service\Directory::findByLdapFilter
      */
     public function testFindByLdapFilter()
     {


### PR DESCRIPTION
PHPStorm has been nagging about this for a while now, making it hard in some cases to spot actual errors.

![selection_021](https://cloud.githubusercontent.com/assets/1410427/19446234/ba3b6644-944c-11e6-8e9e-f4f9b94b3df1.png)
