### PR TITLE
Autowire and Autoconfigure the CLI bundle

### DIFF
--- a/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Ilios/CliBundle/Command/AddNewStudentsToSchoolCommand.php
@@ -2,7 +2,7 @@
 
 namespace Ilios\CliBundle\Command;
 
-use Ilios\CoreBundle\Entity\Manager\ManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\UserRoleManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -39,7 +39,7 @@ class AddNewStudentsToSchoolCommand extends Command
     protected $authenticationManager;
     
     /**
-     * @var ManagerInterface
+     * @var UserRoleManager
      */
     protected $userRoleManager;
     
@@ -52,7 +52,7 @@ class AddNewStudentsToSchoolCommand extends Command
         UserManager $userManager,
         SchoolManager $schoolManager,
         AuthenticationManager $authenticationManager,
-        ManagerInterface $userRoleManager,
+        UserRoleManager $userRoleManager,
         Directory $directory
     ) {
         $this->userManager = $userManager;

--- a/src/Ilios/CliBundle/Command/InstallFirstUserCommand.php
+++ b/src/Ilios/CliBundle/Command/InstallFirstUserCommand.php
@@ -3,8 +3,12 @@
 namespace Ilios\CliBundle\Command;
 
 use Ilios\CoreBundle\Entity\AuthenticationInterface;
+use Ilios\CoreBundle\Entity\Manager\AuthenticationManager;
 use Ilios\CoreBundle\Entity\Manager\ManagerInterface;
 
+use Ilios\CoreBundle\Entity\Manager\SchoolManager;
+use Ilios\CoreBundle\Entity\Manager\UserManager;
+use Ilios\CoreBundle\Entity\Manager\UserRoleManager;
 use Ilios\CoreBundle\Entity\SchoolInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -43,22 +47,22 @@ class InstallFirstUserCommand extends Command
     const LAST_NAME = 'User';
 
     /**
-     * @var ManagerInterface
+     * @var UserManager
      */
     protected $userManager;
 
     /**
-     * @var ManagerInterface
+     * @var SchoolManager
      */
     protected $schoolManager;
 
     /**
-     * @var ManagerInterface
+     * @var UserRoleManager
      */
     protected $userRoleManager;
 
     /**
-     * @var  ManagerInterface
+     * @var  AuthenticationManager
      */
     protected $authenticationManager;
 
@@ -69,17 +73,17 @@ class InstallFirstUserCommand extends Command
 
     /**
      * Constructor.
-     * @param ManagerInterface $userManager
-     * @param ManagerInterface $schoolManager
-     * @param ManagerInterface $userRoleManager
-     * @param ManagerInterface $authenticationManager
+     * @param UserManager $userManager
+     * @param SchoolManager $schoolManager
+     * @param UserRoleManager $userRoleManager
+     * @param AuthenticationManager $authenticationManager
      * @param UserPasswordEncoderInterface $passwordEncoder
      */
     public function __construct(
-        ManagerInterface $userManager,
-        ManagerInterface $schoolManager,
-        ManagerInterface $userRoleManager,
-        ManagerInterface $authenticationManager,
+        UserManager $userManager,
+        SchoolManager $schoolManager,
+        UserRoleManager $userRoleManager,
+        AuthenticationManager $authenticationManager,
         UserPasswordEncoderInterface $passwordEncoder
     ) {
         $this->userManager = $userManager;

--- a/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
+++ b/src/Ilios/CliBundle/Command/SendChangeAlertsCommand.php
@@ -5,7 +5,7 @@ namespace Ilios\CliBundle\Command;
 use Ilios\CoreBundle\Entity\AlertInterface;
 use Ilios\CoreBundle\Entity\AuditLogInterface;
 use Ilios\CoreBundle\Entity\Manager\AuditLogManager;
-use Ilios\CoreBundle\Entity\Manager\ManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\AlertManager;
 use Ilios\CoreBundle\Entity\Manager\OfferingManager;
 use Ilios\CoreBundle\Entity\SchoolInterface;
 use Symfony\Component\Console\Command\Command;
@@ -28,7 +28,7 @@ class SendChangeAlertsCommand extends Command
     const DEFAULT_TEMPLATE_NAME = 'offeringchangealert.text.twig';
 
     /**
-     * @var ManagerInterface
+     * @var AlertManager
      */
     protected $alertManager;
 
@@ -58,7 +58,7 @@ class SendChangeAlertsCommand extends Command
     protected $timezone;
 
     /**
-     * @param ManagerInterface $alertManager
+     * @param AlertManager $alertManager
      * @param AuditLogManager $auditLogManager
      * @param OfferingManager $offeringManager
      * @param EngineInterface $templatingEngine
@@ -66,11 +66,11 @@ class SendChangeAlertsCommand extends Command
      * @param string $timezone
      */
     public function __construct(
-        ManagerInterface $alertManager,
+        AlertManager $alertManager,
         AuditLogManager $auditLogManager,
         OfferingManager $offeringManager,
         EngineInterface $templatingEngine,
-        $mailer,
+        \Swift_Mailer $mailer,
         $timezone
     ) {
         parent::__construct();

--- a/src/Ilios/CliBundle/Command/SendTeachingRemindersCommand.php
+++ b/src/Ilios/CliBundle/Command/SendTeachingRemindersCommand.php
@@ -60,7 +60,7 @@ class SendTeachingRemindersCommand extends Command
     public function __construct(
         OfferingManager $offeringManager,
         EngineInterface $templatingEngine,
-        $mailer,
+        \Swift_Mailer $mailer,
         $timezone
     ) {
         parent::__construct();

--- a/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
+++ b/src/Ilios/CliBundle/Command/SyncFormerStudentsCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-use Ilios\CoreBundle\Entity\Manager\ManagerInterface;
+use Ilios\CoreBundle\Entity\Manager\UserRoleManager;
 use Ilios\CoreBundle\Entity\Manager\UserManager;
 use Ilios\CoreBundle\Entity\UserInterface;
 use Ilios\CoreBundle\Service\Directory;
@@ -29,7 +29,7 @@ class SyncFormerStudentsCommand extends Command
     protected $userManager;
     
     /**
-     * @var ManagerInterface
+     * @var UserRoleManager
      */
     protected $userRoleManager;
     
@@ -40,7 +40,7 @@ class SyncFormerStudentsCommand extends Command
     
     public function __construct(
         UserManager $userManager,
-        ManagerInterface $userRoleManager,
+        UserRoleManager $userRoleManager,
         Directory $directory
     ) {
         $this->userManager = $userManager;

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -1,127 +1,22 @@
 services:
-    ilioscli.command.invalidate_user_tokens:
-        class: Ilios\CliBundle\Command\InvalidateUserTokenCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\UserManager', '@Ilios\CoreBundle\Entity\Manager\AuthenticationManager']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.create_user_token:
-        class: Ilios\CliBundle\Command\CreateUserTokenCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\UserManager', '@Ilios\AuthenticationBundle\Service\JsonWebTokenManager']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.sync_user:
-        class: Ilios\CliBundle\Command\SyncUserCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\UserManager', '@Ilios\CoreBundle\Entity\Manager\AuthenticationManager', '@Ilios\CoreBundle\Service\Directory']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.find_directory_user:
-        class: Ilios\CliBundle\Command\FindUserCommand
-        arguments: ['@Ilios\CoreBundle\Service\Directory']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.add_directory_user:
-        class: Ilios\CliBundle\Command\AddDirectoryUserCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\UserManager', '@Ilios\CoreBundle\Entity\Manager\AuthenticationManager', '@Ilios\CoreBundle\Entity\Manager\SchoolManager', '@Ilios\CoreBundle\Service\Directory']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.sync_former_students:
-        class: Ilios\CliBundle\Command\SyncFormerStudentsCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\UserManager', '@Ilios\CoreBundle\Entity\Manager\UserRoleManager', '@Ilios\CoreBundle\Service\Directory']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.add_new_students_to_school:
-        class: Ilios\CliBundle\Command\AddNewStudentsToSchoolCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\UserManager', '@Ilios\CoreBundle\Entity\Manager\SchoolManager', '@Ilios\CoreBundle\Entity\Manager\AuthenticationManager', '@Ilios\CoreBundle\Entity\Manager\UserRoleManager', '@Ilios\CoreBundle\Service\Directory']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.sync_all_users:
-        class: Ilios\CliBundle\Command\SyncAllUsersCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\UserManager', '@Ilios\CoreBundle\Entity\Manager\AuthenticationManager', '@Ilios\CoreBundle\Entity\Manager\PendingUserUpdateManager', '@Ilios\CoreBundle\Service\Directory', '@doctrine.orm.entity_manager']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.migrate_learningmaterials:
-        class: Ilios\CliBundle\Command\MigrateIlios2LearningMaterialsCommand
-        arguments: ['@filesystem', '@Ilios\CoreBundle\Service\IliosFileSystem', '@Ilios\CoreBundle\Entity\Manager\LearningMaterialManager']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.send_teaching_reminders:
-        class: Ilios\CliBundle\Command\SendTeachingRemindersCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\OfferingManager', '@templating', '@mailer', '%ilios_core.timezone%']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.send_change_alerts:
-        class: Ilios\CliBundle\Command\SendChangeAlertsCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\AlertManager', '@Ilios\CoreBundle\Entity\Manager\AuditLogManager', '@Ilios\CoreBundle\Entity\Manager\OfferingManager', '@templating', '@mailer', '%ilios_core.timezone%']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.cleanup_strings:
-        class: Ilios\CliBundle\Command\CleanupStringsCommand
-        arguments: ['@exercise_html_purifier.default', '@doctrine.orm.entity_manager', '@Ilios\CoreBundle\Entity\Manager\ObjectiveManager', '@Ilios\CoreBundle\Entity\Manager\LearningMaterialManager', '@Ilios\CoreBundle\Entity\Manager\CourseLearningMaterialManager', '@Ilios\CoreBundle\Entity\Manager\SessionLearningMaterialManager', '@Ilios\CoreBundle\Entity\Manager\SessionDescriptionManager']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.validate_learning_material_paths:
-        class: Ilios\CliBundle\Command\ValidateLearningMaterialPathsCommand
-        arguments: ['@Ilios\CoreBundle\Service\IliosFileSystem', '@Ilios\CoreBundle\Entity\Manager\LearningMaterialManager']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.add_user:
-        class: Ilios\CliBundle\Command\AddUserCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\UserManager', '@Ilios\CoreBundle\Entity\Manager\AuthenticationManager', '@Ilios\CoreBundle\Entity\Manager\SchoolManager', '@security.password_encoder']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.update_frontend:
-        class: Ilios\CliBundle\Command\UpdateFrontendCommand
-        arguments: ['@iliosweb.jsonindex', '@Ilios\CoreBundle\Service\Filesystem', '%kernel.cache_dir%', '%ilios_web.frontend_release_version%', '%ilios_web.keep_frontend_updated%', '%kernel.environment%']
-        tags:
-            -  { name: console.command }
-            -  { name: kernel.cache_warmer }
-    ilioscli.command.rollover_course:
-        class: Ilios\CliBundle\Command\RolloverCourseCommand
-        arguments: ['@Ilios\CoreBundle\Service\CourseRollover']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.install_first_uer:
-        class: Ilios\CliBundle\Command\InstallFirstUserCommand
-        arguments: ['@Ilios\CoreBundle\Entity\Manager\UserManager', '@Ilios\CoreBundle\Entity\Manager\SchoolManager', '@Ilios\CoreBundle\Entity\Manager\UserRoleManager', '@Ilios\CoreBundle\Entity\Manager\AuthenticationManager', '@security.password_encoder']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.curriculum_inventory_report_rollover:
-        class: Ilios\CliBundle\Command\RolloverCurriculumInventoryReportCommand
-        arguments: [ '@Ilios\CoreBundle\Entity\Manager\CurriculumInventoryReportManager', '@Ilios\CoreBundle\Service\CurriculumInventory\ReportRollover' ]
-        tags:
-            -  { name: console.command }
-    ilioscli.command.list_root_users:
-        class: Ilios\CliBundle\Command\ListRootUsersCommand
-        arguments: [ '@Ilios\CoreBundle\Entity\Manager\UserManager' ]
-        tags:
-            -  { name: console.command }
-    ilioscli.command.add_root_user:
-        class: Ilios\CliBundle\Command\AddRootUserCommand
-        arguments: [ '@Ilios\CoreBundle\Entity\Manager\UserManager' ]
-        tags:
-            -  { name: console.command }
-    ilioscli.command.remove_root_user:
-        class: Ilios\CliBundle\Command\RemoveRootUserCommand
-        arguments: [ '@Ilios\CoreBundle\Entity\Manager\UserManager' ]
-        tags:
-            -  { name: console.command }
-    ilioscli.command.generate_swagger_path:
-        class: Ilios\CliBundle\Command\GenerateSwaggerApiPathYamlCommand
-        arguments: ['@templating']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.generate_swagger_definition:
-        class: Ilios\CliBundle\Command\GenerateSwaggerApiDefinitionYamlCommand
-        arguments: ['@templating', '@doctrine', '@Ilios\CoreBundle\Service\EntityMetadata']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.generate_endpoint_test:
-        class: Ilios\CliBundle\Command\GenerateEndpointTestCommand
-        arguments: ['@templating', '@doctrine', '@Ilios\CoreBundle\Service\EntityMetadata']
-        tags:
-            -  { name: console.command }
-    ilioscli.command.crossing_guard:
-        class: Ilios\CliBundle\Command\CrossingGuardCommand
-        arguments: ['@Ilios\CoreBundle\Service\CrossingGuard']
-        tags:
-            -  { name: console.command }
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Ilios\CliBundle\:
+            resource: '../../*'
+
+    Ilios\CliBundle\Command\SendTeachingRemindersCommand:
+        arguments:
+            $timezone: '%ilios_core.timezone%'
+    Ilios\CliBundle\Command\SendChangeAlertsCommand:
+        arguments:
+            $timezone: '%ilios_core.timezone%'
+    Ilios\CliBundle\Command\UpdateFrontendCommand:
+        arguments:
+            $kernelCacheDir: '%kernel.cache_dir%'
+            $releaseVersion: '%ilios_web.frontend_release_version%'
+            $keepFrontendUpdated: '%ilios_web.keep_frontend_updated%'
+            $environment: '%kernel.environment%'

--- a/src/Ilios/CoreBundle/Entity/Manager/AlertManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/AlertManager.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ilios\CoreBundle\Entity\Manager;
+
+/**
+ * Class AlertManager
+ * @package Ilios\CoreBundle\Entity\Manager
+ */
+class AlertManager extends DTOManager
+{
+}

--- a/src/Ilios/CoreBundle/Entity/Manager/UserRoleManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserRoleManager.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ilios\CoreBundle\Entity\Manager;
+
+/**
+ * Class UserRoleManager
+ * @package Ilios\CoreBundle\Entity\Manager
+ */
+class UserRoleManager extends DTOManager
+{
+}

--- a/src/Ilios/CoreBundle/Resources/config/dto-managers.yml
+++ b/src/Ilios/CoreBundle/Resources/config/dto-managers.yml
@@ -20,10 +20,6 @@ services:
         class: Ilios\CoreBundle\Entity\Manager\DTOManager
         arguments:
             $class: 'Ilios\CoreBundle\Entity\AlertChangeType'
-    Ilios\CoreBundle\Entity\Manager\AlertManager:
-        class: Ilios\CoreBundle\Entity\Manager\DTOManager
-        arguments:
-            $class: 'Ilios\CoreBundle\Entity\Alert'
     Ilios\CoreBundle\Entity\Manager\ApplicationConfigManager:
         class: Ilios\CoreBundle\Entity\Manager\DTOManager
         arguments:
@@ -124,10 +120,6 @@ services:
         class: Ilios\CoreBundle\Entity\Manager\DTOManager
         arguments:
             $class: 'Ilios\CoreBundle\Entity\UserMadeReminder'
-    Ilios\CoreBundle\Entity\Manager\UserRoleManager:
-        class: Ilios\CoreBundle\Entity\Manager\DTOManager
-        arguments:
-            $class: 'Ilios\CoreBundle\Entity\UserRole'
     Ilios\CoreBundle\Entity\Manager\VocabularyManager:
         class: Ilios\CoreBundle\Entity\Manager\DTOManager
         arguments:

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -107,6 +107,10 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, priority: 256 }
 
+    Ilios\CoreBundle\Entity\Manager\AlertManager:
+        public: true
+        arguments:
+            $class: 'Ilios\CoreBundle\Entity\Alert'
     Ilios\CoreBundle\Entity\Manager\AuditLogManager:
         public: true
         arguments:
@@ -197,3 +201,7 @@ services:
         public: true
         arguments:
             $class: 'Ilios\CoreBundle\Entity\User'
+    Ilios\CoreBundle\Entity\Manager\UserRoleManager:
+        public: true
+        arguments:
+            $class: 'Ilios\CoreBundle\Entity\UserRole'

--- a/tests/CliBundle/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/tests/CliBundle/Command/AddNewStudentsToSchoolCommandTest.php
@@ -2,6 +2,10 @@
 namespace Tests\CliBundle\Command;
 
 use Ilios\CliBundle\Command\AddNewStudentsToSchoolCommand;
+use Ilios\CoreBundle\Entity\Manager\AuthenticationManager;
+use Ilios\CoreBundle\Entity\Manager\SchoolManager;
+use Ilios\CoreBundle\Entity\Manager\UserManager;
+use Ilios\CoreBundle\Entity\Manager\UserRoleManager;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -27,10 +31,10 @@ class AddNewStudentsToSchoolCommandTest extends TestCase
     
     public function setUp()
     {
-        $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManager');
-        $this->userRoleManager = m::mock('Ilios\CoreBundle\Entity\Manager\ManagerInterface');
-        $this->schoolManager = m::mock('Ilios\CoreBundle\Entity\Manager\SchoolManager');
-        $this->authenticationManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuthenticationManager');
+        $this->userManager = m::mock(UserManager::class);
+        $this->userRoleManager = m::mock(UserRoleManager::class);
+        $this->schoolManager = m::mock(SchoolManager::class);
+        $this->authenticationManager = m::mock(AuthenticationManager::class);
         $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
         
         $command = new AddNewStudentsToSchoolCommand(

--- a/tests/CliBundle/Command/InstallFirstUserCommandTest.php
+++ b/tests/CliBundle/Command/InstallFirstUserCommandTest.php
@@ -2,12 +2,17 @@
 namespace Tests\CliBundle\Command;
 
 use Ilios\CliBundle\Command\InstallFirstUserCommand;
+use Ilios\CoreBundle\Entity\Manager\AuthenticationManager;
+use Ilios\CoreBundle\Entity\Manager\SchoolManager;
+use Ilios\CoreBundle\Entity\Manager\UserManager;
+use Ilios\CoreBundle\Entity\Manager\UserRoleManager;
 use Ilios\CoreBundle\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 use Mockery as m;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 /**
  * Class InstallFirstUserCommandTest
@@ -35,12 +40,11 @@ class InstallFirstUserCommandTest extends KernelTestCase
      */
     public function setUp()
     {
-        $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManager');
-        $this->authenticationManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuthenticationManager');
-        $this->schoolManager = m::mock('Ilios\CoreBundle\Entity\Manager\SchoolManager');
-        $this->userRoleManager = m::mock('Ilios\CoreBundle\Entity\Manager\BaseManager');
-        $this->encoder = m::mock('Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface');
-
+        $this->userManager = m::mock(UserManager::class);
+        $this->authenticationManager = m::mock(AuthenticationManager::class);
+        $this->schoolManager = m::mock(SchoolManager::class);
+        $this->userRoleManager = m::mock(UserRoleManager::class);
+        $this->encoder = m::mock(UserPasswordEncoderInterface::class);
 
         $command = new InstallFirstUserCommand(
             $this->userManager,

--- a/tests/CliBundle/Command/SendChangeAlertsCommandTest.php
+++ b/tests/CliBundle/Command/SendChangeAlertsCommandTest.php
@@ -12,6 +12,9 @@ use Ilios\CoreBundle\Entity\Course;
 use Ilios\CoreBundle\Entity\InstructorGroup;
 use Ilios\CoreBundle\Entity\LearnerGroup;
 use Ilios\CoreBundle\Entity\LearnerGroupInterface;
+use Ilios\CoreBundle\Entity\Manager\AlertManager;
+use Ilios\CoreBundle\Entity\Manager\AuditLogManager;
+use Ilios\CoreBundle\Entity\Manager\OfferingManager;
 use Ilios\CoreBundle\Entity\Offering;
 use Ilios\CoreBundle\Entity\OfferingInterface;
 use Ilios\CoreBundle\Entity\School;
@@ -63,9 +66,9 @@ class SendChangeAlertsCommandTest extends KernelTestCase
 
     public function setUp()
     {
-        $this->offeringManager = m::mock('Ilios\CoreBundle\Entity\Manager\OfferingManager');
-        $this->alertManager = m::mock('Ilios\CoreBundle\Entity\Manager\ManagerInterface');
-        $this->auditLogManager = m::mock('Ilios\CoreBundle\Entity\Manager\AuditLogManager');
+        $this->offeringManager = m::mock(OfferingManager::class);
+        $this->alertManager = m::mock(AlertManager::class);
+        $this->auditLogManager = m::mock(AuditLogManager::class);
 
         $kernel = $this->createKernel();
         $kernel->boot();

--- a/tests/CliBundle/Command/SyncFormerStudentsCommandTest.php
+++ b/tests/CliBundle/Command/SyncFormerStudentsCommandTest.php
@@ -2,6 +2,9 @@
 namespace Tests\CliBundle\Command;
 
 use Ilios\CliBundle\Command\SyncFormerStudentsCommand;
+use Ilios\CoreBundle\Entity\Manager\UserManager;
+use Ilios\CoreBundle\Entity\Manager\UserRoleManager;
+use Ilios\CoreBundle\Service\Directory;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -22,9 +25,9 @@ class SyncFormerStudentsCommandTest extends TestCase
     
     public function setUp()
     {
-        $this->userManager = m::mock('Ilios\CoreBundle\Entity\Manager\UserManager');
-        $this->userRoleManager = m::mock('Ilios\CoreBundle\Entity\Manager\BaseManager');
-        $this->directory = m::mock('Ilios\CoreBundle\Service\Directory');
+        $this->userManager = m::mock(UserManager::class);
+        $this->userRoleManager = m::mock(UserRoleManager::class);
+        $this->directory = m::mock(Directory::class);
         
         $command = new SyncFormerStudentsCommand($this->userManager, $this->userRoleManager, $this->directory);
         $application = new Application();


### PR DESCRIPTION
Removes the services.yml boilerplate for setting up and registering the
commands. Followed the guide at https://symfony.com/doc/current/service_container/3.3-di-changes.html