### PR TITLE
Warmup the cache when composer installs or updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
         "symfony-bin-dir": "bin",
         "symfony-var-dir": "var",
         "symfony-web-dir": "web",
+        "symfony-cache-warmup": true,
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
             "file": "app/config/parameters.yml",


### PR DESCRIPTION
We need the cache to be warmed to our index.html file will get built.
Even if we instruct users to run a cache clear they may not, so lets
just make it part of the install.