### PR TITLE
drop unnecessary index from schema.

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20180102185950.php
+++ b/app/Resources/DoctrineMigrations/Version20180102185950.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Drops superfluous index from table.
+ */
+class Version20180102185950 extends AbstractMigration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX UNIQ_FEB4C9FD217BBB47 ON authentication');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_FEB4C9FD217BBB47 ON authentication (person_id)');
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/Authentication.php
+++ b/src/Ilios/CoreBundle/Entity/Authentication.php
@@ -25,7 +25,7 @@ class Authentication implements AuthenticationInterface
      * @ORM\Id
      * @ORM\OneToOne(targetEntity="User", inversedBy="authentication")
      * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="person_id", referencedColumnName="user_id", unique=true, onDelete="CASCADE")
+     *   @ORM\JoinColumn(name="person_id", referencedColumnName="user_id", onDelete="CASCADE")
      * })
      *
      * @Assert\NotBlank()


### PR DESCRIPTION
fixes #2023 

that column already has an primary index on it, which enforces uniqueness. so no need to have an additional unique index on it.