### PR TITLE
Timestamp updated entities outside of the normal flow

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Manager/BaseManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/BaseManager.php
@@ -6,12 +6,6 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Id\AssignedGenerator;
-use Ilios\CoreBundle\Entity\Offering;
-use Ilios\CoreBundle\Entity\SessionStampableInterface;
-use Ilios\CoreBundle\Traits\OfferingsEntityInterface;
-use Ilios\CoreBundle\Entity\Session;
-use Ilios\CoreBundle\Entity\SessionInterface;
-use Ilios\CoreBundle\Traits\TimestampableEntityInterface;
 
 /**
  * Class BaseManager
@@ -145,7 +139,6 @@ class BaseManager implements ManagerInterface
         $forceId = false
     ) {
         $this->em->persist($entity);
-        $this->stamp($entity);
 
         if ($forceId) {
             $metadata = $this->em->getClassMetaData(get_class($entity));
@@ -163,7 +156,6 @@ class BaseManager implements ManagerInterface
     public function delete(
         $entity
     ) {
-        $this->stamp($entity);
         $this->em->remove($entity);
         $this->em->flush();
     }
@@ -175,31 +167,5 @@ class BaseManager implements ManagerInterface
     {
         $class = $this->getClass();
         return new $class();
-    }
-
-    protected function stamp($entity)
-    {
-
-        if ($entity instanceof TimestampableEntityInterface) {
-            $entity->stampUpdate();
-        }
-
-        if ($entity instanceof OfferingsEntityInterface) {
-            $offerings = $entity->getOfferings();
-            $em = $this->registry->getManagerForClass(Offering::class);
-            foreach ($offerings as $offering) {
-                $offering->stampUpdate();
-                $em->persist($offering);
-            }
-        }
-
-        if ($entity instanceof SessionStampableInterface) {
-            $sessions = $entity->getSessions();
-            $em = $this->registry->getManagerForClass(Session::class);
-            foreach ($sessions as $session) {
-                $session->stampUpdate();
-                $em->persist($session);
-            }
-        }
     }
 }

--- a/src/Ilios/CoreBundle/EventListener/TimestampEntityChanges.php
+++ b/src/Ilios/CoreBundle/EventListener/TimestampEntityChanges.php
@@ -1,0 +1,68 @@
+<?php
+namespace Ilios\CoreBundle\EventListener;
+
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Ilios\CoreBundle\Service\Timestamper;
+use Ilios\CoreBundle\Traits\TimestampableEntityInterface;
+use Ilios\CoreBundle\Traits\OfferingsEntityInterface;
+use Ilios\CoreBundle\Entity\SessionStampableInterface;
+
+/**
+ * Doctrine event listener.
+ * Listen for every change to an entity and timestamp it if appropriate.
+ *
+ * Class TimestampEntityChanges
+ * @package Ilios\CoreBundle\EventListener
+ */
+class TimestampEntityChanges
+{
+    /**
+     * @var Timestamper
+     */
+    protected $timeStamper;
+
+    /**
+     * TimestampEntityChanges constructor.
+     * @param Timestamper $timeStamper
+     */
+    public function __construct(Timestamper $timeStamper)
+    {
+        $this->timeStamper = $timeStamper;
+    }
+
+    public function onFlush(OnFlushEventArgs $eventArgs)
+    {
+        $entityManager = $eventArgs->getEntityManager();
+        $uow = $entityManager->getUnitOfWork();
+        $entities = array_merge(
+            $uow->getScheduledEntityInsertions(),
+            $uow->getScheduledEntityUpdates(),
+            $uow->getScheduledEntityDeletions()
+        );
+
+        foreach ($entities as $entity) {
+            $this->stamp($entity);
+        }
+    }
+
+    protected function stamp($entity)
+    {
+        if ($entity instanceof TimestampableEntityInterface) {
+            $this->timeStamper->add($entity);
+        }
+
+        if ($entity instanceof OfferingsEntityInterface) {
+            $offerings = $entity->getOfferings();
+            foreach ($offerings as $offering) {
+                $this->timeStamper->add($offering);
+            }
+        }
+
+        if ($entity instanceof SessionStampableInterface) {
+            $sessions = $entity->getSessions();
+            foreach ($sessions as $session) {
+                $this->timeStamper->add($session);
+            }
+        }
+    }
+}

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -20,6 +20,11 @@ services:
             - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
         calls:
             - [ setContainer, ['@service_container'] ]
+    ilioscore.listener.timestampentity:
+        class: Ilios\CoreBundle\EventListener\TimestampEntityChanges
+        arguments: ['@ilioscore.timestamper']
+        tags:
+            - { name: doctrine.event_listener, event: onFlush }
     ilioscore.dataimport_filelocator:
         class: Ilios\CoreBundle\Classes\DataimportFileLocator
         arguments: [ '@file_locator' ]
