### PR TITLE
Remove default limit of 20 on API endpoints

### DIFF
--- a/src/Ilios/ApiBundle/Controller/ApiController.php
+++ b/src/Ilios/ApiBundle/Controller/ApiController.php
@@ -411,7 +411,7 @@ class ApiController extends Controller implements ApiControllerInterface
     {
         $parameters = [
             'offset' => $request->query->get('offset'),
-            'limit' => !is_null($request->query->get('limit')) ? $request->query->get('limit') : 20,
+            'limit' => $request->query->get('limit'),
             'orderBy' => $request->query->get('order_by'),
             'criteria' => []
         ];

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/aamcmethod.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/aamcmethod.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/aamcpcrs.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/aamcpcrs.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/aamcresourcetype.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/aamcresourcetype.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/alert.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/alert.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/alertchangetype.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/alertchangetype.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/applicationconfig.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/applicationconfig.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/assessmentoption.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/assessmentoption.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/authentication.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/authentication.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/cohort.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/cohort.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/competency.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/competency.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/course.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/course.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/courseclerkshiptype.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/courseclerkshiptype.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/courselearningmaterial.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/courselearningmaterial.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventoryacademiclevel.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventoryacademiclevel.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventoryinstitution.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventoryinstitution.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventoryreport.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventoryreport.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventorysequence.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventorysequence.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventorysequenceblock.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/curriculuminventorysequenceblock.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/department.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/department.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/ilmsession.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/ilmsession.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/ingestionexception.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/ingestionexception.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/instructorgroup.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/instructorgroup.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/learnergroup.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/learnergroup.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/learningmaterial.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/learningmaterial.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/learningmaterialstatus.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/learningmaterialstatus.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/learningmaterialuserrole.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/learningmaterialuserrole.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/meshconcept.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/meshconcept.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/meshdescriptor.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/meshdescriptor.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/meshpreviousindexing.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/meshpreviousindexing.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/meshqualifier.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/meshqualifier.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/meshsemantictype.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/meshsemantictype.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/meshterm.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/meshterm.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/meshtree.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/meshtree.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/objective.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/objective.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/offering.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/offering.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/pendinguserupdate.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/pendinguserupdate.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/permission.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/permission.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/program.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/program.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/programyear.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/programyear.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/programyearsteward.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/programyearsteward.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/report.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/report.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/school.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/school.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/schoolconfig.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/schoolconfig.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/session.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/session.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/sessiondescription.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/sessiondescription.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/sessionlearningmaterial.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/sessionlearningmaterial.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/sessiontype.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/sessiontype.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/term.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/term.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/user.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/user.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/usermadereminder.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/usermadereminder.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/userrole.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/userrole.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC

--- a/src/Ilios/ApiBundle/Resources/swagger/paths/vocabulary.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/paths/vocabulary.yml
@@ -18,7 +18,6 @@
         description: Limit Results
         required: false
         type: integer
-        default: 20
       - name: order_by
         in: query
         description: Order by fields.  Must by an array ie. &order_by[name]=ASC&order_by[description]=DESC


### PR DESCRIPTION
This defaults all API endpoints to return the full set of values
requested unless a limit is explicitly sent.

Fixes #1909