### PR TITLE
Get Service Worker files from our CDN and serve them up

### DIFF
--- a/src/Ilios/CliBundle/Command/UpdateServiceWorkerCommand.php
+++ b/src/Ilios/CliBundle/Command/UpdateServiceWorkerCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Ilios\CoreBundle\Service\Fetch;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+use Ilios\CoreBundle\Service\Filesystem;
+
+/**
+ * Pull down service worker JS files from cloudfront
+ * So they can be served from the API host since service workers
+ * won't work from a different domain
+ *
+ * Class UpdateServiceWorkerCommand
+ * @package Ilios\CliBUndle\Command
+ */
+class UpdateServiceWorkerCommand extends Command implements CacheWarmerInterface
+{
+    /**
+     * @var string
+     */
+    const SWJS_CACHE_FILE_NAME = '/ilios/sw.js';
+    const SW_REGISTRATION_CACHE_FILE_NAME = '/ilios/sw-registration.js';
+    const PRODUCTION = 'prod';
+    const STAGING = 'stage';
+    const DEVELOPMENT = 'dev';
+    const CDN_ASSET_DOMAIN = 'https://d26vzvixg52o0d.cloudfront.net/';
+
+    /**
+     * @var Fetch
+     */
+    protected $fetch;
+
+    /**
+     * @var Filesystem
+     */
+    protected $fs;
+
+    /**
+     * @var string
+     */
+    protected $cacheDir;
+
+    /**
+     * @var string
+     */
+    protected $environment;
+    
+    public function __construct(
+        Fetch $fetch,
+        Filesystem $fs,
+        $kernelCacheDir,
+        $environment
+    ) {
+        $this->fetch = $fetch;
+        $this->fs = $fs;
+        $this->cacheDir = $kernelCacheDir;
+        $this->environment = $environment;
+
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:maintenance:update-serviceworker')
+            ->setDescription('Updates the service worker javascript to the latest version.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->writeServiceWorkerFile($this->cacheDir);
+
+        $message = 'Service worker updated successfully!';
+
+        $output->writeln("<info>{$message}</info>");
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        try {
+            $this->writeServiceWorkerFile($cacheDir);
+        } catch (\Exception $e) {
+            if ($this->environment === 'prod') {
+                throw new \Exception(
+                    'Unable to load the service worker.  ' .
+                    'Please try again or let the Ilios Team know about this issue.'
+                );
+            }
+
+            print "Unable to load service worker.  Please run ilios:maintenance:update-serviceworker. \n";
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+
+    /**
+     * @param string $cacheDir
+     * @param string $environment
+     *
+     * @throws \Exception
+     */
+    protected function writeServiceWorkerFile($cacheDir)
+    {
+        $swJs = $this->fetch->get(self::CDN_ASSET_DOMAIN . 'sw.js');
+        $this->fs->dumpFile($cacheDir . self::SWJS_CACHE_FILE_NAME, gzencode($swJs));
+
+        $swRegistrationJs = $this->fetch->get(self::CDN_ASSET_DOMAIN . 'sw-registration.js');
+        $this->fs->dumpFile($cacheDir . self::SW_REGISTRATION_CACHE_FILE_NAME, gzencode($swRegistrationJs));
+    }
+}

--- a/src/Ilios/CliBundle/Resources/config/services.yml
+++ b/src/Ilios/CliBundle/Resources/config/services.yml
@@ -20,3 +20,7 @@ services:
             $releaseVersion: '%ilios_web.frontend_release_version%'
             $keepFrontendUpdated: '%ilios_web.keep_frontend_updated%'
             $environment: '%kernel.environment%'
+    Ilios\CliBundle\Command\UpdateServiceWorkerCommand:
+        arguments:
+            $kernelCacheDir: '%kernel.cache_dir%'
+            $environment: '%kernel.environment%'

--- a/src/Ilios/CoreBundle/Service/Fetch.php
+++ b/src/Ilios/CoreBundle/Service/Fetch.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Ilios\CoreBundle\Service;
+use Http\Client\HttpClient;
+use Http\Message\RequestFactory;
+
+/**
+ * Fetch things from the interwebs - exposed as a service for
+ * reusability, error handling, and configuration options
+ *
+ * @package Ilios\CoreBundle\Service
+ *
+ */
+class Fetch
+{
+    /**
+     * @var HttpClient
+     */
+    protected $client;
+
+    /**
+     * @var RequestFactory
+     */
+    protected $requestFactory;
+
+    public function __construct(HttpClient $client, RequestFactory $requestFactory)
+    {
+        $this->client = $client;
+        $this->requestFactory = $requestFactory;
+    }
+
+    public function get(string $url) : string
+    {
+        $request = $this->requestFactory->createRequest('GET', $url);
+        $response = $this->client->sendRequest($request);
+        $fileContents = $response->getBody()->getContents();
+
+        if (empty($fileContents)) {
+            throw new \Exception('Failed to load ' . $url);
+        }
+
+        return $fileContents;
+    }
+}

--- a/src/Ilios/WebBundle/Controller/ServiceWorkerController.php
+++ b/src/Ilios/WebBundle/Controller/ServiceWorkerController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Ilios\WebBundle\Controller;
+
+use Ilios\CoreBundle\Service\Filesystem;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+use Ilios\CliBundle\Command\UpdateServiceWorkerCommand;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class ServiceWorkerController extends Controller
+{
+    public function swJsAction(Filesystem $fs)
+    {
+        $path = $this->getParameter('kernel.cache_dir') . '/' . UpdateServiceWorkerCommand::SWJS_CACHE_FILE_NAME;
+
+        if (!$fs->exists($path)) {
+            throw new NotFoundHttpException('sw.js has not been loaded. ' .
+                'Please run ilios:maintenance:update-serviceworker to load it');
+        }
+
+        $contents = $fs->readFile($path);
+        $response = new Response($contents);
+        $response->headers->set('Content-Type', 'application/javascript');
+        $response->headers->set('Content-Encoding', 'gzip');
+
+        $response->setPublic();
+
+        return $response;
+    }
+
+    public function swRegistrationJsAction(Filesystem $fs)
+    {
+        $path = $this->getParameter('kernel.cache_dir') .
+            '/' .
+            UpdateServiceWorkerCommand::SW_REGISTRATION_CACHE_FILE_NAME;
+
+        if (!$fs->exists($path)) {
+            throw new NotFoundHttpException('sw-registration.js has not been loaded. ' .
+                'Please run ilios:maintenance:update-serviceworker to load it');
+        }
+
+        $contents = $fs->readFile($path);
+        $response = new Response($contents);
+        $response->headers->set('Content-Type', 'application/javascript');
+        $response->headers->set('Content-Encoding', 'gzip');
+
+        $response->setPublic();
+
+        return $response;
+    }
+}

--- a/src/Ilios/WebBundle/Resources/config/routing.yml
+++ b/src/Ilios/WebBundle/Resources/config/routing.yml
@@ -26,6 +26,14 @@ ilios_web_directory_find:
     methods: [GET]
     requirements:
         key: '\d+'
+ilios_web_serviceworker-registration:
+    path:     /sw-registration.js
+    defaults:
+        _controller: IliosWebBundle:ServiceWorker:swRegistrationJs
+ilios_web_serviceworker:
+    path:     /sw.js
+    defaults:
+        _controller: IliosWebBundle:ServiceWorker:swJs
 ilios_web_homepage:
     path:     /{url}
     defaults:

--- a/src/Ilios/WebBundle/Resources/config/services.yml
+++ b/src/Ilios/WebBundle/Resources/config/services.yml
@@ -1,4 +1,14 @@
 services:
-    iliosweb.jsonindex:
-        class: Ilios\WebBundle\Service\WebIndexFromJson
-        arguments:    ['@templating']
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Ilios\WebBundle\:
+            resource: '../../*'
+
+    Ilios\WebBundle\Controller\:
+        resource: '../../Controller'
+        public: true
+        tags: ['controller.service_arguments']

--- a/tests/CliBundle/Command/UpdateServiceWorkerCommandTest.php
+++ b/tests/CliBundle/Command/UpdateServiceWorkerCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace Tests\CliBundle\Command;
+
+use Ilios\CliBundle\Command\UpdateFrontendCommand;
+use Ilios\CliBundle\Command\UpdateServiceWorkerCommand;
+use Ilios\CoreBundle\Service\Fetch;
+use Ilios\CoreBundle\Service\Filesystem;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFileSystem;
+use Mockery as m;
+
+class UpdateServiceWorkerCommandTest extends TestCase
+{
+    const COMMAND_NAME = 'ilios:maintenance:update-serviceworker';
+
+    /** @var CommandTester */
+    protected $commandTester;
+
+    protected $builder;
+    protected $fakeTestFileDir;
+
+    /** @var  m\Mock */
+    protected $fetch;
+
+    /** @var  m\Mock */
+    protected $fs;
+
+
+    public function setUp()
+    {
+        $fs = new SymfonyFileSystem();
+        $this->fakeTestFileDir = __DIR__ . '/FakeTestFiles';
+        if (!$fs->exists($this->fakeTestFileDir)) {
+            $fs->mkdir($this->fakeTestFileDir);
+        }
+
+        $this->fetch = m::mock(Fetch::class);
+        $this->fs = m::mock(Filesystem::class);
+        $command = new UpdateServiceWorkerCommand($this->fetch, $this->fs, $this->fakeTestFileDir, 'prod');
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        $fs = new SymfonyFileSystem();
+        $fs->remove($this->fakeTestFileDir);
+
+        unset($this->fetch);
+        unset($this->fs);
+        m::close();
+    }
+    
+    public function testExecute()
+    {
+        $this->fetch->shouldReceive('get')->with(UpdateServiceWorkerCommand::CDN_ASSET_DOMAIN . 'sw.js')
+            ->once()->andReturn('SWJS');
+        $this->fetch->shouldReceive('get')->with(UpdateServiceWorkerCommand::CDN_ASSET_DOMAIN . 'sw-registration.js')
+            ->once()->andReturn('SWREGJS');
+
+        $this->fs->shouldReceive('dumpFile')->once()->with(
+            $this->fakeTestFileDir . UpdateServiceWorkerCommand::SWJS_CACHE_FILE_NAME,
+            gzencode('SWJS')
+        );
+        $this->fs->shouldReceive('dumpFile')->once()->with(
+            $this->fakeTestFileDir . UpdateServiceWorkerCommand::SW_REGISTRATION_CACHE_FILE_NAME,
+            gzencode('SWREGJS')
+        );
+        
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+        ));
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Service worker updated successfully!/',
+            $output
+        );
+    }
+}

