### PR TITLE
Allow SessionDescription to be set to null

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Session.php
+++ b/src/Ilios/CoreBundle/Entity/Session.php
@@ -457,10 +457,12 @@ class Session implements SessionInterface
     /**
      * @param SessionDescriptionInterface $sessionDescription
      */
-    public function setSessionDescription(SessionDescriptionInterface $sessionDescription)
+    public function setSessionDescription(SessionDescriptionInterface $sessionDescription = null)
     {
         $this->sessionDescription = $sessionDescription;
-        $sessionDescription->setSession($this);
+        if ($sessionDescription) {
+            $sessionDescription->setSession($this);
+        }
     }
 
     /**

--- a/tests/IliosApiBundle/Endpoints/SessionTest.php
+++ b/tests/IliosApiBundle/Endpoints/SessionTest.php
@@ -216,4 +216,13 @@ class SessionTest extends AbstractEndpointTest
         $data['description'] = 'new description';
         $this->relatedTimeStampUpdateTest($data['session'], 'sessiondescriptions', 'sessionDescription', $data);
     }
+
+    public function testSendingNullForSessionDescription()
+    {
+      $dataLoader = $this->getDataLoader();
+      $data = $dataLoader->create();
+      $postData = $data;
+      $postData['sessionDescription'] = null;
+      $this->postTest($data, $postData);
+    }
 }


### PR DESCRIPTION
Session Description isn't required so it should be possible to set it to
null.