### PR TITLE
Use AuthenticationInterface as a different name to avoid conflicts

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/JsonWebTokenAuthenticator.php
+++ b/src/Ilios/AuthenticationBundle/Service/JsonWebTokenAuthenticator.php
@@ -2,7 +2,7 @@
 
 namespace Ilios\AuthenticationBundle\Service;
 
-use Ilios\CoreBundle\Entity\AuthenticationInterface;
+use Ilios\CoreBundle\Entity\AuthenticationInterface as AuthenticationEntityInterface;
 use Ilios\CoreBundle\Entity\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
@@ -89,7 +89,7 @@ class JsonWebTokenAuthenticator implements SimplePreAuthenticatorInterface, Auth
                 'Invalid JSON Web Token: user is disabled'
             );
         }
-        /* @var AuthenticationInterface $authentication */
+        /* @var AuthenticationEntityInterface $authentication */
         $authentication = $user->getAuthentication();
         if ($authentication) {
             $tokenNotValidBefore = $authentication->getInvalidateTokenIssuedBefore();


### PR DESCRIPTION
There is already an AuthenticationInterface in this directory and PHP
did not handle the conflict well.

Fixes #1645