### PR TITLE
Create ancestor relationship when rolling over courses

### DIFF
--- a/src/Ilios/CoreBundle/Classes/CourseRollover.php
+++ b/src/Ilios/CoreBundle/Classes/CourseRollover.php
@@ -157,6 +157,7 @@ class CourseRollover
         $newCourse->setStartDate($newCourseStartDate);
         $newCourse->setEndDate($newCourseEndDate);
         $newCourse->setExternalId($origCourse->getExternalId());
+        $newCourse->setAncestor($origCourse->getAncestorOrSelf());
         if ($clerkshipType = $origCourse->getClerkshipType()) {
             $newCourse->setClerkshipType($clerkshipType);
         }
@@ -462,6 +463,7 @@ class CourseRollover
             $newObjective->setTitle($objective->getTitle());
             $newObjective->setMeshDescriptors($objective->getMeshDescriptors());
             $newObjective->addCourse($newCourse);
+            $newObjective->setAncestor($objective->getAncestorOrSelf());
             $this->objectiveManager->update($newObjective, false, false);
             $newCourseObjectives[$objective->getId()] = $newObjective;
         }
@@ -487,6 +489,7 @@ class CourseRollover
                     $newObjective->setTitle($objective->getTitle());
                     $newObjective->setMeshDescriptors($objective->getMeshDescriptors());
                     $newObjective->addSession($newSession);
+                    $newObjective->setAncestor($objective->getAncestorOrSelf());
                     $newParents = $objective->getParents()
                         ->map(
                             function (ObjectiveInterface $oldParent) use ($newCourseObjectives, $objective) {

--- a/src/Ilios/CoreBundle/Entity/Course.php
+++ b/src/Ilios/CoreBundle/Entity/Course.php
@@ -572,6 +572,16 @@ class Course implements CourseInterface
     /**
      * @inheritdoc
      */
+    public function getAncestorOrSelf()
+    {
+        $ancestor = $this->getAncestor();
+
+        return $ancestor?$ancestor:$this;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function setDescendants(Collection $descendants)
     {
         $this->descendants = new ArrayCollection();

--- a/src/Ilios/CoreBundle/Entity/CourseInterface.php
+++ b/src/Ilios/CoreBundle/Entity/CourseInterface.php
@@ -134,6 +134,11 @@ interface CourseInterface extends
     public function getAncestor();
 
     /**
+     * @return CourseInterface
+     */
+    public function getAncestorOrSelf();
+
+    /**
      * @param Collection $children
      */
     public function setDescendants(Collection $children);

--- a/src/Ilios/CoreBundle/Entity/Objective.php
+++ b/src/Ilios/CoreBundle/Entity/Objective.php
@@ -366,6 +366,18 @@ class Objective implements ObjectiveInterface
     }
 
     /**
+     * If the objective has no ancestor then we need to objective itself
+     *
+     * @return ObjectiveInterface
+     */
+    public function getAncestorOrSelf()
+    {
+        $ancestor = $this->getAncestor();
+
+        return $ancestor?$ancestor:$this;
+    }
+
+    /**
      * @param Collection $descendants
      */
     public function setDescendants(Collection $descendants)

--- a/src/Ilios/CoreBundle/Entity/ObjectiveInterface.php
+++ b/src/Ilios/CoreBundle/Entity/ObjectiveInterface.php
@@ -85,6 +85,11 @@ interface ObjectiveInterface extends
     public function getAncestor();
 
     /**
+     * @return ObjectiveInterface
+     */
+    public function getAncestorOrSelf();
+
+    /**
      * @param Collection $children
      */
     public function setDescendants(Collection $children);

--- a/tests/CoreBundle/Controller/CourseControllerTest.php
+++ b/tests/CoreBundle/Controller/CourseControllerTest.php
@@ -1067,6 +1067,7 @@ class CourseControllerTest extends AbstractControllerTest
         $this->assertSame(count($course['objectives']), count($newCourse['objectives']));
         $this->assertEquals($course['meshDescriptors'], $newCourse['meshDescriptors']);
         $this->assertSame(count($course['learningMaterials']), count($newCourse['learningMaterials']));
+        $this->assertEquals($course['id'], $newCourse['ancestor']);
 
         $newSessions = $newCourse['sessions'];
         $this->assertEquals(count($newSessions), 2);

--- a/tests/CoreBundle/Entity/CourseTest.php
+++ b/tests/CoreBundle/Entity/CourseTest.php
@@ -291,6 +291,24 @@ class CourseTest extends EntityBase
     }
 
     /**
+     * @covers \Ilios\CoreBundle\Entity\Course::getAncestorOrSelf
+     */
+    public function testGetAncestorOrSelfWithAncestor()
+    {
+        $ancestor = m::mock('Ilios\CoreBundle\Entity\Course');
+        $this->object->setAncestor($ancestor);
+        $this->assertSame($ancestor, $this->object->getAncestorOrSelf());
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\Entity\Course::getAncestorOrSelf
+     */
+    public function testGetAncestorOrSelfWithNoAncestor()
+    {
+        $this->assertSame($this->object, $this->object->getAncestorOrSelf());
+    }
+
+    /**
      * @covers \Ilios\CoreBundle\Entity\Course::addDescendant
      */
     public function testAddDescendant()

--- a/tests/CoreBundle/Entity/ObjectiveTest.php
+++ b/tests/CoreBundle/Entity/ObjectiveTest.php
@@ -221,6 +221,24 @@ class ObjectiveTest extends EntityBase
     }
 
     /**
+     * @covers \Ilios\CoreBundle\Entity\Objective::getAncestorOrSelf
+     */
+    public function testGetAncestorOrSelfWithAncestor()
+    {
+        $ancestor = m::mock('Ilios\CoreBundle\Entity\Objective');
+        $this->object->setAncestor($ancestor);
+        $this->assertSame($ancestor, $this->object->getAncestorOrSelf());
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\Entity\Objective::getAncestorOrSelf
+     */
+    public function testGetAncestorOrSelfWithNoAncestor()
+    {
+        $this->assertSame($this->object, $this->object->getAncestorOrSelf());
+    }
+
+    /**
      * @covers \Ilios\CoreBundle\Entity\Objective::addDescendant
      */
     public function testAddDescendant()


### PR DESCRIPTION
Courses and Objectives both track their ancestors so when they are
rolled over they should either inherit the ancestor of the previous
entity or else set the previous entity to be their ancestor.

Refs #729