### PR TITLE
Restrict access to applicationConfig to developers

### DIFF
--- a/src/Ilios/AuthenticationBundle/Voter/Entity/ApplicationConfigEntityVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/Entity/ApplicationConfigEntityVoter.php
@@ -36,20 +36,8 @@ class ApplicationConfigEntityVoter extends AbstractVoter
             return false;
         }
 
-        switch ($attribute) {
-            // grant VIEW privileges to all authenticated users.
-            case self::VIEW:
-                return true;
-                break;
-            case self::CREATE:
-            case self::EDIT:
-            case self::DELETE:
-                // grant CREATE, EDIT and DELETE privileges
-                // if the user has the 'Developer' role
-                return $user->hasRole(['Developer']);
-                break;
-        }
-
-        return false;
+        // only grant VIEW, CREATE, EDIT and DELETE privileges
+        // if the user has the 'Developer' role
+        return $user->hasRole(['Developer']);
     }
 }

--- a/tests/AuthenticationBundle/Voter/AbstractVoterTestCase.php
+++ b/tests/AuthenticationBundle/Voter/AbstractVoterTestCase.php
@@ -4,6 +4,7 @@ namespace Tests\AuthenticationBundle\Voter;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\AuthenticationBundle\Voter\AbstractVoter;
 use Ilios\CoreBundle\Entity\UserRoleInterface;
 use Mockery as m;
 
@@ -69,5 +70,21 @@ abstract class AbstractVoterTestCase extends \PHPUnit_Framework_TestCase
         $mock = m::mock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $mock->shouldReceive('getUser')->andReturn($sessionUser);
         return $mock;
+    }
+
+    /**
+     * Creates a mock object for a user with a given user-roles and user id.
+     * @param int $id The user id.
+     * @param array $roles A list of user-role titles.
+     * @return \Mockery\Mock The user mock object.
+     */
+    protected function createUserInRoles($id, array $roles)
+    {
+        $roles = array_map(function ($role) {
+            return $this->createMockUserRole($role);
+        }, $roles);
+        $user = $this->createMockSessionUserWithUserRoles($roles);
+        $user->shouldReceive('getId')->withNoArgs()->andReturn($id);
+        return $user;
     }
 }

--- a/tests/AuthenticationBundle/Voter/DTO/ApplicationConfigDTOVoterTest.php
+++ b/tests/AuthenticationBundle/Voter/DTO/ApplicationConfigDTOVoterTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace Tests\AuthenticationBundle\Voter\DTO;
+
+use Tests\AuthenticationBundle\Voter\AbstractVoterTestCase;
+use Ilios\AuthenticationBundle\Voter\AbstractVoter;
+use Ilios\AuthenticationBundle\Voter\DTO\ApplicationConfigDTOVoter;
+use Ilios\CoreBundle\Entity\DTO\ApplicationConfigDTO;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * Class ApplicationConfigDTOVoterTest
+ * @package Tests\AuthenticationBundle\\Voter\DTO
+ */
+class ApplicationConfigDTOVoterTest extends AbstractVoterTestCase
+{
+    /**
+     * @var ApplicationConfigDTOVoter
+     */
+    protected $voter;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->voter = new ApplicationConfigDTOVoter();
+    }
+
+    /**
+     * @dataProvider testVoteOnViewAccessProvider
+     * @covers \Ilios\AuthenticationBundle\Voter\DTO\ApplicationConfigDTOVoter::vote
+     */
+    public function testVoteOnViewAccess($token, ApplicationConfigDTO $object, $expectedOutcome, $message)
+    {
+        $attributes = [AbstractVoter::VIEW];
+        $this->assertEquals($expectedOutcome, $this->voter->vote($token, $object, $attributes), $message);
+    }
+
+    /**
+     * @return array
+     */
+    public function testVoteOnViewAccessProvider()
+    {
+        $data = [];
+        $roles = ['Faculty', 'Student', 'Former Student', 'Course Director'];
+        $applicationConfig = new ApplicationConfigDTO(1, 'Test', '');
+
+        $i = 0;
+        foreach ($roles as $role) {
+            ++$i;
+            $currentUser = $this->createUserInRoles($i, [$role]);
+            $token = $this->createMockTokenWithSessionUser($currentUser);
+            $data[] = [
+                $token,
+                $applicationConfig,
+                VoterInterface::ACCESS_DENIED,
+                "${role} can not view applicationConfig."
+            ];
+        }
+
+        $currentUser = $this->createMockSessionUserWithUserRoles([]);
+        $token = $this->createMockTokenWithSessionUser($currentUser);
+        $data[] = [
+            $token,
+            $applicationConfig,
+            VoterInterface::ACCESS_DENIED,
+            "User without roles can not view applicationConfig."
+        ];
+
+        $token = $this->createMockTokenWithSessionUser(null);
+        $data[] = [
+            $token,
+            $applicationConfig,
+            VoterInterface::ACCESS_DENIED,
+            "Unauthorized user can not view applicationConfig."
+        ];
+
+        $currentUser = $this->createMockSessionUserWithUserRoles([
+            $this->createMockUserRole('Developer')
+        ]);
+        $token = $this->createMockTokenWithSessionUser($currentUser);
+        $data[] = [
+            $token,
+            $applicationConfig,
+            VoterInterface::ACCESS_GRANTED,
+            "User with Developer role can view applicationConfig."
+        ];
+
+        return $data;
+    }
+}

