### PR TITLE
Fix incorrect caching or DTOs as entities

### DIFF
--- a/src/Ilios/CoreBundle/Service/CacheFactory.php
+++ b/src/Ilios/CoreBundle/Service/CacheFactory.php
@@ -15,10 +15,10 @@ class CacheFactory
      */
     public static function createCache($environment)
     {
-        if ($environment === 'prod') {
-            $cache = new ApcuCache();
-        } else {
+        if ($environment === 'dev') {
             $cache = new ArrayCache();
+        } else {
+            $cache = new ApcuCache();
         }
 
         return $cache;

--- a/src/Ilios/CoreBundle/Service/EntityMetadata.php
+++ b/src/Ilios/CoreBundle/Service/EntityMetadata.php
@@ -65,9 +65,9 @@ class EntityMetadata
         $this->iliosEntities = $entities;
 
         $dtoKey = self::CACH_KEY_PREFIX . 'dtos';
-        if (!$cache->contains($dtoKey) || !$dtos = $cache->fetch($entityKey)) {
+        if (!$cache->contains($dtoKey) || !$dtos = $cache->fetch($dtoKey)) {
             $dtos = $this->findIliosDtos($kernel);
-            $cache->save($entityKey, $dtos);
+            $cache->save($dtoKey, $dtos);
         }
 
         $this->iliosDtos = $dtos;

--- a/tests/CoreBundle/Service/CacheFactoryTest.php
+++ b/tests/CoreBundle/Service/CacheFactoryTest.php
@@ -31,6 +31,6 @@ class CacheFactoryTest extends TestCase
     public function testCreateTest()
     {
         $cache = CacheFactory::createCache('test');
-        $this->assertInstanceOf(ArrayCache::class, $cache);
+        $this->assertInstanceOf(ApcuCache::class, $cache);
     }
 }


### PR DESCRIPTION
This SNAFU was causing non-dto entities to be un-usable.  I also
switched our testing to use APCu for caching just like production does
which will help catch this kind of failure in the future.