### PR TITLE
Add a development docker container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,100 @@
+FROM ubuntu:xenial
+
+MAINTAINER Ilios Project Team <support@iliosproject.org>
+
+RUN apt-get update && apt-get install -y \
+        apache2 \
+        php \
+        php-mysql \
+        libapache2-mod-php \
+        php-apcu \
+        php-dom \
+        php-json \
+        php-ldap \
+        php-opcache \
+        php-mysql \
+        php-xml \
+        php-phar \
+        php-mbstring \
+        php-ctype \
+        unzip \
+        composer
+
+RUN a2enmod php7.0
+RUN a2enmod rewrite
+
+COPY docker/ilios.ini /etc/php/7.0/apache2/conf.d/
+COPY docker/ilios.ini /etc/php/7.0/cli/conf.d/
+COPY docker/apache.conf /etc/apache2/sites-enabled/000-default.conf
+
+ENV SYMFONY_ENV=prod \
+  ILIOS_API_ENVIRONMENT=prod \
+  ILIOS_API_DEBUG=false \
+  ILIOS_DATABASE_DRIVER=pdo_mysql \
+  ILIOS_DATABASE_HOST=ilios-demo-db \
+  ILIOS_DATABASE_PORT=~ \
+  ILIOS_DATABASE_NAME=ilios \
+  ILIOS_DATABASE_USER=ilios \
+  ILIOS_DATABASE_PASSWORD=ilios \
+  ILIOS_DATABASE_MYSQL_VERSION=5.7 \
+  ILIOS_MAILER_TRANSPORT=smtp \
+  ILIOS_MAILER_HOST=127.0.0.1 \
+  ILIOS_MAILER_USER=~ \
+  ILIOS_MAILER_PASSWORD=~ \
+  ILIOS_LOCALE=en \
+  ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt \
+  ILIOS_AUTHENTICATION_TYPE=form \
+  ILIOS_LEGACY_PASSWORD_SALT=null \
+  ILIOS_FILE_SYSTEM_STORAGE_PATH=/data \
+  ILIOS_INSTITUTION_DOMAIN=example.com \
+  ILIOS_SUPPORTING_LINK=null \
+  ILIOS_LDAP_AUTHENTICATION_HOST=null \
+  ILIOS_LDAP_AUTHENTICATION_PORT=null \
+  ILIOS_LDAP_AUTHENTICATION_BIND_TEMPLATE=null \
+  ILIOS_LDAP_DIRECTORY_URL=null \
+  ILIOS_LDAP_DIRECTORY_USER=null \
+  ILIOS_LDAP_DIRECTORY_PASSWORD=null \
+  ILIOS_LDAP_DIRECTORY_SEARCH_BASE=null \
+  ILIOS_LDAP_DIRECTORY_CAMPUS_ID_PROPERTY=null \
+  ILIOS_LDAP_DIRECTORY_USERNAME_PROPERTY=null \
+  ILIOS_SHIBBOLETH_AUTHENTICATION_LOGIN_PATH=null \
+  ILIOS_SHIBBOLETH_AUTHENTICATION_LOGOUT_PATH=null \
+  ILIOS_SHIBBOLETH_AUTHENTICATION_USER_ID_ATTRIBUTE=null \
+  ILIOS_TIMEZONE='America/Los_Angeles' \
+  ILIOS_FORCEPROTOCOL=http \
+  ILIOS_KEEP_FRONTEND_UPDATED=true \
+  ILIOS_CAS_AUTHENTICATION_SERVER=null \
+  ILIOS_CAS_AUTHENTICATION_VERSION=3 \
+  ILIOS_CAS_AUTHENTICATION_VERIFY_SSL=true \
+  ILIOS_CAS_AUTHENTICATION_CERTIFICATE_PATH=null \
+  ILIOS_ENABLE_TRACKING=false \
+  ILIOS_TRACKING_CODE=UA-XXXXXXXX-1 \
+  COMPOSER_HOME=/tmp
+
+COPY . /var/www/ilios
+RUN mkdir -p \
+    /var/www/ilios/var \
+    /var/www/ilios/var/cache \
+    /var/www/ilios/var/logs \
+    /var/www/ilios/var/session \
+    /var/www/ilios/var/tmp \
+    /var/www/ilios/vendor \
+    /data \
+    && \
+    chown -R www-data:www-data /var/www/ilios && \
+    chown -R www-data:www-data /data
+
+USER www-data
+
+RUN /usr/bin/composer install \
+  --working-dir /var/www/ilios \
+  --prefer-dist \
+  --no-dev \
+  --no-progress \
+  --optimize-autoloader
+RUN /var/www/ilios/bin/console ilios:maintenance:update-frontend  -env=prod
+
+USER root
+
+EXPOSE 80
+CMD /usr/sbin/apache2ctl -D FOREGROUND

--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+  ServerAdmin nobody@example.com
+  DocumentRoot /var/www/ilios/web
+
+  <Directory /var/www/ilios/>
+      Options Indexes FollowSymLinks MultiViews
+      AllowOverride All
+      Order deny,allow
+      Allow from all
+  </Directory>
+
+  ErrorLog ${APACHE_LOG_DIR}/error.log
+  CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+</VirtualHost>

--- a/docker/ilios.ini
+++ b/docker/ilios.ini
@@ -1,0 +1,6 @@
+date.timezone = UTC
+
+# Recommended Symfony cache settings
+opcache.max_accelerated_files = 20000
+realpath_cache_size=4096K
+realpath_cache_ttl=600


### PR DESCRIPTION
This is useful for broader testing - especially frontened integration
testing where the PHP server's single threaded nature makes requests way
too slow.