### PR TITLE
Add session attributes to events APIs

### DIFF
--- a/src/Ilios/ApiBundle/Resources/swagger/definitions/CalendarEvent.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/definitions/CalendarEvent.yml
@@ -59,3 +59,19 @@ CalendarEvent:
    readOnly: true
    items:
     type: integer
+  attireRequired:
+   description: Is attireRequired
+   type: boolean
+   readOnly: true
+  equipmentRequired:
+   description: Is equipmentRequired
+   type: boolean
+   readOnly: true
+  supplemental:
+   description: Is supplemental
+   type: boolean
+   readOnly: true
+  attendanceRequired:
+   description: Is attendanceRequired
+   type: boolean
+   readOnly: true

--- a/src/Ilios/ApiBundle/Resources/swagger/definitions/CalendarEvent.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/definitions/CalendarEvent.yml
@@ -60,18 +60,18 @@ CalendarEvent:
    items:
     type: integer
   attireRequired:
-   description: Is attireRequired
+   description: Is special attire required by the attendee of this session
    type: boolean
    readOnly: true
   equipmentRequired:
-   description: Is equipmentRequired
+   description: Is special equipment required by the attendee of this session
    type: boolean
    readOnly: true
   supplemental:
-   description: Is supplemental
+   description: Is this a supplemental session
    type: boolean
    readOnly: true
   attendanceRequired:
-   description: Is attendanceRequired
+   description: Is attendance required at this session
    type: boolean
    readOnly: true

--- a/src/Ilios/CoreBundle/Classes/CalendarEvent.php
+++ b/src/Ilios/CoreBundle/Classes/CalendarEvent.php
@@ -107,6 +107,34 @@ abstract class CalendarEvent
     public $instructors = array();
 
     /**
+     * @var bool
+     * @IS\Expose
+     * @IS\Type("boolean")
+     */
+    public $attireRequired;
+
+    /**
+     * @var bool
+     * @IS\Expose
+     * @IS\Type("boolean")
+     */
+    public $equipmentRequired;
+
+    /**
+     * @var bool
+     * @IS\Expose
+     * @IS\Type("boolean")
+     */
+    public $supplemental;
+
+    /**
+     * @var bool
+     * @IS\Expose
+     * @IS\Type("boolean")
+     */
+    public $attendanceRequired;
+
+    /**
      * Clean out all the data for scheduled events
      *
      * This information is not available to un-privileged users
@@ -120,6 +148,10 @@ abstract class CalendarEvent
             $this->ilmSession = null;
             $this->color = null;
             $this->location = null;
+            $this->attireRequired = null;
+            $this->equipmentRequired = null;
+            $this->supplemental = null;
+            $this->attendanceRequired = null;
 
             $this->instructors = [];
         }

--- a/src/Ilios/CoreBundle/Entity/Repository/SchoolRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/SchoolRepository.php
@@ -171,6 +171,7 @@ class SchoolRepository extends EntityRepository
         $what = 'o.id, o.startDate, o.endDate, o.room, o.updatedAt, o.updatedAt AS offeringUpdatedAt, ' .
           's.updatedAt AS sessionUpdatedAt, s.title, st.calendarColor, ' .
           's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
+          's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, ' .
           'c.publishedAsTbd as coursePublishedAsTbd, c.published as coursePublished, c.title as courseTitle';
         $qb->add('select', $what)->from('IliosCoreBundle:School', 'school');
         $qb->join('school.courses', 'c');
@@ -202,7 +203,7 @@ class SchoolRepository extends EntityRepository
      * @param \DateTime $from
      * @param \DateTime $to
      *
-     * @return UserEvent[]
+     * @return SchoolEvent[]
      */
     protected function getIlmSessionEventsFor(
         $id,
@@ -215,6 +216,7 @@ class SchoolRepository extends EntityRepository
         $what = 'ilm.id, ilm.dueDate, ' .
             's.updatedAt, s.title, st.calendarColor, ' .
             's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
+            's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, ' .
             'c.publishedAsTbd as coursePublishedAsTbd, c.published as coursePublished, c.title as courseTitle';
         $qb->add('select', $what)->from('IliosCoreBundle:School', 'school');
 
@@ -243,7 +245,7 @@ class SchoolRepository extends EntityRepository
      * @param integer $schoolId
      * @param array $results
      *
-     * @return UserEvent[]
+     * @return SchoolEvent[]
      */
     protected function createEventObjectsForOfferings($schoolId, array $results)
     {
@@ -260,6 +262,10 @@ class SchoolRepository extends EntityRepository
             $event->isPublished = $arr['sessionPublished']  && $arr['coursePublished'];
             $event->isScheduled = $arr['sessionPublishedAsTbd'] || $arr['coursePublishedAsTbd'];
             $event->courseTitle = $arr['courseTitle'];
+            $event->attireRequired = $arr['attireRequired'];
+            $event->equipmentRequired = $arr['equipmentRequired'];
+            $event->supplemental = $arr['supplemental'];
+            $event->attendanceRequired = $arr['attendanceRequired'];
             return $event;
         }, $results);
     }
