### PR TITLE
Fix link to API docs

### DIFF
--- a/src/Ilios/CoreBundle/Resources/views/apiinfo.html.twig
+++ b/src/Ilios/CoreBundle/Resources/views/apiinfo.html.twig
@@ -1,2 +1,2 @@
 <h1>API Info</h1>
-<p>You can find documentation for the api at: <a href="{{ path('al_swagger_ui_home') }}">API Docs</a>
+<p>You can find documentation for the api at: <a href="{{ path('ilios_swagger_index') }}">API Docs</a>


### PR DESCRIPTION
We're no longer using the bundle for this, just our own route will do.