### PR TITLE
track API usage

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -44,6 +44,7 @@ class AppKernel extends Kernel
             new Ilios\WebBundle\IliosWebBundle(),
             new Ilios\AuthenticationBundle\IliosAuthenticationBundle(),
             new Ilios\CliBundle\IliosCliBundle(),
+            new Happyr\GoogleAnalyticsBundle\HappyrGoogleAnalyticsBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -44,6 +44,7 @@ class AppKernel extends Kernel
             new Ilios\WebBundle\IliosWebBundle(),
             new Ilios\AuthenticationBundle\IliosAuthenticationBundle(),
             new Ilios\CliBundle\IliosCliBundle(),
+            new Http\HttplugBundle\HttplugBundle(),
             new Happyr\GoogleAnalyticsBundle\HappyrGoogleAnalyticsBundle(),
         ];
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -177,11 +177,11 @@ httplug:
     plugins:
         logger: ~
     clients:
-        acme:
+        ga:
             factory: 'httplug.factory.guzzle6'
             plugins: ['httplug.plugin.logger']
             config:
-                verify: false
+                verify: true
                 timeout: 2
 
 happyr_google_analytics:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -173,3 +173,4 @@ ilios_authentication:
 
 happyr_google_analytics:
     tracking_id: "%google_analytics_ua_code%"
+    http_message_factory: 'httplug.message_factory'

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -153,7 +153,7 @@ ilios_core:
     supporting_link: "%supporting_link%"
     timezone: "%timezone%"
     enable_tracking: "%enable_tracking%"
-    google_analytics_ua_code: "%google_analytics_ua_code%"
+    tracking_code: "%tracking_code%"
 
 ilios_web:
     frontend_release_version: 80f4118be5ab8d22742f0112e27eb5d6
@@ -185,5 +185,5 @@ httplug:
                 timeout: 2
 
 happyr_google_analytics:
-    tracking_id: "%ilios_core.google_analytics_ua_code%"
+    tracking_id: "%ilios_core.tracking_code%"
     http_message_factory: 'httplug.message_factory'

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -152,7 +152,7 @@ ilios_core:
     institution_domain: "%institution_domain%"
     supporting_link: "%supporting_link%"
     timezone: "%timezone%"
-    enable_api_tracking: "%enable_api_tracking%"
+    enable_tracking: "%enable_tracking%"
     google_analytics_ua_code: "%google_analytics_ua_code"
 
 ilios_web:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -152,6 +152,7 @@ ilios_core:
     institution_domain: "%institution_domain%"
     supporting_link: "%supporting_link%"
     timezone: "%timezone%"
+    google_analytics_ua_code: "%google_analytics_ua_code"
 
 ilios_web:
     frontend_release_version: 80f4118be5ab8d22742f0112e27eb5d6
@@ -172,5 +173,5 @@ ilios_authentication:
     cas_authentication_certificate_path: "%cas_authentication_certificate_path%"
 
 happyr_google_analytics:
-    tracking_id: "%google_analytics_ua_code%"
+    tracking_id: "%ilios_core.google_analytics_ua_code%"
     http_message_factory: 'httplug.message_factory'

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -170,3 +170,6 @@ ilios_authentication:
     cas_authentication_version: "%cas_authentication_version%"
     cas_authentication_verify_ssl: "%cas_authentication_verify_ssl%"
     cas_authentication_certificate_path: "%cas_authentication_certificate_path%"
+
+happyr_google_analytics:
+    tracking_id: "%google_analytics_ua_code%"

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -152,6 +152,7 @@ ilios_core:
     institution_domain: "%institution_domain%"
     supporting_link: "%supporting_link%"
     timezone: "%timezone%"
+    enable_api_tracking: "%enable_api_tracking%"
     google_analytics_ua_code: "%google_analytics_ua_code"
 
 ilios_web:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -153,7 +153,7 @@ ilios_core:
     supporting_link: "%supporting_link%"
     timezone: "%timezone%"
     enable_tracking: "%enable_tracking%"
-    google_analytics_ua_code: "%google_analytics_ua_code"
+    google_analytics_ua_code: "%google_analytics_ua_code%"
 
 ilios_web:
     frontend_release_version: 80f4118be5ab8d22742f0112e27eb5d6

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -172,6 +172,17 @@ ilios_authentication:
     cas_authentication_verify_ssl: "%cas_authentication_verify_ssl%"
     cas_authentication_certificate_path: "%cas_authentication_certificate_path%"
 
+httplug:
+    plugins:
+        logger: ~
+    clients:
+        acme:
+            factory: 'httplug.factory.guzzle6'
+            plugins: ['httplug.plugin.logger']
+            config:
+                verify: false
+                timeout: 2
+
 happyr_google_analytics:
     tracking_id: "%ilios_core.google_analytics_ua_code%"
     http_message_factory: 'httplug.message_factory'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -47,3 +47,4 @@ parameters:
     cas_authentication_version: 3
     cas_authentication_verify_ssl: true
     cas_authentication_certificate_path: null
+    google_analytics_ua_code: null

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -47,5 +47,5 @@ parameters:
     cas_authentication_version: 3
     cas_authentication_verify_ssl: true
     cas_authentication_certificate_path: null
-    enable_api_tracking: false
+    enable_tracking: false
     google_analytics_ua_code: UA-XXXXXX

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -47,4 +47,4 @@ parameters:
     cas_authentication_version: 3
     cas_authentication_verify_ssl: true
     cas_authentication_certificate_path: null
