### PR TITLE
Save bandwidth by using a cached version of the frontend

### DIFF
--- a/src/Ilios/CliBundle/Command/UpdateFrontendCommand.php
+++ b/src/Ilios/CliBundle/Command/UpdateFrontendCommand.php
@@ -99,17 +99,11 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
         $this->environment = $environment;
 
         $temporaryFileStorePath = $kernelProjectDir . '/var/tmp/frontend-update-files';
-        if (!$this->fs->exists($temporaryFileStorePath)) {
-            $this->fs->mkdir($temporaryFileStorePath);
-        }
+        $this->fs->mkdir($temporaryFileStorePath);
         $this->productionTemporaryFileStore = $temporaryFileStorePath . '/prod';
-        if (!$this->fs->exists($this->productionTemporaryFileStore)) {
-            $this->fs->mkdir($this->productionTemporaryFileStore);
-        }
+        $this->fs->mkdir($this->productionTemporaryFileStore);
         $this->stagingTemporaryFileStore = $temporaryFileStorePath . '/stage';
-        if (!$this->fs->exists($this->stagingTemporaryFileStore)) {
-            $this->fs->mkdir($this->stagingTemporaryFileStore);
-        }
+        $this->fs->mkdir($this->stagingTemporaryFileStore);
 
         parent::__construct();
     }

--- a/src/Ilios/CoreBundle/Service/Fetch.php
+++ b/src/Ilios/CoreBundle/Service/Fetch.php
@@ -4,6 +4,8 @@ namespace Ilios\CoreBundle\Service;
 
 use Http\Client\HttpClient;
 use Http\Message\RequestFactory;
+use \DateTime;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Fetch things from the interwebs - exposed as a service for
@@ -30,11 +32,34 @@ class Fetch
         $this->requestFactory = $requestFactory;
     }
 