@@ -64,3 +69,9 @@ services:
     ilioscore.usermaterial.factory:
         class: Ilios\CoreBundle\Service\UserMaterialFactory
         arguments: [ "@router", Ilios\CoreBundle\Classes\UserMaterial ]
+    ilioscore.timestamper:
+        class: Ilios\CoreBundle\Service\Timestamper
+        arguments: [ "@doctrine" ]
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: flush }
+            - { name: kernel.event_listener, event: console.terminate, method: flush }

--- a/src/Ilios/CoreBundle/Service/Timestamper.php
+++ b/src/Ilios/CoreBundle/Service/Timestamper.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Ilios\CoreBundle\Service;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Ilios\CoreBundle\Traits\IdentifiableEntityInterface;
+use Ilios\CoreBundle\Traits\TimestampableEntityInterface;
+
+class Timestamper
+{
+    /**
+     * @var array
+     */
+    protected $entities;
+
+    /**
+     * @var Registry
+     */
+    protected $registry;
+
+    /**
+     * @param Registry $registry
+     */
+    public function __construct(Registry $registry)
+    {
+        $this->registry   = $registry;
+        $this->entities   = [];
+    }
+
+    /**
+     * Add an entity to be time stamped
+     * @param TimestampableEntityInterface $entity
+     * @throws \Exception
+     */
+    public function add(TimestampableEntityInterface $entity)
+    {
+        $class = $entity->getClassName();
+        if (!array_key_exists($class, $this->entities)) {
+            $this->entities[$class] = [];
+        }
+        if (!$entity instanceof IdentifiableEntityInterface) {
+            throw new \Exception("Tried to timestamp a non identifiable entity {$class}");
+        }
+        $this->entities[$class][] = $entity->getId();
+    }
+
+    public function flush()
+    {
+        if (count($this->entities)) {
+            $om = $this->registry->getManager();
+            $now = new \DateTime();
+            foreach ($this->entities as $class => $ids) {
+                $qb = $om->createQueryBuilder();
+                $qb->update($class, 'c')
+                    ->set('c.updatedAt', ':now')
+                    ->where($qb->expr()->in('c.id', $ids))
+                    ->setParameter('now', $now);
+                $query = $qb->getQuery();
+                $query->execute();
+            }
+            $this->entities = [];
+        }
+    }
+}

--- a/src/Ilios/CoreBundle/Traits/TimestampableEntity.php
+++ b/src/Ilios/CoreBundle/Traits/TimestampableEntity.php
@@ -45,4 +45,12 @@ trait TimestampableEntity
     {
         $this->createdAt = $createdAt;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getClassName()
+    {
+        return __CLASS__;
+    }
 }

--- a/src/Ilios/CoreBundle/Traits/TimestampableEntityInterface.php
+++ b/src/Ilios/CoreBundle/Traits/TimestampableEntityInterface.php
@@ -32,4 +32,9 @@ interface TimestampableEntityInterface
      * @param \DateTime $createdAt
      */
     public function setCreatedAt(\DateTime $createdAt);
+
+    /**
+     * @return string
+     */
+    public function getClassName();
 }

--- a/tests/CoreBundle/Controller/SessionControllerTest.php
+++ b/tests/CoreBundle/Controller/SessionControllerTest.php
@@ -484,7 +484,7 @@ class SessionControllerTest extends AbstractControllerTest
         unset($postData['courseLearningMaterials']);
         unset($postData['sessionLearningMaterials']);
 
-        $postData['status'] = '2';
+        $postData['status'] = '1';
         $this->createJsonRequest(
             'PUT',
             $this->getUrl(

--- a/tests/CoreBundle/Entity/Manager/OfferingManagerTest.php
+++ b/tests/CoreBundle/Entity/Manager/OfferingManagerTest.php
@@ -38,8 +38,6 @@ class OfferingManagerTest extends \PHPUnit_Framework_TestCase
             ->mock();
         
         $entity = m::mock($class);
-        $entity->shouldReceive('stampUpdate')->once();
-        $entity->shouldReceive('getSessions')->once()->andReturn([]);
         $manager = new OfferingManager($registry, $class);
         $manager->delete($entity);
     }


### PR DESCRIPTION
By moving the timestamping of entities changed and their related changed
sessions and offerings into its own post flush process we will hopefully
avoid deadlocks which have frequently occurred here. I had to use the
query builder instead of just calling stampUpdate on the entities
because when a relationship is deleted in the flush (like
sessionDescription) it still attempts to save it in our postFlush event.
This causes issues so instead I'm only working with the IDs and not the
entities.

Fixes #1683