### PR TITLE
new perms and voters

### DIFF
--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
@@ -26,6 +26,7 @@ use Ilios\CoreBundle\Entity\DTO\MeshPreviousIndexingDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshQualifierDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshTermDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshTreeDTO;
+use Ilios\CoreBundle\Entity\DTO\ObjectiveDTO;
 use Ilios\CoreBundle\Entity\DTO\ProgramDTO;
 use Ilios\CoreBundle\Entity\DTO\ProgramYearDTO;
 use Ilios\CoreBundle\Entity\DTO\SchoolDTO;

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
@@ -19,6 +19,7 @@ use Ilios\CoreBundle\Entity\DTO\CurriculumInventorySequenceDTO;
 use Ilios\CoreBundle\Entity\DTO\DepartmentDTO;
 use Ilios\CoreBundle\Entity\DTO\IlmSessionDTO;
 use Ilios\CoreBundle\Entity\DTO\InstructorGroupDTO;
+use Ilios\CoreBundle\Entity\DTO\LearningMaterialStatusDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshConceptDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshDescriptorDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshPreviousIndexingDTO;
@@ -62,6 +63,7 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof DepartmentDTO
                 || $subject instanceof IlmSessionDTO
                 || $subject instanceof InstructorGroupDTO
+                || $subject instanceof LearningMaterialStatusDTO
                 || $subject instanceof MeshConceptDTO
                 || $subject instanceof MeshDescriptorDTO
                 || $subject instanceof MeshPreviousIndexingDTO

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
@@ -70,6 +70,7 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof MeshQualifierDTO
                 || $subject instanceof MeshTermDTO
                 || $subject instanceof MeshTreeDTO