--- a/tests/AuthenticationBundle/Voter/DTO/SchoolDTOVoterTest.php
+++ b/tests/AuthenticationBundle/Voter/DTO/SchoolDTOVoterTest.php
@@ -75,20 +75,4 @@ class SchoolDTOVoterTest extends AbstractVoterTestCase
         $attributes = [AbstractVoter::VIEW];
         $this->assertEquals($expectedOutcome, $this->voter->vote($token, $object, $attributes), $message);
     }
-
-    /**
-     * Creates a mock object for a user with a given user-roles and user id.
-     * @param int $id The user id.
-     * @param array $roles A list of user-role titles.
-     * @return \Mockery\Mock The user mock object.
-     */
-    protected function createUserInRoles($id, array $roles)
-    {
-        $roles = array_map(function ($role) {
-            return $this->createMockUserRole($role);
-        }, $roles);
-        $user = $this->createMockSessionUserWithUserRoles($roles);
-        $user->shouldReceive('getId')->withNoArgs()->andReturn($id);
-        return $user;
-    }
 }

--- a/tests/AuthenticationBundle/Voter/Entity/ApplicationConfigEntityVoterTest.php
+++ b/tests/AuthenticationBundle/Voter/Entity/ApplicationConfigEntityVoterTest.php
@@ -1,0 +1,102 @@
+<?php
+namespace Tests\AuthenticationBundle\Voter\Entity;
+
+use Tests\AuthenticationBundle\Voter\AbstractVoterTestCase;
+use Ilios\AuthenticationBundle\Voter\AbstractVoter;
+use Ilios\AuthenticationBundle\Voter\Entity\ApplicationConfigEntityVoter;
+use Ilios\CoreBundle\Entity\ApplicationConfig;
+use Ilios\CoreBundle\Entity\ApplicationConfigInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * Class ApplicationConfigEntityVoterTest
+ * @package Tests\AuthenticationBundle\\Voter
+ */
+class ApplicationConfigEntityVoterTest extends AbstractVoterTestCase
+{
+    /**
+     * @var ApplicationConfigEntityVoter
+     */
+    protected $voter;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->voter = new ApplicationConfigEntityVoter();
+    }
+
+    /**
+     * @dataProvider voteProvider
+     * @covers \Ilios\AuthenticationBundle\Voter\ApplicationConfigEntityVoter::vote
+     */
+    public function testVoteOnView($token, ApplicationConfigInterface $object, $expectedOutcome, $message)
+    {
+        $attributes = [AbstractVoter::VIEW];
+        $this->assertEquals($expectedOutcome, $this->voter->vote($token, $object, $attributes), $message);
+    }
+
+    /**
+     * @dataProvider voteProvider
+     * @covers \Ilios\AuthenticationBundle\Voter\ApplicationConfigEntityVoter::vote
+     * @no
+     */
+    public function testVoteOnCreate($token, ApplicationConfigInterface $object, $expectedOutcome, $message)
+    {
+        $attributes = [AbstractVoter::CREATE];
+        $this->assertEquals($expectedOutcome, $this->voter->vote($token, $object, $attributes), $message);
+    }
+
+    /**
+     * @dataProvider voteProvider
+     * @covers \Ilios\AuthenticationBundle\Voter\ApplicationConfigEntityVoter::vote
+     */
+    public function testVoteOnEdit($token, ApplicationConfigInterface $object, $expectedOutcome, $message)
+    {
+        $attributes = [AbstractVoter::EDIT];
+        $this->assertEquals($expectedOutcome, $this->voter->vote($token, $object, $attributes), $message);
+    }
+
+    /**
+     * @dataProvider voteProvider
+     * @covers \Ilios\AuthenticationBundle\Voter\ApplicationConfigEntityVoter::vote
+     */
+    public function testVoteOnDelete($token, ApplicationConfigInterface $object, $expectedOutcome, $message)
+    {
+        $attributes = [AbstractVoter::DELETE];
+        $this->assertEquals($expectedOutcome, $this->voter->vote($token, $object, $attributes), $message);
+    }
+
+    /**
+     * @return array
+     */
+    public function voteProvider()
+    {
+        $data = [];
+        $currentUser = $this->createMockSessionUserWithUserRoles([
+            $this->createMockUserRole('Developer')
+        ]);
+        $token = $this->createMockTokenWithSessionUser($currentUser);
+        $data[] = [
+            $token,
+            new ApplicationConfig(),
+            VoterInterface::ACCESS_GRANTED,
+            'Developer can take action.',
+        ];
+        foreach (['Faculty', 'Course Director', 'Student', 'Former Student'] as $role) {
+            $currentUser = $this->createMockSessionUserWithUserRoles([
+                $this->createMockUserRole($role)
+            ]);
+            $token = $this->createMockTokenWithSessionUser($currentUser);
+            $data[] = [
+                $token,
+                new ApplicationConfig(),
+                VoterInterface::ACCESS_DENIED,
+                "{$role} cannot take action.",
+            ];
+        }
+        return $data;
+    }
+}


### PR DESCRIPTION
This configuration is for the system and should only be readable /
writable by developers as it may contain sensitive information like the
LDAP credentials and the JWT signing key.

Fixes #1819