### PR TITLE
include learning materials in school event.

### DIFF
--- a/src/Ilios/ApiBundle/Controller/SchooleventController.php
+++ b/src/Ilios/ApiBundle/Controller/SchooleventController.php
@@ -68,13 +68,16 @@ class SchooleventController extends Controller
         });
 
         $result = $userManager->addInstructorsToEvents($events);
+        $result = $userManager->addMaterialsToEvents($result);
 
         $user = $tokenStorage->getToken()->getUser();
 
         //Un-privileged users get less data
         if (!$user->hasRole(['Faculty', 'Course Director', 'Developer'])) {
             /** @var SchoolEvent $event */
+            $now = new \DateTime();
             foreach ($events as $event) {
+                $event->clearTimedMaterials($now);
                 $event->clearDataForScheduledEvent();
             }
         }

--- a/src/Ilios/ApiBundle/Controller/SchooleventController.php
+++ b/src/Ilios/ApiBundle/Controller/SchooleventController.php
@@ -77,6 +77,7 @@ class SchooleventController extends Controller
             /** @var SchoolEvent $event */
             $now = new \DateTime();
             foreach ($events as $event) {
+                $event->removeMaterialsInDraft();
                 $event->clearTimedMaterials($now);
                 $event->clearDataForScheduledEvent();
             }

--- a/src/Ilios/ApiBundle/Controller/UsereventController.php
+++ b/src/Ilios/ApiBundle/Controller/UsereventController.php
@@ -77,6 +77,7 @@ class UsereventController extends AbstractController
             $now = new \DateTime();
             /* @var UserEvent $event */
             foreach ($events as $event) {
+                $event->removeMaterialsInDraft();
                 $event->clearTimedMaterials($now);
                 $event->clearDataForScheduledEvent();
             }

--- a/src/Ilios/ApiBundle/Controller/UsermaterialController.php
+++ b/src/Ilios/ApiBundle/Controller/UsermaterialController.php
@@ -62,6 +62,10 @@ class UsermaterialController extends AbstractController
 
         $materials = $manager->findMaterialsForUser($user->getId(), $criteria);
 
+        $materials = array_filter($materials, function ($entity) use ($authorizationChecker) {
+            return $authorizationChecker->isGranted('view', $entity);
+        });
+
         $sessionUser = new SessionUser($user);
 
         //Un-privileged users get less data

--- a/src/Ilios/ApiBundle/Resources/swagger/definitions/CalendarEvent.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/definitions/CalendarEvent.yml
@@ -75,3 +75,9 @@ CalendarEvent:
    description: Is attendance required at this session
    type: boolean
    readOnly: true
+  learningMaterials:
+   description: Attached learning materials.
+   type: array
+   readOnly: true
+   items:
+    $ref: '#/definitions/UserMaterial'

--- a/src/Ilios/AuthenticationBundle/Voter/UsermaterialVoter.php
+++ b/src/Ilios/AuthenticationBundle/Voter/UsermaterialVoter.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\Voter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Classes\UserMaterial;
+use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Class UsermaterialVoter
+ * @package Ilios\AuthenticationBundle\Voter
+ */
+class UsermaterialVoter extends AbstractVoter
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof UserMaterial && in_array($attribute, array(self::VIEW));
+    }
+
+    /**
+     * @param string $attribute
+     * @param UserMaterial $material
+     * @param TokenInterface $token
+     * @return bool
+     */
+    protected function voteOnAttribute($attribute, $material, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                // Deny access to LMs that are 'in draft' if the current user
+                // does not have elevated privileges.
+                return LearningMaterialStatusInterface::IN_DRAFT !== $material->status
+                    || $user->hasRole(['Faculty', 'Course Director', 'Developer']);
+
+        }
+        return false;
+    }
+}

--- a/src/Ilios/CoreBundle/Classes/CalendarEvent.php
+++ b/src/Ilios/CoreBundle/Classes/CalendarEvent.php
@@ -3,6 +3,8 @@
 namespace Ilios\CoreBundle\Classes;
 
 use Ilios\ApiBundle\Annotation as IS;
+use Ilios\CoreBundle\Entity\LearningMaterialInterface;
+use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
 
 /**
  * Class CalendarEvent
@@ -172,6 +174,16 @@ abstract class CalendarEvent
             $this->instructors = [];
             $this->learningMaterials = [];
         }
+    }
+
+    /**
+     * Removes any materials that are in draft mode.
+     */
+    public function removeMaterialsInDraft()
+    {
+        $this->learningMaterials = array_values(array_filter($this->learningMaterials, function(UserMaterial $lm) {
+            return $lm->status !== LearningMaterialStatusInterface::IN_DRAFT;
+        }));
     }
 
 

