### PR TITLE
Compress Assets Once

### DIFF
--- a/src/Ilios/CoreBundle/Service/FinderFactory.php
+++ b/src/Ilios/CoreBundle/Service/FinderFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Ilios\CoreBundle\Service;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Convenience Service for getting a Finder injected which is
+ * useful when we need to test something where the finder is used.
+ * Class FinderFactory
+ * @package Ilios\CoreBundle\Service
+ */
+class FinderFactory
+{
+
+    /**
+     * @return Finder
+     */
+    public static function create()
+    {
+        return new Finder();
+    }
+}

--- a/src/Ilios/WebBundle/Controller/IndexController.php
+++ b/src/Ilios/WebBundle/Controller/IndexController.php
@@ -2,6 +2,7 @@
 
 namespace Ilios\WebBundle\Controller;
 
+use Http\Discovery\Exception\NotFoundException;
 use Ilios\CoreBundle\Service\Filesystem;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -81,6 +82,7 @@ class IndexController extends Controller
             $templatePath = $this->getTemplatePath();
 
             $content = $this->templatingEngine->render($templatePath, $options);
+            $content = gzencode($content);
             $file = new \SplFileObject($path, 'r');
             $lastModified = \DateTime::createFromFormat('U', $file->getMTime());
             $response = $this->responseFromString($content, $request, $lastModified);
@@ -229,8 +231,9 @@ class IndexController extends Controller
         $response->setEtag(sha1($content));
         $response->setLastModified($lastModified);
         $response->setPublic();
