### PR TITLE
Add query results caching and invalidation

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/CourseRepository.php
@@ -45,9 +45,11 @@ class CourseRepository extends EntityRepository implements DTORepositoryInterfac
     {
         $qb = $this->_em->createQueryBuilder()->select('c')->distinct()->from('IliosCoreBundle:Course', 'c');
         $this->attachCriteriaToQueryBuilder($qb, $criteria, $orderBy, $limit, $offset);
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
 
         $courseDTOs = [];
-        foreach ($qb->getQuery()->getResult(AbstractQuery::HYDRATE_ARRAY) as $arr) {
+        foreach ($query->getResult(AbstractQuery::HYDRATE_ARRAY) as $arr) {
             $courseDTOs[$arr['id']] = new CourseDTO(
                 $arr['id'],
                 $arr['title'],
@@ -73,7 +75,10 @@ class CourseRepository extends EntityRepository implements DTORepositoryInterfac
             ->where($qb->expr()->in('c.id', ':courseIds'))
             ->setParameter('courseIds', $courseIds);
 
-        foreach ($qb->getQuery()->getResult() as $arr) {
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+
+        foreach ($query->getResult() as $arr) {
             $courseDTOs[$arr['courseId']]->school = (int) $arr['schoolId'];
             $courseDTOs[$arr['courseId']]->clerkshipType = $arr['clerkshipTypeId']?(int)$arr['clerkshipTypeId']:null;
             $courseDTOs[$arr['courseId']]->ancestor = $arr['ancestorId']?(int)$arr['ancestorId']:null;
@@ -98,8 +103,10 @@ class CourseRepository extends EntityRepository implements DTORepositoryInterfac
                 ->where($qb->expr()->in('c.id', ':courseIds'))
                 ->orderBy('relId')
                 ->setParameter('courseIds', $courseIds);
+            $query = $qb->getQuery();
+            $query->useResultCache(true);
 
-            foreach ($qb->getQuery()->getResult() as $arr) {
+            foreach ($query->getResult() as $arr) {
                 $courseDTOs[$arr['courseId']]->{$rel}[] = $arr['relId'];
             }
         }

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -27,7 +27,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         $qb->select('DISTINCT u')->from('IliosCoreBundle:User', 'u');
         $this->attachCriteriaToQueryBuilder($qb, $criteria, $orderBy, $limit, $offset);
 
-        return $qb->getQuery()->getResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        return $query->getResult();
     }
 
     /**
@@ -87,7 +89,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             $qb->setMaxResults($limit);
         }
 
-        return $qb->getQuery()->getResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        return $query->getResult();
     }
 
     /**
@@ -319,7 +323,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         $qb->setParameter('date_from', $from, DoctrineType::DATETIME);
         $qb->setParameter('date_to', $to, DoctrineType::DATETIME);
 
-        $results = $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        $results = $query->getArrayResult();
         return $this->createEventObjectsForOfferings($id, $results);
     }
 
@@ -361,7 +367,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         $qb->setParameter('date_from', $from, DoctrineType::DATETIME);
         $qb->setParameter('date_to', $to, DoctrineType::DATETIME);
 
-        $results = $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        $results = $query->getArrayResult();
         return $this->createEventObjectsForIlmSessions($id, $results);
     }
 
@@ -457,7 +465,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             $qb->expr()->in('o.id', ':offerings')
         );
         $qb->setParameter(':offerings', $ids);
-        $instructedOfferings = $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        $instructedOfferings = $query->getArrayResult();
 
 
         $qb = $this->_em->createQueryBuilder();
@@ -469,7 +479,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             $qb->expr()->in('o.id', ':offerings')
         );
         $qb->setParameter(':offerings', $ids);
-        $groupOfferings = $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        $groupOfferings = $query->getArrayResult();
 
         $results = array_merge($instructedOfferings, $groupOfferings);
 
@@ -503,7 +515,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             $qb->expr()->in('ilm.id', ':ilms')
         );
         $qb->setParameter(':ilms', $ids);
-        $instructedIlms = $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        $instructedIlms = $query->getArrayResult();
 
         $qb = $this->_em->createQueryBuilder();
         $qb->select('ilm.id AS ilmId, u.id AS userId, u.firstName, u.lastName')
@@ -514,7 +528,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             $qb->expr()->in('ilm.id', ':ilms')
         );
         $qb->setParameter(':ilms', $ids);
-        $groupIlms = $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        $groupIlms = $query->getArrayResult();
 
         $results = array_merge($instructedIlms, $groupIlms);
 
@@ -809,7 +825,10 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
     protected function createUserDTOs(AbstractQuery $query)
     {
         $userDTOs = [];
-        foreach ($query->getResult(AbstractQuery::HYDRATE_ARRAY) as $arr) {
+        $query->useResultCache(true);
+        $results = $query->getArrayResult();
+
+        foreach ($results as $arr) {
             $userDTOs[$arr['id']] = new UserDTO(
                 $arr['id'],
                 $arr['firstName'],
@@ -840,7 +859,10 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             ->where($qb->expr()->in('u.id', ':userIds'))
             ->setParameter('userIds', $userIds);
 
-        foreach ($qb->getQuery()->getResult() as $arr) {
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        $results = $query->getResult();
+        foreach ($results as $arr) {
             $userDTOs[$arr['userId']]->primaryCohort = $arr['primaryCohortId'] ? $arr['primaryCohortId'] : null;
             $userDTOs[$arr['userId']]->school = $arr['schoolId'];
             $userDTOs[$arr['userId']]->authentication = $arr['authenticationId'] ? $arr['authenticationId'] : null;
@@ -878,7 +900,10 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
                 ->orderBy('relId')
                 ->setParameter('ids', $userIds);
 
-            foreach ($qb->getQuery()->getResult() as $arr) {
+            $query = $qb->getQuery();
+            $query->useResultCache(true);
+            $results = $query->getResult();
+            foreach ($results as $arr) {
                 $userDTOs[$arr['userId']]->{$rel}[] = $arr['relId'];
             }
         }
@@ -925,7 +950,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         }
         $qb->setParameter('user_id', $id);
 
-        $offeringSessions = $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        $offeringSessions = $query->getArrayResult();
 
         $ilmQb = $this->_em->createQueryBuilder();
         $ilmQb->select('learnerIlmSession.id')->from('IliosCoreBundle:User', 'learnerU');
@@ -956,7 +983,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         }
         $qb->setParameter('user_id', $id);
 
-        $ilmSessions = $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        $ilmSessions = $query->getArrayResult();
         $offeringIds = array_map(function (array $arr) {
             return $arr['offeringId'];
         }, $offeringSessions);
@@ -1122,7 +1151,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         $qb->setParameter(':sessions', $sessionIds);
         $qb->distinct();
 
-        return $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        return $query->getArrayResult();
     }
 
     /**
@@ -1154,6 +1185,8 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         $qb->setParameter(':sessions', $sessionIds);
         $qb->distinct();
 
-        return $qb->getQuery()->getArrayResult();
+        $query = $qb->getQuery();
+        $query->useResultCache(true);
+        return $query->getArrayResult();
     }
 }

--- a/src/Ilios/CoreBundle/EventListener/FlushResultsCache.php
+++ b/src/Ilios/CoreBundle/EventListener/FlushResultsCache.php
@@ -1,0 +1,31 @@
+<?php
+namespace Ilios\CoreBundle\EventListener;
+
+use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * Doctrine event listener.
+ * Flush the cache when changes are made
+ *
+ * Class FlushResultsCache
+ */
+class FlushResultsCache
+{
+    //We have to inject the container to avoid a circular service reference
+    use ContainerAwareTrait;
+
+    /**
+    * Get all the entities that have changed and create log entries for them
+    *
+    * @param OnFlushEventArgs $eventArgs
+    */
+    public function onFlush(OnFlushEventArgs $eventArgs)
+    {
+        $entityManager = $eventArgs->getEntityManager();
+        /** @var CacheProvider $resultsCache */
+        $resultsCache = $entityManager->getConfiguration()->getResultCacheImpl();
+        $resultsCache->deleteAll();
+    }
+}

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -30,6 +30,12 @@ services:
         calls:
             - [ setContainer, ['@service_container'] ]
 
+    Ilios\CoreBundle\EventListener\FlushResultsCache:
+        tags:
+            - { name: doctrine.event_listener, event: onFlush }
+        calls:
+            - [ setContainer, ['@service_container'] ]
+
     Ilios\CoreBundle\EventListener\TrackApiUsageListener:
         tags:
             - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }


### PR DESCRIPTION
This is a start on an idea to cache all of our query results and then
clear the entire results cache anytime something is saved. Ideally we
would only invalidate some items, but our current cache doesn't
implement tagging so we need to just dump the cache on save. This is
still a big boost in speed when updates are infrequent and clearing the
cache is fast.