### PR TITLE
Call services using their class name

### DIFF
--- a/src/Ilios/CoreBundle/EventListener/LogEntityChanges.php
+++ b/src/Ilios/CoreBundle/EventListener/LogEntityChanges.php
@@ -83,7 +83,7 @@ class LogEntityChanges
                 $updates[$entityClass]['changes'][] = 'Ref:' . $ref->getShortName();
             }
         }
-        $loggerQueue = $this->container->get('Ilios\CoreBundle\Service\LoggerQueue');
+        $loggerQueue = $this->container->get(LoggerQueue::class);
         foreach ($updates as $arr) {
             $valuesChanged = implode($arr['changes'], ',');
             $loggerQueue->add($arr['action'], $arr['entity'], $valuesChanged);

--- a/src/Ilios/WebBundle/Controller/ConfigController.php
+++ b/src/Ilios/WebBundle/Controller/ConfigController.php
@@ -2,6 +2,7 @@
 
 namespace Ilios\WebBundle\Controller;
 
+use Ilios\AuthenticationBundle\Service\CasManager;
 use Ilios\WebBundle\Service\WebIndexFromJson;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -25,7 +26,7 @@ class ConfigController extends Controller
             $configuration['loginUrl'] = $url . $loginPath;
         }
         if ($authenticationType === 'cas') {
-            $cas = $this->container->get('Ilios\AuthenticationBundle\Service\CasManager');
+            $cas = $this->container->get(CasManager::class);
 
             $configuration['casLoginUrl'] = $cas->getLoginUrl();
         }

--- a/tests/CoreBundle/Traits/JsonControllerTest.php
+++ b/tests/CoreBundle/Traits/JsonControllerTest.php
@@ -79,7 +79,7 @@ trait JsonControllerTest
             $container = $client->getContainer();
 
             /** @var JsonWebTokenManager $jwtManager **/
-            $jwtManager = $container->get('Ilios\AuthenticationBundle\Service\JsonWebTokenManager');
+            $jwtManager = $container->get(JsonWebTokenManager::class);
             $token = $jwtManager->createJwtFromUserId($userId);
 
             $tokens[$userId] = $token;

--- a/tests/IliosApiBundle/Endpoints/AcademicYearTest.php
+++ b/tests/IliosApiBundle/Endpoints/AcademicYearTest.php
@@ -3,6 +3,7 @@
 namespace Tests\IliosApiBundle\Endpoints;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\CoreBundle\DataLoader\CourseData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 
 /**
@@ -141,7 +142,7 @@ class AcademicYearTest extends AbstractEndpointTest
 
     protected function getYears()
     {
-        $loader = $this->container->get('Tests\CoreBundle\DataLoader\CourseData');
+        $loader = $this->container->get(CourseData::class);
         $data = $loader->getAll();
         $academicYears = array_map(function ($arr) {
             return $arr['year'];

--- a/tests/IliosApiBundle/Endpoints/AuthenticationTest.php
+++ b/tests/IliosApiBundle/Endpoints/AuthenticationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\IliosApiBundle\Endpoints;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\CoreBundle\DataLoader\UserData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -72,7 +73,7 @@ class AuthenticationTest extends AbstractEndpointTest
 
     protected function createMany($count)
     {
-        $userDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\UserData');
+        $userDataLoader = $this->container->get(UserData::class);
         $users = $userDataLoader->createMany($count);
         $savedUsers = $this->postMany('users', 'users', $users);
 

--- a/tests/IliosApiBundle/Endpoints/CohortTest.php
+++ b/tests/IliosApiBundle/Endpoints/CohortTest.php
@@ -3,6 +3,7 @@
 namespace Tests\IliosApiBundle\Endpoints;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\CoreBundle\DataLoader\ProgramYearData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -206,7 +207,7 @@ class CohortTest extends AbstractEndpointTest
      */
     protected function getProgramYear($id)
     {
-        $programYearDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\ProgramYearData');
+        $programYearDataLoader = $this->container->get(ProgramYearData::class);
         $allProgramYears = $programYearDataLoader->getAll();
         $programYearsById = [];
         foreach ($allProgramYears as $arr) {

--- a/tests/IliosApiBundle/Endpoints/CourseTest.php
+++ b/tests/IliosApiBundle/Endpoints/CourseTest.php
@@ -3,6 +3,10 @@
 namespace Tests\IliosApiBundle\Endpoints;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\CoreBundle\DataLoader\IlmSessionData;
+use Tests\CoreBundle\DataLoader\OfferingData;
+use Tests\CoreBundle\DataLoader\SessionData;
+use Tests\CoreBundle\DataLoader\SessionDescriptionData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -246,14 +250,14 @@ class CourseTest extends AbstractEndpointTest
 
         $newSessions = $newCourse['sessions'];
         $this->assertEquals(count($newSessions), 2);
-        $sessions = $this->container->get('Tests\CoreBundle\DataLoader\SessionData')->getAll();
+        $sessions = $this->container->get(SessionData::class)->getAll();
         $lastSessionId = array_pop($sessions)['id'];
 
         $this->assertEquals($lastSessionId + 1, $newSessions[0], 'incremented session id 1');
         $this->assertEquals($lastSessionId + 2, $newSessions[1], 'incremented session id 2');
 
         $newSessionsData = $this->getFiltered('sessions', 'sessions', ['filters[id]' => $newSessions]);
-        $offerings = $this->container->get('Tests\CoreBundle\DataLoader\OfferingData')->getAll();
+        $offerings = $this->container->get(OfferingData::class)->getAll();
         $lastOfferingId = array_pop($offerings)['id'];
 
         $firstSessionOfferings = array_map('strval', [$lastOfferingId + 1, $lastOfferingId + 2]);
@@ -266,7 +270,7 @@ class CourseTest extends AbstractEndpointTest
             return $session['sessionDescription'];
         }, $newSessionsData);
         $this->assertEquals(count($newDescriptionIds), 2);
