### PR TITLE
filter terms by school via owning vocabulary, not by linked sessions/courses.

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/TermRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/TermRepository.php
@@ -272,9 +272,8 @@ class TermRepository extends EntityRepository
 
         if (array_key_exists('schools', $criteria)) {
             $ids = is_array($criteria['schools']) ? $criteria['schools'] : [$criteria['schools']];
-            $qb->join('t.sessions', 'sc_session');
-            $qb->join('sc_session.course', 'sc_course');
-            $qb->join('sc_course.school', 'sc_school');
+            $qb->join('t.vocabulary', 'sc_vocabulary');
+            $qb->join('sc_vocabulary.school', 'sc_school');
             $qb->andWhere($qb->expr()->in('sc_school.id', ':schools'));
             $qb->setParameter(':schools', $ids);
         }

--- a/tests/IliosApiBundle/Endpoints/TermTest.php
+++ b/tests/IliosApiBundle/Endpoints/TermTest.php
@@ -94,7 +94,7 @@ class TermTest extends AbstractEndpointTest
             'competencies' => [[0, 1, 2, 3, 4, 5], ['competencies' => [1, 2]]],
             'meshDescriptors' => [[0, 1, 2, 3, 4, 5], ['meshDescriptors' => ['abc1', 'abc2', 'abc3']]],
             'programs' => [[0, 3], ['programs' => [1]]],
-            'schools' => [[0, 1, 2, 3, 4, 5], ['schools' => [1]]],
+            'schools' => [[0, 1, 2], ['schools' => [1]]],
         ];
     }
 }


### PR DESCRIPTION
fixes #1839 