### PR TITLE
Handle compression for file requests ourselves

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -54,20 +54,3 @@ DirectoryIndex app.php
         # RedirectTemp cannot be used instead
     </IfModule>
 </IfModule>
-
-<IfModule mod_deflate.c>
-    AddOutputFilterByType DEFLATE text/css
-    AddOutputFilterByType DEFLATE text/javascript
-    AddOutputFilterByType DEFLATE application/x-javascript
-    AddOutputFilterByType DEFLATE application/javascript
-    AddOutputFilterByType DEFLATE text/x-component
-    AddOutputFilterByType DEFLATE text/html
-    AddOutputFilterByType DEFLATE text/richtext
-    AddOutputFilterByType DEFLATE image/svg+xml
-    AddOutputFilterByType DEFLATE text/plain
-    AddOutputFilterByType DEFLATE text/xsd
-    AddOutputFilterByType DEFLATE text/xsl
-    AddOutputFilterByType DEFLATE text/xml
-    AddOutputFilterByType DEFLATE image/x-icon
-    AddOutputFilterByType DEFLATE application/json
-</IfModule>


### PR DESCRIPTION
Apache munges the etag header when it deflates static files. This causes
us to send the full file instead of a 304 and slows down user requests.
If we handle the compression step ourselves we can work around this and
not need to worry about individual web server configurations.

Fixes #1967