@@ -270,7 +276,7 @@ class SchoolRepository extends EntityRepository
      * @param integer $schoolId
      * @param array $results
      *
-     * @return UserEvent[]
+     * @return SchoolEvent[]
      */
     protected function createEventObjectsForIlmSessions($schoolId, array $results)
     {
@@ -288,6 +294,10 @@ class SchoolRepository extends EntityRepository
             $event->isPublished = $arr['sessionPublished']  && $arr['coursePublished'];
             $event->isScheduled = $arr['sessionPublishedAsTbd'] || $arr['coursePublishedAsTbd'];
             $event->courseTitle = $arr['courseTitle'];
+            $event->attireRequired = $arr['attireRequired'];
+            $event->equipmentRequired = $arr['equipmentRequired'];
+            $event->supplemental = $arr['supplemental'];
+            $event->attendanceRequired = $arr['attendanceRequired'];
             return $event;
         }, $results);
     }

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -291,6 +291,7 @@ class UserRepository extends EntityRepository
         $what = 'c.id as courseId, s.id AS sessionId, o.id, o.startDate, o.endDate, o.room, ' .
             'o.updatedAt AS offeringUpdatedAt, s.updatedAt AS sessionUpdatedAt, s.title, st.calendarColor, ' .
             's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
+            's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, ' .
             'c.publishedAsTbd as coursePublishedAsTbd, c.published as coursePublished, c.title AS courseTitle, ' .
             'sd.description AS sessionDescription, st.title AS sessionTypeTitle, c.externalId AS courseExternalId';
         $qb->add('select', $what)->from('IliosCoreBundle:School', 'school');
@@ -338,6 +339,7 @@ class UserRepository extends EntityRepository
         $what = 'c.id as courseId, s.id AS sessionId, ilm.id, ilm.dueDate, ' .
             's.updatedAt, s.title, st.calendarColor, ' .
             's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
+            's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, ' .
             'c.publishedAsTbd as coursePublishedAsTbd, c.published as coursePublished, c.title as courseTitle,' .
             'sd.description AS sessionDescription, st.title AS sessionTypeTitle, c.externalId AS courseExternalId';
 
@@ -391,6 +393,10 @@ class UserRepository extends EntityRepository
             $event->sessionDescription = $arr['sessionDescription'];
             $event->sessionId = $arr['sessionId'];
             $event->courseId = $arr['courseId'];
+            $event->attireRequired = $arr['attireRequired'];
+            $event->equipmentRequired = $arr['equipmentRequired'];
+            $event->supplemental = $arr['supplemental'];
+            $event->attendanceRequired = $arr['attendanceRequired'];
             return $event;
         }, $results);
     }
@@ -423,6 +429,10 @@ class UserRepository extends EntityRepository
             $event->sessionDescription = $arr['sessionDescription'];
             $event->sessionId = $arr['sessionId'];
             $event->courseId = $arr['courseId'];
+            $event->attireRequired = $arr['attireRequired'];
+            $event->equipmentRequired = $arr['equipmentRequired'];
+            $event->supplemental = $arr['supplemental'];
+            $event->attendanceRequired = $arr['attendanceRequired'];
             return $event;
         }, $results);
     }

--- a/src/Ilios/WebBundle/Service/WebIndexFromJson.php
+++ b/src/Ilios/WebBundle/Service/WebIndexFromJson.php
@@ -11,7 +11,7 @@ class WebIndexFromJson
      * @var string
      */
     const DEFAULT_TEMPLATE_NAME = 'webindex.html.twig';
-    const API_VERSION = 'v1.19';
+    const API_VERSION = 'v1.20';
     const AWS_BUCKET = 'https://s3-us-west-2.amazonaws.com/frontend-json-config/';
 
     const PRODUCTION = 'prod';