-    google_analytics_ua_code: null
+    google_analytics_ua_code: UA-XXXXXX

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -48,4 +48,4 @@ parameters:
     cas_authentication_verify_ssl: true
     cas_authentication_certificate_path: null
     enable_tracking: false
-    google_analytics_ua_code: UA-XXXXXX
+    google_analytics_ua_code: UA-XXXXXXXX-1

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -48,4 +48,4 @@ parameters:
     cas_authentication_verify_ssl: true
     cas_authentication_certificate_path: null
     enable_tracking: false
-    google_analytics_ua_code: UA-XXXXXXXX-1
+    tracking_code: UA-XXXXXXXX-1

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -47,4 +47,5 @@ parameters:
     cas_authentication_version: 3
     cas_authentication_verify_ssl: true
     cas_authentication_certificate_path: null
+    enable_api_tracking: false
     google_analytics_ua_code: UA-XXXXXX

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -40,4 +40,4 @@ parameters:
     cas_authentication_version: null
     cas_authentication_certificate_path: null
     enable_tracking: false
-    google_analytics_ua_code: UA-XXXXXXXX-1
+    tracking_code: UA-XXXXXXXX-1

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -39,4 +39,4 @@ parameters:
     cas_authentication_server: null
     cas_authentication_version: null
     cas_authentication_certificate_path: null
-    google_analytics_ua_code: null
+    google_analytics_ua_code: UA-XXXXXX

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -39,5 +39,5 @@ parameters:
     cas_authentication_server: null
     cas_authentication_version: null
     cas_authentication_certificate_path: null
-    enable_api_tracking: false
+    enable_tracking: false
     google_analytics_ua_code: UA-XXXXXX

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -39,4 +39,5 @@ parameters:
     cas_authentication_server: null
     cas_authentication_version: null
     cas_authentication_certificate_path: null
+    enable_api_tracking: false
     google_analytics_ua_code: UA-XXXXXX

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -39,4 +39,4 @@ parameters:
     cas_authentication_server: null
     cas_authentication_version: null
     cas_authentication_certificate_path: null
-
+    google_analytics_ua_code: null

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -40,4 +40,4 @@ parameters:
     cas_authentication_version: null
     cas_authentication_certificate_path: null
     enable_tracking: false
-    google_analytics_ua_code: UA-XXXXXX
+    google_analytics_ua_code: UA-XXXXXXXX-1

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "exercise/htmlpurifier-bundle": "@stable",
         "ocramius/proxy-manager": "^1.0",
         "paragonie/random_compat": "^2.0",
-        "easycorp/easy-log-handler": "^1.0"
+        "easycorp/easy-log-handler": "^1.0",
+        "happyr/google-analytics-bundle": "^4.0"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "ocramius/proxy-manager": "^1.0",
         "paragonie/random_compat": "^2.0",
         "easycorp/easy-log-handler": "^1.0",
