### PR TITLE
Prevent users from editing their own account

### DIFF
--- a/src/Ilios/AuthenticationBundle/Voter/Entity/UserEntityVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/Entity/UserEntityVoter.php
@@ -84,6 +84,13 @@ class UserEntityVoter extends AbstractVoter
             return false;
         }
 
+        /**
+         * Temporary mitigation for #1762
+         */
+        if ($this->usersAreIdentical($user, $requestedUser)) {
+            return false;
+        }
+
         // current user must have developer role and share the same school affiliations than the requested user.
         if ($this->userHasRole($user, ['Developer'])
             && ($requestedUser->getAllSchools()->contains($user->getSchool())


### PR DESCRIPTION
Without this check it is possible for a user to add roles to their own
account.  This happens because doctrine keeps the User object in sync
between our authentication token and the user we modify in the
controller.  Since our process is to modify users and then check
authentication anyone can send a set of roles they want and the roles
will be applied before the authorization is checked.

Fixes #1762