--- a/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
+++ b/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
@@ -39,47 +39,87 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[0]['startDate'], $offerings[2]['startDate']);
         $this->assertEquals($events[0]['endDate'], $offerings[2]['endDate']);
         $this->assertEquals($events[0]['courseTitle'], $courses[0]['title']);
+        $this->assertTrue($events[0]['attireRequired'], 'attireRequired is correct for event 0');
+        $this->assertTrue($events[0]['equipmentRequired'], 'equipmentRequired is correct for event 0');
+        $this->assertTrue($events[0]['supplemental'], 'supplemental is correct for event 0');
+        $this->assertTrue($events[0]['attendanceRequired'], 'attendanceRequired is correct for event 0');
 
         $this->assertEquals($events[1]['offering'], 4);
         $this->assertEquals($events[1]['startDate'], $offerings[3]['startDate']);
         $this->assertEquals($events[1]['endDate'], $offerings[3]['endDate']);
         $this->assertEquals($events[1]['courseTitle'], $courses[0]['title']);
+        $this->assertTrue($events[1]['attireRequired'], 'attireRequired is correct for event 1');
+        $this->assertTrue($events[1]['equipmentRequired'], 'equipmentRequired is correct for event 1');
+        $this->assertTrue($events[1]['supplemental'], 'supplemental is correct for event 1');
+        $this->assertTrue($events[1]['attendanceRequired'], 'attendanceRequired is correct for event 1');
 
         $this->assertEquals($events[2]['offering'], 5);
         $this->assertEquals($events[2]['startDate'], $offerings[4]['startDate']);
         $this->assertEquals($events[2]['endDate'], $offerings[4]['endDate']);
         $this->assertEquals($events[2]['courseTitle'], $courses[0]['title']);
+        $this->assertTrue($events[2]['attireRequired'], 'attireRequired is correct for event 2');
+        $this->assertTrue($events[2]['equipmentRequired'], 'equipmentRequired is correct for event 2');
+        $this->assertTrue($events[2]['supplemental'], 'supplemental is correct for event 2');
+        $this->assertTrue($events[2]['attendanceRequired'], 'attendanceRequired is correct for event 2');
 
         $this->assertEquals($events[3]['offering'], 6);
         $this->assertEquals($events[3]['startDate'], $offerings[5]['startDate']);
         $this->assertEquals($events[3]['endDate'], $offerings[5]['endDate']);
         $this->assertEquals($events[3]['courseTitle'], $courses[1]['title']);
+        $this->assertFalse($events[3]['attireRequired'], 'attireRequired is correct for event 3');
+        $this->assertFalse($events[3]['equipmentRequired'], 'equipmentRequired is correct for event 3');
+        $this->assertTrue($events[3]['supplemental'], 'supplemental is correct for event 3');
+        $this->assertArrayNotHasKey('attendanceRequired', $events[3], 'attendanceRequired is correct for event 3');
 
         $this->assertEquals($events[4]['offering'], 7);
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate']);
         $this->assertEquals($events[4]['endDate'], $offerings[6]['endDate']);
         $this->assertEquals($events[4]['courseTitle'], $courses[1]['title']);
+        $this->assertFalse($events[4]['attireRequired'], 'attireRequired is correct for event 4');
+        $this->assertFalse($events[4]['equipmentRequired'], 'equipmentRequired is correct for event 4');
+        $this->assertTrue($events[4]['supplemental'], 'supplemental is correct for event 4');
+        $this->assertArrayNotHasKey('attendanceRequired', $events[4], 'attendanceRequired is correct for event 4');
 
         $this->assertEquals($events[5]['ilmSession'], 1);
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate']);
         $this->assertEquals($events[5]['courseTitle'], $courses[1]['title']);
+        $this->assertFalse($events[5]['attireRequired'], 'attireRequired is correct for event 5');
+        $this->assertFalse($events[5]['equipmentRequired'], 'equipmentRequired is correct for event 5');
+        $this->assertFalse($events[5]['supplemental'], 'supplemental is correct for event 5');
+        $this->assertArrayNotHasKey('attendanceRequired', $events[5], 'attendanceRequired is correct for event 5');
 
         $this->assertEquals($events[6]['ilmSession'], 2);
         $this->assertEquals($events[6]['startDate'], $ilmSessions[1]['dueDate']);
         $this->assertEquals($events[6]['courseTitle'], $courses[1]['title']);
