### PR TITLE
Fail gracefully on missing frontend

### DIFF
--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -71,7 +71,7 @@ services:
             -  { name: console.command }
     ilioscli.command.update_frontend:
         class: Ilios\CliBundle\Command\UpdateFrontendCommand
-        arguments: ["@iliosweb.jsonindex", "@ilioscore.symfonyfilesystem", "%kernel.cache_dir%", "%ilios_web.frontend_release_version%", "%ilios_web.keep_frontend_updated%"]
+        arguments: ["@iliosweb.jsonindex", "@ilioscore.symfonyfilesystem", "%kernel.cache_dir%", "%ilios_web.frontend_release_version%", "%ilios_web.keep_frontend_updated%", "%kernel.environment%"]
         tags:
             -  { name: console.command }
             -  { name: kernel.cache_warmer }

--- a/src/Ilios/WebBundle/Controller/IndexController.php
+++ b/src/Ilios/WebBundle/Controller/IndexController.php
@@ -14,13 +14,15 @@ class IndexController extends Controller
         $path = $this->getParameter('kernel.cache_dir') . '/' . UpdateFrontendCommand::CACHE_FILE_NAME;
 
         if (!$fs->exists($path)) {
-            throw new \Exception(
-                "Unable to load the index file at {$path}.  Run ilios:maintenance:update-frontend to create it."
+            $response = new Response(
+                $this->renderView('IliosWebBundle:Index:error.html.twig')
             );
-        }
-        $contents = $fs->readFile($path);
+        } else {
+            $contents = $fs->readFile($path);
 
-        $response = new Response($contents);
+            $response = new Response($contents);
+        }
+
         $response->headers->set('Content-Type', 'text/html');
 
         $response->setPublic();

--- a/src/Ilios/WebBundle/Resources/views/Index/error.html.twig
+++ b/src/Ilios/WebBundle/Resources/views/Index/error.html.twig
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Ilios</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css">
+</head>
+<body>
+
+    <div class="section hero">
+        <div class="container">
+            <div class="six columns">
+                <h4 class="hero-heading">
+                    Whoops! There was a problem loading the Ilios front-end!
+                    Please have an administrator update the frontend to the latest version.
+                </h4>
+                <a class="button button-primary" href="https://github.com/ilios/ilios/blob/master/INSTALL.md#frontend">More Information</a>
+            </div>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/src/Ilios/WebBundle/Service/WebIndexFromJson.php
+++ b/src/Ilios/WebBundle/Service/WebIndexFromJson.php
@@ -11,7 +11,7 @@ class WebIndexFromJson
      * @var string
      */
     const DEFAULT_TEMPLATE_NAME = 'webindex.html.twig';
-    const API_VERSION = 'v1.14';
+    const API_VERSION = 'v1.15';
     const AWS_BUCKET = 'https://s3-us-west-2.amazonaws.com/frontend-json-config/';
 
     const PRODUCTION = 'prod';

--- a/tests/CliBundle/Command/UpdateFrontendCommandTest.php
+++ b/tests/CliBundle/Command/UpdateFrontendCommandTest.php
@@ -26,7 +26,7 @@ class UpdateFrontendCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->builder = m::mock('Ilios\WebBundle\Service\WebIndexFromJson');
         $this->fs = m::mock('Ilios\CoreBundle\Classes\Filesystem');
-        $command = new UpdateFrontendCommand($this->builder, $this->fs, $this->fakeTestFileDir, 'blank', true);
+        $command = new UpdateFrontendCommand($this->builder, $this->fs, $this->fakeTestFileDir, 'blank', true, 'prod');
         $application = new Application();
         $application->add($command);
         $commandInApp = $application->find(self::COMMAND_NAME);

--- a/tests/WebBundle/Controller/IndexControllerTest.php
+++ b/tests/WebBundle/Controller/IndexControllerTest.php
@@ -11,15 +11,6 @@ class IndexControllerTest extends WebTestCase
         $client = static::createClient();
         $client->request('GET', '/');
         $response = $client->getResponse();
-        $content = $response->getContent();
-
-        $container = $client->getContainer();
-        $builder = $container->get('iliosweb.jsonindex');
-        $text = $builder->getIndex('prod');
-
-        $text = preg_replace('/\s+/', '', $text);
-        $content = preg_replace('/\s+/', '', $content);
-        $this->assertSame($text, $content);
 
         //ensure we have a 60 second max age
         $this->assertSame(60, $response->getMaxAge());


### PR DESCRIPTION
Instead of just dying we can be much better with this.  By messaging the
user during cache:clear and then presenting an error page we can ensure
that tests will run even if there is an API mismatch between Ilios and
the fronted and no comparable fronted is yet available.

Fixes #1626 

The user will see this screen if they attempt to load ilios while there is no frontend:

<img width="502" alt="no-frontend" src="https://cloud.githubusercontent.com/assets/349624/22998429/90fc8da0-f38b-11e6-86cf-7a7b2bbbf19e.png">

