### PR TITLE
Re-balance test groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ matrix:
   - php: '7.1'
   include:
   - php: '7'
-    env: TEST_PHPUNIT_OTHERS=true
+    env: TEST_EVERYTHING_ELSE=true
   - php: '7.1'
-    env: TEST_PHPUNIT_OTHERS=true
+    env: TEST_EVERYTHING_ELSE=true
   - php: '7'
     env: TEST_PHPUNIT_API1=true
   - php: '7.1'
@@ -29,17 +29,9 @@ matrix:
   - php: '7.1'
     env: TEST_PHPUNIT_API4=true
   - php: '7'
-    env: TEST_PHPUNIT_MESH_DATA_IMPORT=true
+    env: TEST_PHPUNIT_API5=true
   - php: '7.1'
-    env: TEST_PHPUNIT_MESH_DATA_IMPORT=true
-  - php: '7'
-    env: VALIDATE_SCHEMA=true
-  - php: '7.1'
-    env: VALIDATE_SCHEMA=true
-  - php: '7'
-    env: CHECK_CODING_STANDARDS=true
-  - php: '7.1'
-    env: CHECK_CODING_STANDARDS=true
+    env: TEST_PHPUNIT_API5=true
 php:
 - '7'
 - '7.1'
@@ -49,10 +41,8 @@ env:
   - TEST_PHPUNIT_API2=false
   - TEST_PHPUNIT_API3=false
   - TEST_PHPUNIT_API4=false
-  - TEST_PHPUNIT_OTHERS=false
-  - TEST_PHPUNIT_MESH_DATA_IMPORT=false
-  - VALIDATE_SCHEMA=false
-  - CHECK_CODING_STANDARDS=false
+  - TEST_PHPUNIT_API5=false
+  - TEST_EVERYTHING_ELSE=false
 cache:
   directories:
   - "$HOME/.composer/cache"
@@ -71,18 +61,6 @@ before_script:
 - bin/console doctrine:migrations:migrate  --env=dev --no-interaction
 - bin/console cache:clear --env=test --no-interaction
 script:
-- if [ "$VALIDATE_SCHEMA" = true ];
-  then (bin/console doctrine:schema:validate --env=dev);
-  fi
-- if [ "$CHECK_CODING_STANDARDS" = true ];
-  then (vendor/bin/phpcs --standard=app/phpcs.xml src && vendor/bin/phpcs --standard=app/phpcs.xml tests);
-  fi
-- if [ "$CHECK_CODING_STANDARDS" = true ];
-  then (bin/console security:check --end-point=http://security.sensiolabs.org/check_lock);
-  fi
-- if [ "$TEST_PHPUNIT_MESH_DATA_IMPORT" = true ];
-  then (vendor/bin/phpunit -c phpunit.xml.dist --group mesh_data_import);
-  fi
 - if [ "$TEST_PHPUNIT_API1" = true ];
   then (vendor/bin/phpunit -c phpunit.xml.dist --group api_1);
   fi
@@ -95,8 +73,14 @@ script:
 - if [ "$TEST_PHPUNIT_API4" = true ];
   then (vendor/bin/phpunit -c phpunit.xml.dist --group api_4);
   fi
-- if [ "$TEST_PHPUNIT_OTHERS" = true ];
-  then (vendor/bin/phpunit -c phpunit.xml.dist --exclude-group mesh_data_import,api_1,api_2,api_3,api_4);
+- if [ "$TEST_PHPUNIT_API5" = true ];
+  then (vendor/bin/phpunit -c phpunit.xml.dist --group api_5);
+  fi
+- if [ "$TEST_EVERYTHING_ELSE" = true ];then
+   bin/console doctrine:schema:validate --env=dev;
+   vendor/bin/phpcs --standard=app/phpcs.xml src && vendor/bin/phpcs --standard=app/phpcs.xml tests;
+   bin/console security:check --end-point=http://security.sensiolabs.org/check_lock;
+   vendor/bin/phpunit -c phpunit.xml.dist --exclude-group api_1,api_2,api_3,api_4,api_5;
   fi
 notifications:
   slack:

--- a/tests/IliosApiBundle/Endpoints/AamcPcrsTest.php
+++ b/tests/IliosApiBundle/Endpoints/AamcPcrsTest.php
@@ -9,7 +9,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * AamcPcrses API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_2
+ * @group api_5
  */
 class AamcPcrsTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/AcademicYearTest.php
+++ b/tests/IliosApiBundle/Endpoints/AcademicYearTest.php
@@ -8,7 +8,7 @@ use Tests\IliosApiBundle\AbstractEndpointTest;
 /**
  * AamcMethod API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_4
+ * @group api_5
  */
 class AcademicYearTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/AlertTest.php
+++ b/tests/IliosApiBundle/Endpoints/AlertTest.php
@@ -8,7 +8,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * Alert API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_2
+ * @group api_5
  */
 class AlertTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/AuthenticationTest.php
+++ b/tests/IliosApiBundle/Endpoints/AuthenticationTest.php
@@ -9,7 +9,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * Authentication API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_1
+ * @group api_5
  */
 class AuthenticationTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/CompetencyTest.php
+++ b/tests/IliosApiBundle/Endpoints/CompetencyTest.php
@@ -8,7 +8,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * Competency API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_3
+ * @group api_5
  */
 class CompetencyTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/IliosApiBundle/Endpoints/CurriculumInventoryReportTest.php
@@ -9,7 +9,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * CurriculumInventoryReport API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_3
+ * @group api_5
  */
 class CurriculumInventoryReportTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/MeshConceptTest.php
+++ b/tests/IliosApiBundle/Endpoints/MeshConceptTest.php
@@ -8,7 +8,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * MeshConcept API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_2
+ * @group api_5
  */
 class MeshConceptTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/ObjectiveTest.php
+++ b/tests/IliosApiBundle/Endpoints/ObjectiveTest.php
@@ -9,7 +9,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * Objective API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_1
+ * @group api_5
  */
 class ObjectiveTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/SchoolConfigTest.php
+++ b/tests/IliosApiBundle/Endpoints/SchoolConfigTest.php
@@ -8,7 +8,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * SchoolConfig API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_1
+ * @group api_5
  */
 class SchoolConfigTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/SchoolTest.php
+++ b/tests/IliosApiBundle/Endpoints/SchoolTest.php
@@ -8,7 +8,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * School API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_3
+ * @group api_5
  */
 class SchoolTest extends AbstractEndpointTest
 {

--- a/tests/IliosApiBundle/Endpoints/SessionDescriptionTest.php
+++ b/tests/IliosApiBundle/Endpoints/SessionDescriptionTest.php
@@ -8,7 +8,7 @@ use Tests\IliosApiBundle\EndpointTestsTrait;
 /**
  * SessionDescription API endpoint Test.
  * @package Tests\IliosApiBundle\Endpoints
- * @group api_4
+ * @group api_5
  */
 class SessionDescriptionTest extends AbstractEndpointTest
 {


### PR DESCRIPTION
Consolidating several smaller test runs in CI allows us to expand the
number of API groups and hopefully make each tests a bit quicker.