-        "happyr/google-analytics-bundle": "^4.0"
+        "happyr/google-analytics-bundle": "^4.0",
+        "php-http/httplug-bundle": "^1.3"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,242 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "87827ee15a4df1b7006f4ea4dc032435",
-    "content-hash": "2d6a4daaa2271de13d6cb5288255d401",
+    "hash": "65a2908c5d2d5f517fa92daa9d5588d2",
+    "content-hash": "cea9229908ab5b08423f5d1d65bdcf4f",
     "packages": [
+        {
+            "name": "cache/adapter-common",
+            "version": "0.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/adapter-common.git",
+                "reference": "874256105aefaa52b60599ab02858a4575e61095"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/adapter-common/zipball/874256105aefaa52b60599ab02858a4575e61095",
+                "reference": "874256105aefaa52b60599ab02858a4575e61095",
+                "shasum": ""
+            },
+            "require": {
+                "cache/taggable-cache": "^0.4",
+                "php": "^5.5 || ^7.0",
+                "psr/cache": "^1.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.10",
+                "phpunit/phpunit": "^4.0 || ^5.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Adapter\\Common\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "Common classes for PSR-6 adapters",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr-6",
+                "tag"
+            ],
+            "time": "2016-07-31 18:10:41"
+        },
+        {
+            "name": "cache/hierarchical-cache",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/hierarchical-cache.git",
+                "reference": "783e179acc3c9d47c469513a2380219022bfa0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/hierarchical-cache/zipball/783e179acc3c9d47c469513a2380219022bfa0bc",
+                "reference": "783e179acc3c9d47c469513a2380219022bfa0bc",
+                "shasum": ""
+            },
+            "require": {
+                "cache/taggable-cache": "^0.4",
+                "php": "^5.5 || ^7.0",
+                "psr/cache": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Hierarchy\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "A helper trait and interface to your PSR-6 cache to support hierarchical keys.",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "hierarchical",
+                "psr-6",
+                "tag"
+            ],
+            "time": "2016-08-07 14:49:33"
+        },
+        {
+            "name": "cache/taggable-cache",
+            "version": "0.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/taggable-cache.git",
+                "reference": "8ae3042edd1ac9546c9eae1020dc2b438ef10742"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/taggable-cache/zipball/8ae3042edd1ac9546c9eae1020dc2b438ef10742",
+                "reference": "8ae3042edd1ac9546c9eae1020dc2b438ef10742",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "psr/cache": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.11",
+                "phpunit/phpunit": "^4.0 || ^5.1",
+                "symfony/cache": "^3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Taggable\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "Add tag support to your PSR-6 cache implementation",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "Taggable",
+                "cache",
+                "psr6",
+                "tag"
+            ],
+            "time": "2016-08-08 17:20:09"
+        },
+        {
+            "name": "cache/void-adapter",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/void-adapter.git",
+                "reference": "a946b2e83e6cf8996f01a05811c76869cf11c009"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/void-adapter/zipball/a946b2e83e6cf8996f01a05811c76869cf11c009",
+                "reference": "a946b2e83e6cf8996f01a05811c76869cf11c009",
+                "shasum": ""
+            },
+            "require": {
+                "cache/adapter-common": "^0.3",
+                "cache/hierarchical-cache": "^0.3",
+                "cache/taggable-cache": "^0.4",
+                "php": "^5.5 || ^7.0",
+                "psr/cache": "^1.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.11",
+                "phpunit/phpunit": "^4.0 || ^5.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Adapter\\Void\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "A PSR-6 cache implementation using Void. This implementation supports tags",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr-6",
+                "tag",
+                "void"
+            ],
+            "time": "2016-08-07 15:04:55"
+        },
         {
             "name": "danielstjules/stringy",
             "version": "2.3.2",
@@ -1459,6 +1692,62 @@
             "time": "2015-12-29 16:02:50"
         },
         {
+            "name": "happyr/google-analytics-bundle",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Happyr/GoogleAnalyticsBundle.git",
+                "reference": "47c13fae1372af1ab20150ac68622932c5825a6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Happyr/GoogleAnalyticsBundle/zipball/47c13fae1372af1ab20150ac68622932c5825a6c",
+                "reference": "47c13fae1372af1ab20150ac68622932c5825a6c",
+                "shasum": ""
+            },
+            "require": {
+                "cache/void-adapter": "^0.3",
+                "php": "^5.5 || ^7.0",
+                "php-http/httplug": "^1.0",
+                "php-http/message-factory": "^1.0",
+                "psr/cache": "^1.0",
+                "symfony/framework-bundle": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+                "phpunit/phpunit": "^4.5 || ^5.4",
+                "symfony/symfony": "^2.7 || ^3.0"
+            },
+            "suggest": {
+                "happyr/google-site-authenticator-bundle": "To be able to fetch data from google analytics.",
+                "php-http/httplug-bundle": "To register HTTP clients as services"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Happyr\\GoogleAnalyticsBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                }
+            ],
+            "description": "The Google Analytics Bundle lets you send data (like event tracking) to Google.",
+            "homepage": "http://developer.happyr.com/symfony2-bundles/google-analytics-bundle",
+            "keywords": [
+                "analytics",
+                "google",
+                "google analytics"
+            ],
+            "time": "2016-08-03 11:27:12"
+        },
+        {
             "name": "incenteev/composer-parameter-handler",
             "version": "v2.1.2",
             "source": {
@@ -2382,6 +2671,162 @@
             "time": "2016-10-17 15:23:22"
         },
         {
+            "name": "php-http/httplug",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "1c6381726c18579c4ca2ef1ec1498fdae8bdf018"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/1c6381726c18579c4ca2ef1ec1498fdae8bdf018",
+                "reference": "1c6381726c18579c4ca2ef1ec1498fdae8bdf018",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "php-http/promise": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "time": "2016-08-31 08:30:17"
+        },
+        {
+            "name": "php-http/message-factory",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message-factory.git",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message-factory/zipball/a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Factory interfaces for PSR-7 HTTP Message",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2015-12-19 14:08:53"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "dc494cdc9d7160b9a09bd5573272195242ce7980"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/dc494cdc9d7160b9a09bd5573272195242ce7980",
+                "reference": "dc494cdc9d7160b9a09bd5573272195242ce7980",
+                "shasum": ""
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-01-26 13:27:02"
+        },
+        {
             "name": "phpcollection/phpcollection",
             "version": "0.5.0",
             "source": {
@@ -2524,6 +2969,56 @@
                 "psr-6"
             ],
             "time": "2016-08-06 20:24:11"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "psr/log",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "65a2908c5d2d5f517fa92daa9d5588d2",
-    "content-hash": "cea9229908ab5b08423f5d1d65bdcf4f",
+    "hash": "b3c7033fe77c9ed90482577eb2f72ffd",
+    "content-hash": "5d89e7fc3ea24182b6d80d56684577e8",
     "packages": [
         {
             "name": "cache/adapter-common",
@@ -239,6 +239,55 @@
                 "void"
             ],
             "time": "2016-08-07 15:04:55"
+        },
+        {
+            "name": "clue/stream-filter",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/php-stream-filter.git",
+                "reference": "e3bf9415da163d9ad6701dccb407ed501ae69785"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/php-stream-filter/zipball/e3bf9415da163d9ad6701dccb407ed501ae69785",
+                "reference": "e3bf9415da163d9ad6701dccb407ed501ae69785",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\StreamFilter\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "A simple and modern approach to stream filtering in PHP",
+            "homepage": "https://github.com/clue/php-stream-filter",
+            "keywords": [
+                "bucket brigade",
+                "callback",
+                "filter",
+                "php_user_filter",
+                "stream",
+                "stream_filter_append",
+                "stream_filter_register"
+            ],
+            "time": "2015-11-08 23:41:30"
         },
         {
             "name": "danielstjules/stringy",
@@ -1692,6 +1741,177 @@
             "time": "2015-12-29 16:02:50"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2016-10-08 15:01:37"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-05-18 16:56:05"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2016-06-24 23:00:38"
+        },
+        {
             "name": "happyr/google-analytics-bundle",
             "version": "4.0.1",
             "source": {
@@ -2671,6 +2891,245 @@
             "time": "2016-10-17 15:23:22"
         },
         {
+            "name": "php-http/cache-plugin",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/cache-plugin.git",
+                "reference": "b4e421cb5214ad9ef8b25bb32214ed4b71a8b356"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/cache-plugin/zipball/b4e421cb5214ad9ef8b25bb32214ed4b71a8b356",
+                "reference": "b4e421cb5214ad9ef8b25bb32214ed4b71a8b356",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0",
+                "php-http/client-common": "^1.1",
+                "php-http/message-factory": "^1.0",
+                "psr/cache": "^1.0",
+                "symfony/options-resolver": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\Common\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "PSR-6 Cache plugin for HTTPlug",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "cache",
+                "http",
+                "httplug",
+                "plugin"
+            ],
+            "time": "2016-08-16 12:12:50"
+        },
+        {
+            "name": "php-http/client-common",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/client-common.git",
+                "reference": "3cf7eb93a2e19bded055efff1a267a1fa6d46074"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/client-common/zipball/3cf7eb93a2e19bded055efff1a267a1fa6d46074",
+                "reference": "3cf7eb93a2e19bded055efff1a267a1fa6d46074",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "php-http/httplug": "^1.1",
+                "php-http/message": "^1.2",
+                "php-http/message-factory": "^1.0",
+                "symfony/options-resolver": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "suggest": {
+                "php-http/cache-plugin": "PSR-6 Cache plugin",
+                "php-http/logger-plugin": "PSR-3 Logger plugin",
+                "php-http/stopwatch-plugin": "Symfony Stopwatch plugin"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\Common\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Common HTTP Client implementations and tools for HTTPlug",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "common",
+                "http",
+                "httplug"
+            ],
+            "time": "2016-11-04 09:19:15"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "5a236c5e43486286efbd6b36f5151e0b962cfdb5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/5a236c5e43486286efbd6b36f5151e0b962cfdb5",
+                "reference": "5a236c5e43486286efbd6b36f5151e0b962cfdb5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^2.0.2",
+                "php-http/httplug": "^1.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^2.4",
+                "puli/composer-plugin": "1.0.0-beta10"
+            },
+            "suggest": {
+                "php-http/message": "Allow to use Guzzle, Diactoros or Slim Framework factories",
+                "puli/composer-plugin": "Sets up Puli which is recommended for Discovery to work. Check http://docs.php-http.org/en/latest/discovery.html for more details."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds installed HTTPlug implementations and PSR-7 message factories",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr7"
+            ],
+            "time": "2016-10-20 08:05:06"
+        },
+        {
+            "name": "php-http/guzzle6-adapter",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/guzzle6-adapter.git",
+                "reference": "a56941f9dc6110409cfcddc91546ee97039277ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/guzzle6-adapter/zipball/a56941f9dc6110409cfcddc91546ee97039277ab",
+                "reference": "a56941f9dc6110409cfcddc91546ee97039277ab",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "php": ">=5.5.0",
+                "php-http/httplug": "^1.0"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "1.0",
+                "php-http/client-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "php-http/adapter-integration-tests": "^0.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Adapter\\Guzzle6\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "David de Boer",
+                    "email": "david@ddeboer.nl"
+                }
+            ],
+            "description": "Guzzle 6 HTTP Adapter",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "Guzzle",
+                "http"
+            ],
+            "time": "2016-05-10 06:13:32"
+        },
+        {
             "name": "php-http/httplug",
             "version": "v1.1.0",
             "source": {
@@ -2725,6 +3184,212 @@
                 "http"
             ],
             "time": "2016-08-31 08:30:17"
+        },
+        {
+            "name": "php-http/httplug-bundle",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/HttplugBundle.git",
+                "reference": "d45367deacc8fbc2d718f089cfa985d9afaa1cee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/HttplugBundle/zipball/d45367deacc8fbc2d718f089cfa985d9afaa1cee",
+                "reference": "d45367deacc8fbc2d718f089cfa985d9afaa1cee",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "php-http/cache-plugin": "^1.0",
+                "php-http/client-common": "^1.2",
+                "php-http/client-implementation": "^1.0",
+                "php-http/discovery": "^1.0",
+                "php-http/logger-plugin": "^1.0",
+                "php-http/message": "^1.3",
+                "php-http/message-factory": "^1.0.2",
+                "php-http/stopwatch-plugin": "^1.0",
+                "symfony/event-dispatcher": "^2.7 || ^3.0",
+                "symfony/framework-bundle": "^2.7 || ^3.0",
+                "symfony/options-resolver": "^2.7 || ^3.0",
+                "twig/twig": "^1.18 || ^2.0"
+            },
+            "conflict": {
+                "php-http/guzzle6-adapter": "<1.1"
+            },
+            "require-dev": {
+                "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+                "php-http/buzz-adapter": "^0.3",
+                "php-http/curl-client": "^1.0",
+                "php-http/guzzle6-adapter": "^1.1.1",
+                "php-http/react-adapter": "^0.2.1",
+                "php-http/socket-client": "^1.0",
+                "phpunit/phpunit": "^4.5 || ^5.4",
+                "polishsymfonycommunity/symfony-mocker-container": "^1.0",
+                "symfony/symfony": "^2.7 || ^3.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\HttplugBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Buchmann",
+                    "email": "mail@davidbu.ch"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                }
+            ],
+            "description": "Symfony integration for HTTPlug",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "adapter",
+                "bundle",
+                "discovery",
+                "factory",
+                "http",
+                "httplug",
+                "message",
+                "php-http"
+            ],
+            "time": "2016-08-16 10:32:13"
+        },
+        {
+            "name": "php-http/logger-plugin",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/logger-plugin.git",
+                "reference": "d6c2ac7d542bf9928a0ac7a8a249d02848b824ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/logger-plugin/zipball/d6c2ac7d542bf9928a0ac7a8a249d02848b824ec",
+                "reference": "d6c2ac7d542bf9928a0ac7a8a249d02848b824ec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "php-http/client-common": "^1.1",
+                "php-http/message": "^1.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\Common\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "PSR-3 Logger plugin for HTTPlug",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "http",
+                "httplug",
+                "logger",
+                "plugin"
+            ],
+            "time": "2016-05-04 22:43:46"
+        },
+        {
+            "name": "php-http/message",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message.git",
+                "reference": "20ffbdc291a127e93f66007742693fbdf020d223"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message/zipball/20ffbdc291a127e93f66007742693fbdf020d223",
+                "reference": "20ffbdc291a127e93f66007742693fbdf020d223",
+                "shasum": ""
+            },
+            "require": {
+                "clue/stream-filter": "^1.3",
+                "php": ">=5.4",
+                "php-http/message-factory": "^1.0.2",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "akeneo/phpspec-skip-example-extension": "^1.0",
+                "coduo/phpspec-data-provider-extension": "^1.0",
+                "ext-zlib": "*",
+                "guzzlehttp/psr7": "^1.0",
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4",
+                "slim/slim": "^3.0",
+                "zendframework/zend-diactoros": "^1.0"
+            },
+            "suggest": {
+                "ext-zlib": "Used with compressor/decompressor streams",
+                "guzzlehttp/psr7": "Used with Guzzle PSR-7 Factories",
+                "slim/slim": "Used with Slim Framework PSR-7 implementation",
+                "zendframework/zend-diactoros": "Used with Diactoros Factories"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                },
+                "files": [
+                    "src/filters.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "HTTP Message related tools",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7"
+            ],
+            "time": "2016-10-20 06:59:05"
         },
         {
             "name": "php-http/message-factory",
@@ -2825,6 +3490,60 @@
                 "promise"
             ],
             "time": "2016-01-26 13:27:02"