+        $this->assertFalse($events[6]['attireRequired'], 'attireRequired is correct for event 6');
+        $this->assertFalse($events[6]['equipmentRequired'], 'equipmentRequired is correct for event 6');
+        $this->assertFalse($events[6]['supplemental'], 'supplemental is correct for event 6');
+        $this->assertArrayNotHasKey('attendanceRequired', $events[6], 'attendanceRequired is correct for event 6');
 
         $this->assertEquals($events[7]['ilmSession'], 3);
         $this->assertEquals($events[7]['startDate'], $ilmSessions[2]['dueDate']);
         $this->assertEquals($events[7]['courseTitle'], $courses[1]['title']);
+        $this->assertFalse($events[7]['attireRequired'], 'attireRequired is correct for event 7');
+        $this->assertFalse($events[7]['equipmentRequired'], 'equipmentRequired is correct for event 7');
+        $this->assertFalse($events[7]['supplemental'], 'supplemental is correct for event 7');
+        $this->assertArrayNotHasKey('attendanceRequired', $events[7], 'attendanceRequired is correct for event 7');
 
         $this->assertEquals($events[8]['ilmSession'], 4);
         $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate']);
         $this->assertEquals($events[8]['courseTitle'], $courses[1]['title']);
+        $this->assertFalse($events[8]['attireRequired'], 'attireRequired is correct for event 8');
+        $this->assertFalse($events[8]['equipmentRequired'], 'equipmentRequired is correct for event 8');
+        $this->assertFalse($events[8]['supplemental'], 'supplemental is correct for event 8');
+        $this->assertArrayNotHasKey('attendanceRequired', $events[8], 'attendanceRequired is correct for event 8');
 
         $this->assertEquals($events[9]['offering'], 1);
         $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate']);
         $this->assertEquals($events[9]['endDate'], $offerings[0]['endDate']);
         $this->assertEquals($events[9]['courseTitle'], $courses[0]['title']);
+        $this->assertFalse($events[9]['attireRequired'], 'attireRequired is correct for event 9');
+        $this->assertArrayNotHasKey('equipmentRequired', $events[9], 'equipmentRequired is correct for event 9');
+        $this->assertFalse($events[9]['supplemental'], 'supplemental is correct for event 9');
+        $this->assertArrayNotHasKey('attendanceRequired', $events[9], 'attendanceRequired is correct for event 9');
 
         $this->assertEquals(8, $events[10]['offering']);
 
@@ -88,6 +128,10 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[10]['startDate'], $offering->getStartDate()->format('c'));
         $this->assertEquals($events[10]['endDate'], $offering->getEndDate()->format('c'));
         $this->assertEquals($events[10]['courseTitle'], $courses[1]['title']);
+        $this->assertFalse($events[10]['attireRequired'], 'attireRequired is correct for event 10');
+        $this->assertFalse($events[10]['equipmentRequired'], 'equipmentRequired is correct for event 10');
+        $this->assertTrue($events[10]['supplemental'], 'supplemental is correct for event 10');
+        $this->assertArrayNotHasKey('attendanceRequired', $events[10], 'attendanceRequired is correct for event 10');
 
 
         foreach ($events as $event) {

--- a/tests/IliosApiBundle/Endpoints/UsereventTest.php
+++ b/tests/IliosApiBundle/Endpoints/UsereventTest.php
@@ -81,6 +81,22 @@ class UsereventTest extends AbstractEndpointTest
             3,
             'Event 0 has the correct number of learning materials'
         );
+        $this->assertTrue(
+            $events[0]['attireRequired'],
+            'attire is correct for event 0'
+        );
+        $this->assertTrue(
+            $events[0]['equipmentRequired'],
+            'equipmentRequired is correct for event 0'
+        );
+        $this->assertTrue(
+            $events[0]['supplemental'],
+            'supplemental is correct for event 0'
+        );
+        $this->assertTrue(
+            $events[0]['attendanceRequired'],
+            'attendanceRequired is correct for event 0'
+        );
 
         $this->assertEquals($events[1]['offering'], 4, 'offering is correct for event 1');
         $this->assertEquals(
@@ -109,6 +125,22 @@ class UsereventTest extends AbstractEndpointTest
             count($events[1]['learningMaterials']),
             3,
             'Event 1 has the correct number of learning materials'
+        );
+        $this->assertTrue(
+            $events[1]['attireRequired'],
+            'attire is correct for event 1'
+        );
+        $this->assertTrue(
+            $events[1]['equipmentRequired'],
+            'equipmentRequired is correct for event 1'
+        );
+        $this->assertTrue(
+            $events[1]['supplemental'],
+            'supplemental is correct for event 1'
+        );
+        $this->assertTrue(
+            $events[1]['attendanceRequired'],
+            'attendanceRequired is correct for event 1'
         );
 
         $this->assertEquals($events[2]['offering'], 5, 'offering is correct for event 2');
