### PR TITLE
Allow courses to be rolled over in the previous year

### DIFF
--- a/src/Ilios/CoreBundle/Classes/CourseRollover.php
+++ b/src/Ilios/CoreBundle/Classes/CourseRollover.php
@@ -115,9 +115,9 @@ class CourseRollover
         $newStartDate = (!empty($options['new-start-date'])) ? new \DateTime($options['new-start-date']) : null;
 
         //make sure that the new course's academic year or new start date year is not in the past
-        $this->confirmYearIsNotInPast($newAcademicYear);
+        $this->confirmYearIsValid($newAcademicYear);
         if (!empty($newStartDate)) {
-            $this->confirmYearIsNotInPast($newStartDate->format('Y'));
+            $this->confirmYearIsValid($newStartDate->format('Y'));
         }
 
         //get the original course object
@@ -403,12 +403,12 @@ class CourseRollover
      * @param int $newAcademicYear
      * @throws \Exception
      */
-    private function confirmYearIsNotInPast($newAcademicYear)
+    private function confirmYearIsValid($newAcademicYear)
     {
-        $currentYear = date('Y');
-        if ($newAcademicYear < $currentYear) {
+        $lastYear = date('Y') - 1;
+        if ($newAcademicYear < $lastYear) {
             throw new \Exception(
-                "You cannot rollover a course to a new year or start date that is already in the past."
+                "Courses cannot be rolled over to a new year before {$lastYear}."
             );
         }
     }

--- a/tests/CoreBundle/Classes/CourseRolloverTest.php
+++ b/tests/CoreBundle/Classes/CourseRolloverTest.php
@@ -913,7 +913,7 @@ class CourseRolloverTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(
             \Exception::class,
-            "You cannot rollover a course to a new year or start date that is already in the past."
+            "Courses cannot be rolled over to a new year before"
         );
 
         $this->service->rolloverCourse($courseId, $year, []);


### PR DESCRIPTION
This allows for rolling over a spring course in the 2016 - 2017 academic
year in January 2017.

Fixes #1711