+        },
+        {
+            "name": "php-http/stopwatch-plugin",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/stopwatch-plugin.git",
+                "reference": "9a097099904a1d218ffcfe32be8344eb03da41d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/stopwatch-plugin/zipball/9a097099904a1d218ffcfe32be8344eb03da41d8",
+                "reference": "9a097099904a1d218ffcfe32be8344eb03da41d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "php-http/client-common": "^1.1",
+                "symfony/stopwatch": "^2.7|^3.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\Common\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Symfony Stopwatch plugin for HTTPlug",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "http",
+                "httplug",
+                "plugin",
+                "stopwatch"
+            ],
+            "time": "2016-05-19 06:10:14"
         },
         {
             "name": "phpcollection/phpcollection",

--- a/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
@@ -54,9 +54,9 @@ class Configuration implements ConfigurationInterface
                     ->defaultFalse()
                     ->info('If set to TRUE, then API usage tracking will be enabled.')
                     ->end()
-                ->scalarNode('google_analytics_ua_code')
+                ->scalarNode('tracking_code')
                     ->defaultValue('UA-XXXXXXXX-1')
-                    ->info('Google Analytics UA code, used for measuring API access.')
+                    ->info('Analytics tracking code.')
                     ->end()
             ->end();
 

--- a/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
@@ -50,7 +50,7 @@ class Configuration implements ConfigurationInterface
                     )
                 ->end()
                 ->scalarNode('timezone')->end()