@@ -139,6 +171,22 @@ class UsereventTest extends AbstractEndpointTest
             3,
             'Event 2 has the correct number of learning materials'
         );
+        $this->assertTrue(
+            $events[2]['attireRequired'],
+            'attire is correct for event 2'
+        );
+        $this->assertTrue(
+            $events[2]['equipmentRequired'],
+            'equipmentRequired is correct for event 2'
+        );
+        $this->assertTrue(
+            $events[2]['supplemental'],
+            'supplemental is correct for event 2'
+        );
+        $this->assertTrue(
+            $events[2]['attendanceRequired'],
+            'attendanceRequired is correct for event 2'
+        );
 
         $this->assertEquals($events[3]['offering'], 6, 'offering is correct for event 3');
         $this->assertEquals($events[3]['startDate'], $offerings[5]['startDate'], 'startDate is correct for event 3');
@@ -156,6 +204,24 @@ class UsereventTest extends AbstractEndpointTest
         );
         $this->assertEquals(count($events[3]['learningMaterials']), 0, 'Event 3 has no learning materials');
 
+        $this->assertFalse(
+            $events[3]['attireRequired'],
+            'attire is correct for event 3'
+        );
+        $this->assertFalse(
+            $events[3]['equipmentRequired'],
+            'equipmentRequired is correct for event 3'
+        );
+        $this->assertTrue(
+            $events[3]['supplemental'],
+            'supplemental is correct for event 3'
+        );
+        $this->assertArrayNotHasKey(
+            'attendanceRequired',
+            $events[3],
+            'attendanceRequired is correct for event 3'
+        );
+
         $this->assertEquals($events[4]['offering'], 7, 'offering is correct for event 4');
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate'], 'startDate is correct for event 4');
         $this->assertEquals($events[4]['endDate'], $offerings[6]['endDate'], 'endDate is correct for event 4');
@@ -172,6 +238,24 @@ class UsereventTest extends AbstractEndpointTest
         );
         $this->assertEquals(count($events[4]['learningMaterials']), 0, 'Event 4 has no learning materials');
 
+        $this->assertFalse(
+            $events[4]['attireRequired'],
+            'attire is correct for event 4'
+        );
+        $this->assertFalse(
+            $events[4]['equipmentRequired'],
+            'equipmentRequired is correct for event 4'
+        );
+        $this->assertTrue(
+            $events[4]['supplemental'],
+            'supplemental is correct for event 4'
+        );
+        $this->assertArrayNotHasKey(
+            'attendanceRequired',
+            $events[4],
+            'attendanceRequired is correct for event 4'
+        );
+
         $this->assertEquals($events[5]['ilmSession'], 1, 'ilmSession is correct for 5');
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate'], 'dueDate is correct for 5');
         $this->assertEquals($events[5]['courseTitle'], $courses[1]['title'], 'title is correct for 5');
@@ -187,6 +271,24 @@ class UsereventTest extends AbstractEndpointTest
         );
         $this->assertEquals(count($events[5]['learningMaterials']), 0, 'Event 5 has no learning materials');
 
+        $this->assertFalse(
+            $events[5]['attireRequired'],
+            'attire is correct for event 5'
+        );
+        $this->assertFalse(
+            $events[5]['equipmentRequired'],
+            'equipmentRequired is correct for event 5'
+        );
+        $this->assertFalse(
+            $events[5]['supplemental'],
+            'supplemental is correct for event 5'
+        );
+        $this->assertArrayNotHasKey(
+            'attendanceRequired',
+            $events[5],
+            'attendanceRequired is correct for event 5'
+        );
+
         $this->assertEquals($events[6]['ilmSession'], 2, 'ilmSession is correct for event 6');
         $this->assertEquals($events[6]['startDate'], $ilmSessions[1]['dueDate'], 'dueDate is correct for event 6');
         $this->assertEquals($events[6]['courseTitle'], $courses[1]['title'], 'ilmSession is correct for event 6');
