### PR TITLE
Correctly apply maximum TTL for tokens

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/JsonWebTokenManager.php
+++ b/src/Ilios/AuthenticationBundle/Service/JsonWebTokenManager.php
@@ -72,7 +72,7 @@ class JsonWebTokenManager
     {
         return $this->createJwtFromUserId($user->getId(), $timeToLive);
     }
-
+    
     /**
      * Build a token from a userId
      * @param  integer $userId
@@ -84,8 +84,15 @@ class JsonWebTokenManager
     {
         $requestedInterval = new \DateInterval($timeToLive);
         $maximumInterval = new \DateInterval('P364D');
-        $interval = $requestedInterval > $maximumInterval?$maximumInterval:$requestedInterval;
         $now = new DateTime();
+
+        //DateIntervals are not comparable so we have to create DateTimes first with are
+        $requestedFromToday = clone $now;
+        $requestedFromToday->add($requestedInterval);
+        $maximumFromToday = clone $now;
+        $maximumFromToday->add($maximumInterval);
+
+        $interval = $requestedFromToday > $maximumFromToday?$maximumInterval:$requestedInterval;
         $expires = clone $now;
         $expires->add($interval);
 

--- a/tests/AuthenticationBundle/Service/JsonWebTokenManagerTest.php
+++ b/tests/AuthenticationBundle/Service/JsonWebTokenManagerTest.php
@@ -74,8 +74,8 @@ class JsonWebTokenManagerTest extends TestCase
         $jwt = $obj->createJwtFromUser($user, 'P400D');
         $now = new DateTime();
         $expiresAt = $obj->getExpiresAtFromToken($jwt);
-        
-        $this->assertTrue($now->diff($expiresAt)->d < 365);
+
+        $this->assertTrue($now->diff($expiresAt)->days < 365, 'maximum ttl not applied');
     }
     
     protected function buildToken(array $values = array(), $secretKey = 'ilios.jwt.key.secret')


### PR DESCRIPTION
It is not possible to compare DateInterval objects.  We first need to
apply them to a DateTime and then calculate that difference.

Fixes #1709