--- a/tests/WebBundle/Controller/ServiceWorkerControllerTest.php
+++ b/tests/WebBundle/Controller/ServiceWorkerControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\WebBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ServiceWorkerControllerTest extends WebTestCase
+{
+    public function testSwJs()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/sw.js');
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode(), substr($response->getContent(), 0, 500));
+    }
+    public function testSwRegistrationJs()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/sw-registration.js');
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode(), substr($response->getContent(), 0, 500));
+    }
+}

--- a/tests/WebBundle/DependencyInjection/IliosWebExtensionTest.php
+++ b/tests/WebBundle/DependencyInjection/IliosWebExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\WebBundle\DependencyInjection;
 
+use Ilios\WebBundle\Service\WebIndexFromJson;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Ilios\WebBundle\DependencyInjection\IliosWebExtension;
 
@@ -48,7 +49,7 @@ class IliosWebExtensionTest extends AbstractExtensionTestCase
     public function testServicesSet()
     {
         $services = array(
-            'iliosweb.jsonindex',
+            WebIndexFromJson::class,
         );
         $this->load();
         foreach ($services as $service) {

--- a/tests/WebBundle/Service/WebIndexFromJsonTest.php
+++ b/tests/WebBundle/Service/WebIndexFromJsonTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Tests\WebBundle\Service;
 
+use Ilios\CoreBundle\Service\Fetch;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Mockery as m;
 
 use Ilios\WebBundle\Service\WebIndexFromJson;
+use Symfony\Component\Templating\EngineInterface;
 
 class WebIndexFromJsonTest extends TestCase
 {
@@ -21,13 +23,12 @@ class WebIndexFromJsonTest extends TestCase
 
     public function testGetIndex()
     {
-        $mockTemplating = m::mock('Symfony\Component\Templating\EngineInterface');
+        $mockTemplating = m::mock(EngineInterface::class);
+        $mockFetch = m::mock(Fetch::class);
 
-        $obj = m::mock(WebIndexFromJson::class . '[getIndexFromAWS]', array($mockTemplating));
-        $obj->shouldAllowMockingProtectedMethods()
-            ->shouldReceive('getIndexFromAWS')->once()->andReturn($this->sampleJson);
-        $this->assertTrue($obj instanceof WebIndexFromJson);
+        $obj = new WebIndexFromJson($mockTemplating, $mockFetch);
 
+        $mockFetch->shouldReceive('get')->once()->andReturn($this->sampleJson);
         $mockTemplating->shouldReceive('exists')
             ->with('@custom_webindex_templates/webindex.html.twig')->andReturn(false);
         $mockTemplating->shouldReceive('exists')


### PR DESCRIPTION
Service worker JS files MUST come from the same domain as the index.html
file so we have to pull them directly and serve them from the API just
like our index file.