### PR TITLE
Fix bad mimetypes in learning materials

### DIFF
--- a/src/Ilios/CliBundle/Command/FixLearningMaterialMimeTypesCommand.php
+++ b/src/Ilios/CliBundle/Command/FixLearningMaterialMimeTypesCommand.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Ilios\CliBundle\Command;
+
+use Ilios\CoreBundle\Entity\LearningMaterialInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+use Ilios\CoreBundle\Entity\Manager\LearningMaterialManager;
+use Ilios\CoreBundle\Service\IliosFileSystem;
+use Symfony\Component\Debug\Exception\ContextErrorException;
+
+/**
+ * Cleanup incorrectly stored mime types for learning materials.
+ */
+class FixLearningMaterialMimeTypesCommand extends Command
+{
+    /**
+     * @var IliosFileSystem
+     */
+    protected $iliosFileSystem;
+    
+    /**
+     * @var LearningMaterialManager
+     */
+    protected $learningMaterialManager;
+    
+    public function __construct(
+        IliosFileSystem $iliosFileSystem,
+        LearningMaterialManager $learningMaterialManager
+    ) {
+        $this->iliosFileSystem = $iliosFileSystem;
+        $this->learningMaterialManager = $learningMaterialManager;
+        
+        parent::__construct();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:maintenance:fix-mime-types')
+            ->setDescription('Cleanup incorrectly stored mime types for learning materials.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $totalLearningMaterialsCount = $this->learningMaterialManager->getTotalLearningMaterialCount();
+
+        $helper = $this->getHelper('question');
+        $output->writeln('');
+        $question = new ConfirmationQuestion(
+            '<question>Ready to fix ' . $totalLearningMaterialsCount .
+            ' learning materials. Shall we continue? </question>' . "\n",
+            true
+        );
+        
+        if ($helper->ask($input, $output, $question)) {
+            $progress = new ProgressBar($output, $totalLearningMaterialsCount);
+            $progress->setRedrawFrequency(208);
+            $output->writeln("<info>Starting cleanup of learning materials...</info>");
+            $progress->start();
+
+            $fixed = 0;
+            $skipped = 0;
+            $offset = 0;
+            $limit = 50;
+            $errors = [];
+
+            while ($fixed + $skipped < $totalLearningMaterialsCount) {
+                /** @var LearningMaterialInterface[] $learningMaterials */
+                $learningMaterials = $this->learningMaterialManager->findBy([], ['id' => 'desc'], $limit, $offset);
+                foreach ($learningMaterials as $lm) {
+                    $mimetype = $lm->getMimetype();
+                    if ($path = $lm->getRelativePath()) {
+                        if (in_array($mimetype, ['link', 'citation'])) {
+                            $file = $this->iliosFileSystem->getFile($path);
+                            if (false === $file) {
+                                $errors[] = 'File not found for learning material # ' . $lm->getId();
+                                $skipped++;
+                            } else {
+                                try {
+                                    $newMimeType = $file->getMimeType();
+                                } catch (\ErrorException $e) {
+                                    $fileName = $lm->getFilename();
+                                    $newMimeType = $this->getMimetypeForFileName($fileName);
+                                }
+                                $lm->setMimetype($newMimeType);
+                                $this->learningMaterialManager->update($lm, false);
+                                $fixed++;
+                            }
+                        } else {
+                            $skipped++;
+                        }
+                    } elseif (null !== $lm->getCitation()) {
+                        if ($mimetype != 'citation') {
+                            $lm->setMimetype('citation');
+                            $this->learningMaterialManager->update($lm, false);
+                            $fixed++;
+                        } else {
+                            $skipped++;
+                        }
+                    } elseif (null !== $lm->getLink()) {
+                        if ($mimetype != 'link') {
+                            $lm->setMimetype('link');
+                            $this->learningMaterialManager->update($lm, false);
+                            $fixed++;
+                        } else {
+                            $skipped++;
+                        }
+                    } else {
+                        $skipped++;
+                    }
+                    $progress->advance();
+                }
+                $this->learningMaterialManager->flushAndClear();
+                $offset += $limit;
+            }
+
+            $progress->finish();
+            $output->writeln('');
+            
+            $output->writeln("<info>Updated mimetypes for {$fixed} learning materials successfully!</info>");
+            if ($skipped) {
+                $msg = "<comment>{$skipped} learning materials did not need to be fixed.</comment>";
+                $output->writeln($msg);
+            }
+            if (count($errors)) {
+                foreach ($errors as $message) {
+                    $output->writeln("<error>${message}</error>");
+                }
+            }
+        } else {
+            $output->writeln('<comment>Update canceled.</comment>');
+        }
+    }
+
+    protected function getMimetypeForFileName($name)
+    {
+        //taken from https://stackoverflow.com/questions/35299457/getting-mime-type-from-file-name-in-php
+        $typesByExtension = [
+            'txt' => 'text/plain',
+            'htm' => 'text/html',
+            'html' => 'text/html',
+            'php' => 'text/html',
+            'css' => 'text/css',
+            'js' => 'application/javascript',
+            'json' => 'application/json',
+            'xml' => 'application/xml',
+            'swf' => 'application/x-shockwave-flash',
+            'flv' => 'video/x-flv',
+            'png' => 'image/png',
+            'jpe' => 'image/jpeg',
+            'jpeg' => 'image/jpeg',
+            'jpg' => 'image/jpeg',
+            'gif' => 'image/gif',
+            'bmp' => 'image/bmp',
+            'ico' => 'image/vnd.microsoft.icon',
+            'tiff' => 'image/tiff',
+            'tif' => 'image/tiff',
+            'svg' => 'image/svg+xml',
+            'svgz' => 'image/svg+xml',
+            'zip' => 'application/zip',
+            'rar' => 'application/x-rar-compressed',
+            'exe' => 'application/x-msdownload',
+            'msi' => 'application/x-msdownload',
+            'cab' => 'application/vnd.ms-cab-compressed',
+            'mp3' => 'audio/mpeg',
+            'qt' => 'video/quicktime',
+            'mov' => 'video/quicktime',
+            'pdf' => 'application/pdf',
+            'psd' => 'image/vnd.adobe.photoshop',
+            'ai' => 'application/postscript',
+            'eps' => 'application/postscript',
+            'ps' => 'application/postscript',
+            'doc' => 'application/msword',
+            'rtf' => 'application/rtf',
+            'xls' => 'application/vnd.ms-excel',
+            'ppt' => 'application/vnd.ms-powerpoint',
+            'docx' => 'application/msword',
+            'xlsx' => 'application/vnd.ms-excel',
+            'pptx' => 'application/vnd.ms-powerpoint',
+            'odt' => 'application/vnd.oasis.opendocument.text',
+            'ods' => 'application/vnd.oasis.opendocument.spreadsheet',
+        ];
+
+        $parts = explode('.', $name);
+        $extension = array_pop($parts);
+        if ($extension && array_key_exists($extension, $typesByExtension)) {
+            return $typesByExtension[$extension];
+        }
+
+        return 'application/octet-stream';
+    }
+}

--- a/src/Ilios/CliBundle/Command/MigrateIlios2LearningMaterialsCommand.php
+++ b/src/Ilios/CliBundle/Command/MigrateIlios2LearningMaterialsCommand.php
@@ -14,9 +14,9 @@ use Ilios\CoreBundle\Entity\Manager\LearningMaterialManager;
 use Ilios\CoreBundle\Service\IliosFileSystem;
 
 /**
- * Sync a user with their directory information
+ * Migrate Learning materials from Ilios2 location to Ilios3 location
  *
- * Class SyncUserCommand
+ * Class MigrateIlios2LearningMaterialsCommand
  */
 class MigrateIlios2LearningMaterialsCommand extends Command
 {

--- a/tests/CliBundle/Command/FixLearningMaterialMimeTypesCommandTest.php
+++ b/tests/CliBundle/Command/FixLearningMaterialMimeTypesCommandTest.php
@@ -1,0 +1,238 @@
+<?php
+namespace Tests\CliBundle\Command;
+
+use Ilios\CliBundle\Command\FixLearningMaterialMimeTypesCommand;
+use Ilios\CoreBundle\Entity\LearningMaterialInterface;
+use Ilios\CoreBundle\Entity\Manager\LearningMaterialManager;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Ilios\CoreBundle\Service\IliosFileSystem;
+use Symfony\Component\HttpFoundation\File\File;
+
+class FixLearningMaterialMimeTypesCommandTest extends TestCase
+{
+    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
+    const COMMAND_NAME = 'ilios:maintenance:fix-mime-types';
+    
+    protected $iliosFileSystem;
+    protected $learningMaterialManager;
+    protected $commandTester;
+
+    public function setUp()
+    {
+        $this->iliosFileSystem = m::mock(IliosFileSystem::class);
+        $this->learningMaterialManager = m::mock(LearningMaterialManager::class);
+
+        $command = new FixLearningMaterialMimeTypesCommand(
+            $this->iliosFileSystem,
+            $this->learningMaterialManager
+        );
+        $application = new Application();
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown()
+    {
+        unset($this->iliosFileSystem);
+        unset($this->learningMaterialManager);
+        unset($this->commandTester);
+    }
+    
+    public function testFixCitationType()
+    {
+        $this->learningMaterialManager->shouldReceive('getTotalLearningMaterialCount')
+            ->once()->andReturn(1);
+        $mockLm = m::mock(LearningMaterialInterface::class);
+        $mockLm->shouldReceive('getRelativePath')->once()->andReturn(null);
+        $mockLm->shouldReceive('getCitation')->once()->andReturn('MST3k The Return S1 E6');
+        $mockLm->shouldReceive('getMimetype')->once()->andReturn('link');
+        $mockLm->shouldReceive('setMimetype')->with('citation')->once();
+        $this->learningMaterialManager->shouldReceive('findBy')->with([], ['id' => 'desc'], 50, 0)
+            ->once()->andReturn([$mockLm]);
+        $this->learningMaterialManager->shouldReceive('update')->with($mockLm, false);
+        $this->learningMaterialManager->shouldReceive('flushAndClear')->once();
+
+        $this->commandTester->setInputs(['Yes']);
+        $this->commandTester->execute([
+            'command' => self::COMMAND_NAME
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Ready to fix 1 learning materials. Shall we continue?/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Updated mimetypes for 1 learning materials successfully!/',
+            $output
+        );
+    }
+
+    public function testFixBlankCitationType()
+    {
+        $this->learningMaterialManager->shouldReceive('getTotalLearningMaterialCount')
+            ->once()->andReturn(1);
+        $mockLm = m::mock(LearningMaterialInterface::class);
+        $mockLm->shouldReceive('getRelativePath')->once()->andReturn(null);
+        $mockLm->shouldReceive('getCitation')->once()->andReturn('');
+        $mockLm->shouldReceive('getMimetype')->once()->andReturn('link');
+        $mockLm->shouldReceive('setMimetype')->with('citation')->once();
+        $this->learningMaterialManager->shouldReceive('findBy')->with([], ['id' => 'desc'], 50, 0)
+            ->once()->andReturn([$mockLm]);
+        $this->learningMaterialManager->shouldReceive('update')->with($mockLm, false);
+        $this->learningMaterialManager->shouldReceive('flushAndClear')->once();
+
+        $this->commandTester->setInputs(['Yes']);
+        $this->commandTester->execute([
+            'command' => self::COMMAND_NAME
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Ready to fix 1 learning materials. Shall we continue?/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Updated mimetypes for 1 learning materials successfully!/',
+            $output
+        );
+    }
+
+    public function testFixLinkType()
+    {
+        $this->learningMaterialManager->shouldReceive('getTotalLearningMaterialCount')
+            ->once()->andReturn(1);
+        $mockLm = m::mock(LearningMaterialInterface::class);
+        $mockLm->shouldReceive('getRelativePath')->once()->andReturn(null);
+        $mockLm->shouldReceive('getCitation')->once()->andReturn(null);
+        $mockLm->shouldReceive('getLink')->once()->andReturn('https://example.com');
+        $mockLm->shouldReceive('getMimetype')->once()->andReturn('citation');
+        $mockLm->shouldReceive('setMimetype')->with('link')->once();
+        $this->learningMaterialManager->shouldReceive('findBy')->with([], ['id' => 'desc'], 50, 0)
+            ->once()->andReturn([$mockLm]);
+        $this->learningMaterialManager->shouldReceive('update')->with($mockLm, false);
+        $this->learningMaterialManager->shouldReceive('flushAndClear')->once();
+
+        $this->commandTester->setInputs(['Yes']);
+        $this->commandTester->execute([
+            'command' => self::COMMAND_NAME
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Ready to fix 1 learning materials. Shall we continue?/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Updated mimetypes for 1 learning materials successfully!/',
+            $output
+        );
+    }
+
+    public function testFixBlankLinkType()
+    {
+        $this->learningMaterialManager->shouldReceive('getTotalLearningMaterialCount')
+            ->once()->andReturn(1);
+        $mockLm = m::mock(LearningMaterialInterface::class);
+        $mockLm->shouldReceive('getRelativePath')->once()->andReturn(null);
+        $mockLm->shouldReceive('getCitation')->once()->andReturn(null);
+        $mockLm->shouldReceive('getLink')->once()->andReturn('');
+        $mockLm->shouldReceive('getMimetype')->once()->andReturn('citation');
+        $mockLm->shouldReceive('setMimetype')->with('link')->once();
+        $this->learningMaterialManager->shouldReceive('findBy')->with([], ['id' => 'desc'], 50, 0)
+            ->once()->andReturn([$mockLm]);
+        $this->learningMaterialManager->shouldReceive('update')->with($mockLm, false);
+        $this->learningMaterialManager->shouldReceive('flushAndClear')->once();
+
+        $this->commandTester->setInputs(['Yes']);
+        $this->commandTester->execute([
+            'command' => self::COMMAND_NAME
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Ready to fix 1 learning materials. Shall we continue?/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Updated mimetypes for 1 learning materials successfully!/',
+            $output
+        );
+    }
+
+    public function testFixFileType()
+    {
+        $this->learningMaterialManager->shouldReceive('getTotalLearningMaterialCount')
+            ->once()->andReturn(1);
+        $mockLm = m::mock(LearningMaterialInterface::class);
+        $mockLm->shouldReceive('getRelativePath')->once()->andReturn('/tmp/somewhere');
+        $mockLm->shouldReceive('getMimetype')->once()->andReturn('citation');
+        $mockLm->shouldReceive('setMimetype')->with('pdf-type-file')->once();
+
+        $mockFile = m::mock(File::class)->shouldReceive('getMimeType')->once()->andReturn('pdf-type-file')->mock();
+        $this->iliosFileSystem->shouldReceive('getFile')->once()->with('/tmp/somewhere')->andReturn($mockFile);
+
+        $this->learningMaterialManager->shouldReceive('findBy')->with([], ['id' => 'desc'], 50, 0)
+            ->once()->andReturn([$mockLm]);
+        $this->learningMaterialManager->shouldReceive('update')->with($mockLm, false);
+        $this->learningMaterialManager->shouldReceive('flushAndClear')->once();
+
+        $this->commandTester->setInputs(['Yes']);
+        $this->commandTester->execute([
+            'command' => self::COMMAND_NAME
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Ready to fix 1 learning materials. Shall we continue?/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Updated mimetypes for 1 learning materials successfully!/',
+            $output
+        );
+    }
+
+    public function testFixFileWithUndetectableTypeType()
+    {
+        $this->learningMaterialManager->shouldReceive('getTotalLearningMaterialCount')
+            ->once()->andReturn(1);
+        $mockLm = m::mock(LearningMaterialInterface::class);
+        $mockLm->shouldReceive('getRelativePath')->once()->andReturn('/tmp/somewhere');
+        $mockLm->shouldReceive('getMimetype')->once()->andReturn('citation');
+        $mockLm->shouldReceive('setMimetype')->with('application/pdf')->once();
+        $mockLm->shouldReceive('getFilename')->once()->andReturn('test.pdf');
+
+
+        $mockFile = m::mock(File::class)->shouldReceive('getMimeType')
+            ->once()->andThrow(\ErrorException::class)->mock();
+        $this->iliosFileSystem->shouldReceive('getFile')->once()->with('/tmp/somewhere')->andReturn($mockFile);
+
+        $this->learningMaterialManager->shouldReceive('findBy')->with([], ['id' => 'desc'], 50, 0)
+            ->once()->andReturn([$mockLm]);
+        $this->learningMaterialManager->shouldReceive('update')->with($mockLm, false);
+        $this->learningMaterialManager->shouldReceive('flushAndClear')->once();
+
+        $this->commandTester->setInputs(['Yes']);
+        $this->commandTester->execute([
+            'command' => self::COMMAND_NAME
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Ready to fix 1 learning materials. Shall we continue?/',
+            $output
+        );
+        $this->assertRegExp(
+            '/Updated mimetypes for 1 learning materials successfully!/',
+            $output
+        );
+    }
+}


### PR DESCRIPTION
We were incorrectly storing some learning materials mimetypes to
link or citation, but that can be fixed.
This command looks through all learning materials to find
ones with a problem and fixes them. First we try and detect the type
from the file itself then we fallback to using the extension on the
filename.

Fixes #1897 