### PR TITLE
Use variable date from offering fixture in tests

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/SchoolRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/SchoolRepository.php
@@ -139,9 +139,13 @@ class SchoolRepository extends EntityRepository
         }
 
         $events = array_merge($events, $uniqueIlmEvents);
-        //sort events by startDate for consistency
+        //sort events by startDate and endDate for consistency
         usort($events, function ($a, $b) {
-            return $a->startDate->getTimestamp() - $b->startDate->getTimestamp();
+            $diff = $a->startDate->getTimestamp() - $b->startDate->getTimestamp();
+            if ($diff === 0) {
+                $diff = $a->endDate->getTimestamp() - $b->endDate->getTimestamp();
+            }
+            return $diff;
         });
 
         return $events;

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -184,9 +184,13 @@ class UserRepository extends EntityRepository
         }
 
         $events = array_merge($events, $uniqueIlmEvents);
-        //sort events by startDate for consistency
+        //sort events by startDate and endDate for consistency
         usort($events, function ($a, $b) {
-            return $a->startDate->getTimestamp() - $b->startDate->getTimestamp();
+            $diff = $a->startDate->getTimestamp() - $b->startDate->getTimestamp();
+            if ($diff === 0) {
+                $diff = $a->endDate->getTimestamp() - $b->endDate->getTimestamp();
+            }
+            return $diff;
         });
 
         return $events;

--- a/tests/CoreBundle/Controller/AbstractControllerTest.php
+++ b/tests/CoreBundle/Controller/AbstractControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\CoreBundle\Controller;
 
+use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
@@ -22,10 +23,15 @@ abstract class AbstractControllerTest extends WebTestCase
      */
     protected $container;
 
-        /**
+    /**
      * @var Client
      */
     protected $client;
+
+    /**
+     * @var ProxyReferenceRepository
+     */
+    protected $fixtures;
 
     /**
      * @return array|FixtureInterface
@@ -51,7 +57,7 @@ abstract class AbstractControllerTest extends WebTestCase
         $this->client = static::createClient();
         $this->client->followRedirects();
         $this->container = $this->client->getContainer();
-        $this->loadFixtures($this->getFixtures());
+        $this->fixtures = $this->loadFixtures($this->getFixtures())->getReferenceRepository();
     }
     
     public function tearDown()

--- a/tests/CoreBundle/Controller/CourseControllerTest.php
+++ b/tests/CoreBundle/Controller/CourseControllerTest.php
@@ -1187,10 +1187,9 @@ class CourseControllerTest extends AbstractControllerTest
 
         $response = $this->client->getResponse();
         $this->assertJsonResponse($response, Codes::HTTP_OK);
-        $session1fferingData = json_decode($response->getContent(), true)['offerings'];
+        $session1OfferingData = json_decode($response->getContent(), true)['offerings'];
 
-        $this->assertEquals('2017-02-09T15:00:00+00:00', $session1fferingData[0]['startDate']);
-        $this->assertEquals('2017-02-08T17:00:00+00:00', $session1fferingData[1]['startDate']);
+        $this->assertEquals('2017-02-09T15:00:00+00:00', $session1OfferingData[0]['startDate']);
     }
 
     /**

--- a/tests/CoreBundle/Controller/SchooleventsControllerTest.php
+++ b/tests/CoreBundle/Controller/SchooleventsControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\CoreBundle\Controller;
 
 use FOS\RestBundle\Util\Codes;
 use DateTime;
+use Ilios\CoreBundle\Entity\Offering;
 
 /**
  * UserRole controller Test.
@@ -97,14 +98,16 @@ class SchooleventsControllerTest extends AbstractControllerTest
         $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate']);
         $this->assertEquals($events[8]['courseTitle'], $courses[1]['title']);
 
-        $this->assertEquals($events[9]['offering'], 2);
-        $this->assertEquals($events[9]['startDate'], $offerings[1]['startDate']);
-        $this->assertEquals($events[9]['endDate'], $offerings[1]['endDate']);
+        $this->assertEquals($events[9]['offering'], 1);
+        $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate']);
+        $this->assertEquals($events[9]['endDate'], $offerings[0]['endDate']);
         $this->assertEquals($events[9]['courseTitle'], $courses[0]['title']);
 
-        $this->assertEquals($events[10]['offering'], 1);
-        $this->assertEquals($events[10]['startDate'], $offerings[0]['startDate']);
-        $this->assertEquals($events[10]['endDate'], $offerings[0]['endDate']);
+        $this->assertEquals($events[10]['offering'], 2);
+        /** @var Offering $offering */
+        $offering = $this->fixtures->getReference('offerings2');
+        $this->assertEquals($events[10]['startDate'], $offering->getStartDate()->format('c'));
+        $this->assertEquals($events[10]['endDate'], $offering->getEndDate()->format('c'));
         $this->assertEquals($events[10]['courseTitle'], $courses[0]['title']);
 
 

--- a/tests/CoreBundle/Controller/SchooleventsControllerTest.php
+++ b/tests/CoreBundle/Controller/SchooleventsControllerTest.php
@@ -103,12 +103,12 @@ class SchooleventsControllerTest extends AbstractControllerTest
         $this->assertEquals($events[9]['endDate'], $offerings[0]['endDate']);
         $this->assertEquals($events[9]['courseTitle'], $courses[0]['title']);
 
