### PR TITLE
Remove debug parameters which are only used in dev

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -116,10 +116,6 @@ locale: en
 #be EXTREMELY dangerous in a production enviroment!
 secret: ThisCanBeWhateverYouLike,JustMakeSureYouChangeIt!
 
-#These should all be set to 'false' in a production environment
-debug_toolbar: false
-debug_redirects: false
-
 # can currently be 'form' (default),'ldap', or 'shibboleth' depeding on your institution
 authentication_type: form
 

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -9,8 +9,8 @@ framework:
     profiler: { only_exceptions: false }
 
 web_profiler:
-    toolbar: "%debug_toolbar%"
-    intercept_redirects: "%debug_redirects%"
+    toolbar: true
+    intercept_redirects: false
 
 monolog:
     handlers:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -18,9 +18,6 @@ parameters:
     # A secret key that's used to generate certain security-related tokens
     secret:            ThisTokenIsNotSoSecretChangeIt
 
-    debug_toolbar:          true
-    debug_redirects:        false
-
     authentication_type: "form"
     legacy_password_salt: "Ilios2 ilios_authentication_internal_auth_salt value"
     file_system_storage_path: "A path on your server's file system where Ilios can store files like learning_materials"

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -13,8 +13,6 @@ parameters:
     mailer_password: null
     locale: en
     secret: ThisTokenIsNotSoSecretChangeIt
-    debug_toolbar: true
-    debug_redirects: false
     authentication_type: form
     legacy_password_salt: null
     file_system_storage_path: /tmp


### PR DESCRIPTION
debug_toolbar and debug_redirects are never used in anything but the dev
environment and there they can just be set in config_dev.yml and they
are usually true and false respectively anyway.  Lets remove them and
remove some complication from configuration.