+                || $subject instanceof ObjectiveDTO
                 || $subject instanceof ProgramDTO
                 || $subject instanceof ProgramYearDTO
                 || $subject instanceof SchoolDTO

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/LearnerGroup.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/LearnerGroup.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\LearnerGroupInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class LearnerGroup extends AbstractVoter
+{
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof LearnerGroupInterface
+            && in_array(
+                $attribute,
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+            );
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return $user->performsNonLearnerFunction();
+                break;
+            case self::CREATE:
+                return $this->permissionChecker->canCreateLearnerGroup($user, $subject->getSchool()->getId());
+                break;
+            case self::EDIT:
+                return $this->permissionChecker->canUpdateLearnerGroup(
+                    $user,
+                    $subject->getSchool()->getId()
+                );
+                break;
+            case self::DELETE:
+                return $this->permissionChecker->canDeleteLearnerGroup(
+                    $user,
+                    $subject->getSchool()->getId()
+                );
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/LearningMaterialStatus.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/LearningMaterialStatus.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class LearningMaterialStatus extends AbstractVoter
+{
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof LearningMaterialStatusInterface
+            && in_array(
+                $attribute,
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+            );
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        if ($subject instanceof LearningMaterialStatusInterface) {
+            return self::VIEW === $attribute;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/Objective.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/Objective.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\CoreBundle\Entity\CourseInterface;
+use Ilios\CoreBundle\Entity\ObjectiveInterface;
+use Ilios\CoreBundle\Entity\ProgramYearInterface;
+use Ilios\CoreBundle\Entity\SessionInterface;
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Class Objective
+ */
+class Objective extends AbstractVoter
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof ObjectiveInterface && in_array($attribute, array(
+                self::VIEW, self::CREATE, self::EDIT, self::DELETE
+            ));
+    }
+
+    /**
+     * @param string $attribute
+     * @param ObjectiveInterface $objective
+     * @param TokenInterface $token
+     * @return bool
+     */
+    protected function voteOnAttribute($attribute, $objective, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return true;
+                break;
+            case self::CREATE:
+            case self::EDIT:
+            case self::DELETE:
+                if (!$objective->getCourses()->isEmpty()) { // got courses? if so, it's a course objective.
+                    return $this->isCreateEditDeleteGrantedForCourseObjective($objective, $user);
+                } elseif (!$objective->getSessions()->isEmpty()) { // and so on..
+                    return $this->isCreateEditDeleteGrantedForSessionObjective($objective, $user);
+                } elseif (!$objective->getProgramYears()->isEmpty()) { // and so on ..
+                    return $this->isCreateEditDeleteGrantedForProgramYearObjective($objective, $user);
+                }
+                break;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ObjectiveInterface $objective
+     * @param SessionUserInterface $user
+     * @return bool
+     */
+    protected function isCreateEditDeleteGrantedForProgramYearObjective(
+        ObjectiveInterface $objective,
+        SessionUserInterface $user
+    ) {
+
+        /* @var ProgramYearInterface $programYear */
+        $programYear = $objective->getProgramYears()->first(); // there should ever only be one
+
+        return $this->permissionChecker->canUpdateProgramYear(
+            $user,
+            $programYear->getId(),
+            $programYear->getProgram()->getId(),
+            $programYear->getProgram()->getSchool()->getId()
+        );
+    }
+
+    /**
+     * @param ObjectiveInterface $objective
+     * @param SessionUserInterface $user
+     * @return bool
+     */
+    protected function isCreateEditDeleteGrantedForSessionObjective(
+        ObjectiveInterface $objective,
+        SessionUserInterface $user
+    ) {
+        /* @var SessionInterface $session */
+        $session = $objective->getSessions()->first(); // there should ever only be one
+
+        return $this->permissionChecker->canUpdateSession(
+            $user,
+            $session->getId(),
+            $session->getCourse()->getId(),
+            $session->getCourse()->getSchool()->getId()
+        );
+    }
+
+    /**
+     * @param ObjectiveInterface $objective
+     * @param SessionUserInterface $user
+     * @return bool
+     */
+    protected function isCreateEditDeleteGrantedForCourseObjective($objective, $user)
+    {
+        /* @var CourseInterface $course */
+        $course = $objective->getCourses()->first(); // there should ever only be one
+
+        return $this->permissionChecker->canUpdateCourse(
+            $user,
+            $course->getId(),
+            $course->getSchool()->getId()
+        );
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/ProgramYear.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/ProgramYear.php
@@ -47,12 +47,12 @@ class ProgramYear extends AbstractVoter
                 );
                 break;
             case self::DELETE:
-            return $this->permissionChecker->canDeleteProgramYear(
-                $user,
-                $subject->getId(),
-                $subject->getProgram()->getId(),
-                $subject->getSchool()->getId()
-            );
+                return $this->permissionChecker->canDeleteProgramYear(
+                    $user,
+                    $subject->getId(),
+                    $subject->getProgram()->getId(),
+                    $subject->getSchool()->getId()
+                );
             break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/Report.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/Report.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\AuthenticationBundle\Voter\AbstractVoter;
+use Ilios\CoreBundle\Entity\DTO\ReportDTO;
+use Ilios\CoreBundle\Entity\ReportInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Class Report
+ */
+class Report extends AbstractVoter
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports($attribute, $subject)
+    {
+        return ($subject instanceof ReportDTO && self::VIEW === $attribute) ||
+            ($subject instanceof ReportInterface && in_array(
+                $attribute,
+                array(
+                        self::VIEW,
+                        self::CREATE,
+                        self::EDIT,
+                        self::DELETE,
+                    )
+            ));
+    }
+
+    /**
+     * @param string $attribute
+     * @param ReportInterface $report
+     * @param TokenInterface $token
+     * @return bool
+     */
+    protected function voteOnAttribute($attribute, $report, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::CREATE:
+            case self::VIEW:
+            case self::EDIT:
+            case self::DELETE:
+                return $user->isTheUser($report->getUser());
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/Service/PermissionChecker.php
+++ b/src/Ilios/AuthenticationBundle/Service/PermissionChecker.php
@@ -204,7 +204,7 @@ class PermissionChecker
 
             $arr[self::CAN_UPDATE_THEIR_COHORTS] = $allRoles;
             $arr[self::CAN_DELETE_THEIR_COHORTS] = $allRoles;
-;
+            ;
             $arr[self::CAN_UPDATE_SCHOOL_CONFIGS] = $allRoles;
             $arr[self::CAN_CREATE_SCHOOL_CONFIGS] = $allRoles;
             $arr[self::CAN_DELETE_SCHOOL_CONFIGS] = $allRoles;

--- a/src/Ilios/AuthenticationBundle/Service/PermissionChecker.php
+++ b/src/Ilios/AuthenticationBundle/Service/PermissionChecker.php
@@ -122,6 +122,12 @@ class PermissionChecker
     const CAN_UPDATE_CURRICULUM_INVENTORY_INSTITUTIONS = 'canUpdateCurriculumInventoryInstitutions';
     /** @var string */
     const CAN_DELETE_CURRICULUM_INVENTORY_INSTITUTIONS = 'canDeleteCurriculumInventoryInstitutions';
+    /** @var string */
+    const CAN_CREATE_LEARNER_GROUPS = 'canCreateLearnerGroups';
+    /** @var string */
+    const CAN_UPDATE_LEARNER_GROUPS = 'canUpdateLearnerGroups';
+    /** @var string */
+    const CAN_DELETE_LEARNER_GROUPS = 'canDeleteLearnerGroups';
 
     /**
      * @var SchoolManager
@@ -233,6 +239,9 @@ class PermissionChecker
             $arr[self::CAN_CREATE_CURRICULUM_INVENTORY_INSTITUTIONS] = $allRoles;
             $arr[self::CAN_DELETE_CURRICULUM_INVENTORY_INSTITUTIONS] = $allRoles;
 
+            $arr[self::CAN_UPDATE_LEARNER_GROUPS] = $allRoles;
+            $arr[self::CAN_CREATE_LEARNER_GROUPS] = $allRoles;
+            $arr[self::CAN_DELETE_LEARNER_GROUPS] = $allRoles;
 
             $this->matrix[$schoolDto->id] = $arr;
         }
@@ -1012,6 +1021,48 @@ class PermissionChecker
         if ($this->hasPermission(
             $schoolId,
             PermissionChecker::CAN_CREATE_CURRICULUM_INVENTORY_INSTITUTIONS,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function canUpdateLearnerGroup(SessionUserInterface $sessionUser, int $schoolId): bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+        if ($this->hasPermission(
+            $schoolId,
+            PermissionChecker::CAN_UPDATE_LEARNER_GROUPS,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function canDeleteLearnerGroup(SessionUserInterface $sessionUser, int $schoolId): bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+        if ($this->hasPermission(
+            $schoolId,
+            PermissionChecker::CAN_DELETE_LEARNER_GROUPS,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function canCreateLearnerGroup(SessionUserInterface $sessionUser, int $schoolId): bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+        if ($this->hasPermission(
+            $schoolId,
+            PermissionChecker::CAN_CREATE_LEARNER_GROUPS,
             $rolesInSchool
         )) {
             return true;

--- a/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -21,6 +21,7 @@ use Ilios\CoreBundle\Entity\DTO\CurriculumInventorySequenceDTO;
 use Ilios\CoreBundle\Entity\DTO\DepartmentDTO;
 use Ilios\CoreBundle\Entity\DTO\IlmSessionDTO;
 use Ilios\CoreBundle\Entity\DTO\InstructorGroupDTO;
+use Ilios\CoreBundle\Entity\DTO\LearningMaterialStatusDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshConceptDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshDescriptorDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshPreviousIndexingDTO;
@@ -72,6 +73,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [DepartmentDTO::class],
             [IlmSessionDTO::class],
             [InstructorGroupDTO::class],
+            [LearningMaterialStatusDTO::class]
             [MeshConceptDTO::class],
             [MeshDescriptorDTO::class],
             [MeshPreviousIndexingDTO::class],

--- a/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -74,7 +74,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [DepartmentDTO::class],
             [IlmSessionDTO::class],
             [InstructorGroupDTO::class],
-            [LearningMaterialStatusDTO::class]
+            [LearningMaterialStatusDTO::class],
             [MeshConceptDTO::class],
             [MeshDescriptorDTO::class],
             [MeshPreviousIndexingDTO::class],

--- a/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -28,6 +28,7 @@ use Ilios\CoreBundle\Entity\DTO\MeshPreviousIndexingDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshQualifierDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshTermDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshTreeDTO;
+use Ilios\CoreBundle\Entity\DTO\ObjectiveDTO;
 use Ilios\CoreBundle\Entity\DTO\ProgramDTO;
 use Ilios\CoreBundle\Entity\DTO\ProgramYearDTO;
 use Ilios\CoreBundle\Entity\DTO\SchoolDTO;
@@ -80,6 +81,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [MeshQualifierDTO::class],
             [MeshTermDTO::class],
             [MeshTreeDTO::class],
+            [ObjectiveDTO::class],
             [ProgramDTO::class],
             [ProgramYearDTO::class],
             [SchoolDTO::class],

--- a/tests/AuthenticationBundle/RelationshipVoter/LearnerGroupTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/LearnerGroupTest.php
@@ -1,0 +1,119 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\LearnerGroup as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\LearnerGroup;
+use Ilios\CoreBundle\Entity\School;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class LearnerGroupTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(LearnerGroup::class);
+    }
+
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        $entity = m::mock(LearnerGroup::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $entity = m::mock(LearnerGroup::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
+    }
+
+    public function testCanEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearnerGroup::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateLearnerGroup')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearnerGroup::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateLearnerGroup')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearnerGroup::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canDeleteLearnerGroup')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearnerGroup::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canDeleteLearnerGroup')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearnerGroup::class);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canCreateLearnerGroup')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearnerGroup::class);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canCreateLearnerGroup')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/LearningMaterialStatusTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/LearningMaterialStatusTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\LearningMaterialStatus as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\LearningMaterialStatus;
+use Ilios\CoreBundle\Entity\DTO\LearningMaterialStatusDTO;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class LearningMaterialStatusTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(LearningMaterialStatus::class);
+    }
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterialStatus::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterialStatus::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanNotDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterialStatus::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanNotCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterialStatus::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/ObjectiveTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/ObjectiveTest.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\Objective as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\Course;
+use Ilios\CoreBundle\Entity\Objective;
+use Ilios\CoreBundle\Entity\ObjectiveInterface;
+use Ilios\CoreBundle\Entity\Offering;
+use Ilios\CoreBundle\Entity\Program;
+use Ilios\CoreBundle\Entity\ProgramYear;
+use Ilios\CoreBundle\Entity\Session;
+use Ilios\CoreBundle\Entity\School;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class ObjectiveTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(ObjectiveInterface::class);
+    }
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanCreateProgramYearObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $programYear = m::mock(ProgramYear::class);
+        $program = m::mock(Program::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection([$programYear]));
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $programYear->shouldReceive('getProgram')->andReturn($program);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $program->shouldReceive('getSchool')->andReturn($school);
+        $program->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreateProgramYearObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $programYear = m::mock(ProgramYear::class);
+        $program = m::mock(Program::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection([$programYear]));
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $programYear->shouldReceive('getProgram')->andReturn($program);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $program->shouldReceive('getSchool')->andReturn($school);
+        $program->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+
+    public function testCanEditProgramYearObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $programYear = m::mock(ProgramYear::class);
+        $program = m::mock(Program::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection([$programYear]));
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $programYear->shouldReceive('getProgram')->andReturn($program);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $program->shouldReceive('getSchool')->andReturn($school);
+        $program->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEditProgramYearObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $programYear = m::mock(ProgramYear::class);
+        $program = m::mock(Program::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection([$programYear]));
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $programYear->shouldReceive('getProgram')->andReturn($program);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $program->shouldReceive('getSchool')->andReturn($school);
+        $program->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDeleteProgramYearObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $programYear = m::mock(ProgramYear::class);
+        $program = m::mock(Program::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection([$programYear]));
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $programYear->shouldReceive('getProgram')->andReturn($program);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $program->shouldReceive('getSchool')->andReturn($school);
+        $program->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDeleteProgramYearObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $programYear = m::mock(ProgramYear::class);
+        $program = m::mock(Program::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection([$programYear]));
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $programYear->shouldReceive('getProgram')->andReturn($program);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $program->shouldReceive('getSchool')->andReturn($school);
+        $program->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanCreateCourseObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection([$course]));
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreateCourseObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection([$course]));
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+
+    public function testCanEditCourseObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection([$course]));
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEditCourseObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection([$course]));
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDeleteCourseObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection([$course]));
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDeleteCourseObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection([$course]));
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection());
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanCreateSessionObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $session = m::mock(Session::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection([$session]));
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreateSessionObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $session = m::mock(Session::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection([$session]));
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+
+    public function testCanEditSessionObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $session = m::mock(Session::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection([$session]));
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEditSessionObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $session = m::mock(Session::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection([$session]));
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDeleteSessionObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $session = m::mock(Session::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection([$session]));
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDeleteSessionObjective()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Objective::class);
+        $session = m::mock(Session::class);
+        $course = m::mock(Course::class);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getProgramYears')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getCourses')->andReturn(new ArrayCollection());
+        $entity->shouldReceive('getSessions')->andReturn(new ArrayCollection([$session]));
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school->shouldReceive('getId')->andReturn(1);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create allowed");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/OfferingTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/OfferingTest.php
@@ -5,7 +5,6 @@ use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
 use Ilios\AuthenticationBundle\RelationshipVoter\Offering as Voter;
 use Ilios\AuthenticationBundle\Service\PermissionChecker;
 use Ilios\CoreBundle\Entity\Course;
-use Ilios\CoreBundle\Entity\DTO\OfferingDTO;
 use Ilios\CoreBundle\Entity\Offering;
 use Ilios\CoreBundle\Entity\Session;
 use Ilios\CoreBundle\Entity\School;

--- a/tests/AuthenticationBundle/RelationshipVoter/ReportTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/ReportTest.php
@@ -1,0 +1,124 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\Report as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\Report;
+use Ilios\CoreBundle\Entity\DTO\ReportDTO;
+use Ilios\CoreBundle\Entity\UserInterface;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class ReportTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(Report::class);
+    }
+
+    public function testCanViewDTO()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $dto = m::mock(ReportDTO::class);
+        $dto->shouldReceive('getUser')->andReturn(m::mock(UserInterface::class));
+        $user->shouldReceive('isTheUser')->andReturn(true);
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View DTO allowed");
+    }
+
+    public function testCanNotViewDTO()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $dto = m::mock(ReportDTO::class);
+        $dto->shouldReceive('getUser')->andReturn(m::mock(UserInterface::class));
+        $user->shouldReceive('isTheUser')->andReturn(false);
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View DTO denied");
+    }
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(Report::class);
+        $entity->shouldReceive('getUser')->andReturn(m::mock(UserInterface::class));
+        $user->shouldReceive('isTheUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(Report::class);
+        $entity->shouldReceive('getUser')->andReturn(m::mock(UserInterface::class));
+        $user->shouldReceive('isTheUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(Report::class);
+        $entity->shouldReceive('getUser')->andReturn(m::mock(UserInterface::class));
+        $user->shouldReceive('isTheUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(Report::class);
+        $entity->shouldReceive('getUser')->andReturn(m::mock(UserInterface::class));
+        $user->shouldReceive('isTheUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(Report::class);
+        $entity->shouldReceive('getUser')->andReturn(m::mock(UserInterface::class));
+        $user->shouldReceive('isTheUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(Report::class);
+        $entity->shouldReceive('getUser')->andReturn(m::mock(UserInterface::class));
+        $user->shouldReceive('isTheUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(Report::class);
+        $entity->shouldReceive('getUser')->andReturn(m::mock(UserInterface::class));
+        $user->shouldReceive('isTheUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+}

--- a/tests/IliosApiBundle/Endpoints/CurriculumInventorySequenceBlockTest.php
+++ b/tests/IliosApiBundle/Endpoints/CurriculumInventorySequenceBlockTest.php
@@ -449,11 +449,11 @@ class CurriculumInventorySequenceBlockTest extends AbstractEndpointTest
             ['filters[parent]' => $parent['id']]
         );
 
-         $this->assertEquals(
-             count($childrenBeforeMove),
-             count($childrenAfterMove),
-             'Sequence contains the same number of blocks as before.'
-         );
+        $this->assertEquals(
+            count($childrenBeforeMove),
+            count($childrenAfterMove),
+            'Sequence contains the same number of blocks as before.'
+        );
 
         $childrenAfterMove = $this->sortOrderedSequence($childrenAfterMove);
 


### PR DESCRIPTION
refs #1950

some notes:

- learner groups: need elevated privileges to view.
- learning material status: can be read by everyone, but only modified by root.
- reports: CRUD privileges only to report owner, and root.
- objectives: readable by all, create/update/delete checks are performed against program-year/course/session context as applicable.