-        $this->assertEquals($events[10]['offering'], 2);
+        $this->assertEquals(8, $events[10]['offering']);
         /** @var Offering $offering */
-        $offering = $this->fixtures->getReference('offerings2');
+        $offering = $this->fixtures->getReference('offerings8');
         $this->assertEquals($events[10]['startDate'], $offering->getStartDate()->format('c'));
         $this->assertEquals($events[10]['endDate'], $offering->getEndDate()->format('c'));
-        $this->assertEquals($events[10]['courseTitle'], $courses[0]['title']);
+        $this->assertEquals($events[10]['courseTitle'], $courses[1]['title']);
 
 
         foreach ($events as $event) {

--- a/tests/CoreBundle/Controller/UsereventControllerTest.php
+++ b/tests/CoreBundle/Controller/UsereventControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\CoreBundle\Controller;
 
 use FOS\RestBundle\Util\Codes;
 use DateTime;
+use Ilios\CoreBundle\Entity\Offering;
 
 /**
  * UserRole controller Test.
@@ -98,10 +99,21 @@ class UsereventControllerTest extends AbstractControllerTest
         $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate'], 'dueDate is correct for event 8');
         $this->assertEquals($events[8]['courseTitle'], $courses[1]['title'], 'title is correct for event 8');
 
-        $this->assertEquals($events[9]['startDate'], $offerings[1]['startDate'], 'startDate is correct for event 9');
-        $this->assertEquals($events[9]['endDate'], $offerings[1]['endDate'], 'endDate is correct for event 9');
-        $this->assertEquals($events[10]['startDate'], $offerings[0]['startDate'], 'startDate is correct for event 10');
-        $this->assertEquals($events[10]['endDate'], $offerings[0]['endDate'], 'endDate is correct for event 10');
+        $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate'], 'startDate is correct for event 9');
+        $this->assertEquals($events[9]['endDate'], $offerings[0]['endDate'], 'endDate is correct for event 9');
+
+        /** @var Offering $offering */
+        $offering = $this->fixtures->getReference('offerings2');
+        $this->assertEquals(
+            $events[10]['startDate'],
+            $offering->getStartDate()->format('c'),
+            'startDate is correct for event 10'
+        );
+        $this->assertEquals(
+            $events[10]['endDate'],
+            $offering->getEndDate()->format('c'),
+            'endDate is correct for event 10'
+        );
 
 
         foreach ($events as $event) {

--- a/tests/CoreBundle/Controller/UsereventControllerTest.php
+++ b/tests/CoreBundle/Controller/UsereventControllerTest.php
@@ -103,7 +103,8 @@ class UsereventControllerTest extends AbstractControllerTest
         $this->assertEquals($events[9]['endDate'], $offerings[0]['endDate'], 'endDate is correct for event 9');
 
         /** @var Offering $offering */
-        $offering = $this->fixtures->getReference('offerings2');
+        $offering = $this->fixtures->getReference('offerings8');
+        $this->assertEquals(8, $events[10]['offering'], 'offering is correct for event 10');
         $this->assertEquals(
             $events[10]['startDate'],
             $offering->getStartDate()->format('c'),

--- a/tests/CoreBundle/Controller/UsermaterialsControllerTest.php
+++ b/tests/CoreBundle/Controller/UsermaterialsControllerTest.php
@@ -67,7 +67,7 @@ class UsermaterialsControllerTest extends AbstractControllerTest
         $this->assertRegExp('/^session1Title/', $materials[0]['sessionTitle']);
         $this->assertEquals('1', $materials[0]['course']);
         $this->assertRegExp('/^firstCourse/', $materials[0]['courseTitle']);
-        $this->assertEquals('2016-09-07T17:00:00+00:00', $materials[0]['firstOfferingDate']);
+        $this->assertEquals('2016-09-08T15:00:00+00:00', $materials[0]['firstOfferingDate']);
 
         $this->assertEquals('1', $materials[1]['id']);
         $this->assertEquals('1', $materials[1]['course']);

--- a/tests/CoreBundle/DataLoader/OfferingData.php
+++ b/tests/CoreBundle/DataLoader/OfferingData.php
@@ -8,7 +8,6 @@ class OfferingData extends AbstractDataLoader
 {
     protected function getData()
     {
-        $today = new \DateTime();
         $arr = array();
 
         $arr[] = array(
@@ -102,13 +101,12 @@ class OfferingData extends AbstractDataLoader
             'instructors' => [],
         );
 
-        $halfHourFromNow = new DateTime('+30 minutes');
         $arr[] = array(
             'id' => 8,
             'room' => $this->faker->text(10),
             'site' => $this->faker->text(10),
-            'startDate' => $today->format('c'),
-            'endDate' => $halfHourFromNow->format('c'),
+            'startDate' => $this->getFormattedDate('now'),
+            'endDate' => $this->getFormattedDate('+30 minutes'),
             'session' => '3',
             'learnerGroups' => [],
             'instructorGroups' => [],


### PR DESCRIPTION
One of the offerings now uses a variable date in order to stay current.
Instead of looking for a static date we need to grab the correct entity
and check that date.

Fixes #1716