### PR TITLE
Intercept requests with a crossing guard

### DIFF
--- a/src/Ilios/CliBundle/Command/CrossingGuardCommand.php
+++ b/src/Ilios/CliBundle/Command/CrossingGuardCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Ilios\CoreBundle\Service\CrossingGuard;
+
+/**
+ * Enable, disable, and check the status of the crossing guard service
+ *
+ * Class CrossingGuardCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class CrossingGuardCommand extends Command
+{
+    const ENABLED_MESSAGE = 'Crossing Guard is down - Requests will be held until further notice.';
+    const DISABLED_MESSAGE = 'Crossing Guard is up - Requests are flowing normally.';
+    /**
+     * @var CrossingGuard
+     */
+    protected $crossingGuard;
+    
+    public function __construct(
+        CrossingGuard $crossingGuard
+    ) {
+        $this->crossingGuard = $crossingGuard;
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('ilios:maintenance:crossing-guard')
+            ->setDescription('Enable, disable, and check the status of the crossing guard.')
+            ->addArgument(
+                'action',
+                InputArgument::REQUIRED,
+                'status|down|up'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $action = strtolower($input->getArgument('action'));
+        if (!in_array($action, ['down', 'up', 'status'])) {
+            throw new \Exception("'${action} is not a valid action (status|enable|disable)'");
+        }
+
+        if ($action === 'down') {
+            $this->crossingGuard->enable();
+        }
+        if ($action === 'up') {
+            $this->crossingGuard->disable();
+        }
+
+        $status = $this->crossingGuard->isStopped();
+        $message = $status?self::ENABLED_MESSAGE:self::DISABLED_MESSAGE;
+        $output->writeln('');
+        $output->writeln("<info>${message} </info>");
+        $output->writeln('');
+    }
+}

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -120,3 +120,8 @@ services:
         arguments: ["@templating", "@doctrine", "@ilioscore.entitymetadata"]
         tags:
             -  { name: console.command }
+    ilioscli.command.crossing_guard:
+        class: Ilios\CliBundle\Command\CrossingGuardCommand
+        arguments: ["@ilioscore.crossing_gurad"]
+        tags:
+            -  { name: console.command }

--- a/src/Ilios/CoreBundle/Classes/TemporaryFileSystem.php
+++ b/src/Ilios/CoreBundle/Classes/TemporaryFileSystem.php
@@ -65,7 +65,7 @@ class TemporaryFileSystem
     /**
      * Get a File from a hash
      * @param string $hash
-     * @return File
+     * @return File|boolean
      */
     public function getFile($hash)
     {

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -77,3 +77,8 @@ services:
     ilioscore.exception_controller:
             class: Ilios\CoreBundle\Controller\ExceptionController
             arguments: ['@twig', '%kernel.environment%']
+    ilioscore.crossing_gurad:
+        class: Ilios\CoreBundle\Service\CrossingGuard
+        arguments: [ "@ilioscore.filesystem"]
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, priority: 256 }