-                ->scalarNode('enable_api_tracking')
+                ->scalarNode('enable_tracking')
                     ->defaultFalse()
                     ->info('If set to TRUE, then API usage tracking will be enabled.')
                     ->end()

--- a/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
@@ -55,7 +55,9 @@ class Configuration implements ConfigurationInterface
                     ->info('If set to TRUE, then API usage tracking will be enabled.')
                     ->end()
                 ->scalarNode('google_analytics_ua_code')
+                    ->defaultValue('UA-XXXXXXXX-1')
                     ->info('Google Analytics UA code, used for measuring API access.')
+                    ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
@@ -51,6 +51,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('timezone')->end()
                 ->scalarNode('google_analytics_ua_code')
+                    ->info('Google Analytics UA code, used for measuring API access.')
             ->end();
 
         return $treeBuilder;

--- a/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
@@ -50,6 +50,10 @@ class Configuration implements ConfigurationInterface
                     )
                 ->end()
                 ->scalarNode('timezone')->end()
+                ->scalarNode('enable_api_tracking')
+                    ->defaultFalse()
+                    ->info('If set to TRUE, then API usage tracking will be enabled.')
+                    ->end()
                 ->scalarNode('google_analytics_ua_code')
                     ->info('Google Analytics UA code, used for measuring API access.')
             ->end();

