### PR TITLE
Remove production composer install test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,6 @@ before_install:
   then wget http://get.sensiolabs.org/security-checker.phar -O security-checker.phar;
   fi
 install:
-- SYMFONY_ENV=prod composer install --no-interaction --no-dev --prefer-dist
 - composer install --no-interaction --prefer-dist -d ${TRAVIS_BUILD_DIR}
 before_script:
 - bin/console doctrine:database:drop --force --env=dev


### PR DESCRIPTION
This test was put in to prevent issues where the AppKernel.php file and
the composer dependencies were out of sync with a dev composer
dependency in the production kernel tree.  Unfortunately it prevents
testing when a suitable release of the frontend cannot be found to match
the API version.  Since the version mismatch happens every couple of
weeks and then AppKernel issue has only happened once in 2 years we
should err on the side of useful and likely here.