### PR TITLE
Add courseId and title to session usermaterials

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -955,6 +955,7 @@ class UserRepository extends EntityRepository
 
         $qb = $this->_em->createQueryBuilder();
         $what = 's.title as sessionTitle, s.id as sessionId, ' .
+            'c.id as courseId, c.title as courseTitle, ' .
             'slm.notes, slm.required, slm.publicNotes, ' .
             'lm.id, lm.title, lm.description, lm.originalAuthor, lm.token, ' .
             'lm.citation, lm.link, lm.filename, lm.mimetype';

--- a/tests/CoreBundle/Controller/UsermaterialsControllerTest.php
+++ b/tests/CoreBundle/Controller/UsermaterialsControllerTest.php
@@ -58,7 +58,6 @@ class UsermaterialsControllerTest extends AbstractControllerTest
         $this->assertCount(4, $materials, 'All expected materials returned');
         $this->assertEquals('1', $materials[0]['id']);
         $this->assertEquals('1', $materials[0]['session']);
-        $this->assertFalse(array_key_exists('course', $materials[0]));
         $this->assertFalse($materials[0]['required']);
         $this->assertRegExp('/^firstlm/', $materials[0]['title']);
         $this->assertRegExp('/^desc1/', $materials[0]['description']);
@@ -66,8 +65,8 @@ class UsermaterialsControllerTest extends AbstractControllerTest
         $this->assertRegExp('/^citation1/', $materials[0]['citation']);
         $this->assertEquals('citation', $materials[0]['mimetype']);
         $this->assertRegExp('/^session1Title/', $materials[0]['sessionTitle']);
-        $this->assertFalse(isset($materials[0]['courseTitle']));
-        $this->assertFalse(isset($materials[0]['course']));
+        $this->assertEquals('1', $materials[0]['course']);
+        $this->assertRegExp('/^firstCourse/', $materials[0]['courseTitle']);
         $this->assertEquals('2016-09-07T17:00:00+00:00', $materials[0]['firstOfferingDate']);
 
         $this->assertEquals('1', $materials[1]['id']);

--- a/tests/CoreBundle/DataLoader/CourseData.php
+++ b/tests/CoreBundle/DataLoader/CourseData.php
@@ -10,7 +10,7 @@ class CourseData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 1,
-            'title' => $this->faker->text(25),
+            'title' => 'firstCourse' . $this->faker->text(25),
             'level' => 1,
             'year' => 2016,
             'startDate' => "2016-09-04T00:00:00+00:00",


### PR DESCRIPTION
Sending this information about the course will prevent extra lookups to
get LM metadata.

Fixes #1672