### PR TITLE
Read content from scripts when pulling frontend JSON

### DIFF
--- a/src/Ilios/WebBundle/Resources/views/WebIndex/webindex.html.twig
+++ b/src/Ilios/WebBundle/Resources/views/WebIndex/webindex.html.twig
@@ -36,7 +36,15 @@
 <div id='initialpageloader' class='ember-load-indicator'><header class='main'><div class='logo'><span class='image'></span></div></header><div id='site-container'><h1><i class='fa fa-spinner fa-pulse fa-3x'></i></h1><p id='browsererrormessage' class='hidden'>It is possible that your browser is not supported by Ilios.  Please refresh this page or try a different browser.</p></div></div></div>
 
 {% for s in scripts %}
-    <script src="{{ s }}"></script>
+    {% if s.src %}
+        <script src="{{ s.src }}"></script>
+    {% else %}
+        <script>
+            {% autoescape false %}
+                {{ s.content }}
+            {% endautoescape %}
+        </script>
+    {% endif %}
 {% endfor %}
 
 </body>

--- a/src/Ilios/WebBundle/Service/WebIndexFromJson.php
+++ b/src/Ilios/WebBundle/Service/WebIndexFromJson.php
@@ -11,7 +11,7 @@ class WebIndexFromJson
      * @var string
      */
     const DEFAULT_TEMPLATE_NAME = 'webindex.html.twig';
-    const API_VERSION = 'v1.13';
+    const API_VERSION = 'v1.14';
     const AWS_BUCKET = 'https://s3-us-west-2.amazonaws.com/frontend-json-config/';
 
     const PRODUCTION = 'prod';
@@ -71,7 +71,10 @@ class WebIndexFromJson
         }, $json->link);
 
         $scripts = array_map(function ($obj) {
-            return $obj->src;
+            return [
+                'src' => property_exists($obj, 'src')?$obj->src:null,
+                'content' => property_exists($obj, 'content')?$obj->content:null,
+            ];
         }, $json->script);
 
         $options = [

--- a/tests/WebBundle/Service/WebIndexFromJsonTest.php
+++ b/tests/WebBundle/Service/WebIndexFromJsonTest.php
@@ -15,7 +15,8 @@ class WebIndexFromJsonTest extends TestCase
     {
         $this->sampleJson = '{"meta":[{"name":"ilios/config/environment",' .
             '"content":"test-config"}],"link":[{"rel":"stylesheet","href":"first.css"},{"rel":"stylesheet",' .
-            '"href":"second.css"}],"script":[{"src":"first.js"},{"src":"second.js"},{"src":"third.js"}]}';
+            '"href":"second.css"}],"script":[{"src":"first.js"},{"src":"second.js"},{"src":"third.js"}, ' .
+            '{"content": "<script></script>"}]}';
     }
 
     public function tearDown()
@@ -55,9 +56,22 @@ class WebIndexFromJsonTest extends TestCase
 
             ],
             'scripts' => [
-                'first.js',
-                'second.js',
-                'third.js',
+                [
+                    'src' => 'first.js',
+                    'content' => null
+                ],
+                [
+                    'src' => 'second.js',
+                    'content' => null
+                ],
+                [
+                    'src' => 'third.js',
+                    'content' => null
+                ],
+                [
+                    'src' => null,
+                    'content' => '<script></script>'
+                ],
             ],
         ])->once()->andReturn('compiledtemplatestring');
         $result = $obj->getIndex(WebIndexFromJson::DEVELOPMENT);


### PR DESCRIPTION
Our frontend JSON now includes script tags with no src attribute but
with actual JS inside the content property.

Fixes #1692