### PR TITLE
fixed route to ci rollover report endpoint.

### DIFF
--- a/src/Ilios/CoreBundle/Resources/config/routing.yml
+++ b/src/Ilios/CoreBundle/Resources/config/routing.yml
@@ -126,7 +126,7 @@ api_curriculuminventoryreport_v1:
     defaults: {_format:json}
 
 api_curriculuminventoryreport_rollover_v1:
-    path:     /v1/curriculumInventoryReport/{id}/rollover.{_format}
+    path:     /v1/curriculuminventoryreports/{id}/rollover.{_format}
     defaults: { _format: json, _controller: IliosCoreBundle:CurriculumInventoryReport:rollover }
     methods: [POST]
 


### PR DESCRIPTION
fixes #1650 

![selection_036](https://cloud.githubusercontent.com/assets/1410427/19629073/4b883c02-9921-11e6-88f5-a1458d4cc5aa.png)
