### PR TITLE
Send content type with swagger files

### DIFF
--- a/src/Ilios/ApiBundle/Controller/SwaggerDocsController.php
+++ b/src/Ilios/ApiBundle/Controller/SwaggerDocsController.php
@@ -4,6 +4,7 @@ namespace Ilios\ApiBundle\Controller;
 
 use Ilios\ApiBundle\Service\SwaggerDocBuilder;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -70,7 +71,15 @@ class SwaggerDocsController extends AbstractController
             throw new NotFoundHttpException("${fileName} can't be found");
         }
 
-        return new Response(file_get_contents($filePath));
+        $response = new BinaryFileResponse($filePath);
+        $info = pathinfo($filePath);
+        if ($info['extension'] === 'css') {
+            $response->headers->set('Content-Type', 'text/css');
+        }
+        if ($info['extension'] === 'js') {
+            $response->headers->set('Content-Type', 'text/javascript');
+        }
+        return $response;
     }
 
     /**

--- a/src/Ilios/ApiBundle/Resources/views/swagger/index.html.twig
+++ b/src/Ilios/ApiBundle/Resources/views/swagger/index.html.twig
@@ -11,15 +11,15 @@
   <style>
     html
     {
-        box-sizing: border-box;
-        overflow: -moz-scrollbars-vertical;
-        overflow-y: scroll;
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
     }
     *,
     *:before,
     *:after
     {
-        box-sizing: inherit;
+      box-sizing: inherit;
     }
 
     body {
@@ -34,7 +34,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
   <defs>
     <symbol viewBox="0 0 20 20" id="unlocked">
-          <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
+      <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
     </symbol>
 
     <symbol viewBox="0 0 20 20" id="locked">
@@ -84,7 +84,7 @@ window.onload = function() {
         SwaggerUIBundle.plugins.DownloadUrl
     ],
     layout: "StandaloneLayout",
-  })
+  });
 
   window.ui = ui
 }


### PR DESCRIPTION
Not sending text/css causes some browsers not to interpret the CSS and
leaves us with an ugly page.