### PR TITLE
Enable already installed apcu extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,10 @@ before_install:
 - mysql -e "create database IF NOT EXISTS ilios;" -uroot
 - echo $TRAVIS_PHP_VERSION
 - if [ "$TRAVIS_PHP_VERSION" = "5.6" ];
-  then (echo yes | pecl install apcu-4.0.10;);
-  else (echo yes | pecl install apcu;);
+  then (echo yes | pecl install apcu-4.0.11;);
+  fi
+- if [ "$TRAVIS_PHP_VERSION" != "5.6" ];
+  then (echo "extension=apcu.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini);
   fi
 - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini


### PR DESCRIPTION
We no longer need to install apcu ourselves in PHP 7+, we just need to let travis
know it should be activated.

Fixes #1777