### PR TITLE
Clarify error message for large file uploads

### DIFF
--- a/src/Ilios/CoreBundle/Controller/UploadController.php
+++ b/src/Ilios/CoreBundle/Controller/UploadController.php
@@ -24,7 +24,8 @@ class UploadController extends Controller
         $uploadedFile = $request->files->get('file');
         if (is_null($uploadedFile)) {
             return new JsonResponse(array(
-                'errors' => 'No file parameter was found in the request'
+                'errors' => 'Unable to find file in the request. ' .
+                            'The uploaded file may have exceeded the maximum allowed size'
             ), JsonResponse::HTTP_BAD_REQUEST);
         }
         if (!$uploadedFile->isValid()) {

--- a/tests/CoreBundle/Controller/UploadControllerTest.php
+++ b/tests/CoreBundle/Controller/UploadControllerTest.php
@@ -87,6 +87,9 @@ class UploadControllerTest extends WebTestCase
         $this->assertJsonResponse($response, Codes::HTTP_BAD_REQUEST);
         
         $data = json_decode($response->getContent(), true);
-        $this->assertSame($data['errors'], 'No file parameter was found in the request');
+        $this->assertSame(
+            $data['errors'],
+            'Unable to find file in the request. The uploaded file may have exceeded the maximum allowed size'
+        );
     }
 }


### PR DESCRIPTION
There doesn't seem to be a better way to trap the error when a posted
file exceeds the PHP post_max_size limit. So I added some text to the
error to indicate that this is probable the case.

Fixes #1196