--- a/src/Ilios/CoreBundle/Classes/CalendarEvent.php
+++ b/src/Ilios/CoreBundle/Classes/CalendarEvent.php
@@ -141,6 +141,16 @@ abstract class CalendarEvent
     public $attendanceRequired;
 
     /**
+     * @var int
+     */
+    public $sessionId;
+
+    /**
+     * @var int
+     */
+    public $courseId;
+
+    /**
      * Clean out all the data for scheduled events
      *
      * This information is not available to un-privileged users

--- a/src/Ilios/CoreBundle/Classes/CalendarEvent.php
+++ b/src/Ilios/CoreBundle/Classes/CalendarEvent.php
@@ -106,6 +106,13 @@ abstract class CalendarEvent
     public $instructors = array();
 
     /**
+     * @var array
+     * @IS\Expose
+     * @IS\Type("entityCollection")
+     */
+    public $learningMaterials = array();
+
+    /**
      * @var bool
      * @IS\Expose
      * @IS\Type("boolean")
@@ -153,6 +160,19 @@ abstract class CalendarEvent
             $this->attendanceRequired = null;
 
             $this->instructors = [];
+            $this->learningMaterials = [];
+        }
+    }
+
+
+    /**
+     * @param \DateTime $dateTime
+     */
+    public function clearTimedMaterials(\DateTime $dateTime)
+    {
+        /** @var UserMaterial $lm */
+        foreach ($this->learningMaterials as $lm) {
+            $lm->clearTimedMaterial($dateTime);
         }
     }
 }

--- a/src/Ilios/CoreBundle/Classes/UserEvent.php
+++ b/src/Ilios/CoreBundle/Classes/UserEvent.php
@@ -47,13 +47,6 @@ class UserEvent extends CalendarEvent
     public $sessionTypeTitle;
 
     /**
-     * @var array
-     * @IS\Expose
-     * @IS\Type("entityCollection")
-     */
-    public $learningMaterials = array();
-
-    /**
      * @var int
      */
     public $sessionId;
@@ -74,18 +67,7 @@ class UserEvent extends CalendarEvent
             $this->sessionDescription = null;
             $this->sessionTitle = null;
             $this->sessionTypeTitle = null;
-            $this->learningMaterials = [];
         }
     }
 
-    /**
-     * @param \DateTime $dateTime
-     */
-    public function clearTimedMaterials(\DateTime $dateTime)
-    {
-        /** @var UserMaterial $lm */
-        foreach ($this->learningMaterials as $lm) {
-            $lm->clearTimedMaterial($dateTime);
-        }
-    }
 }

--- a/src/Ilios/CoreBundle/Classes/UserEvent.php
+++ b/src/Ilios/CoreBundle/Classes/UserEvent.php
@@ -47,16 +47,6 @@ class UserEvent extends CalendarEvent
     public $sessionTypeTitle;
 
     /**
-     * @var int
-     */
-    public $sessionId;
-
-    /**
-     * @var int
-     */
-    public $courseId;
-
-    /**
      * @inheritdoc
      */
     public function clearDataForScheduledEvent()

--- a/src/Ilios/CoreBundle/Classes/UserMaterial.php
+++ b/src/Ilios/CoreBundle/Classes/UserMaterial.php
@@ -199,6 +199,10 @@ class UserMaterial
      */
     public $isBlanked;
 