--- a/src/Ilios/CoreBundle/Service/CrossingGuard.php
+++ b/src/Ilios/CoreBundle/Service/CrossingGuard.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Ilios\CoreBundle\Service;
+
+use Ilios\CoreBundle\Classes\IliosFileSystem;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+class CrossingGuard
+{
+    const GUARD = 'crossing-guard-enabled.lock';
+
+    protected $fs;
+
+    /**
+     * CrossingGuard constructor.
+     */
+    public function __construct(IliosFileSystem $fs)
+    {
+        $this->fs = $fs;
+    }
+
+    /**
+     * Check if the crossing guard is down
+     * @return bool
+     */
+    public function isStopped()
+    {
+        return $this->fs->hasLock(self::GUARD);
+    }
+
+    public function enable()
+    {
+        $this->fs->createLock(self::GUARD);
+    }
+
+    public function disable()
+    {
+        $this->fs->releaseLock(self::GUARD);
+    }
+
+    /**
+     * Listen to all requests and, if they are stopped, wait
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        while ($this->isStopped()) {
+            sleep(1);
+        }
+
+        return;
+    }
+}

--- a/tests/CliBundle/Command/CrossingGuardCommandTest.php
+++ b/tests/CliBundle/Command/CrossingGuardCommandTest.php
@@ -1,0 +1,101 @@
+<?php
+namespace Tests\CliBundle\Command;
+
+use Ilios\CliBundle\Command\CrossingGuardCommand;
+use Ilios\CoreBundle\Service\CrossingGuard;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+/**
+ * Class CrossingGuardCommandTest
+ * @package Tests\CliBundle\\Command
+ */
+class CrossingGuardCommandTest extends \PHPUnit_Framework_TestCase
+{
+    const COMMAND_NAME = 'ilios:maintenance:crossing-guard';
+
+    protected $crossingGuard;
+    protected $commandTester;
+    
+    public function setUp()
+    {
+        $this->crossingGuard = m::mock('Ilios\CoreBundle\Service\CrossingGuard');
+
+        $command = new CrossingGuardCommand(
+            $this->crossingGuard
+        );
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->crossingGuard);
+        unset($this->commandTester);
+        m::close();
+    }
+    
+    public function testEnable()
+    {
+        $this->crossingGuard->shouldReceive('enable')->once();
+        $this->crossingGuard->shouldReceive('isStopped')->once()->andReturn(true);
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'action'         => 'down'
+        ));
+        $output = $this->commandTester->getDisplay();
+        $this->assertEquals(
+            CrossingGuardCommand::ENABLED_MESSAGE,
+            trim($output)
+        );
+    }
+
+    public function testDisable()
+    {
+        $this->crossingGuard->shouldReceive('disable')->once();
+        $this->crossingGuard->shouldReceive('isStopped')->once()->andReturn(false);
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'action'         => 'up'
+        ));
+        $output = $this->commandTester->getDisplay();
+        $this->assertEquals(
+            CrossingGuardCommand::DISABLED_MESSAGE,
+            trim($output)
+        );
+    }
+
+    public function testStatusEnabled()
+    {
+        $this->crossingGuard->shouldReceive('isStopped')->once()->andReturn(true);
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'action'         => 'status'
+        ));
+        $output = $this->commandTester->getDisplay();
+        $this->assertEquals(
+            CrossingGuardCommand::ENABLED_MESSAGE,
+            trim($output)
+        );
+    }
+
+    public function testStatusDisabled()
+    {
+        $this->crossingGuard->shouldReceive('isStopped')->once()->andReturn(false);
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+            'action'         => 'status'
+        ));
+        $output = $this->commandTester->getDisplay();
+        $this->assertEquals(
+            CrossingGuardCommand::DISABLED_MESSAGE,
+            trim($output)
+        );
+    }
+}

--- a/tests/CoreBundle/Service/CrossingGuardTest.php
+++ b/tests/CoreBundle/Service/CrossingGuardTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Tests\CoreBundle\Service;
+
+use Ilios\CoreBundle\Service\CrossingGuard;
+use Mockery as m;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+
+class CrossingGuardTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\Service\CrossingGuard::__construct
+     */
+    public function testConstructor()
+    {
+        $fs = m::mock('Ilios\CoreBundle\Classes\IliosFileSystem');
+        $obj = new CrossingGuard($fs);
+        $this->assertTrue($obj instanceof CrossingGuard);
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\Service\CrossingGuard::isStopped
+     */
+    public function testNotStoppedWhenNoLock()
+    {
+        $fs = m::mock('Ilios\CoreBundle\Classes\IliosFileSystem');
+        $fs->shouldReceive('hasLock')->with(CrossingGuard::GUARD)->once()->andReturn(false);
+        $obj = new CrossingGuard($fs);
+        $this->assertFalse($obj->isStopped());
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\Service\CrossingGuard::isStopped
+     */
+    public function testStoppedWhenLockFileExists()
+    {
+        $fs = m::mock('Ilios\CoreBundle\Classes\IliosFileSystem');
+        $fs->shouldReceive('hasLock')->with(CrossingGuard::GUARD)->once()->andReturn(true);
+        $obj = new CrossingGuard($fs);
+        $this->assertTrue($obj->isStopped());
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\Service\CrossingGuard::enable
+     */
+    public function testEnable()
+    {
+        $fs = m::mock('Ilios\CoreBundle\Classes\IliosFileSystem');
+        $fs->shouldReceive('createLock')->with(CrossingGuard::GUARD)->once();
+        $fs->shouldReceive('hasLock')->with(CrossingGuard::GUARD)->once()->andReturn(true);
+        $obj = new CrossingGuard($fs);
+        $obj->enable();
+        $this->assertTrue($obj->isStopped());
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\Service\CrossingGuard::enable
+     */
+    public function testDisable()
+    {
+        $fs = m::mock('Ilios\CoreBundle\Classes\IliosFileSystem');
+        $fs->shouldReceive('releaseLock')->with(CrossingGuard::GUARD)->once();
+        $fs->shouldReceive('hasLock')->with(CrossingGuard::GUARD)->once()->andReturn(false);
+        $obj = new CrossingGuard($fs);
+        $obj->disable();
+        $this->assertFalse($obj->isStopped());
+    }
+}


### PR DESCRIPTION
When the crossing guard is down requests will be queued and held until
it is up again. This is useful for putting the API into a very temporary
maintenance mode while running any necessary migrations during
deployment. Instead of blocking and erroring we can simply hold off on
responding to requests until the DB is ready.

I implemented this using a lock file as it was the only repeatable strategy I could come up with.  Attempting to store the value in an ENV didn't work since those don't carry over to other running scripts and putting it in the cache failed as well.