### PR TITLE
Remove temporary user modification workaround

### DIFF
--- a/src/Ilios/AuthenticationBundle/Voter/Entity/UserEntityVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/Entity/UserEntityVoter.php
@@ -72,20 +72,14 @@ class UserEntityVoter extends AbstractVoter
             return false;
         }
 
-        /**
-         * Temporary mitigation for #1762
-         */
-        if ($user->isTheUser($requestedUser)) {
-            return false;
-        }
         $schoolIds = $requestedUser->getAllSchools()->map(function (SchoolInterface $school) {
             return $school->getId();
         });
 
         // current user must have developer role and share the same school affiliations than the requested user.
         if ($user->hasRole(['Developer'])
-            && ($requestedUser->getAllSchools()->contains($user->getSchool())
-                || $user->hasReadPermissionToSchools($schoolIds))) {
+            && ($user->isThePrimarySchool($requestedUser->getSchool())
+                || $user->hasWritePermissionToSchools($schoolIds))) {
             return true;
         }
 

--- a/tests/IliosApiBundle/Endpoints/UserTest.php
+++ b/tests/IliosApiBundle/Endpoints/UserTest.php
@@ -445,4 +445,21 @@ class UserTest extends AbstractEndpointTest
 
         $this->postTest($data, $postData);
     }
+
+    public function testUpdateOwnIcsFeedKey()
+    {
+        $dataLoader = $this->getDataLoader();
+        $user = $dataLoader->getOne();
+
+        //root users have too much permission
+        $this->assertFalse($user['root']);
+        $userId = $user['id'];
+        $user['icsFeedKey'] = str_repeat('x', 64);
+
+        $this->putOne('users', 'user', $userId, $user, false, $userId);
+        //re-fetch the data to test persistence
+        $responseData = $this->getOne('users', 'users', $userId);
+
+        $this->compareData($user, $responseData);
+    }
 }


### PR DESCRIPTION
This is now unnecessary since users permissions are now stored
immutably in the SessionUser.