### PR TITLE
Fix for users not able to create users in non-primary school

### DIFF
--- a/src/Ilios/AuthenticationBundle/Voter/Entity/UserEntityVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/Entity/UserEntityVoter.php
@@ -79,7 +79,7 @@ class UserEntityVoter extends AbstractVoter
         // current user must have developer role and share the same school affiliations than the requested user.
         if ($user->hasRole(['Developer'])
             && ($user->isThePrimarySchool($requestedUser->getSchool())
-                || $user->hasWritePermissionToSchools($schoolIds))) {
+                || $user->hasWritePermissionToSchools($schoolIds->toArray()))) {
             return true;
         }
 


### PR DESCRIPTION
We were passing a doctrine collection to the
SessionUser::hasWritePermissionToSchools method and it requires an
array.

Fixes #1829