-    public function get(string $url) : string
+    /**
+     * Get a file
+     *
+     * If passed a $file it will use that to check if the response would be a 304 Not Modified
+     * and if so just return the contents of $file to save bandwidth downloading it again
+     * 
+     * @param string $url
+     * @param \SplFileObject|null $file
+     * @return string
+     * @throws \Exception
+     */
+    public function get(string $url, \SplFileObject $file = null) : string
     {
         $request = $this->requestFactory->createRequest('GET', $url);
+
+        if ($file) {
+            $lastModifiedTime = $file->getMTime();
+            $lastModified = new DateTime();
+            $lastModified->setTimestamp($lastModifiedTime);
+            $request = $request->withHeader('if-modified-since', $lastModified->format('D, d M Y H:i:s T'));
+        }
+
         $response = $this->client->sendRequest($request);
-        $fileContents = $response->getBody()->getContents();
+        if ($response->getStatusCode() === Response::HTTP_NOT_MODIFIED) {
+            $fileContents = $file->fread($file->getSize());
+        } else {
+            $fileContents = $response->getBody()->getContents();
+        }
 
         if (empty($fileContents)) {
             throw new \Exception('Failed to load ' . $url);

--- a/src/Ilios/CoreBundle/Service/Fetch.php
+++ b/src/Ilios/CoreBundle/Service/Fetch.php
@@ -55,7 +55,7 @@ class Fetch
         }
 
         $response = $this->client->sendRequest($request);
-        if ($response->getStatusCode() === Response::HTTP_NOT_MODIFIED) {
+        if ($file && $response->getStatusCode() === Response::HTTP_NOT_MODIFIED) {
             $fileContents = $file->fread($file->getSize());
         } else {
             $fileContents = $response->getBody()->getContents();

--- a/tests/CliBundle/Command/UpdateFrontendCommandTest.php
+++ b/tests/CliBundle/Command/UpdateFrontendCommandTest.php
@@ -45,7 +45,7 @@ class UpdateFrontendCommandTest extends TestCase
         $this->fetch = m::mock(Fetch::class);
         $this->fs = m::mock(Filesystem::class);
         $this->config = m::mock(Config::class);
-        $this->fs->shouldReceive('exists')->once()->andReturn(true);
+        $this->fs->shouldReceive('exists')->times(3)->andReturn(true);
         $this->zippy = m::mock(Zippy::class);
         $command = new UpdateFrontendCommand(
             $this->fetch,
@@ -81,11 +81,17 @@ class UpdateFrontendCommandTest extends TestCase
     public function testExecute()
     {
         $fileName = self::TEST_API_VERSION . '/' . UpdateFrontendCommand::ARCHIVE_FILE_NAME;
-        $this->fetch->shouldReceive('get')->with(UpdateFrontendCommand::PRODUCTION_CDN_ASSET_DOMAIN . $fileName)
+        $this->fetch->shouldReceive('get')->with(UpdateFrontendCommand::PRODUCTION_CDN_ASSET_DOMAIN . $fileName, null)
             ->once()->andReturn('ARCHIVE_FILE');
 
-        $archiveDir = $this->fakeProjectFileDir  . '/var/tmp/frontend-update-files';
-        $archivePath = $archiveDir . '/' . UpdateFrontendCommand::ARCHIVE_FILE_NAME;
+        $archiveDir = $this->fakeProjectFileDir  . '/var/tmp/frontend-update-files/prod';
+        $parts = [
+            $archiveDir,
+            self::TEST_API_VERSION,
+            'active',
+            UpdateFrontendCommand::ARCHIVE_FILE_NAME
+        ];
+        $archivePath = join(DIRECTORY_SEPARATOR, $parts);
 
         $this->fs->shouldReceive('dumpFile')->once()->with($archivePath, 'ARCHIVE_FILE');
         $archive = m::mock(ArchiveInterface::class);
@@ -111,11 +117,17 @@ class UpdateFrontendCommandTest extends TestCase
     public function testExecuteStagingBuild()
     {
         $fileName = self::TEST_API_VERSION . '/' . UpdateFrontendCommand::ARCHIVE_FILE_NAME;
-        $this->fetch->shouldReceive('get')->with(UpdateFrontendCommand::STAGING_CDN_ASSET_DOMAIN . $fileName)
+        $this->fetch->shouldReceive('get')->with(UpdateFrontendCommand::STAGING_CDN_ASSET_DOMAIN . $fileName, null)
             ->once()->andReturn('ARCHIVE_FILE');
 
-        $archiveDir = $this->fakeProjectFileDir  . '/var/tmp/frontend-update-files';
-        $archivePath = $archiveDir . '/' . UpdateFrontendCommand::ARCHIVE_FILE_NAME;
+        $archiveDir = $this->fakeProjectFileDir  . '/var/tmp/frontend-update-files/stage';
+        $parts = [
+            $archiveDir,
+            self::TEST_API_VERSION,
+            'active',
+            UpdateFrontendCommand::ARCHIVE_FILE_NAME
+        ];
+        $archivePath = join(DIRECTORY_SEPARATOR, $parts);
 
         $this->fs->shouldReceive('dumpFile')->once()->with($archivePath, 'ARCHIVE_FILE');
         $archive = m::mock(ArchiveInterface::class);
@@ -143,11 +155,17 @@ class UpdateFrontendCommandTest extends TestCase
     public function testExecuteVersionBuild()
     {
         $fileName = self::TEST_API_VERSION . '/' . UpdateFrontendCommand::ARCHIVE_FILE_NAME . ':foo.bar';
-        $this->fetch->shouldReceive('get')->with(UpdateFrontendCommand::PRODUCTION_CDN_ASSET_DOMAIN . $fileName)
+        $this->fetch->shouldReceive('get')->with(UpdateFrontendCommand::PRODUCTION_CDN_ASSET_DOMAIN . $fileName, null)
             ->once()->andReturn('ARCHIVE_FILE');
 
-        $archiveDir = $this->fakeProjectFileDir  . '/var/tmp/frontend-update-files';
-        $archivePath = $archiveDir . '/' . UpdateFrontendCommand::ARCHIVE_FILE_NAME;
+        $archiveDir = $this->fakeProjectFileDir  . '/var/tmp/frontend-update-files/prod';
+        $parts = [
+            $archiveDir,
+            self::TEST_API_VERSION,
+            'foo.bar',
+            UpdateFrontendCommand::ARCHIVE_FILE_NAME
+        ];
+        $archivePath = join(DIRECTORY_SEPARATOR, $parts);
 
         $this->fs->shouldReceive('dumpFile')->once()->with($archivePath, 'ARCHIVE_FILE');
         $archive = m::mock(ArchiveInterface::class);

--- a/tests/CliBundle/Command/UpdateFrontendCommandTest.php
+++ b/tests/CliBundle/Command/UpdateFrontendCommandTest.php
@@ -45,7 +45,7 @@ class UpdateFrontendCommandTest extends TestCase
         $this->fetch = m::mock(Fetch::class);
         $this->fs = m::mock(Filesystem::class);
         $this->config = m::mock(Config::class);
-        $this->fs->shouldReceive('exists')->times(3)->andReturn(true);
+        $this->fs->shouldReceive('mkdir')->times(3)->andReturn(true);
         $this->zippy = m::mock(Zippy::class);
         $command = new UpdateFrontendCommand(
             $this->fetch,


### PR DESCRIPTION
By keeping the frontend in a version and environment specific cache we
can sent the right headers to CloudFront so we get a 304 Not Modified
response back when the frontend has not been updated. That way we don't
need to download it again.