### PR TITLE
Exclude draft LMs from ICS Feed

### DIFF
--- a/src/Ilios/WebBundle/Controller/IcsController.php
+++ b/src/Ilios/WebBundle/Controller/IcsController.php
@@ -5,6 +5,7 @@ namespace Ilios\WebBundle\Controller;
 use Ilios\CoreBundle\Classes\UserEvent;
 use Ilios\CoreBundle\Entity\CourseLearningMaterialInterface;
 use Ilios\CoreBundle\Entity\LearningMaterialInterface;
+use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
 use Ilios\CoreBundle\Entity\ObjectiveInterface;
 use Ilios\CoreBundle\Entity\SessionLearningMaterialInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -110,15 +111,29 @@ class IcsController extends Controller
         })->toArray();
         $sessionMaterials =
             $session->getLearningMaterials()
+                ->filter(function (SessionLearningMaterialInterface $learningMaterial) {
+                    /** @var LearningMaterialInterface $lm */
+                    $lm = $learningMaterial->getLearningMaterial();
+                    $status = $lm->getStatus();
+                    return $status->getId() !== LearningMaterialStatusInterface::IN_DRAFT;
+                })
                 ->map(function (SessionLearningMaterialInterface $learningMaterial) {
-                    return $this->getTextForLearningMaterial(($learningMaterial->getLearningMaterial()));
-                })->toArray();
+                    return $this->getTextForLearningMaterial($learningMaterial->getLearningMaterial());
+                })
+                ->toArray();
 
         $courseMaterials =
             $session->getCourse()->getLearningMaterials()
+                ->filter(function (CourseLearningMaterialInterface $learningMaterial) {
+                    /** @var LearningMaterialInterface $lm */
+                    $lm = $learningMaterial->getLearningMaterial();
+                    $status = $lm->getStatus();
+                    return $status->getId() !== LearningMaterialStatusInterface::IN_DRAFT;
+                })
                 ->map(function (CourseLearningMaterialInterface $learningMaterial) {
-                    return $this->getTextForLearningMaterial(($learningMaterial->getLearningMaterial()));
-                })->toArray();
+                    return $this->getTextForLearningMaterial($learningMaterial->getLearningMaterial());
+                })
+                ->toArray();
 
         $lines = [
             $this->purify($description),

--- a/tests/CoreBundle/DataLoader/LearningMaterialData.php
+++ b/tests/CoreBundle/DataLoader/LearningMaterialData.php
@@ -2,6 +2,8 @@
 
 namespace Tests\CoreBundle\DataLoader;
 
+use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
+
 class LearningMaterialData extends AbstractDataLoader
 {
 
@@ -18,7 +20,7 @@ class LearningMaterialData extends AbstractDataLoader
             'description' => 'desc1' . $this->faker->text,
             'originalAuthor' => 'author1' . $this->faker->name,
             'userRole' => "1",
-            'status' => "1",
+            'status' => LearningMaterialStatusInterface::FINALIZED,
             'owningUser' => "1",
             'copyrightRationale' => $this->faker->text,
             'copyrightPermission' => true,
@@ -34,7 +36,7 @@ class LearningMaterialData extends AbstractDataLoader
             'description' => 'desc2' . $this->faker->text,
             'originalAuthor' => $this->faker->name,
             'userRole' => "2",
-            'status' => "1",
+            'status' => LearningMaterialStatusInterface::IN_DRAFT,
             'owningUser' => "1",
             'copyrightRationale' => $this->faker->text,
             'copyrightPermission' => true,
@@ -50,7 +52,7 @@ class LearningMaterialData extends AbstractDataLoader
             'description' => 'desc3' . $this->faker->text,
             'originalAuthor' => $this->faker->name,
             'userRole' => "2",
-            'status' => "1",
+            'status' => LearningMaterialStatusInterface::REVISED,
             'owningUser' => "1",
             'copyrightRationale' => $this->faker->text,
             'copyrightPermission' => true,

--- a/tests/CoreBundle/DataLoader/LearningMaterialStatusData.php
+++ b/tests/CoreBundle/DataLoader/LearningMaterialStatusData.php
@@ -2,6 +2,8 @@
 
 namespace Tests\CoreBundle\DataLoader;
 
+use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
+
 class LearningMaterialStatusData extends AbstractDataLoader
 {
     protected function getData()
@@ -9,14 +11,17 @@ class LearningMaterialStatusData extends AbstractDataLoader
         $arr = array();
 
         $arr[] = array(
-            'id' => 1,
-            'title' => $this->faker->text(10)
+            'id' => LearningMaterialStatusInterface::IN_DRAFT,
+            'title' => 'Draft'
         );
         $arr[] = array(
-            'id' => 2,
-            'title' => $this->faker->text(10)
+            'id' => LearningMaterialStatusInterface::FINALIZED,
+            'title' => 'Final'
         );
-
+        $arr[] = array(
+            'id' => LearningMaterialStatusInterface::REVISED,
+            'title' => 'Revised'
+        );
 
         return $arr;
     }
@@ -24,7 +29,7 @@ class LearningMaterialStatusData extends AbstractDataLoader
     public function create()
     {
         return array(
-            'id' => 3,
+            'id' => 4,
             'title' => $this->faker->text(10)
         );
     }

--- a/tests/WebBundle/Controller/IcsControllerTest.php
+++ b/tests/WebBundle/Controller/IcsControllerTest.php
@@ -60,4 +60,29 @@ class IcsControllerTest extends WebTestCase
             'LM Links are absolute paths'
         );
     }
+
+    public function testDraftLmsNotInFeedForStudents()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $users = $container->get('ilioscore.dataloader.user')->getAll();
+        $studentUser = $users[4];
+        $this->assertEmpty($studentUser['roles']);
+
+        $url = '/ics/' . $studentUser['icsFeedKey'];
+        $client->request('GET', $url);
+        $response = $client->getResponse();
+
+        $content = $response->getContent();
+
+        $this->assertEquals(
+            Codes::HTTP_OK,
+            $response->getStatusCode(),
+            "Status Code: {$response->getStatusCode()} is not OK"
+        );
+        $this->assertRegexp('/firstlm/', $content);
+        $this->assertRegexp('/thirdlm/', $content);
+        $this->assertFalse(strpos($content, 'secondlm'));
+    }
 }


### PR DESCRIPTION
We were not correctly filtering out those learning materials which are
in draft status and should not be shown.

Fixes #1659