### PR TITLE
Add API version to configuration

### DIFF
--- a/src/Ilios/WebBundle/Controller/ConfigController.php
+++ b/src/Ilios/WebBundle/Controller/ConfigController.php
@@ -2,6 +2,7 @@
 
 namespace Ilios\WebBundle\Controller;
 
+use Ilios\WebBundle\Service\WebIndexFromJson;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,6 +39,7 @@ class ConfigController extends Controller
             $configuration['userSearchType'] = 'local';
         }
         $configuration['maxUploadSize'] = UploadedFile::getMaxFilesize();
+        $configuration['apiVersion'] = WebIndexFromJson::API_VERSION;
 
 
         return new JsonResponse(array('config' => $configuration));

--- a/tests/WebBundle/Controller/ConfigControllerTest.php
+++ b/tests/WebBundle/Controller/ConfigControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Tests\WebBundle\Controller;
 
+use Ilios\WebBundle\Service\WebIndexFromJson;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use FOS\RestBundle\Util\Codes;
 use Tests\CoreBundle\Traits\JsonControllerTest;
@@ -32,7 +33,8 @@ class ConfigControllerTest extends WebTestCase
             array(
                 'type' => 'form',
                 'locale' => 'en',
-                'userSearchType' => 'local'
+                'userSearchType' => 'local',
+                'apiVersion' => WebIndexFromJson::API_VERSION
             ),
             $data
         );


### PR DESCRIPTION
This makes it possible to detect issues on the frontend where a mismatch
might occur.

Fixes #1655