### PR TITLE
Improve caching of frontend assets

### DIFF
--- a/src/Ilios/WebBundle/Controller/IndexController.php
+++ b/src/Ilios/WebBundle/Controller/IndexController.php
@@ -44,7 +44,7 @@ class IndexController extends Controller
      *
      * @return BinaryFileResponse|Response
      */
-    public function getAction(Request $request, $fileName, $versionedStaticFile)
+    public function getAction(Request $request, $fileName, $versionedStaticFile = false)
     {
         if ('index.html' === $fileName || empty($fileName)) {
             return $this->getIndex($request);

--- a/src/Ilios/WebBundle/Controller/IndexController.php
+++ b/src/Ilios/WebBundle/Controller/IndexController.php
@@ -38,19 +38,23 @@ class IndexController extends Controller
     /**
      * Respond to GET requests
      *
-     * @return Response
+     * @param Request $request
+     * @param $fileName
+     * @param $versionedStaticFile
+     *
+     * @return BinaryFileResponse|Response
      */
-    public function getAction(Request $request, $fileName)
+    public function getAction(Request $request, $fileName, $versionedStaticFile)
     {
         if ('index.html' === $fileName || empty($fileName)) {
-            return $this->getIndex();
+            return $this->getIndex($request);
         }
 
         $path = $this->getFilePath($fileName);
         //when files don't exist they are probably calls to a frontend route like /dashboard or /courses
         //in that case we just return the index.html file and let Ember handle it
         if (!$path) {
-            return $this->getIndex();
+            return $this->getIndex($request);
         }
 
         $response = new BinaryFileResponse($path);
@@ -67,15 +71,24 @@ class IndexController extends Controller
         if ($extension === 'js') {
             $response->headers->set('Content-Type', 'text/javascript');
         }
+        if ($versionedStaticFile) {
+            //cache for one year
+            $response->setMaxAge(60 * 60 * 24 * 365);
+        } else {
+            // doesn't actually mean don't cache - it means that the server must
+            // check the status and if a 304 is returned it can use the cached version
+            $response->headers->addCacheControlDirective('no-cache');
+        }
 
         return $response;
     }
 
     /**
      * Load the index.html file or a nice error message if it doesn't exist
+     * @param Request $request
      * @return Response
      */
-    protected function getIndex()
+    protected function getIndex(Request $request)
     {
         $path = $this->getFilePath('index.json');
         if (!$path) {
@@ -83,15 +96,23 @@ class IndexController extends Controller
                 $this->renderView('IliosWebBundle:Index:error.html.twig')
             );
             $response->setStatusCode(Response::HTTP_NOT_FOUND);
+            $response->headers->addCacheControlDirective('no-cache');
+            $response->headers->addCacheControlDirective('no-store');
+            $response->setMaxAge(1);
         } else {
             $options = $this->extractOptions($path);
             $templatePath = $this->getTemplatePath();
 
             $response = $this->render($templatePath, $options);
+            $response->setPublic();
+            // doesn't actually mean don't cache - it means that the server must
+            // check the status and if a 304 is returned it can use the cached version
+            $response->headers->addCacheControlDirective('no-cache');
+            $response->setEtag(sha1_file($path));
+            $file = new \SplFileObject($path, 'r');
+            $response->setLastModified(\DateTime::createFromFormat('U', $file->getMTime()));
+            $response->isNotModified($request);
         }
-        
-        $response->setPublic();
-        $response->setMaxAge(60);
 
         return $response;
     }

--- a/src/Ilios/WebBundle/Resources/config/routing.yml
+++ b/src/Ilios/WebBundle/Resources/config/routing.yml
@@ -30,7 +30,6 @@ ilios_web_sw_registraton_js:
     path:     /sw-registration.js
     defaults:
         fileName: sw-registration.js
-        versionedStaticFile: false
         _controller: IliosWebBundle:Index:get
     requirements:
         fileName: ".+"
@@ -38,7 +37,6 @@ ilios_web_sw_js:
     path:     /sw.js
     defaults:
         fileName: sw.js
-        versionedStaticFile: false
         _controller: IliosWebBundle:Index:get
     requirements:
         fileName: ".+"

--- a/src/Ilios/WebBundle/Resources/config/routing.yml
+++ b/src/Ilios/WebBundle/Resources/config/routing.yml
@@ -26,10 +26,27 @@ ilios_web_directory_find:
     methods: [GET]
     requirements:
         key: '\d+'
+ilios_web_sw_registraton_js:
+    path:     /sw-registration.js
+    defaults:
+        fileName: sw-registration.js
+        versionedStaticFile: false
+        _controller: IliosWebBundle:Index:get
+    requirements:
+        fileName: ".+"
+ilios_web_sw_js:
+    path:     /sw.js
+    defaults:
+        fileName: sw.js
+        versionedStaticFile: false
+        _controller: IliosWebBundle:Index:get
+    requirements:
+        fileName: ".+"
 ilios_web_assets:
     path:     /{fileName}
     defaults:
         fileName: null
+        versionedStaticFile: true
         _controller: IliosWebBundle:Index:get
     requirements:
         fileName: ".+"

--- a/tests/WebBundle/Controller/IndexControllerTest.php
+++ b/tests/WebBundle/Controller/IndexControllerTest.php
@@ -66,8 +66,8 @@ class IndexControllerTest extends WebTestCase
         $this->client->request('GET', '/');
         $response = $this->client->getResponse();
 
-        //ensure we have a 60 second max age
-        $this->assertEquals(60, $response->getMaxAge(), substr($response->getContent(), 0, 500));
+        //ensure we have correct cache headers
+        $this->assertTrue($response->headers->getCacheControlDirective('no-cache'));
     }
 
     public function testABinaryFile()


### PR DESCRIPTION
Three different caching strategies are needed:
1) The index.html file should be cached by browsers, but it must be
checked on every request to ensure it is fresh. If it is then return a
304 No Change header
2) sw.js and sw-registration.js are handed like index.html to ensure all
updated get noticed immediately.
3) The rest of our files are fingerprinted and they can be cached
forever (I set it to one year) browsers never need to check back as they
will get a new fingerprint if they are ever updated.