### PR TITLE
Add firstOfferingDate to course learning materials

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -1008,7 +1008,7 @@ class UserRepository extends EntityRepository
     ) {
 
         $qb = $this->_em->createQueryBuilder();
-        $what = 'c.title as courseTitle, c.id as courseId, ' .
+        $what = 'c.title as courseTitle, c.id as courseId, c.startDate as firstOfferingDate, ' .
             'clm.notes, clm.required, clm.publicNotes, ' .
             'lm.id, lm.title, lm.description, lm.originalAuthor, lm.token, ' .
             'lm.citation, lm.link, lm.filename, lm.mimetype';

--- a/tests/CoreBundle/Controller/UsermaterialsControllerTest.php
+++ b/tests/CoreBundle/Controller/UsermaterialsControllerTest.php
@@ -74,9 +74,11 @@ class UsermaterialsControllerTest extends AbstractControllerTest
         $this->assertFalse(array_key_exists('session', $materials[1]));
         $this->assertEquals('2', $materials[2]['id']);
         $this->assertEquals('1', $materials[2]['course']);
+        $this->assertEquals('2016-09-04T00:00:00+00:00', $materials[2]['firstOfferingDate']);
         $this->assertFalse(array_key_exists('session', $materials[2]));
         $this->assertEquals('3', $materials[3]['id']);
         $this->assertEquals('1', $materials[3]['course']);
+        $this->assertEquals('2016-09-04T00:00:00+00:00', $materials[2]['firstOfferingDate']);
         $this->assertFalse(array_key_exists('session', $materials[3]));
     }
 


### PR DESCRIPTION
Uses to course date to present a first offering date for user materials.

Fixes #1676