### PR TITLE
Allow group parents to be removed

### DIFF
--- a/src/Ilios/CoreBundle/Entity/LearnerGroup.php
+++ b/src/Ilios/CoreBundle/Entity/LearnerGroup.php
@@ -265,7 +265,7 @@ class LearnerGroup implements LearnerGroupInterface
     /**
      * @param LearnerGroupInterface $parent
      */
-    public function setParent(LearnerGroupInterface $parent)
+    public function setParent(LearnerGroupInterface $parent = null)
     {
         $this->parent = $parent;
     }

--- a/src/Ilios/CoreBundle/Entity/LearnerGroupInterface.php
+++ b/src/Ilios/CoreBundle/Entity/LearnerGroupInterface.php
@@ -51,7 +51,7 @@ interface LearnerGroupInterface extends
     /**
      * @param LearnerGroupInterface $parent
      */
-    public function setParent(LearnerGroupInterface $parent);
+    public function setParent(LearnerGroupInterface $parent = null);
 
     /**
      * @return LearnerGroupInterface

--- a/tests/IliosApiBundle/Endpoints/LearnerGroupTest.php
+++ b/tests/IliosApiBundle/Endpoints/LearnerGroupTest.php
@@ -42,6 +42,7 @@ class LearnerGroupTest extends AbstractEndpointTest
             'location' => ['location', $this->getFaker()->text(100)],
             'cohort' => ['cohort', 3],
             'parent' => ['parent', 2],
+            'removeParent' => ['parent', null],
             'children' => ['children', [1], $skipped = true],
             'ilmSessions' => ['ilmSessions', [2]],
             'offerings' => ['offerings', [2]],


### PR DESCRIPTION
This is already working through a workaround we have in the serializer,
this just removes the error from the logs.

Refs #1878