-        $descriptions = $this->container->get('Tests\CoreBundle\DataLoader\SessionDescriptionData')->getAll();
+        $descriptions = $this->container->get(SessionDescriptionData::class)->getAll();
         $lastDescriptionId = $descriptions[1]['id'];
 
         $this->assertEquals($lastDescriptionId + 1, $newDescriptionIds[0], 'incremented description id 1');
@@ -322,7 +326,7 @@ class CourseTest extends AbstractEndpointTest
         $this->assertSame(2030, $newCourse['year']);
         $newSessions = $newCourse['sessions'];
         $this->assertEquals(count($newSessions), 2);
-        $sessions = $this->container->get('Tests\CoreBundle\DataLoader\SessionData')->getAll();
+        $sessions = $this->container->get(SessionData::class)->getAll();
         $lastSessionId = array_pop($sessions)['id'];
 
         $this->assertEquals($lastSessionId + 1, $newSessions[0], 'incremented session id 1');
@@ -377,7 +381,7 @@ class CourseTest extends AbstractEndpointTest
         }, $newSessionsWithILMs);
         $newIlmIds = array_values($newIlmIds);
 
-        $ilms = $this->container->get('Tests\CoreBundle\DataLoader\IlmSessionData')->getAll();
+        $ilms = $this->container->get(IlmSessionData::class)->getAll();
         $lastIlmId = $ilms[key(array_slice($ilms, -1, 1, true))]['id'];
 
         $this->assertEquals($lastIlmId + 1, $newIlmIds[0], 'incremented ilm id 1');

--- a/tests/IliosApiBundle/Endpoints/CurriculumInventoryInstitutionTest.php
+++ b/tests/IliosApiBundle/Endpoints/CurriculumInventoryInstitutionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\IliosApiBundle\Endpoints;
 
+use Tests\CoreBundle\DataLoader\SchoolData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -86,7 +87,7 @@ class CurriculumInventoryInstitutionTest extends AbstractEndpointTest
             'This seems like too much of a pain to test this right now.'
         );
         $count = 26;
-        $schoolDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\SchoolData');
+        $schoolDataLoader = $this->container->get(SchoolData::class);
         $schools = $schoolDataLoader->createMany($count);
         $savedSchools = $this->postMany('schools', 'schools', $schools);
 

--- a/tests/IliosApiBundle/Endpoints/CurriculumInventorySequenceTest.php
+++ b/tests/IliosApiBundle/Endpoints/CurriculumInventorySequenceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\IliosApiBundle\Endpoints;
 
