### PR TITLE
force ubuntu precise.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: precise
 services: mysql
 sudo: false
 matrix:


### PR DESCRIPTION
we're getting build errors, could be related to the travis' recent switch from ubuntu precise to trusty.

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

refs #1882.

 forcing precise until we can figure out what's up, hopefully that works.