### PR TITLE
Convert dateTimes to the server timezone when they are sent

### DIFF
--- a/src/Ilios/ApiBundle/Normalizer/Entity.php
+++ b/src/Ilios/ApiBundle/Normalizer/Entity.php
@@ -95,6 +95,7 @@ class Entity extends ObjectNormalizer
         $type = $this->entityMetadata->getTypeOfProperty($exposedProperties[$property]);
 
         if ($type === 'dateTime') {
+            /** @var \DateTime $value */
             $value = $this->propertyAccessor->getValue($object, $property);
             if ($value) {
                 return $value->format('c');
@@ -253,7 +254,9 @@ class Entity extends ObjectNormalizer
         }
 
         if (null !== $value and $type === 'dateTime') {
+            $defaultTimezone = new \DateTimeZone(date_default_timezone_get());
             $value = new \DateTime($value);
+            $value->setTimezone($defaultTimezone);
         }
 
         if (null !== $value and $type === 'boolean') {

--- a/tests/IliosApiBundle/Endpoints/IlmSessionTest.php
+++ b/tests/IliosApiBundle/Endpoints/IlmSessionTest.php
@@ -95,4 +95,37 @@ class IlmSessionTest extends AbstractEndpointTest
 
         $this->postManyTest($data);
     }
+
+    public function testDueDateInSystemTimeZone()
+    {
+        $systemTimeZone = new \DateTimeZone(date_default_timezone_get());
+        $now = new \DateTime('now', $systemTimeZone);
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->create();
+        $data['dueDate'] = $now->format('c');
+        $postData = $data;
+        $this->postTest($data, $postData);
+    }
+
+    public function testDueDateConvertedToSystemTimeZone()
+    {
+        $americaLa = new \DateTimeZone('America/Los_Angeles');
+        $utc = new \DateTimeZone('UTC');
+        $systemTimeZone = date_default_timezone_get();
+        if ($systemTimeZone === 'UTC') {
+            $systemTime = $utc;
+            $now = new \DateTime('now', $americaLa);
+        } else {
+            $systemTime = $americaLa;
+            $now = new \DateTime('now', $utc);
+        }
+
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->create();
+        $postData = $data;
+        $postData['dueDate'] = $now->format('c');
+        $data['dueDate'] = $now->setTimezone($systemTime)->format('c');
+
+        $this->postTest($data, $postData);
+    }
 }


### PR DESCRIPTION
Datetimes are sent with their own timezon, but mysql doesn't respect
this so we need to convert each one to server time before it is stored
in the database.

Fixes #1808 