### PR TITLE
Improve Serialization

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -25,7 +25,7 @@ framework:
     fragments:       ~
     http_method_override: true
     serializer:
-        enabled: true
+        enabled: false
     assets: ~
 
 # Twig Configuration

--- a/src/Ilios/ApiBundle/Controller/ApiController.php
+++ b/src/Ilios/ApiBundle/Controller/ApiController.php
@@ -502,6 +502,6 @@ class ApiController extends Controller implements ApiControllerInterface
      */
     protected function getSerializer()
     {
-        return $this->get('serializer');
+        return $this->get('ilios_api.serializer');
     }
 }

--- a/src/Ilios/ApiBundle/Controller/CurrentSessionController.php
+++ b/src/Ilios/ApiBundle/Controller/CurrentSessionController.php
@@ -30,7 +30,7 @@ class CurrentSessionController extends Controller
         }
         $currentSession = new CurrentSession($user);
 
-        $serializer = $this->get('serializer');
+        $serializer = $this->get('ilios_api.serializer');
         return new Response(
             $serializer->serialize($currentSession, 'json'),
             Response::HTTP_OK,

--- a/src/Ilios/ApiBundle/Controller/SchooleventController.php
+++ b/src/Ilios/ApiBundle/Controller/SchooleventController.php
@@ -66,7 +66,7 @@ class SchooleventController extends Controller
         $result = $userManager->addInstructorsToEvents($events);
 
         $response['events'] = $result ? array_values($result) : [];
-        $serializer = $this->get('serializer');
+        $serializer = $this->get('ilios_api.serializer');
         return new Response(
             $serializer->serialize($response, 'json'),
             Response::HTTP_OK,

--- a/src/Ilios/ApiBundle/Controller/UsereventController.php
+++ b/src/Ilios/ApiBundle/Controller/UsereventController.php
@@ -69,7 +69,7 @@ class UsereventController extends Controller
         $result = $manager->addInstructorsToEvents($events);
 
         $response['userEvents'] = $result ? array_values($result) : [];
-        $serializer = $this->get('serializer');
+        $serializer = $this->get('ilios_api.serializer');
         return new Response(
             $serializer->serialize($response, 'json'),
             Response::HTTP_OK,

--- a/src/Ilios/ApiBundle/Controller/UsermaterialController.php
+++ b/src/Ilios/ApiBundle/Controller/UsermaterialController.php
@@ -51,7 +51,7 @@ class UsermaterialController extends Controller
 
         //If there are no matches return an empty array
         $response['userMaterials'] = $materials ? array_values($materials) : [];
-        $serializer = $this->get('serializer');
+        $serializer = $this->get('ilios_api.serializer');
         return new Response(
             $serializer->serialize($response, 'json'),
             Response::HTTP_OK,

--- a/src/Ilios/ApiBundle/Resources/config/services.yml
+++ b/src/Ilios/ApiBundle/Resources/config/services.yml
@@ -1,21 +1,15 @@
 services:
     ilios_api.normalizer.entity:
         class: Ilios\ApiBundle\Normalizer\Entity
-        parent: serializer.normalizer.object
         calls:
           - [setEntityMetadata, ['@ilioscore.entitymetadata']]
           - [setRegistry, ['@doctrine']]
           - [setPurifier, ['@exercise_html_purifier.default']]
-        tags:
-          - { name: serializer.normalizer }
 
     ilios_api.normalizer.dto:
         class: Ilios\ApiBundle\Normalizer\DTO
-        parent: serializer.normalizer.object
         calls:
           - [setEntityMetadata, ['@ilioscore.entitymetadata']]
-        tags:
-          - { name: serializer.normalizer }
 
     ilios_api.valid_object_listener:
             class: Ilios\ApiBundle\EventListener\ValidApiObjectListener
@@ -30,3 +24,8 @@ services:
     ilios_api.swagger_doc_builder:
         class: Ilios\ApiBundle\Service\SwaggerDocBuilder
         arguments: ["@kernel", "@templating", "@router", "%forceProtocol%"]
+
+    ilios_api.serializer:
+      class:     Symfony\Component\Serializer\Serializer
+      factory:   ['Ilios\ApiBundle\Service\SerializerFactory', createSerializer]
+      arguments: ["@ilios_api.normalizer.entity", "@ilios_api.normalizer.dto"]

--- a/src/Ilios/ApiBundle/Service/SerializerFactory.php
+++ b/src/Ilios/ApiBundle/Service/SerializerFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ilios\ApiBundle\Service;
+
+use Ilios\ApiBundle\Normalizer\DTO;
+use Ilios\ApiBundle\Normalizer\Entity;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Class SerializerFactory
+ * Ensures that we only serialize the things we want to
+ * and don't fall back to any defaults.
+ *
+ * @package Ilios\ApiBundle\Service
+ */
+class SerializerFactory
+{
+    /**
+     * Build our own serializer just the way we like it
+     * @param Entity $entityNormalizer
+     * @param DTO $dtoNormalizer
+     * @return Serializer
+     */
+    public static function createSerializer(Entity $entityNormalizer, DTO $dtoNormalizer)
+    {
+        $jsonEncoder = new JsonEncoder();
+        $array = new ArrayDenormalizer();
+        $dateTime = new DateTimeNormalizer();
+        $processors = [$array, $dateTime, $jsonEncoder, $entityNormalizer, $dtoNormalizer];
+        return new Serializer($processors, $processors);
+    }
+}

--- a/src/Ilios/CoreBundle/Classes/CurrentSession.php
+++ b/src/Ilios/CoreBundle/Classes/CurrentSession.php
@@ -3,21 +3,31 @@
 namespace Ilios\CoreBundle\Classes;
 
 use Ilios\CoreBundle\Entity\UserInterface;
+use Ilios\ApiBundle\Annotation as IS;
 
+/**
+ * Class CurrentSession
+ * @package Ilios\CoreBundle\Classes
+ *
+ * @IS\DTO
+ */
 class CurrentSession
 {
     /**
-     * @var UserInterface
+     * @var integer
+     *
+     * @IS\Expose
+     * @IS\Type("string")
      */
-    protected $user;
+    protected $userId;
 
     /**
      * Constructor
-     * @param  User $user
+     * @param  UserInterface $user
      */
     public function __construct(UserInterface $user)
     {
-        $this->user = $user;
+        $this->userId = $user->getId();
     }
 
     /**
@@ -27,6 +37,6 @@ class CurrentSession
      */
     public function getUserId()
     {
-        return $this->user->getId();
+        return $this->userId;
     }
 }

--- a/src/Ilios/CoreBundle/Service/EntityMetadata.php
+++ b/src/Ilios/CoreBundle/Service/EntityMetadata.php
@@ -57,18 +57,20 @@ class EntityMetadata
         );
 
         $entityKey = self::CACH_KEY_PREFIX . 'entities';
-        if (!$cache->contains($entityKey)) {
-            $cache->save($entityKey, $this->findIliosEntities($kernel));
+        if (!$cache->contains($entityKey) || !$entities = $cache->fetch($entityKey)) {
+            $entities = $this->findIliosEntities($kernel);
+            $cache->save($entityKey, $entities);
         }
 
-        $this->iliosEntities = $cache->fetch($entityKey);
+        $this->iliosEntities = $entities;
 
         $dtoKey = self::CACH_KEY_PREFIX . 'dtos';
-        if (!$cache->contains($dtoKey)) {
-            $cache->save($dtoKey, $this->findIliosDtos($kernel));
+        if (!$cache->contains($dtoKey) || !$dtos = $cache->fetch($entityKey)) {
+            $dtos = $this->findIliosDtos($kernel);
+            $cache->save($entityKey, $dtos);
         }
 
-        $this->iliosDtos = $cache->fetch($dtoKey);
+        $this->iliosDtos = $dtos;
     }
 
     /**

--- a/tests/CoreBundle/Traits/JsonControllerTest.php
+++ b/tests/CoreBundle/Traits/JsonControllerTest.php
@@ -33,7 +33,9 @@ trait JsonControllerTest
                     'Content-Type',
                     'application/json'
                 ),
-                "Content-type is not application/json headers: [\n" . $response->headers . ']'
+                "Content-type is not application/json. \n" .
+                "Headers: [\n" . $response->headers . ']' .
+                "Content: [\n" . substr($response->getContent(), 0, 1000) . ']'
             );
 
             $decode = json_decode($response->getContent());


### PR DESCRIPTION
Don't trust Cache:contains completely: This method sometimes returns true when the actual Cache::fetch() returns false instead of what the cache should have.  This seems to have to do with APCu's memory or other settings.

The default Symfony serializer falls back all the way to an
ObjectNormalizer that will serialize ANY object it is given.  We don't
want to serialize any random object - just those Entities and DTOs that
we have crafted.  By creating our own serializer we can control exactly
what is serializable.

Fixes #1798