+    /**
+     * @var int
+     */
+    public $status;
 
     /**
      * Blanks out properties of timed learning materials that are outside their given

--- a/src/Ilios/CoreBundle/Entity/Repository/SchoolRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/SchoolRepository.php
@@ -118,7 +118,7 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
         $groupEvents = $this->getOfferingEventsFor($id, $from, $to);
         $offeringEvents = array_merge($offeringEvents, $groupEvents);
 
-        
+
         $events = [];
         //extract unique offeringEvents by using the offering ID
         foreach ($offeringEvents as $userEvent) {
@@ -151,7 +151,7 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
 
         return $events;
     }
-    
+
     /**
      * Use the query builder to get a set of offering based school events.
      *
@@ -167,7 +167,8 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
         \DateTime $to
     ) {
         $qb = $this->_em->createQueryBuilder();
-        $what = 'o.id, o.startDate, o.endDate, o.room, o.updatedAt, o.updatedAt AS offeringUpdatedAt, ' .
+        $what = 'c.id as courseId, s.id AS sessionId, ' .
+          'o.id, o.startDate, o.endDate, o.room, o.updatedAt, o.updatedAt AS offeringUpdatedAt, ' .
           's.updatedAt AS sessionUpdatedAt, s.title, st.calendarColor, ' .
           's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
           's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, ' .
@@ -194,7 +195,7 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
         $results = $qb->getQuery()->getArrayResult();
         return $this->createEventObjectsForOfferings($id, $results);
     }
-    
+
     /**
      * Use the query builder to get a set of ILMSession based user events.
      *
@@ -212,7 +213,8 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
 
         $qb = $this->_em->createQueryBuilder();
 
-        $what = 'ilm.id, ilm.dueDate, ' .
+        $what = 'c.id as courseId, s.id AS sessionId, ' .
+            'ilm.id, ilm.dueDate, ' .
             's.updatedAt, s.title, st.calendarColor, ' .
             's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
             's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, ' .
@@ -237,7 +239,7 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
         return $this->createEventObjectsForIlmSessions($id, $results);
     }
 
-    
+
     /**
      * Convert offerings into UserEvent objects.
      *
@@ -261,6 +263,8 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
             $event->isPublished = $arr['sessionPublished']  && $arr['coursePublished'];
             $event->isScheduled = $arr['sessionPublishedAsTbd'] || $arr['coursePublishedAsTbd'];
             $event->courseTitle = $arr['courseTitle'];
+            $event->sessionId = $arr['sessionId'];
+            $event->courseId = $arr['courseId'];
             $event->attireRequired = $arr['attireRequired'];
             $event->equipmentRequired = $arr['equipmentRequired'];
             $event->supplemental = $arr['supplemental'];
@@ -269,7 +273,7 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
         }, $results);
     }
 
-    
+
     /**
      * Convert IlmSessions into UserEvent objects
      * @param integer $schoolId
@@ -293,6 +297,8 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
             $event->isPublished = $arr['sessionPublished']  && $arr['coursePublished'];
             $event->isScheduled = $arr['sessionPublishedAsTbd'] || $arr['coursePublishedAsTbd'];
             $event->courseTitle = $arr['courseTitle'];
+            $event->sessionId = $arr['sessionId'];
+            $event->courseId = $arr['courseId'];
             $event->attireRequired = $arr['attireRequired'];
             $event->equipmentRequired = $arr['equipmentRequired'];
             $event->supplemental = $arr['supplemental'];

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\AbstractQuery;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\DBAL\Types\Type as DoctrineType;
+use Ilios\CoreBundle\Classes\CalendarEvent;
 use Ilios\CoreBundle\Classes\UserEvent;
 use Ilios\CoreBundle\Classes\UserMaterial;
 use Ilios\CoreBundle\Entity\UserInterface;
@@ -1024,15 +1025,15 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
     }
 
     /**
-     * Finds and adds learning materials to a given list of user events.
+     * Finds and adds learning materials to a given list of calendar events.
      *
-     * @param UserEvent[] $events
+     * @param CalendarEvent[] $events
      * @param UserMaterialFactory $factory
-     * @return UserEvent[]
+     * @return CalendarEvent[]
      */
     public function addMaterialsToEvents(array $events, UserMaterialFactory $factory)
     {
-        $sessionIds = array_map(function (UserEvent $event) {
+        $sessionIds = array_map(function (CalendarEvent $event) {
             return $event->sessionId;
         }, $events);
 

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -1109,10 +1109,11 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             'c.id as courseId, c.title as courseTitle, ' .
             'slm.id as slmId, slm.position, slm.notes, slm.required, slm.publicNotes, slm.startDate, slm.endDate, ' .
             'lm.id, lm.title, lm.description, lm.originalAuthor, lm.token, ' .
-            'lm.citation, lm.link, lm.filename, lm.filesize, lm.mimetype';
+            'lm.citation, lm.link, lm.filename, lm.filesize, lm.mimetype, lms.id AS status';
         $qb->select($what)->from('IliosCoreBundle:Session', 's');
         $qb->join('s.learningMaterials', 'slm');
         $qb->join('slm.learningMaterial', 'lm');
+        $qb->join('lm.status', 'lms');
         $qb->join('s.course', 'c');
 
         $qb->andWhere($qb->expr()->in('s.id', ':sessions'));
@@ -1141,11 +1142,13 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         $what = 'c.title as courseTitle, c.id as courseId, c.startDate as firstOfferingDate, ' .
             'clm.id as clmId, clm.position, clm.notes, clm.required, clm.publicNotes, clm.startDate, clm.endDate, ' .
             'lm.id, lm.title, lm.description, lm.originalAuthor, lm.token, ' .
-            'lm.citation, lm.link, lm.filename, lm.filesize, lm.mimetype';
+            'lm.citation, lm.link, lm.filename, lm.filesize, lm.mimetype, lms.id AS status';
         $qb->select($what)->from('IliosCoreBundle:Session', 's');
         $qb->join('s.course', 'c');
         $qb->join('c.learningMaterials', 'clm');
         $qb->join('clm.learningMaterial', 'lm');
+        $qb->join('lm.status', 'lms');
+
 
         $qb->andWhere($qb->expr()->in('s.id', ':sessions'));
         $qb->andWhere($qb->expr()->eq('c.published', 1));

--- a/src/Ilios/CoreBundle/Service/UserMaterialFactory.php
+++ b/src/Ilios/CoreBundle/Service/UserMaterialFactory.php
@@ -70,6 +70,7 @@ class UserMaterialFactory
         $obj->mimetype = $material['mimetype'];
         $obj->startDate = $material['startDate'];
         $obj->endDate = $material['endDate'];
+        $obj->status = (int) $material['status'];
         $obj->isBlanked = false;
 
         return $obj;

--- a/tests/CoreBundle/Classes/UserEventTest.php
+++ b/tests/CoreBundle/Classes/UserEventTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace Tests\CoreBundle\Classes;
+
+use Ilios\CoreBundle\Classes\CalendarEvent;
+use Ilios\CoreBundle\Classes\UserEvent;
+use Ilios\CoreBundle\Classes\UserMaterial;
+use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+
+/**
+ * Class UserEventTest
+ * @package Tests\CoreBundle\Classes
+ * @covers \Ilios\CoreBundle\Classes\CalendarEvent
+ * @covers \Ilios\CoreBundle\Classes\UserEvent
+ */
+class UserEventTest extends TestCase
+{
+    /**
+     * @var UserEvent
+     */
+    protected $userEvent;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->userEvent = new UserEvent();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDown()
+    {
+        unset($this->userEvent);
+    }
+
+    /**
+     * @covers CalendarEvent::removeMaterialsInDraft
+     */
+    public function testRemoveMaterialsInDraft()
+    {
+        $draftMaterial = new UserMaterial();
+        $draftMaterial->status = LearningMaterialStatusInterface::IN_DRAFT;
+        $revisedMaterial = new UserMaterial();
+        $revisedMaterial->status = LearningMaterialStatusInterface::REVISED;
+        $finalizedMaterial = new UserMaterial();
+        $finalizedMaterial->status = LearningMaterialStatusInterface::FINALIZED;
+
+        $this->userEvent->learningMaterials = [ $draftMaterial, $revisedMaterial, $finalizedMaterial ];
+        $this->userEvent->removeMaterialsInDraft();
+        $this->assertEquals(2, count($this->userEvent->learningMaterials));
+        $this->assertTrue(in_array($finalizedMaterial, $this->userEvent->learningMaterials));
+        $this->assertTrue(in_array($revisedMaterial, $this->userEvent->learningMaterials));
+    }
+}

--- a/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
+++ b/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
@@ -25,8 +25,80 @@ class SchooleventsTest extends AbstractEndpointTest
         return [
             'Tests\CoreBundle\Fixture\LoadOfferingData',
             'Tests\CoreBundle\Fixture\LoadIlmSessionData',
-            'Tests\CoreBundle\Fixture\LoadSchoolData'
+            'Tests\CoreBundle\Fixture\LoadSchoolData',
+            'Tests\CoreBundle\Fixture\LoadLearningMaterialData',
+            'Tests\CoreBundle\Fixture\LoadCourseLearningMaterialData',
+            'Tests\CoreBundle\Fixture\LoadSessionLearningMaterialData',
         ];
+    }
+
+    public function testAttachedUserMaterials()
+    {
+        $school = $this->container->get(SchoolData::class)->getOne();
+        $userId = 5;
+        $events = $this->getEvents($school['id'], 0, 100000000000, $userId);
+        $lms = $events[3]['learningMaterials'];
+
+        $this->assertEquals(10, count($lms));
+        $this->assertEquals(15, count($lms[0]));
+        $this->assertEquals('1', $lms[0]['id']);
+        $this->assertEquals('1', $lms[0]['sessionLearningMaterial']);
+        $this->assertEquals('1', $lms[0]['session']);
+        $this->assertEquals('1', $lms[0]['course']);
+        $this->assertEquals('1', $lms[0]['position']);
+        $this->assertTrue($lms[0]['required']);
+        $this->assertStringStartsWith('firstlm', $lms[0]['title']);
+        $this->assertEquals('desc1', $lms[0]['description']);
+        $this->assertEquals('author1', $lms[0]['originalAuthor']);
+        $this->assertEquals('citation1', $lms[0]['citation']);
+        $this->assertEquals('citation', $lms[0]['mimetype']);
+        $this->assertEquals('session1Title', $lms[0]['sessionTitle']);
+        $this->assertEquals('firstCourse', $lms[0]['courseTitle']);
+        $this->assertEquals('2016-09-04T00:00:00+00:00', $lms[5]['firstOfferingDate']);
+        $this->assertEquals(0, count($lms[0]['instructors']));
+        $this->assertFalse($lms[0]['isBlanked']);
+
+        $this->assertEquals(15, count($lms[1]));
+        $this->assertFalse($lms[1]['isBlanked']);
+
+        $this->assertEquals(15, count($lms[2]));
+        $this->assertFalse($lms[2]['isBlanked']);
+
+        $this->assertEquals(17, count($lms[3]));
+        $this->assertFalse($lms[3]['isBlanked']);
+
+        $this->assertEquals(18, count($lms[4]));
+        $this->assertFalse($lms[4]['isBlanked']);
+
+        $this->assertEquals(10, count($lms[5]));
+        $this->assertEquals('6', $lms[5]['id']);
+        $this->assertEquals('6', $lms[5]['courseLearningMaterial']);
+        $this->assertEquals('1', $lms[5]['course']);
+        $this->assertEquals('4', $lms[5]['position']);
+        $this->assertEquals('sixthlm', $lms[5]['title']);
+        $this->assertEquals('firstCourse', $lms[5]['courseTitle']);
+        $this->assertEquals('2016-09-04T00:00:00+00:00', $lms[5]['firstOfferingDate']);
+        $this->assertEmpty($lms[5]['instructors']);
+        $this->assertNotEmpty($lms[5]['startDate']);
+        $this->assertTrue($lms[5]['isBlanked']);
+
+        $this->assertEquals(18, count($lms[6]));
+        $this->assertNotEmpty($lms[6]['endDate']);
+        $this->assertFalse($lms[6]['isBlanked']);
+
+        $this->assertEquals(10, count($lms[7]));
+        $this->assertNotEmpty($lms[7]['endDate']);
+        $this->assertTrue($lms[7]['isBlanked']);
+
+        $this->assertEquals(19, count($lms[8]));
+        $this->assertNotEmpty($lms[8]['startDate']);
+        $this->assertNotEmpty($lms[8]['endDate']);
+        $this->assertFalse($lms[8]['isBlanked']);
+
+        $this->assertEquals(11, count($lms[9]));
+        $this->assertNotEmpty($lms[9]['startDate']);
+        $this->assertNotEmpty($lms[9]['endDate']);
+        $this->assertTrue($lms[9]['isBlanked']);
     }
 
     public function testGetEvents()
@@ -38,6 +110,9 @@ class SchooleventsTest extends AbstractEndpointTest
 
         $events = $this->getEvents($school['id'], 0, 100000000000);
 
+        $this->assertEquals(12, count($events), 'Expected events returned');
+
+
         $this->assertEquals($events[0]['offering'], 3);
         $this->assertEquals($events[0]['startDate'], $offerings[2]['startDate']);
         $this->assertEquals($events[0]['endDate'], $offerings[2]['endDate']);
@@ -46,6 +121,11 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertTrue($events[0]['equipmentRequired'], 'equipmentRequired is correct for event 0');
         $this->assertTrue($events[0]['supplemental'], 'supplemental is correct for event 0');
         $this->assertTrue($events[0]['attendanceRequired'], 'attendanceRequired is correct for event 0');
+        $this->assertEquals(
+            count($events[0]['learningMaterials']),
+            9,
+            'Event 0 has the correct number of learning materials'
+        );
 
         $this->assertEquals($events[1]['offering'], 4);
         $this->assertEquals($events[1]['startDate'], $offerings[3]['startDate']);
@@ -55,6 +135,11 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertTrue($events[1]['equipmentRequired'], 'equipmentRequired is correct for event 1');
         $this->assertTrue($events[1]['supplemental'], 'supplemental is correct for event 1');
         $this->assertTrue($events[1]['attendanceRequired'], 'attendanceRequired is correct for event 1');
+        $this->assertEquals(
+            count($events[1]['learningMaterials']),
+            9,
+            'Event 1 has the correct number of learning materials'
+        );
 
         $this->assertEquals($events[2]['offering'], 5);
         $this->assertEquals($events[2]['startDate'], $offerings[4]['startDate']);
@@ -64,6 +149,11 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertTrue($events[2]['equipmentRequired'], 'equipmentRequired is correct for event 2');
         $this->assertTrue($events[2]['supplemental'], 'supplemental is correct for event 2');
         $this->assertTrue($events[2]['attendanceRequired'], 'attendanceRequired is correct for event 2');
+        $this->assertEquals(
+            count($events[2]['learningMaterials']),
+            9,
+            'Event 2 has the correct number of learning materials'
+        );
 
         $this->assertEquals($events[3]['offering'], 6);
         $this->assertEquals($events[3]['startDate'], $offerings[5]['startDate']);
@@ -73,6 +163,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[3]['equipmentRequired'], 'equipmentRequired is correct for event 3');
         $this->assertTrue($events[3]['supplemental'], 'supplemental is correct for event 3');
         $this->assertArrayNotHasKey('attendanceRequired', $events[3], 'attendanceRequired is correct for event 3');
+        $this->assertEquals(count($events[3]['learningMaterials']), 0, 'Event 3 has no learning materials');
 
         $this->assertEquals($events[4]['offering'], 7);
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate']);
@@ -82,6 +173,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[4]['equipmentRequired'], 'equipmentRequired is correct for event 4');
         $this->assertTrue($events[4]['supplemental'], 'supplemental is correct for event 4');
         $this->assertArrayNotHasKey('attendanceRequired', $events[4], 'attendanceRequired is correct for event 4');
