### PR TITLE
Fix error in prod config

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -10,7 +10,7 @@ monolog:
             handler:      nested
         nested:
             type:  stream
-            path:  'kernel.logs_dir%/%kernel.environment%.log'
+            path:  '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
         console:
             type:  console


### PR DESCRIPTION
Missing an `%` in this config file blows up the production environment.