### PR TITLE
escape search terms when dynamically building LDAP filter.

### DIFF
--- a/src/Ilios/CoreBundle/Service/Directory.php
+++ b/src/Ilios/CoreBundle/Service/Directory.php
@@ -24,7 +24,7 @@ class Directory
         $this->ldapManager = $ldapManager;
         $this->ldapCampusIdProperty = $ldapCampusIdProperty;
     }
-    
+
     /**
      * Get directory information for a single user
      * @param  string $campusId
@@ -38,10 +38,10 @@ class Directory
         if (count($users)) {
             return $users[0];
         }
-        
+
         return false;
     }
-    
+
     /**
      * Get directory information for a list of users
      * @param  array $campusIds
@@ -56,15 +56,15 @@ class Directory
         }, $campusIds);
         $filterTermsString = implode($filterTerms, '');
         $filter = "(|{$filterTermsString})";
-        
+
         $users = $this->ldapManager->search($filter);
         if (count($users)) {
             return $users;
         }
-        
+
         return false;
     }
-    
+
     /**
      * Find everyone in the directory matching these terms
      * @param  array $searchTerms
@@ -74,6 +74,7 @@ class Directory
     public function find(array $searchTerms)
     {
         $filterTerms = array_map(function ($term) {
+            $term = ldap_escape($term, null, LDAP_ESCAPE_FILTER);
             return "(|(sn={$term}*)(givenname={$term}*)(mail={$term}*)({$this->ldapCampusIdProperty}={$term}*))";
         }, $searchTerms);
         $filterTermsString = implode($filterTerms, '');
@@ -83,10 +84,10 @@ class Directory
         if (count($users)) {
             return $users;
         }
-        
+
         return false;
     }
-    
+
     /**
      * Find all users matching LDAP filter
      * @param  string $filter
@@ -99,7 +100,7 @@ class Directory
         if (count($users)) {
             return $users;
         }
-        
+
         return false;
     }
 }

--- a/tests/CoreBundle/Service/DirectoryTest.php
+++ b/tests/CoreBundle/Service/DirectoryTest.php
@@ -26,7 +26,7 @@ class DirectoryTest extends TestCase
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
         $obj = new Directory($ldapManager, 'campusId');
         $ldapManager->shouldReceive('search')->with('(campusId=1234)')->andReturn(array(1));
-        
+
         $result = $obj->findByCampusId(1234);
         $this->assertSame($result, 1);
     }
@@ -39,7 +39,7 @@ class DirectoryTest extends TestCase
         $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
         $obj = new Directory($ldapManager, 'campusId');
         $ldapManager->shouldReceive('search')->with('(|(campusId=1234)(campusId=1235))')->andReturn(array(1));
-        
+
         $result = $obj->findByCampusIds([1234, 1235]);
         $this->assertSame($result, [1]);
     }
@@ -53,7 +53,7 @@ class DirectoryTest extends TestCase
         $obj = new Directory($ldapManager, 'campusId');
         $ldapManager->shouldReceive('search')
             ->with(m::mustBe('(|(campusId=1234)(campusId=1235))'))->andReturn(array(1));
-        
+
         $result = $obj->findByCampusIds([1234, 1235, 1234, 1235]);
         $this->assertSame($result, [1]);
     }
@@ -67,8 +67,22 @@ class DirectoryTest extends TestCase
         $obj = new Directory($ldapManager, 'campusId');
         $filter= '(&(|(sn=a*)(givenname=a*)(mail=a*)(campusId=a*))(|(sn=b*)(givenname=b*)(mail=b*)(campusId=b*)))';
         $ldapManager->shouldReceive('search')->with($filter)->andReturn(array(1,2));
-        
+
         $result = $obj->find(array('a', 'b'));
+        $this->assertSame($result, array(1,2));
+    }
+
+    /**
+     * @covers \Ilios\CoreBundle\Service\Directory::find
+     */
+    public function testFindOutputEscaping()
+    {
+        $ldapManager = m::mock('Ilios\CoreBundle\Service\LdapManager');
+        $obj = new Directory($ldapManager, 'campusId');
+        $filter= '(|(sn=a\**)(givenname=a\**)(mail=a\**)(campusId=a\**))';
+        $ldapManager->shouldReceive('search')->with($filter)->andReturn(array(1,2));
+
+        $result = $obj->find(array('a*'));
         $this->assertSame($result, array(1,2));
     }
 
@@ -81,7 +95,7 @@ class DirectoryTest extends TestCase
         $obj = new Directory($ldapManager, 'campusId');
         $filter= '(one)(two)';
         $ldapManager->shouldReceive('search')->with($filter)->andReturn(array(1,2));
-        
+
         $result = $obj->findByLdapFilter($filter);
         $this->assertSame($result, array(1,2));
     }


### PR DESCRIPTION
fixes #1883 