+        $this->assertEquals(count($events[4]['learningMaterials']), 0, 'Event 4 has no learning materials');
 
         $this->assertEquals($events[5]['ilmSession'], 1);
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate']);
@@ -90,6 +182,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[5]['equipmentRequired'], 'equipmentRequired is correct for event 5');
         $this->assertFalse($events[5]['supplemental'], 'supplemental is correct for event 5');
         $this->assertArrayNotHasKey('attendanceRequired', $events[5], 'attendanceRequired is correct for event 5');
+        $this->assertEquals(count($events[5]['learningMaterials']), 0, 'Event 5 has no learning materials');
 
         $this->assertEquals($events[6]['ilmSession'], 2);
         $this->assertEquals($events[6]['startDate'], $ilmSessions[1]['dueDate']);
@@ -98,6 +191,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[6]['equipmentRequired'], 'equipmentRequired is correct for event 6');
         $this->assertFalse($events[6]['supplemental'], 'supplemental is correct for event 6');
         $this->assertArrayNotHasKey('attendanceRequired', $events[6], 'attendanceRequired is correct for event 6');
+        $this->assertEquals(count($events[6]['learningMaterials']), 0, 'Event 6 has no learning materials');
 
         $this->assertEquals($events[7]['ilmSession'], 3);
         $this->assertEquals($events[7]['startDate'], $ilmSessions[2]['dueDate']);
