### PR TITLE
Use Symfony builtin to detect maximum file upload size

### DIFF
--- a/src/Ilios/CoreBundle/Controller/UploadController.php
+++ b/src/Ilios/CoreBundle/Controller/UploadController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ilios\CoreBundle\Controller;
 
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -21,6 +22,7 @@ class UploadController extends Controller
             throw $this->createAccessDeniedException('Unauthorized access!');
         }
 
+        /** @var UploadedFile $uploadedFile */
         $uploadedFile = $request->files->get('file');
         if (is_null($uploadedFile)) {
             return new JsonResponse(array(

--- a/src/Ilios/WebBundle/Controller/ConfigController.php
+++ b/src/Ilios/WebBundle/Controller/ConfigController.php
@@ -5,8 +5,7 @@ namespace Ilios\WebBundle\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use phpCAS;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * Class ConfigController
@@ -38,55 +37,9 @@ class ConfigController extends Controller
         } else {
             $configuration['userSearchType'] = 'local';
         }
-        $configuration['maxUploadSize'] = $this->fileUploadMaxSize();
+        $configuration['maxUploadSize'] = UploadedFile::getMaxFilesize();
 
 
         return new JsonResponse(array('config' => $configuration));
-    }
-
-    /**
-     * Get the maximum configured upload size for files
-     * combines information from post_max_size and upload_max_size to get the size in bytes
-     * Modified from http://stackoverflow.com/a/25370978/796999
-     * @return int
-     */
-    protected function fileUploadMaxSize()
-    {
-        static $maxSize = -1;
-
-        if ($maxSize < 0) {
-            // Start with post_max_size.
-            $maxSize = $this->parseSize(ini_get('post_max_size'));
-
-            // If upload_max_size is less, then reduce. Except if upload_max_size is
-            // zero, which indicates no limit.
-            $uploadMax = $this->parseSize(ini_get('upload_max_filesize'));
-            if ($uploadMax > 0 && $uploadMax < $maxSize) {
-                $maxSize = $uploadMax;
-            }
-        }
-        return $maxSize;
-    }
-
-    /**
-     * Convert human readable strings about size into bytes
-     * Modified from http://stackoverflow.com/a/25370978/796999
-     *
-     * @param string $size
-     * @return float
-     */
-    protected function parseSize($size)
-    {
-        //Remove the non-unit characters from the size.
-        $unit = preg_replace('/[^bkmgtpezy]/i', '', $size);
-        //Remove the non-numeric characters from the size.
-        $size = preg_replace('/[^0-9\.]/', '', $size);
-        if ($unit) {
-            // Find the position of the unit in the ordered string
-            // which is the power of magnitude to multiply a kilobyte by.
-            return round($size * pow(1024, stripos('bkmgtpezy', $unit[0])));
-        } else {
-            return round($size);
-        }
     }
 }


### PR DESCRIPTION
Instead of calculating this on our own just use the static method built
into the Symfony UploadFile class.