+use Tests\CoreBundle\DataLoader\CurriculumInventoryReportData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -70,7 +71,7 @@ class CurriculumInventorySequenceTest extends AbstractEndpointTest
     public function testPostMany()
     {
         $count = 4;
-        $reportDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\CurriculumInventoryReportData');
+        $reportDataLoader = $this->container->get(CurriculumInventoryReportData::class);
         $reports = $reportDataLoader->createMany($count);
         $savedReports = $this->postMany('curriculuminventoryreports', 'curriculumInventoryReports', $reports);
 

--- a/tests/IliosApiBundle/Endpoints/IlmSessionTest.php
+++ b/tests/IliosApiBundle/Endpoints/IlmSessionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\IliosApiBundle\Endpoints;
 
+use Tests\CoreBundle\DataLoader\SessionData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -79,7 +80,7 @@ class IlmSessionTest extends AbstractEndpointTest
     public function testPostMany()
     {
         $count = 51;
-        $sessionDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\SessionData');
+        $sessionDataLoader = $this->container->get(SessionData::class);
         $sessions = $sessionDataLoader->createMany($count);
         $savedSessions = $this->postMany('sessions', 'sessions', $sessions);
 

--- a/tests/IliosApiBundle/Endpoints/MeshPreviousIndexingTest.php
+++ b/tests/IliosApiBundle/Endpoints/MeshPreviousIndexingTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\IliosApiBundle\Endpoints;
 
+use Tests\CoreBundle\DataLoader\MeshDescriptorData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -71,7 +72,7 @@ class MeshPreviousIndexingTest extends AbstractEndpointTest
     public function testPostMany()
     {
         $count = 51;
-        $descriptorDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\MeshDescriptorData');
+        $descriptorDataLoader = $this->container->get(MeshDescriptorData::class);
         $descriptors = $descriptorDataLoader->createMany($count);
         $savedDescriptors = $this->postMany('meshdescriptors', 'meshDescriptors', $descriptors);
 

--- a/tests/IliosApiBundle/Endpoints/ObjectiveTest.php
+++ b/tests/IliosApiBundle/Endpoints/ObjectiveTest.php
@@ -3,6 +3,7 @@
 namespace Tests\IliosApiBundle\Endpoints;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\CoreBundle\DataLoader\ObjectiveData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -124,7 +125,7 @@ class ObjectiveTest extends AbstractEndpointTest
      */
     public function testInputSanitation($input, $output)
     {
-        $postData = $this->container->get('Tests\CoreBundle\DataLoader\ObjectiveData')
+        $postData = $this->container->get(ObjectiveData::class)
             ->create();
         $postData['title'] = $input;
         unset($postData['id']);
@@ -172,7 +173,7 @@ class ObjectiveTest extends AbstractEndpointTest
      */
     public function testInputSanitationFailure()
     {
-        $postData = $this->container->get('Tests\CoreBundle\DataLoader\ObjectiveData')
+        $postData = $this->container->get(ObjectiveData::class)
             ->create();
         // this markup will get stripped out, leaving a blank string as input.
         // which in turn will cause the form validation to fail.

--- a/tests/IliosApiBundle/Endpoints/OfferingTest.php
+++ b/tests/IliosApiBundle/Endpoints/OfferingTest.php
@@ -3,6 +3,8 @@
 namespace Tests\IliosApiBundle\Endpoints;
 
 use Ilios\CoreBundle\Entity\AlertChangeTypeInterface;
+use Tests\CoreBundle\DataLoader\InstructorGroupData;
+use Tests\CoreBundle\DataLoader\LearnerGroupData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -208,7 +210,7 @@ class OfferingTest extends AbstractEndpointTest
 
     public function testUpdatingLearnerGroupUpdatesOfferingStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\LearnerGroupData');
+        $dataLoader = $this->container->get(LearnerGroupData::class);
         $data = $dataLoader->getOne();
         $data['title'] = $this->getFaker()->text(20);
         $this->relatedTimeStampUpdateTest($data['offerings'][0], 'learnergroups', 'learnerGroup', $data);
@@ -216,7 +218,7 @@ class OfferingTest extends AbstractEndpointTest
 
     public function testUpdatingInstructorGroupUpdatesOfferingStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\InstructorGroupData');
+        $dataLoader = $this->container->get(InstructorGroupData::class);
         $data = $dataLoader->getOne();
         $data['title'] = $this->getFaker()->text(20);
         $this->relatedTimeStampUpdateTest($data['offerings'][0], 'instructorgroups', 'instructorGroup', $data);

--- a/tests/IliosApiBundle/Endpoints/PermissionTest.php
+++ b/tests/IliosApiBundle/Endpoints/PermissionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\IliosApiBundle\Endpoints;
 
+use Tests\CoreBundle\DataLoader\UserData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -74,7 +75,7 @@ class PermissionTest extends AbstractEndpointTest
 
     public function testPostMany()
     {
-        $userDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\UserData');
+        $userDataLoader = $this->container->get(UserData::class);
         $users = $userDataLoader->createMany(51);
         $savedUsers = $this->postMany('users', 'users', $users);
 

--- a/tests/IliosApiBundle/Endpoints/ProgramYearStewardTest.php
+++ b/tests/IliosApiBundle/Endpoints/ProgramYearStewardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\IliosApiBundle\Endpoints;
 
+use Tests\CoreBundle\DataLoader\DepartmentData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -70,7 +71,7 @@ class ProgramYearStewardTest extends AbstractEndpointTest
      */
     public function testPostMany()
     {
-        $departmentDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\DepartmentData');
+        $departmentDataLoader = $this->container->get(DepartmentData::class);
         $departments = $departmentDataLoader->createMany(51);
         $savedDepartments = $this->postMany('departments', 'departments', $departments);
 

--- a/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
+++ b/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
@@ -4,6 +4,10 @@ namespace Tests\IliosApiBundle\Endpoints;
 
 use Ilios\CoreBundle\Entity\OfferingInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\CoreBundle\DataLoader\CourseData;
+use Tests\CoreBundle\DataLoader\IlmSessionData;
+use Tests\CoreBundle\DataLoader\OfferingData;
+use Tests\CoreBundle\DataLoader\SchoolData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use DateTime;
 
@@ -27,10 +31,10 @@ class SchooleventsTest extends AbstractEndpointTest
 
     public function testGetEvents()
     {
-        $school = $this->container->get('Tests\CoreBundle\DataLoader\SchoolData')->getOne();
-        $offerings = $this->container->get('Tests\CoreBundle\DataLoader\OfferingData')->getAll();
-        $ilmSessions = $this->container->get('Tests\CoreBundle\DataLoader\IlmSessionData')->getAll();
-        $courses = $this->container->get('Tests\CoreBundle\DataLoader\CourseData')->getAll();
+        $school = $this->container->get(SchoolData::class)->getOne();
+        $offerings = $this->container->get(OfferingData::class)->getAll();
+        $ilmSessions = $this->container->get(IlmSessionData::class)->getAll();
+        $courses = $this->container->get(CourseData::class)->getAll();
 
         $events = $this->getEvents($school['id'], 0, 100000000000);
 
@@ -140,8 +144,8 @@ class SchooleventsTest extends AbstractEndpointTest
 
     public function testMultidayEvent()
     {
-        $school = $this->container->get('Tests\CoreBundle\DataLoader\SchoolData')->getOne();
-        $offerings = $this->container->get('Tests\CoreBundle\DataLoader\OfferingData')->getAll();
+        $school = $this->container->get(SchoolData::class)->getOne();
+        $offerings = $this->container->get(OfferingData::class)->getAll();
         $from = new DateTime('2015-01-30 00:00:00');
         $to = new DateTime('2015-01-30 23:59:59');
 

--- a/tests/IliosApiBundle/Endpoints/SessionDescriptionTest.php
+++ b/tests/IliosApiBundle/Endpoints/SessionDescriptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\IliosApiBundle\Endpoints;
 
+use Tests\CoreBundle\DataLoader\SessionData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -69,7 +70,7 @@ class SessionDescriptionTest extends AbstractEndpointTest
     public function testPostMany()
     {
         $count = 51;
-        $sessionDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\SessionData');
+        $sessionDataLoader = $this->container->get(SessionData::class);
         $sessions = $sessionDataLoader->createMany($count);
         $savedSessions = $this->postMany('sessions', 'sessions', $sessions);
 

--- a/tests/IliosApiBundle/Endpoints/SessionTest.php
+++ b/tests/IliosApiBundle/Endpoints/SessionTest.php
@@ -2,6 +2,10 @@
 
 namespace Tests\IliosApiBundle\Endpoints;
 
+use Tests\CoreBundle\DataLoader\IlmSessionData;
+use Tests\CoreBundle\DataLoader\LearningMaterialData;
+use Tests\CoreBundle\DataLoader\SessionDescriptionData;
+use Tests\CoreBundle\DataLoader\SessionLearningMaterialData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -134,7 +138,7 @@ class SessionTest extends AbstractEndpointTest
 
     public function testUpdatingIlmUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\IlmSessionData');
+        $dataLoader = $this->container->get(IlmSessionData::class);
         $data = $dataLoader->getOne();
         $data['instructors'] = ["1", "2"];
         $this->relatedTimeStampUpdateTest($data['session'], 'ilmsessions', 'ilmSession', $data);
@@ -142,7 +146,7 @@ class SessionTest extends AbstractEndpointTest
 
     public function testUpdatingIlmInstructorUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\IlmSessionData');
+        $dataLoader = $this->container->get(IlmSessionData::class);
         $data = $dataLoader->getOne();
         $data['instructors'] = ["1", "2"];
         $this->relatedTimeStampUpdateTest($data['session'], 'ilmsessions', 'ilmSession', $data);
@@ -150,7 +154,7 @@ class SessionTest extends AbstractEndpointTest
 
     public function testUpdatingIlmInstructorGroupsUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\IlmSessionData');
+        $dataLoader = $this->container->get(IlmSessionData::class);
         $data = $dataLoader->getOne();
         $data['instructorGroups'] = ["1", "2"];
         $this->relatedTimeStampUpdateTest($data['session'], 'ilmsessions', 'ilmSession', $data);
@@ -158,7 +162,7 @@ class SessionTest extends AbstractEndpointTest
 
     public function testUpdatingIlmLearnerGroupsUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\IlmSessionData');
+        $dataLoader = $this->container->get(IlmSessionData::class);
         $data = $dataLoader->getOne();
         $data['learnerGroups'] = ["1", "2"];
         $this->relatedTimeStampUpdateTest($data['session'], 'ilmsessions', 'ilmSession', $data);
@@ -166,7 +170,7 @@ class SessionTest extends AbstractEndpointTest
 
     public function testUpdatingIlmLearnersUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\IlmSessionData');
+        $dataLoader = $this->container->get(IlmSessionData::class);
         $data = $dataLoader->getOne();
         $data['learners'] = ["1", "2"];
         $this->relatedTimeStampUpdateTest($data['session'], 'ilmsessions', 'ilmSession', $data);
@@ -174,7 +178,7 @@ class SessionTest extends AbstractEndpointTest
 
     public function testUpdatingLearningMaterialUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\LearningMaterialData');
+        $dataLoader = $this->container->get(LearningMaterialData::class);
         $data = $dataLoader->getOne();
         $data['status'] = '1';
         $this->relatedTimeStampUpdateTest(1, 'learningmaterials', 'learningMaterial', $data);
@@ -182,14 +186,14 @@ class SessionTest extends AbstractEndpointTest
 
     public function testNewSessionLearningMaterialUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\SessionLearningMaterialData');
+        $dataLoader = $this->container->get(SessionLearningMaterialData::class);
         $data = $dataLoader->create();
         $this->relatedTimeStampPostTest(1, 'sessionlearningmaterials', 'sessionLearningMaterials', $data);
     }
 
     public function testUpdatingSessionLearningMaterialUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\SessionLearningMaterialData');
+        $dataLoader = $this->container->get(SessionLearningMaterialData::class);
         $data = $dataLoader->getOne();
         $data['required'] = !$data['required'];
         $this->relatedTimeStampUpdateTest(1, 'sessionlearningmaterials', 'sessionLearningMaterial', $data);
@@ -197,21 +201,21 @@ class SessionTest extends AbstractEndpointTest
 
     public function testDeletingSessionLearningMaterialUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\SessionLearningMaterialData');
+        $dataLoader = $this->container->get(SessionLearningMaterialData::class);
         $data = $dataLoader->getOne();
         $this->relatedTimeStampDeleteTest(1, 'sessionlearningmaterials', $data['id']);
     }
 
     public function testDeletingSessionDescriptionUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\SessionDescriptionData');
+        $dataLoader = $this->container->get(SessionDescriptionData::class);
         $data = $dataLoader->getOne();
         $this->relatedTimeStampDeleteTest($data['session'], 'sessiondescriptions', $data['id']);
     }
 
     public function testUpdatingSessionDescriptionUpdatesSessionStamp()
     {
-        $dataLoader = $this->container->get('Tests\CoreBundle\DataLoader\SessionDescriptionData');
+        $dataLoader = $this->container->get(SessionDescriptionData::class);
         $data = $dataLoader->getOne();
         $data['description'] = 'new description';
         $this->relatedTimeStampUpdateTest($data['session'], 'sessiondescriptions', 'sessionDescription', $data);

--- a/tests/IliosApiBundle/Endpoints/SessionTypeTest.php
+++ b/tests/IliosApiBundle/Endpoints/SessionTypeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\IliosApiBundle\Endpoints;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\CoreBundle\DataLoader\SessionData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -115,7 +116,7 @@ class SessionTypeTest extends AbstractEndpointTest
     public function testPostMany()
     {
         $count = 51;
-        $sessionDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\SessionData');
+        $sessionDataLoader = $this->container->get(SessionData::class);
         $sessions = $sessionDataLoader->createMany($count);
         $savedSessions = $this->postMany('sessions', 'sessions', $sessions);
 

--- a/tests/IliosApiBundle/Endpoints/UserTest.php
+++ b/tests/IliosApiBundle/Endpoints/UserTest.php
@@ -3,6 +3,7 @@
 namespace Tests\IliosApiBundle\Endpoints;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\CoreBundle\DataLoader\PermissionData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use Tests\IliosApiBundle\EndpointTestsTrait;
 
@@ -477,7 +478,7 @@ class UserTest extends AbstractEndpointTest
 
         $newUserSchool = 2;
 
-        $permissionDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\PermissionData');
+        $permissionDataLoader = $this->container->get(PermissionData::class);
         $permission = $permissionDataLoader->create();
         $permission['user'] = $user['id'];
         $permission['canRead'] = true;
@@ -518,7 +519,7 @@ class UserTest extends AbstractEndpointTest
             $user['roles'],
             'User #1 should be a developer or this test is garbage'
         );
-        $permissionDataLoader = $this->container->get('Tests\CoreBundle\DataLoader\PermissionData');
+        $permissionDataLoader = $this->container->get(PermissionData::class);
         $permission = $permissionDataLoader->create();
         $permission['user'] = $user['id'];
         $permission['canRead'] = true;

--- a/tests/IliosApiBundle/Endpoints/UsereventTest.php
+++ b/tests/IliosApiBundle/Endpoints/UsereventTest.php
@@ -4,6 +4,12 @@ namespace Tests\IliosApiBundle\Endpoints;
 
 use Ilios\CoreBundle\Entity\OfferingInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\CoreBundle\DataLoader\CourseData;
+use Tests\CoreBundle\DataLoader\IlmSessionData;
+use Tests\CoreBundle\DataLoader\LearningMaterialData;
+use Tests\CoreBundle\DataLoader\OfferingData;
+use Tests\CoreBundle\DataLoader\SessionDescriptionData;
+use Tests\CoreBundle\DataLoader\SessionTypeData;
 use Tests\IliosApiBundle\AbstractEndpointTest;
 use DateTime;
 
@@ -32,12 +38,12 @@ class UsereventTest extends AbstractEndpointTest
 
     public function testGetEvents()
     {
-        $offerings = $this->container->get('Tests\CoreBundle\DataLoader\OfferingData')->getAll();
-        $sessionTypes = $this->container->get('Tests\CoreBundle\DataLoader\SessionTypeData')->getAll();
-        $learningMaterials = $this->container->get('Tests\CoreBundle\DataLoader\LearningMaterialData')->getAll();
-        $sessionDescriptions = $this->container->get('Tests\CoreBundle\DataLoader\SessionDescriptionData')->getAll();
-        $ilmSessions = $this->container->get('Tests\CoreBundle\DataLoader\IlmSessionData')->getAll();
-        $courses = $this->container->get('Tests\CoreBundle\DataLoader\CourseData')->getAll();
+        $offerings = $this->container->get(OfferingData::class)->getAll();
+        $sessionTypes = $this->container->get(SessionTypeData::class)->getAll();
+        $learningMaterials = $this->container->get(LearningMaterialData::class)->getAll();
+        $sessionDescriptions = $this->container->get(SessionDescriptionData::class)->getAll();
+        $ilmSessions = $this->container->get(IlmSessionData::class)->getAll();
+        $courses = $this->container->get(CourseData::class)->getAll();
 
         $userId = 2;
 
@@ -473,7 +479,7 @@ class UsereventTest extends AbstractEndpointTest
 
     public function testMultidayEvent()
     {
-        $offerings = $this->container->get('Tests\CoreBundle\DataLoader\OfferingData')->getAll();
+        $offerings = $this->container->get(OfferingData::class)->getAll();
         $userId = 2;
         $from = new DateTime('2015-01-30 00:00:00');
         $to = new DateTime('2015-01-30 23:59:59');


### PR DESCRIPTION
This removes any possibility of confusion over what service is being
loaded and makes refactoring much simpler since bad definitions will be
called out in static import analysis and not just when running the code.