@@ -106,6 +200,8 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[7]['equipmentRequired'], 'equipmentRequired is correct for event 7');
         $this->assertFalse($events[7]['supplemental'], 'supplemental is correct for event 7');
         $this->assertArrayNotHasKey('attendanceRequired', $events[7], 'attendanceRequired is correct for event 7');
+        $this->assertEquals(count($events[7]['learningMaterials']), 0, 'Event 7 has no learning materials');
+
 
         $this->assertEquals($events[8]['ilmSession'], 4);
         $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate']);
@@ -114,6 +210,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[8]['equipmentRequired'], 'equipmentRequired is correct for event 8');
         $this->assertFalse($events[8]['supplemental'], 'supplemental is correct for event 8');
         $this->assertArrayNotHasKey('attendanceRequired', $events[8], 'attendanceRequired is correct for event 8');
+        $this->assertEquals(count($events[8]['learningMaterials']), 0, 'Event 8 has no learning materials');
 
         $this->assertEquals($events[9]['offering'], 1);
         $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate']);
@@ -123,8 +220,12 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertArrayNotHasKey('equipmentRequired', $events[9], 'equipmentRequired is correct for event 9');
         $this->assertFalse($events[9]['supplemental'], 'supplemental is correct for event 9');
         $this->assertArrayNotHasKey('attendanceRequired', $events[9], 'attendanceRequired is correct for event 9');