@@ -201,6 +303,23 @@ class UsereventTest extends AbstractEndpointTest
             'session type title is correct for event 6'
         );
         $this->assertEquals(count($events[6]['learningMaterials']), 0, 'Event 6 has no learning materials');
+        $this->assertFalse(
+            $events[6]['attireRequired'],
+            'attire is correct for event 6'
+        );
+        $this->assertFalse(
+            $events[6]['equipmentRequired'],
+            'equipmentRequired is correct for event 6'
+        );
+        $this->assertFalse(
+            $events[6]['supplemental'],
+            'supplemental is correct for event 6'
+        );
+        $this->assertArrayNotHasKey(
+            'attendanceRequired',
+            $events[6],
+            'attendanceRequired is correct for event 6'
+        );
 
         $this->assertEquals($events[7]['ilmSession'], 3, 'ilmSession is correct for event 7');
         $this->assertEquals($events[7]['startDate'], $ilmSessions[2]['dueDate'], 'dueDate is correct for event 7');
@@ -216,6 +335,23 @@ class UsereventTest extends AbstractEndpointTest
             'session type title is correct for event 7'
         );
         $this->assertEquals(count($events[7]['learningMaterials']), 0, 'Event 7 has no learning materials');
+        $this->assertFalse(
+            $events[7]['attireRequired'],
+            'attire is correct for event 7'
+        );
+        $this->assertFalse(
+            $events[7]['equipmentRequired'],
+            'equipmentRequired is correct for event 7'
+        );
+        $this->assertFalse(
+            $events[7]['supplemental'],
+            'supplemental is correct for event 7'
+        );
+        $this->assertArrayNotHasKey(
+            'attendanceRequired',
+            $events[7],
+            'attendanceRequired is correct for event 7'
+        );
 
         $this->assertEquals($events[8]['ilmSession'], 4, 'ilmSession is correct for event 8');
         $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate'], 'dueDate is correct for event 8');
@@ -231,6 +367,23 @@ class UsereventTest extends AbstractEndpointTest
             'session type title is correct for event 8'
         );
         $this->assertEquals(count($events[8]['learningMaterials']), 0, 'Event 8 has no learning materials');
+        $this->assertFalse(
+            $events[8]['attireRequired'],
+            'attire is correct for event 8'
+        );
+        $this->assertFalse(
+            $events[8]['equipmentRequired'],
+            'equipmentRequired is correct for event 8'
+        );
+        $this->assertFalse(
+            $events[8]['supplemental'],
+            'supplemental is correct for event 8'
+        );
+        $this->assertArrayNotHasKey(
+            'attendanceRequired',
+            $events[8],
+            'attendanceRequired is correct for event 8'
+        );
 
         $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate'], 'startDate is correct for event 9');
         $this->assertEquals($events[9]['endDate'], $offerings[0]['endDate'], 'endDate is correct for event 9');
@@ -253,6 +406,24 @@ class UsereventTest extends AbstractEndpointTest
             count($events[9]['learningMaterials']),
             4,
             'Event 6 has the correct number of learning materials'
+        );
+        $this->assertFalse(
+            $events[9]['attireRequired'],
+            'attire is correct for event 9'
+        );
+        $this->assertArrayNotHasKey(
+            'equipmentRequired',
+            $events[9],
+            'equipmentRequired is correct for event 9'
+        );
+        $this->assertFalse(
+            $events[9]['supplemental'],
+            'supplemental is correct for event 9'
+        );
+        $this->assertArrayNotHasKey(
+            'attendanceRequired',
+            $events[9],
+            'attendanceRequired is correct for event 9'
         );
 
         /** @var OfferingInterface $offering */
@@ -277,6 +448,23 @@ class UsereventTest extends AbstractEndpointTest
             $events[10]['courseExternalId'],
             $courses[1]['externalId'],
             'course external id correct for event 10'
+        );
+        $this->assertFalse(
+            $events[10]['attireRequired'],
+            'attire is correct for event 10'
+        );
+        $this->assertFalse(
+            $events[10]['equipmentRequired'],
+            'equipmentRequired is correct for event 10'
+        );
+        $this->assertTrue(
+            $events[10]['supplemental'],
+            'supplemental is correct for event 10'
+        );
+        $this->assertArrayNotHasKey(
+            'attendanceRequired',
+            $events[10],
+            'attendanceRequired is correct for event 10'
         );
 
         foreach ($events as $event) {


### PR DESCRIPTION
For both user and school events having access to these attributes will
prevent needing to traverse the API to get to this data and speed up the
user experience.