### PR TITLE
Bump the API to v1.23

### DIFF
--- a/src/Ilios/WebBundle/Service/WebIndexFromJson.php
+++ b/src/Ilios/WebBundle/Service/WebIndexFromJson.php
@@ -11,7 +11,7 @@ class WebIndexFromJson
      * @var string
      */
     const DEFAULT_TEMPLATE_NAME = 'webindex.html.twig';
-    const API_VERSION = 'v1.22';
+    const API_VERSION = 'v1.23';
     const AWS_BUCKET = 'https://s3-us-west-2.amazonaws.com/frontend-json-config/';
 
     const PRODUCTION = 'prod';


### PR DESCRIPTION
Ensures that Version20170818144244 migration is run before the frontend
starts looking for the `active` flag on session types.