### PR TITLE
Split up the code style check into two lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,8 @@ script:
   fi
 - if [ "$TEST_EVERYTHING_ELSE" = true ];then
    bin/console doctrine:schema:validate --env=dev;
-   vendor/bin/phpcs --standard=app/phpcs.xml src && vendor/bin/phpcs --standard=app/phpcs.xml tests;
+   vendor/bin/phpcs --standard=app/phpcs.xml src;
+   vendor/bin/phpcs --standard=app/phpcs.xml tests;
    bin/console security:check --end-point=http://security.sensiolabs.org/check_lock;
    vendor/bin/phpunit -c phpunit.xml.dist --exclude-group api_1,api_2,api_3,api_4,api_5;
   fi


### PR DESCRIPTION
Single lines wasn't always failing when it should have.