### PR TITLE
Handle String ENV variables better

### DIFF
--- a/src/Ilios/CoreBundle/Service/Config.php
+++ b/src/Ilios/CoreBundle/Service/Config.php
@@ -62,8 +62,9 @@ class Config
         $envName = 'ILIOS_' .  s($name)->underscored()->toUpperCase();
         if (isset($_SERVER[$envName])) {
             $result = $_SERVER[$envName];
-            if (in_array($result, ['null', 'false', 'true'])) {
-                $result = json_decode($result);
+            $lowerCaseResult = strtolower($result);
+            if (in_array($lowerCaseResult, ['null', 'false', 'true'])) {
+                $result = json_decode($lowerCaseResult);
             }
             return $result;
         }

--- a/src/Ilios/CoreBundle/Service/Config.php
+++ b/src/Ilios/CoreBundle/Service/Config.php
@@ -44,7 +44,7 @@ class Config
     public function get($name)
     {
         $result = $this->getValueFromEnv($name);
-        if (null == $result) {
+        if (null === $result) {
             $result = $this->getValueFromDb($name);
         }
 
@@ -61,7 +61,11 @@ class Config
     {
         $envName = 'ILIOS_' .  s($name)->underscored()->toUpperCase();
         if (isset($_SERVER[$envName])) {
-            return $_SERVER[$envName];
+            $result = $_SERVER[$envName];
+            if (in_array($result, ['null', 'false', 'true'])) {
+                $result = json_decode($result);
+            }
+            return $result;
         }
 
         return null;

--- a/src/Ilios/CoreBundle/Service/Fetch.php
+++ b/src/Ilios/CoreBundle/Service/Fetch.php
@@ -37,7 +37,7 @@ class Fetch
      *
      * If passed a $file it will use that to check if the response would be a 304 Not Modified
      * and if so just return the contents of $file to save bandwidth downloading it again
-     * 
+     *
      * @param string $url
      * @param \SplFileObject|null $file
      * @return string

--- a/tests/CoreBundle/Service/ConfigTest.php
+++ b/tests/CoreBundle/Service/ConfigTest.php
@@ -38,4 +38,41 @@ class ConfigTest extends TestCase
         $result = $config->get($key);
         $this->assertEquals($value, $result);
     }
+
+    public function testConvertsStringFalseToBooleanFalse()
+    {
+        $manager = m::mock(ApplicationConfigManager::class);
+        $config = new Config($manager);
+        $value = 'false';
+        $key = 'random-key-99';
+        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $_SERVER[$envKey] = $value;
+        $result = $config->get($key);
+        $this->assertTrue($result === false);
+        unset($_SERVER[$envKey]);
+    }
+
+    public function testConvertsStringTrueToBooleanTrue()
+    {
+        $manager = m::mock(ApplicationConfigManager::class);
+        $config = new Config($manager);
+        $value = 'true';
+        $key = 'random-key-99';
+        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $_SERVER[$envKey] = $value;
+        $result = $config->get($key);
+        $this->assertTrue($result === true);
+        unset($_SERVER[$envKey]);
+    }
+
+    public function testConvertsStringNullToNullNull()
+    {
+        $manager = m::mock(ApplicationConfigManager::class);
+        $config = new Config($manager);
+        $key = 'random-key-99';
+        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $_SERVER[$envKey] = 'null';
+        $manager->shouldReceive('getValue')->with($key)->once();
+        $config->get($key);
+    }
 }

--- a/tests/CoreBundle/Service/ConfigTest.php
+++ b/tests/CoreBundle/Service/ConfigTest.php
@@ -75,4 +75,41 @@ class ConfigTest extends TestCase
         $manager->shouldReceive('getValue')->with($key)->once();
         $config->get($key);
     }
+
+    public function testConvertsUpercaseStringFalseToBooleanFalse()
+    {
+        $manager = m::mock(ApplicationConfigManager::class);
+        $config = new Config($manager);
+        $value = 'FALSE';
+        $key = 'random-key-99';
+        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $_SERVER[$envKey] = $value;
+        $result = $config->get($key);
+        $this->assertTrue($result === false);
+        unset($_SERVER[$envKey]);
+    }
+
+    public function testConvertsUpercaseStringTrueToBooleanTrue()
+    {
+        $manager = m::mock(ApplicationConfigManager::class);
+        $config = new Config($manager);
+        $value = 'TRUE';
+        $key = 'random-key-99';
+        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $_SERVER[$envKey] = $value;
+        $result = $config->get($key);
+        $this->assertTrue($result === true);
+        unset($_SERVER[$envKey]);
+    }
+
+    public function testConvertsUpercaseStringNullToNullNull()
+    {
+        $manager = m::mock(ApplicationConfigManager::class);
+        $config = new Config($manager);
+        $key = 'random-key-99';
+        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $_SERVER[$envKey] = 'NULL';
+        $manager->shouldReceive('getValue')->with($key)->once();
+        $config->get($key);
+    }
 }


### PR DESCRIPTION
When we have an ENV variables set to a string true, false, null we need
to return the actual value and not just the string.