### PR TITLE
Longer timeout for network requests

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -148,7 +148,7 @@ httplug:
             plugins: ['httplug.plugin.logger']
             config:
                 verify: true
-                timeout: 2
+                timeout: 10
 
 happyr_google_analytics:
     tracking_id: '%ilios_core.tracking_code%'


### PR DESCRIPTION
Not sure why this was at 2 seconds, that isn't a lot of time. This gives
us 10 instead for things like updating the frontend.