-
         $this->assertEquals(8, $events[10]['offering']);
+        $this->assertEquals(
+            count($events[9]['learningMaterials']),
+            10,
+            'Event 9 has the correct number of learning materials'
+        );
 
         /** @var OfferingInterface $offering */
         $offering = $this->fixtures->getReference('offerings8');
@@ -135,6 +236,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[10]['equipmentRequired'], 'equipmentRequired is correct for event 10');
         $this->assertTrue($events[10]['supplemental'], 'supplemental is correct for event 10');
         $this->assertArrayNotHasKey('attendanceRequired', $events[10], 'attendanceRequired is correct for event 10');
+        $this->assertEquals(count($events[10]['learningMaterials']), 0, 'Event 8 has no learning materials');
 
 
         foreach ($events as $event) {
@@ -157,7 +259,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[0]['offering'], $offerings[5]['id']);
     }
 
-    protected function getEvents($schoolId, $from, $to)
+    protected function getEvents($schoolId, $from, $to, $userId = null)
     {
         $parameters = [
             'version' => 'v1',
@@ -169,11 +271,13 @@ class SchooleventsTest extends AbstractEndpointTest
             'ilios_api_schoolevents',
             $parameters
         );
+
+        $userToken = isset($userId) ? $this->getTokenForUser($userId): $this->getAuthenticatedUserToken();
         $this->createJsonRequest(
             'GET',
             $url,
             null,
-            $this->getAuthenticatedUserToken()
+            $userToken
         );
 
         $response = $this->client->getResponse();

--- a/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
+++ b/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
@@ -39,7 +39,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $events = $this->getEvents($school['id'], 0, 100000000000, $userId);
         $lms = $events[3]['learningMaterials'];
 
-        $this->assertEquals(10, count($lms));
+        $this->assertEquals(9, count($lms));
         $this->assertEquals(15, count($lms[0]));
         $this->assertEquals('1', $lms[0]['id']);
         $this->assertEquals('1', $lms[0]['sessionLearningMaterial']);
@@ -61,44 +61,41 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals(15, count($lms[1]));
         $this->assertFalse($lms[1]['isBlanked']);
 
-        $this->assertEquals(15, count($lms[2]));
+        $this->assertEquals(17, count($lms[2]));
         $this->assertFalse($lms[2]['isBlanked']);
 
-        $this->assertEquals(17, count($lms[3]));
+        $this->assertEquals(18, count($lms[3]));
         $this->assertFalse($lms[3]['isBlanked']);
 
-        $this->assertEquals(18, count($lms[4]));
-        $this->assertFalse($lms[4]['isBlanked']);
+        $this->assertEquals(10, count($lms[4]));
+        $this->assertEquals('6', $lms[4]['id']);
+        $this->assertEquals('6', $lms[4]['courseLearningMaterial']);
+        $this->assertEquals('1', $lms[4]['course']);
+        $this->assertEquals('4', $lms[4]['position']);
+        $this->assertEquals('sixthlm', $lms[4]['title']);
+        $this->assertEquals('firstCourse', $lms[4]['courseTitle']);
+        $this->assertEquals('2016-09-04T00:00:00+00:00', $lms[4]['firstOfferingDate']);
+        $this->assertEmpty($lms[4]['instructors']);
+        $this->assertNotEmpty($lms[4]['startDate']);
+        $this->assertTrue($lms[4]['isBlanked']);
 
-        $this->assertEquals(10, count($lms[5]));
-        $this->assertEquals('6', $lms[5]['id']);
-        $this->assertEquals('6', $lms[5]['courseLearningMaterial']);
-        $this->assertEquals('1', $lms[5]['course']);
-        $this->assertEquals('4', $lms[5]['position']);
-        $this->assertEquals('sixthlm', $lms[5]['title']);
-        $this->assertEquals('firstCourse', $lms[5]['courseTitle']);
-        $this->assertEquals('2016-09-04T00:00:00+00:00', $lms[5]['firstOfferingDate']);
-        $this->assertEmpty($lms[5]['instructors']);
-        $this->assertNotEmpty($lms[5]['startDate']);
-        $this->assertTrue($lms[5]['isBlanked']);
+        $this->assertEquals(18, count($lms[5]));
+        $this->assertNotEmpty($lms[5]['endDate']);
+        $this->assertFalse($lms[5]['isBlanked']);
 
-        $this->assertEquals(18, count($lms[6]));
+        $this->assertEquals(10, count($lms[6]));
         $this->assertNotEmpty($lms[6]['endDate']);
-        $this->assertFalse($lms[6]['isBlanked']);
+        $this->assertTrue($lms[6]['isBlanked']);
 
-        $this->assertEquals(10, count($lms[7]));
+        $this->assertEquals(19, count($lms[7]));
+        $this->assertNotEmpty($lms[7]['startDate']);
         $this->assertNotEmpty($lms[7]['endDate']);
-        $this->assertTrue($lms[7]['isBlanked']);
+        $this->assertFalse($lms[7]['isBlanked']);
 
-        $this->assertEquals(19, count($lms[8]));
+        $this->assertEquals(11, count($lms[8]));
         $this->assertNotEmpty($lms[8]['startDate']);
         $this->assertNotEmpty($lms[8]['endDate']);
-        $this->assertFalse($lms[8]['isBlanked']);
-
-        $this->assertEquals(11, count($lms[9]));
-        $this->assertNotEmpty($lms[9]['startDate']);
-        $this->assertNotEmpty($lms[9]['endDate']);
-        $this->assertTrue($lms[9]['isBlanked']);
+        $this->assertTrue($lms[8]['isBlanked']);
     }
 
     public function testGetEvents()

