### PR TITLE
Create a customizable cache for Ilios

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -51,8 +51,17 @@ doctrine:
         # path:     "%database_path%"
 
     orm:
-        auto_generate_proxy_classes: "%kernel.debug%"
-        auto_mapping: true
+      auto_generate_proxy_classes: "%kernel.debug%"
+      auto_mapping: true
+      metadata_cache_driver:
+        type: service
+        id: ilioscore.cache
+      result_cache_driver:
+        type: service
+        id: ilioscore.cache
+      query_cache_driver:
+        type: service
+        id: ilioscore.cache
 
 # Swiftmailer Configuration
 swiftmailer:

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -2,12 +2,6 @@ imports:
     - { resource: config.yml }
     - { resource: security.yml }
 
-doctrine:
-   orm:
-       metadata_cache_driver: apcu
-       result_cache_driver: apcu
-       query_cache_driver: apcu
-
 monolog:
     handlers:
         main:

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -70,3 +70,7 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: flush }
             - { name: kernel.event_listener, event: console.terminate, method: flush }
+    ilioscore.cache:
+            class:     Doctrine\Common\Cache\Cache
+            factory: ['Ilios\CoreBundle\Service\CacheFactory', createCache]
+            arguments: ["%kernel.environment%"]

--- a/src/Ilios/CoreBundle/Service/CacheFactory.php
+++ b/src/Ilios/CoreBundle/Service/CacheFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Ilios\CoreBundle\Service;
+
+use Doctrine\Common\Cache\ApcuCache;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Cache;
+
+class CacheFactory
+{
+
+    /**
+     * @param $environment
+     * @return Cache
+     */
+    public static function createCache($environment)
+    {
+        if ($environment === 'prod') {
+            $cache = new ApcuCache();
+        } else {
+            $cache = new ArrayCache();
+        }
+
+        return $cache;
+    }
+}

--- a/tests/CoreBundle/Service/CacheFactoryTest.php
+++ b/tests/CoreBundle/Service/CacheFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace Tests\CoreBundle\Service;
+
+use Doctrine\Common\Cache\ApcuCache;
+use Doctrine\Common\Cache\ArrayCache;
+use Ilios\CoreBundle\Service\CacheFactory;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+
+class CacheFactoryTest extends TestCase
+{
+    /**
+     * @covers \Ilios\CoreBundle\Service\CacheFactory::createCache
+     */
+    public function testCreateDev()
+    {
+        $cache = CacheFactory::createCache('dev');
+        $this->assertInstanceOf(ArrayCache::class, $cache);
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\Service\CacheFactory::createCache
+     */
+    public function testCreateProd()
+    {
+        $cache = CacheFactory::createCache('prod');
+        $this->assertInstanceOf(ApcuCache::class, $cache);
+    }
+    /**
+     * @covers \Ilios\CoreBundle\Service\CacheFactory::createCache
+     */
+    public function testCreateTest()
+    {
+        $cache = CacheFactory::createCache('test');
+        $this->assertInstanceOf(ArrayCache::class, $cache);
+    }
+}


### PR DESCRIPTION
This will allow us to use other configuration parameters to choose the
cache we want in a specific environment.  For now we’re just duplicating our existing APCu cache in production.