### PR TITLE
Limit error messages in production environment

### DIFF
--- a/src/Ilios/CoreBundle/Controller/ExceptionController.php
+++ b/src/Ilios/CoreBundle/Controller/ExceptionController.php
@@ -28,7 +28,7 @@ class ExceptionController
     /**
      * @var bool
      */
-    protected $limitExceptionMessage;
+    protected $showFullErrorMessage;
 
     /**
      * Only show exceptions in the dev environment
@@ -40,7 +40,7 @@ class ExceptionController
     {
         $this->twig = $twig;
         $this->showException = $environment === 'dev';
-        $this->limitExceptionMessage = $environment === 'production';
+        $this->showFullErrorMessage = in_array($environment, ['dev', 'test']);
     }
 
 
@@ -86,7 +86,7 @@ class ExceptionController
             $safeMessage = $exception->getMessage();
         }
 
-        $message = $this->limitExceptionMessage?$safeMessage:$exception->getMessage();
+        $message = $this->showFullErrorMessage?$exception->getMessage():$safeMessage;
 
         $json = json_encode([
             'code' => $code,


### PR DESCRIPTION
We were checking for 'production' here which isn't a valid environment
(it is called 'prod'). This caused us to send full error messages (but
not stack traces) when we should have sent a much more limited response.
Fix this issue and also invert the condition to make it harder to make
this mistake again.