### PR TITLE
Use security checker from composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,9 +86,6 @@ before_install:
 - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 - cp ${TRAVIS_BUILD_DIR}/app/config/parameters.yml.travis ${TRAVIS_BUILD_DIR}/app/config/parameters.yml
-- if [ "$CHECK_CODING_STANDARDS" ];
-  then wget http://get.sensiolabs.org/security-checker.phar -O security-checker.phar;
-  fi
 install:
 - composer install --no-interaction --prefer-dist -d ${TRAVIS_BUILD_DIR}
 before_script:
@@ -104,7 +101,7 @@ script:
   then (vendor/bin/phpcs --standard=app/phpcs.xml src && vendor/bin/phpcs --standard=app/phpcs.xml tests);
   fi
 - if [ "$CHECK_CODING_STANDARDS" = true ];
-  then (php security-checker.phar security:check);
+  then (vendor/bin/security-checker security:check);
   fi
 - if [ "$TEST_PHPUNIT_MESH_DATA_IMPORT" = true ];
   then (vendor/bin/phpunit -c phpunit.xml.dist --group mesh_data_import);


### PR DESCRIPTION
Instead of download a fresh phar file on every test run we can just use
the one we have already installed and is available via composer.