-        if (strpos($acceptEncoding, 'gzip') !== false) {
-            $content = gzencode($content);
+        if (strpos($acceptEncoding, 'gzip') === false) {
+            $content = gzdecode($content);
+        } else {
             $response->headers->add(['Content-Encoding' => 'gzip']);
         }
         $response->setContent($content);

--- a/tests/CliBundle/Command/UpdateFrontendCommandTest.php
+++ b/tests/CliBundle/Command/UpdateFrontendCommandTest.php
@@ -7,11 +7,13 @@ use Ilios\CliBundle\Command\UpdateFrontendCommand;
 use Ilios\CoreBundle\Service\Config;
 use Ilios\CoreBundle\Service\Fetch;
 use Ilios\CoreBundle\Service\Filesystem;
+use Ilios\CoreBundle\Service\FinderFactory;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFileSystem;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
 
 class UpdateFrontendCommandTest extends TestCase
 {
@@ -24,6 +26,8 @@ class UpdateFrontendCommandTest extends TestCase
     protected $fs;
     protected $config;
     protected $zippy;
+    protected $finderFactory;
+    protected $finder;
     protected $fakeCacheFileDir;
     protected $fakeProjectFileDir;
 
@@ -33,25 +37,25 @@ class UpdateFrontendCommandTest extends TestCase
         $testFiles = __DIR__ . '/FakeTestFiles';
 
         $this->fakeCacheFileDir = $testFiles . '/cache';
-        if (!$fs->exists($this->fakeCacheFileDir)) {
-            $fs->mkdir($this->fakeCacheFileDir);
-        }
+        $fs->mkdir($this->fakeCacheFileDir);
         $this->fakeProjectFileDir = $testFiles . '/app';
         $tmpDir = $this->fakeProjectFileDir . '/var/tmp';
-        if (!$fs->exists($tmpDir)) {
-            $fs->mkdir($tmpDir);
-        }
+        $fs->mkdir($tmpDir);
 
         $this->fetch = m::mock(Fetch::class);
         $this->fs = m::mock(Filesystem::class);
         $this->config = m::mock(Config::class);
         $this->fs->shouldReceive('mkdir')->times(3)->andReturn(true);
         $this->zippy = m::mock(Zippy::class);
+        $this->finderFactory = m::mock(FinderFactory::class);
+        $this->finder = m::mock(Finder::class);
+        $this->finderFactory->shouldReceive('create')->once()->andReturn($this->finder);
         $command = new UpdateFrontendCommand(
             $this->fetch,
             $this->fs,
             $this->config,
             $this->zippy,
+            $this->finderFactory,
             $this->fakeCacheFileDir,
             $this->fakeProjectFileDir,
             self::TEST_API_VERSION,
@@ -76,6 +80,8 @@ class UpdateFrontendCommandTest extends TestCase
         unset($this->fs);
         unset($this->config);
         unset($this->zippy);
+        unset($this->finderFactory);
+        unset($this->finder);
     }
     
     public function testExecute()
@@ -97,6 +103,11 @@ class UpdateFrontendCommandTest extends TestCase
         $archive = m::mock(ArchiveInterface::class);
         $archive->shouldReceive('extract')->once()->with($archiveDir);
         $this->zippy->shouldReceive('open')->once()->with($archivePath)->andReturn($archive);
+        $this->finder->shouldReceive('files')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('filter')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('in')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('getIterator')->once()->andReturn(new \ArrayObject([]));
+
 
         $frontendPath = $this->fakeCacheFileDir . UpdateFrontendCommand::FRONTEND_DIRECTORY;
         $this->fs->shouldReceive('remove')->once()->with($frontendPath);
@@ -133,6 +144,10 @@ class UpdateFrontendCommandTest extends TestCase
         $archive = m::mock(ArchiveInterface::class);
         $archive->shouldReceive('extract')->once()->with($archiveDir);
         $this->zippy->shouldReceive('open')->once()->with($archivePath)->andReturn($archive);
+        $this->finder->shouldReceive('files')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('filter')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('in')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('getIterator')->once()->andReturn(new \ArrayObject([]));
 
         $frontendPath = $this->fakeCacheFileDir . UpdateFrontendCommand::FRONTEND_DIRECTORY;
         $this->fs->shouldReceive('remove')->once()->with($frontendPath);
@@ -171,6 +186,10 @@ class UpdateFrontendCommandTest extends TestCase
         $archive = m::mock(ArchiveInterface::class);
         $archive->shouldReceive('extract')->once()->with($archiveDir);
         $this->zippy->shouldReceive('open')->once()->with($archivePath)->andReturn($archive);
+        $this->finder->shouldReceive('files')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('filter')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('in')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('getIterator')->once()->andReturn(new \ArrayObject([]));
 
         $frontendPath = $this->fakeCacheFileDir . UpdateFrontendCommand::FRONTEND_DIRECTORY;
         $this->fs->shouldReceive('remove')->once()->with($frontendPath);
@@ -186,6 +205,55 @@ class UpdateFrontendCommandTest extends TestCase
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Frontend updated successfully to version foo.bar!/',
+            $output
+        );
+    }
+
+    public function testCompressAssets()
+    {
+        $fileName = self::TEST_API_VERSION . '/' . UpdateFrontendCommand::ARCHIVE_FILE_NAME;
+        $this->fetch->shouldReceive('get')->with(UpdateFrontendCommand::PRODUCTION_CDN_ASSET_DOMAIN . $fileName, null)
+            ->once()->andReturn('ARCHIVE_FILE');
+
+        $archiveDir = $this->fakeProjectFileDir  . '/var/tmp/frontend-update-files/prod';
+        $parts = [
+            $archiveDir,
+            self::TEST_API_VERSION,
+            'active',
+            UpdateFrontendCommand::ARCHIVE_FILE_NAME
+        ];
+        $archivePath = join(DIRECTORY_SEPARATOR, $parts);
+
+        $this->fs->shouldReceive('dumpFile')->once()->with($archivePath, 'ARCHIVE_FILE');
+        $archive = m::mock(ArchiveInterface::class);
+        $archive->shouldReceive('extract')->once()->with($archiveDir);
+        $this->zippy->shouldReceive('open')->once()->with($archivePath)->andReturn($archive);
+        $this->finder->shouldReceive('files')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('filter')->once()->andReturn($this->finder);
+        $this->finder->shouldReceive('in')->once()->andReturn($this->finder);
+        $file = m::mock(\SplFileInfo::class);
+        $this->finder->shouldReceive('getIterator')->once()->andReturn(new \ArrayObject([
+            $file
+        ]));
+        $contents = 'somestring';
+        $file->shouldReceive('getContents')->once()->andReturn($contents);
+        $realpath = 'REALPATH';
+        $file->shouldReceive('getRealPath')->andReturn($realpath);
+        $this->fs->shouldReceive('dumpFile')->once()->with($realpath, gzencode($contents));
+        $this->fs->shouldReceive('touch')->once()->with($realpath);
+
+        $frontendPath = $this->fakeCacheFileDir . UpdateFrontendCommand::FRONTEND_DIRECTORY;
+        $this->fs->shouldReceive('remove')->once()->with($frontendPath);
+        $this->fs->shouldReceive('rename')->once()
+            ->with($archiveDir . UpdateFrontendCommand::UNPACKED_DIRECTORY, $frontendPath);
+
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME,
+        ));
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/Frontend updated successfully!/',
             $output
         );
     }