--- a/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/Configuration.php
@@ -49,7 +49,8 @@ class Configuration implements ConfigurationInterface
                         "Optional 'supporting link' for the curriculum inventory exports."
                     )
                 ->end()
-                ->scalarNode('timezone')
+                ->scalarNode('timezone')->end()
+                ->scalarNode('google_analytics_ua_code')
             ->end();
 
         return $treeBuilder;

--- a/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
@@ -33,7 +33,7 @@ class IliosCoreExtension extends Extension
         $container->setParameter('ilios_core.supporting_link', $config['supporting_link']);
         $container->setParameter('ilios_core.timezone', $config['timezone']);
         $container->setParameter('ilios_core.enable_tracking', $config['enable_tracking']);
-        $container->setParameter('ilios_core.google_analytics_ua_code', $config['google_analytics_ua_code']);
+        $container->setParameter('ilios_core.tracking_code', $config['tracking_code']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
@@ -32,6 +32,8 @@ class IliosCoreExtension extends Extension
         $container->setParameter('ilios_core.institution_domain', $config['institution_domain']);
         $container->setParameter('ilios_core.supporting_link', $config['supporting_link']);
         $container->setParameter('ilios_core.timezone', $config['timezone']);
+        $container->setParameter('ilios_core.enable_api_tracking', $config['enable_api_tracking']);
+
         $container->setParameter('ilios_core.google_analytics_ua_code', $config['google_analytics_ua_code']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
@@ -33,7 +33,6 @@ class IliosCoreExtension extends Extension
         $container->setParameter('ilios_core.supporting_link', $config['supporting_link']);
         $container->setParameter('ilios_core.timezone', $config['timezone']);
         $container->setParameter('ilios_core.enable_api_tracking', $config['enable_api_tracking']);
-
         $container->setParameter('ilios_core.google_analytics_ua_code', $config['google_analytics_ua_code']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
@@ -32,7 +32,7 @@ class IliosCoreExtension extends Extension
         $container->setParameter('ilios_core.institution_domain', $config['institution_domain']);
         $container->setParameter('ilios_core.supporting_link', $config['supporting_link']);
         $container->setParameter('ilios_core.timezone', $config['timezone']);
-        $container->setParameter('ilios_core.enable_api_tracking', $config['enable_api_tracking']);
+        $container->setParameter('ilios_core.enable_tracking', $config['enable_tracking']);
         $container->setParameter('ilios_core.google_analytics_ua_code', $config['google_analytics_ua_code']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
+++ b/src/Ilios/CoreBundle/DependencyInjection/IliosCoreExtension.php
@@ -32,6 +32,7 @@ class IliosCoreExtension extends Extension
         $container->setParameter('ilios_core.institution_domain', $config['institution_domain']);
         $container->setParameter('ilios_core.supporting_link', $config['supporting_link']);
         $container->setParameter('ilios_core.timezone', $config['timezone']);
+        $container->setParameter('ilios_core.google_analytics_ua_code', $config['google_analytics_ua_code']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
@@ -40,8 +40,8 @@ class TrackApiUsageListener
             $host = $request->getHost();
             $title = self::class;
             $data = [
-                'dh' => $path,
-                'dp' => $host,
+                'dh' => $host,
+                'dp' => $path,
                 'dt' => $title,
             ];
             $tracker->send($data, 'pageview');

--- a/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
@@ -17,7 +17,7 @@ class TrackApiUsageListener
 
     public function onKernelController(FilterControllerEvent $event)
     {
-        if (true !== $this->container->getParameter('ilios_core.enable_api_tracking')) {
+        if (true !== $this->container->getParameter('ilios_core.enable_tracking')) {
             return;
         }
 

--- a/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
@@ -2,6 +2,7 @@
 namespace Ilios\CoreBundle\EventListener;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 /**
@@ -12,6 +13,8 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
  */
 class TrackApiUsageListener
 {
+    use ContainerAwareTrait;
+
     public function onKernelController(FilterControllerEvent $event)
     {
         $controller = $event->getController();

--- a/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
@@ -31,7 +31,16 @@ class TrackApiUsageListener
 
         if ($controller[0] instanceof Controller) {
             $request = $event->getRequest();
-            // @todo implement. [ST 2016/11/17]
+            $tracker = $this->container->get('happyr.google_analytics.tracker');
+            $path = $request->getRequestUri();
+            $host = $request->getHost();
+            $title = self::class;
+            $data=array(
+                'dh' => $path,
+                'dp' => $host,
+                'dt' => $title,
+            );
+            $tracker->send($data, 'pageview');
         }
     }
 }

--- a/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
@@ -35,11 +35,11 @@ class TrackApiUsageListener
             $path = $request->getRequestUri();
             $host = $request->getHost();
             $title = self::class;
-            $data=array(
+            $data = [
                 'dh' => $path,
                 'dp' => $host,
                 'dt' => $title,
-            );
+            ];
             $tracker->send($data, 'pageview');
         }
     }

--- a/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
@@ -17,6 +17,10 @@ class TrackApiUsageListener
 
     public function onKernelController(FilterControllerEvent $event)
     {
+        if (true !== $this->container->getParameter('ilios_core.enable_api_tracking')) {
+            return;
+        }
+
         $controller = $event->getController();
 
         /*

--- a/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
@@ -33,16 +33,18 @@ class TrackApiUsageListener
             return;
         }
 
-        if ($controller[0] instanceof Controller) {
+        $controller = $controller[0];
+
+        if ($controller instanceof Controller) {
             $request = $event->getRequest();
             $tracker = $this->container->get('happyr.google_analytics.tracker');
             $path = $request->getRequestUri();
             $host = $request->getHost();
-            $title = self::class;
+            $title = get_class($controller);
             $data = [
                 'dh' => $host,
                 'dp' => $path,
-                'dt' => $title,
+                'dt' => $title
             ];
             $tracker->send($data, 'pageview');
         }

--- a/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
+++ b/src/Ilios/CoreBundle/EventListener/TrackApiUsageListener.php
@@ -1,0 +1,34 @@
+<?php
+namespace Ilios\CoreBundle\EventListener;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+
+/**
+ * Pre-controller event listener that will send tracking data.
+ *
+ * Class TrackApiUsageListener
+ * @package Ilios\CoreBundle\EventListener
+ */
+class TrackApiUsageListener
+{
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $controller = $event->getController();
+
+        /*
+         * $controller passed can be either a class or a Closure.
+         * This is not usual in Symfony but it may happen.
+         * If it is a class, it comes in array format
+         * @link http://symfony.com/doc/current/event_dispatcher/before_after_filters.html#creating-an-event-listener
+         */
+        if (!is_array($controller)) {
+            return;
+        }
+
+        if ($controller[0] instanceof Controller) {
+            $request = $event->getRequest();
+            // @todo implement. [ST 2016/11/17]
+        }
+    }
+}

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -14,6 +14,10 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: flushQueue }
             - { name: kernel.event_listener, event: console.terminate, method: flushQueue }
+    ilioscore.listener.trackapiusage:
+        class: Ilios\CoreBundle\EventListener\TrackApiUsageListener
+        tags:
+            - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
     ilioscore.dataimport_filelocator:
         class: Ilios\CoreBundle\Classes\DataimportFileLocator
         arguments: [ '@file_locator' ]

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -18,6 +18,8 @@ services:
         class: Ilios\CoreBundle\EventListener\TrackApiUsageListener
         tags:
             - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
+        calls:
+            - [ setContainer, ['@service_container'] ]
     ilioscore.dataimport_filelocator:
         class: Ilios\CoreBundle\Classes\DataimportFileLocator
         arguments: [ '@file_locator' ]

--- a/src/Ilios/WebBundle/Controller/ConfigController.php
+++ b/src/Ilios/WebBundle/Controller/ConfigController.php
@@ -41,6 +41,10 @@ class ConfigController extends Controller
         $configuration['maxUploadSize'] = UploadedFile::getMaxFilesize();
         $configuration['apiVersion'] = WebIndexFromJson::API_VERSION;
 
+        $configuration['trackingEnabled'] = $this->container->getParameter('ilios_core.enable_tracking');
+        if ($configuration['trackingEnabled']) {
+            $configuration['trackingCode'] = $this->container->getParameter('ilios_core.google_analytics_ua_code');
+        }
 
         return new JsonResponse(array('config' => $configuration));
     }

--- a/src/Ilios/WebBundle/Controller/ConfigController.php
+++ b/src/Ilios/WebBundle/Controller/ConfigController.php
@@ -43,7 +43,7 @@ class ConfigController extends Controller
 
         $configuration['trackingEnabled'] = $this->container->getParameter('ilios_core.enable_tracking');
         if ($configuration['trackingEnabled']) {
-            $configuration['trackingCode'] = $this->container->getParameter('ilios_core.google_analytics_ua_code');
+            $configuration['trackingCode'] = $this->container->getParameter('ilios_core.tracking_code');
         }
 
         return new JsonResponse(array('config' => $configuration));

--- a/tests/CoreBundle/DependencyInjection/IliosCoreExtensionTest.php
+++ b/tests/CoreBundle/DependencyInjection/IliosCoreExtensionTest.php
@@ -24,6 +24,8 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
         $ldapSearchBase = 'ldap.base';
         $ldapCampusIdProperty = 'ldap.camp';
         $ldapUsernameProperty = 'ldap.username';
+        $trackingEnabled = true;
+        $trackingCode = 'UA-XXXXXXXX-1';
         $this->load(array(
             'file_system_storage_path' => $fileSystemStoragePath,
             'ldap_directory_url' => $ldapUrl,
@@ -35,6 +37,8 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
             'institution_domain' => 'ucsf.edu',
             'supporting_link' => 'https://inventory.ucsf.edu',
             'timezone' => 'America\Los_Angeles',
+            'enable_tracking' => $trackingEnabled,
+            'google_analytics_ua_code' => $trackingCode,
         ));
         $parameters = array(
             'ilioscore.form.handler.class' => 'Ilios\CoreBundle\Form\Handler',
@@ -123,7 +127,9 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
             'ilios_core.ldap.username_property' => $ldapUsernameProperty,
             'ilios_core.file_store_path' => $fileSystemStoragePath,
             'ilios_core.institution_domain' => 'ucsf.edu',
-            'ilios_core.supporting_link' => 'https://inventory.ucsf.edu'
+            'ilios_core.supporting_link' => 'https://inventory.ucsf.edu',
+            'ilios_core.enable_tracking' => $trackingEnabled,
+            'ilios_core.google_analytics_ua_code' => $trackingCode,
         );
         foreach ($parameters as $name => $value) {
             $this->assertContainerBuilderHasParameter($name, $value);

--- a/tests/CoreBundle/DependencyInjection/IliosCoreExtensionTest.php
+++ b/tests/CoreBundle/DependencyInjection/IliosCoreExtensionTest.php
@@ -38,7 +38,7 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
             'supporting_link' => 'https://inventory.ucsf.edu',
             'timezone' => 'America\Los_Angeles',
             'enable_tracking' => $trackingEnabled,
-            'google_analytics_ua_code' => $trackingCode,
+            'tracking_code' => $trackingCode,
         ));
         $parameters = array(
             'ilioscore.form.handler.class' => 'Ilios\CoreBundle\Form\Handler',
@@ -129,7 +129,7 @@ class IliosCoreExtensionTest extends AbstractExtensionTestCase
             'ilios_core.institution_domain' => 'ucsf.edu',
             'ilios_core.supporting_link' => 'https://inventory.ucsf.edu',
             'ilios_core.enable_tracking' => $trackingEnabled,
-            'ilios_core.google_analytics_ua_code' => $trackingCode,
+            'ilios_core.tracking_code' => $trackingCode,
         );
         foreach ($parameters as $name => $value) {
             $this->assertContainerBuilderHasParameter($name, $value);

--- a/tests/CoreBundle/EventListener/TrackApiUsageListenerTest.php
+++ b/tests/CoreBundle/EventListener/TrackApiUsageListenerTest.php
@@ -1,0 +1,106 @@
+<?php
+namespace Tests\CoreBundle\EventListener;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Mockery as m;
+
+use Ilios\CoreBundle\EventListener\TrackApiUsageListener;
+
+/**
+ * Class TrackApiUsageListenerTest
+ * @package Tests\CoreBundle\EventListener
+ */
+class TrackApiUsageListenerTest extends TestCase
+{
+    /**
+     * @var m\MockInterface
+     */
+    protected $mockEvent;
+
+    /**
+     * @var m\MockInterface
+     */
+    protected $mockContainer;
+
+    /**
+     * @var m\MockInterface
+     */
+    protected $mockRequest;
+
+    /**
+     * @var m\MockInterface
+     */
+    protected $mockController;
+
+    /**
+     * @var m\MockInterface
+     */
+    protected $mockTracker;
+
+    /**
+     * @var TrackApiUsageListener
+     */
+    protected $listener;
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp()
+    {
+        $this->mockController = m::mock('Symfony\Bundle\FrameworkBundle\Controller\Controller');
+        $this->mockRequest = m::mock('Symfony\Component\HttpFoundation\Request');
+        $this->mockEvent = m::mock('Symfony\Component\HttpKernel\Event\FilterControllerEvent');
+        $this->mockEvent->shouldReceive('getController')->andReturn([$this->mockController]);
+        $this->mockEvent->shouldReceive('getRequest')->andReturn($this->mockRequest);
+        $this->mockTracker = m::mock('Happyr\GoogleAnalyticsBundle\Service\Tracker');
+        $this->mockContainer = m::mock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->mockContainer->shouldReceive('get')
+            ->with('happyr.google_analytics.tracker')
+            ->andReturn($this->mockTracker);
+
+        $this->listener = new TrackApiUsageListener();
+        $this->listener->setContainer($this->mockContainer);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function tearDown()
+    {
+        unset($this->listener);
+        unset($this->mockTracker);
+        unset($this->mockContainer);
+        unset($this->mockEvent);
+        unset($this->mockRequest);
+        unset($this->mockController);
+        m::close();
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\EventListener\TrackApiUsageListener::onKernelController
+     */
+    public function testTrackingIsDisabled()
+    {
+        $this->mockContainer->shouldReceive('getParameter')->with('ilios_core.enable_tracking')->andReturn(false);
+        $this->listener->onKernelController($this->mockEvent);
+        $this->mockTracker->shouldNotHaveReceived('send');
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\EventListener\TrackApiUsageListener::onKernelController
+     */
+    public function testTracking()
+    {
+        $uri = '/api/v1/foo/bar/baz';
+        $host = 'iliosproject.org';
+        $this->mockRequest->shouldReceive('getRequestUri')->andReturn($uri);
+        $this->mockRequest->shouldReceive('getHost')->andReturn($host);
+        $this->mockContainer->shouldReceive('getParameter')->with('ilios_core.enable_tracking')->andReturn(true);
+        $this->mockTracker->shouldReceive('send');
+        $this->listener->onKernelController($this->mockEvent);
+        $this->mockTracker->shouldHaveReceived('send')->withArgs([
+            ['dh' => $host, 'dp' => $uri, 'dt' => get_class($this->mockController)],
+            'pageview'
+        ]);
+    }
+}

--- a/tests/WebBundle/Controller/ConfigControllerTest.php
+++ b/tests/WebBundle/Controller/ConfigControllerTest.php
@@ -34,7 +34,8 @@ class ConfigControllerTest extends WebTestCase
                 'type' => 'form',
                 'locale' => 'en',
                 'userSearchType' => 'local',
-                'apiVersion' => WebIndexFromJson::API_VERSION
+                'apiVersion' => WebIndexFromJson::API_VERSION,
+                'trackingEnabled' => false,
             ),
             $data
         );


### PR DESCRIPTION
fixes #1148 

the "tracking enabled" flag and the tracking code itself are exposed via the config endpoint in the API (the latter only if the tracking has been enabled.)

google will receive the following three data attributes for each API controller hit

- the API server's host name
- the API endpoint URI ("path")
- the fully qualified name of the controller class that was called.
