### PR TITLE
Redirect users instead of sending a 500 error when shib is dumb

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
@@ -107,8 +107,13 @@ class ShibbolethAuthentication implements AuthenticationInterface
             $logVars['HTTP_REFERER'] = $request->server->get('HTTP_REFERER');
             $logVars['REMOTE_ADDR'] = $request->server->get('REMOTE_ADDR');
 
-            $this->logger->error($msg, ['server variables' => var_export($logVars, true)]);
-            throw new \Exception($msg);
+            $this->logger->info($msg, ['server variables' => var_export($logVars, true)]);
+
+            return new JsonResponse([
+                'status' => 'redirect',
+                'errors' => [],
+                'jwt' => null,
+            ], JsonResponse::HTTP_OK);
         }
         /* @var \Ilios\CoreBundle\Entity\AuthenticationInterface $authEntity */
         $authEntity = $this->authManager->findOneBy(['username' => $userId]);

--- a/tests/AuthenticationBundle/Service/ShibbolethAuthenticationTest.php
+++ b/tests/AuthenticationBundle/Service/ShibbolethAuthenticationTest.php
@@ -89,9 +89,14 @@ class ShibbolethAuthenticationTest extends TestCase
             ->mock();
         $request = m::mock(Request::class);
         $request->server = $serverBag;
-        $this->logger->shouldReceive('error')->once();
-        $this->expectException(\Exception::class);
-        $this->obj->login($request);
+        $this->logger->shouldReceive('info')->once();
+
+        $result = $this->obj->login($request);
+
+        $this->assertTrue($result instanceof JsonResponse);
+        $content = $result->getContent();
+        $data = json_decode($content);
+        $this->assertSame($data->status, 'redirect');
     }
     
     public function testNoUserWithEppn()


### PR DESCRIPTION
Sometimes shibboleth gives us a valid session with not user data
attached to it. We shouldn't punish our users for this - instead we can
just tell the frontend to bounce them into the Login again to get better
data.

Fixes #1925 