--- a/tests/WebBundle/Controller/IndexControllerTest.php
+++ b/tests/WebBundle/Controller/IndexControllerTest.php
@@ -6,6 +6,7 @@ use Ilios\CliBundle\Command\UpdateFrontendCommand;
 use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Mockery as m;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -70,7 +71,7 @@ class IndexControllerTest extends WebTestCase
             'noScript' => [],
             'div' => [],
         ]);
-        $this->setupTestFile($jsonPath, $json);
+        $this->setupTestFile($jsonPath, $json, false);
         $this->client->request('GET', '/');
         $response = $this->client->getResponse();
 
@@ -91,7 +92,7 @@ class IndexControllerTest extends WebTestCase
     {
         $path = $this->assetsPath . 'fakeTestFile';
         $string = file_get_contents(__FILE__);
-        $this->setupTestFile($path, $string);
+        $this->setupTestFile($path, $string, true);
 
         $this->client->request('GET', '/fakeTestFile');
         $response = $this->client->getResponse();
@@ -113,7 +114,7 @@ class IndexControllerTest extends WebTestCase
     {
         $path = $this->assetsPath . 'fakeTestFile';
         $string = file_get_contents(__FILE__);
-        $this->setupTestFile($path, $string);
+        $this->setupTestFile($path, $string, true);
         $now = new \DateTime();
         $this->client->request('GET', '/fakeTestFile', [], [], [
             'HTTP_If-Modified-Since' => $now->format('r')
@@ -135,7 +136,7 @@ class IndexControllerTest extends WebTestCase
             'noScript' => [],
             'div' => [],
         ]);
-        $this->setupTestFile($jsonPath, $json);
+        $this->setupTestFile($jsonPath, $json, false);
         $this->client->request(
             'GET',
             '/',
@@ -164,7 +165,7 @@ class IndexControllerTest extends WebTestCase
     {
         $path = $this->assetsPath . 'fakeTestFile';
         $string = file_get_contents(__FILE__);
-        $this->setupTestFile($path, $string);
+        $this->setupTestFile($path, $string, true);
 
         $this->client->request(
             'GET',
@@ -201,7 +202,7 @@ class IndexControllerTest extends WebTestCase
             'noScript' => [],
             'div' => [],
         ]);
-        $this->setupTestFile($jsonPath, $json);
+        $this->setupTestFile($jsonPath, $json, false);
 
         $this->client->request(
             'GET',
@@ -250,7 +251,7 @@ class IndexControllerTest extends WebTestCase
     {
         $path = $this->assetsPath . 'fakeTestFile';
         $string = file_get_contents(__FILE__);
-        $this->setupTestFile($path, $string);
+        $this->setupTestFile($path, $string, true);
 
         $this->client->request(
             'GET',
@@ -295,9 +296,12 @@ class IndexControllerTest extends WebTestCase
         $this->assertEmpty($response->getContent());
     }
 
-    protected function setupTestFile($path, $contents)
+    protected function setupTestFile(string $path, string $contents, bool $compressContents)
     {
         $this->testFiles[] = $path;
+        if ($compressContents) {
+            $contents = gzencode($contents);
+        }
         $this->fileSystem->dumpFile($path, $contents);
     }
 }


### PR DESCRIPTION
Since virtually every client will requests compressed assets we should
do that work up front when the files are downloaded so save resources
when they are requested.