### PR TITLE
Bump API version to 1.27

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -3,7 +3,7 @@ imports:
     - { resource: services.yml }
 
 parameters:
-    ilios_api_version: v1.26
+    ilios_api_version: v1.27
 
 framework:
     #esi:             ~


### PR DESCRIPTION
We are now providing new filters for learning materials and a new set of
administrator relationships for Curriculum Inventory.