--- a/tests/IliosApiBundle/Endpoints/UsereventTest.php
+++ b/tests/IliosApiBundle/Endpoints/UsereventTest.php
@@ -42,7 +42,7 @@ class UsereventTest extends AbstractEndpointTest
         $events = $this->getEvents($userId, 0, 100000000000);
         $lms = $events[0]['learningMaterials'];
 
-        $this->assertEquals(10, count($lms));
+        $this->assertEquals(9, count($lms));
         $this->assertEquals(15, count($lms[0]));
         $this->assertEquals('1', $lms[0]['id']);
         $this->assertEquals('1', $lms[0]['sessionLearningMaterial']);
@@ -64,44 +64,41 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEquals(15, count($lms[1]));
         $this->assertFalse($lms[1]['isBlanked']);
 
-        $this->assertEquals(15, count($lms[2]));
+        $this->assertEquals(17, count($lms[2]));
         $this->assertFalse($lms[2]['isBlanked']);
 
-        $this->assertEquals(17, count($lms[3]));
+        $this->assertEquals(18, count($lms[3]));
         $this->assertFalse($lms[3]['isBlanked']);
 
-        $this->assertEquals(18, count($lms[4]));
-        $this->assertFalse($lms[4]['isBlanked']);
+        $this->assertEquals(10, count($lms[4]));
+        $this->assertEquals('6', $lms[4]['id']);
+        $this->assertEquals('6', $lms[4]['courseLearningMaterial']);
+        $this->assertEquals('1', $lms[4]['course']);
+        $this->assertEquals('4', $lms[4]['position']);
+        $this->assertEquals('sixthlm', $lms[4]['title']);
+        $this->assertEquals('firstCourse', $lms[4]['courseTitle']);
+        $this->assertEquals('2016-09-04T00:00:00+00:00', $lms[4]['firstOfferingDate']);
+        $this->assertEmpty($lms[4]['instructors']);
+        $this->assertNotEmpty($lms[4]['startDate']);
+        $this->assertTrue($lms[4]['isBlanked']);
 
-        $this->assertEquals(10, count($lms[5]));
-        $this->assertEquals('6', $lms[5]['id']);
-        $this->assertEquals('6', $lms[5]['courseLearningMaterial']);
-        $this->assertEquals('1', $lms[5]['course']);
-        $this->assertEquals('4', $lms[5]['position']);
-        $this->assertEquals('sixthlm', $lms[5]['title']);
-        $this->assertEquals('firstCourse', $lms[5]['courseTitle']);
-        $this->assertEquals('2016-09-04T00:00:00+00:00', $lms[5]['firstOfferingDate']);
-        $this->assertEmpty($lms[5]['instructors']);
-        $this->assertNotEmpty($lms[5]['startDate']);
-        $this->assertTrue($lms[5]['isBlanked']);
+        $this->assertEquals(18, count($lms[5]));
+        $this->assertNotEmpty($lms[5]['endDate']);
+        $this->assertFalse($lms[5]['isBlanked']);
 
-        $this->assertEquals(18, count($lms[6]));
+        $this->assertEquals(10, count($lms[6]));
         $this->assertNotEmpty($lms[6]['endDate']);
-        $this->assertFalse($lms[6]['isBlanked']);
+        $this->assertTrue($lms[6]['isBlanked']);
 
-        $this->assertEquals(10, count($lms[7]));
+        $this->assertEquals(19, count($lms[7]));
+        $this->assertNotEmpty($lms[7]['startDate']);
         $this->assertNotEmpty($lms[7]['endDate']);
-        $this->assertTrue($lms[7]['isBlanked']);
+        $this->assertFalse($lms[7]['isBlanked']);
 
-        $this->assertEquals(19, count($lms[8]));
+        $this->assertEquals(11, count($lms[8]));
         $this->assertNotEmpty($lms[8]['startDate']);
         $this->assertNotEmpty($lms[8]['endDate']);
-        $this->assertFalse($lms[8]['isBlanked']);
-
-        $this->assertEquals(11, count($lms[9]));
-        $this->assertNotEmpty($lms[9]['startDate']);
-        $this->assertNotEmpty($lms[9]['endDate']);
-        $this->assertTrue($lms[9]['isBlanked']);
+        $this->assertTrue($lms[8]['isBlanked']);
     }
 
     public function testGetEvents()

--- a/tests/IliosApiBundle/Endpoints/UsermaterialsTest.php
+++ b/tests/IliosApiBundle/Endpoints/UsermaterialsTest.php
@@ -109,6 +109,14 @@ class UsermaterialsTest extends AbstractEndpointTest
         $this->assertTrue($materials[9]['isBlanked']);
     }
 
+    public function testGetAllMaterialsAsStudent() {
+        $userId = 5;
+        $materials = $this->getMaterials($userId, null, null, $userId);
+        $this->assertCount(9, $materials, 'All expected materials returned');
+        $materialIds = array_column($materials, 'id');
+        $this->assertFalse(in_array('2', $materialIds, 'Draft material was filtered out.'));
+    }
+
     public function testGetMaterialsBeforeTheBeginningOfTime()
     {
         $userId = 5;
@@ -138,7 +146,7 @@ class UsermaterialsTest extends AbstractEndpointTest
         $this->assertCount(10, $materials, 'All materials returned');
     }
 
-    protected function getMaterials($userId, $before = null, $after = null)
+    protected function getMaterials($userId, $before = null, $after = null, $authUser = null)
     {
         $parameters = [
             'version' => 'v1',
@@ -154,11 +162,13 @@ class UsermaterialsTest extends AbstractEndpointTest
             'ilios_api_usermaterials',
             $parameters
         );
+
+        $token = isset($authUser) ? $this->getTokenForUser($authUser) : $this->getAuthenticatedUserToken();
         $this->createJsonRequest(
             'GET',
             $url,
             null,
-            $this->getAuthenticatedUserToken()
+            $token
         );
 
         $response = $this->client->getResponse();


### PR DESCRIPTION
fixes #1946.

also refs ilios/frontend#3273

btw, i threw a voter on user materials in the api endpoint to strip out any in-draft materials if the requesting user has no privileges above student. 
not sure if the lack of this voter was by design or an oversight. i'm inclined to think that it's the latter. @saschaben thoughts on that?
