### PR TITLE
new perms and voters

### DIFF
--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/AbstractVoter.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/AbstractVoter.php
@@ -28,6 +28,16 @@ abstract class AbstractVoter extends SymfonyVoter
     const CREATE = 'create';
 
     /**
+     * @var string
+     */
+    const UNLOCK = 'unlock';
+
+    /**
+     * @var string
+     */
+    const UNARCHIVE = 'unarchive';
+
+    /**
      * @var PermissionChecker
      */
     protected $permissionChecker;

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/Authentication.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/Authentication.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\AuthenticationInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class Authentication extends AbstractVoter
+{
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof AuthenticationInterface
+            && in_array(
+                $attribute,
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+            );
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return $user->performsNonLearnerFunction();
+                break;
+            case self::CREATE:
+                return $this->permissionChecker->canUpdateUser($user, $subject->getUser()->getSchool()->getId());
+                break;
+            case self::EDIT:
+                return $this->permissionChecker->canUpdateUser($user, $subject->getUser()->getSchool()->getId());
+                break;
+            case self::DELETE:
+                return $this->permissionChecker->canUpdateUser($user, $subject->getUser()->getSchool()->getId());
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/Cohort.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/Cohort.php
@@ -32,27 +32,13 @@ class Cohort extends AbstractVoter
                 return true;
                 break;
             case self::EDIT:
-                return $this->permissionChecker->canUpdateCohort(
-                    $user,
-                    $subject->getId(),
-                    $subject->getProgram()->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateCohort($user, $subject);
                 break;
             case self::CREATE:
-                return $this->permissionChecker->canCreateCohort(
-                    $user,
-                    $subject->getProgram()->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canCreateCohort($user, $subject->getProgramYear());
                 break;
             case self::DELETE:
-                return $this->permissionChecker->canDeleteCohort(
-                    $user,
-                    $subject->getId(),
-                    $subject->getProgram()->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canDeleteCohort($user, $subject);
                 break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/Course.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/Course.php
@@ -13,7 +13,7 @@ class Course extends AbstractVoter
         return $subject instanceof CourseInterface
             && in_array(
                 $attribute,
-                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE, self::UNLOCK, self::UNARCHIVE]
             );
     }
 
@@ -32,21 +32,19 @@ class Course extends AbstractVoter
                 return true;
                 break;
             case self::CREATE:
-                return $this->permissionChecker->canCreateCourse($user, $subject->getSchool()->getId());
+                return $this->permissionChecker->canCreateCourse($user, $subject->getSchool());
                 break;
             case self::EDIT:
-                return $this->permissionChecker->canUpdateCourse(
-                    $user,
-                    $subject->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateCourse($user, $subject);
                 break;
             case self::DELETE:
-                return $this->permissionChecker->canDeleteCourse(
-                    $user,
-                    $subject->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canDeleteCourse($user, $subject);
+                break;
+            case self::UNLOCK:
+                return $this->permissionChecker->canUnlockCourse($user, $subject);
+                break;
+            case self::UNARCHIVE:
+                return $this->permissionChecker->canUnarchiveCourse($user, $subject);
                 break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/CourseLearningMaterial.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/CourseLearningMaterial.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\CourseLearningMaterialInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class CourseLearningMaterial extends AbstractVoter
+{
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof CourseLearningMaterialInterface
+            && in_array(
+                $attribute,
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+            );
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return true;
+                break;
+            case self::EDIT:
+            case self::CREATE:
+            case self::DELETE:
+                return $this->permissionChecker->canUpdateCourse(
+                    $user,
+                    $subject->getCourse()->getId(),
+                    $subject->getCourse()->getSchool()->getId()
+                );
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/CourseLearningMaterial.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/CourseLearningMaterial.php
@@ -34,11 +34,7 @@ class CourseLearningMaterial extends AbstractVoter
             case self::EDIT:
             case self::CREATE:
             case self::DELETE:
-                return $this->permissionChecker->canUpdateCourse(
-                    $user,
-                    $subject->getCourse()->getId(),
-                    $subject->getCourse()->getSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateCourse($user, $subject->getCourse());
                 break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/ElevatedPermissionsViewDTOVoter.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/ElevatedPermissionsViewDTOVoter.php
@@ -3,8 +3,12 @@
 namespace Ilios\AuthenticationBundle\RelationshipVoter;
 
 use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\DTO\AuthenticationDTO;
+use Ilios\CoreBundle\Entity\DTO\IngestionExceptionDTO;
 use Ilios\CoreBundle\Entity\DTO\LearnerGroupDTO;
 use Ilios\CoreBundle\Entity\DTO\OfferingDTO;
+use Ilios\CoreBundle\Entity\DTO\PendingUserUpdateDTO;
+use Ilios\CoreBundle\Entity\DTO\UserDTO;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
@@ -20,11 +24,17 @@ class ElevatedPermissionsViewDTOVoter extends AbstractVoter
     {
         return (
             array($attribute, [self::VIEW]) && (
-                $subject instanceof OfferingDTO
+                $subject instanceof AuthenticationDTO
+                || $subject instanceof IngestionExceptionDTO
                 || $subject instanceof LearnerGroupDTO
+                || $subject instanceof OfferingDTO
+                || $subject instanceof PendingUserUpdateDTO
+                || $subject instanceof UserDTO
+
             )
         );
     }
+
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
     {
         $user = $token->getUser();

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
@@ -11,6 +11,7 @@ use Ilios\CoreBundle\Entity\DTO\CohortDTO;
 use Ilios\CoreBundle\Entity\DTO\CompetencyDTO;
 use Ilios\CoreBundle\Entity\DTO\CourseClerkshipTypeDTO;
 use Ilios\CoreBundle\Entity\DTO\CourseDTO;
+use Ilios\CoreBundle\Entity\DTO\CourseLearningMaterialDTO;
 use Ilios\CoreBundle\Entity\DTO\CurriculumInventoryAcademicLevelDTO;
 use Ilios\CoreBundle\Entity\DTO\CurriculumInventoryInstitutionDTO;
 use Ilios\CoreBundle\Entity\DTO\CurriculumInventoryReportDTO;
@@ -19,6 +20,7 @@ use Ilios\CoreBundle\Entity\DTO\CurriculumInventorySequenceDTO;
 use Ilios\CoreBundle\Entity\DTO\DepartmentDTO;
 use Ilios\CoreBundle\Entity\DTO\IlmSessionDTO;
 use Ilios\CoreBundle\Entity\DTO\InstructorGroupDTO;
+use Ilios\CoreBundle\Entity\DTO\LearningMaterialDTO;
 use Ilios\CoreBundle\Entity\DTO\LearningMaterialStatusDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshConceptDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshDescriptorDTO;
@@ -33,6 +35,7 @@ use Ilios\CoreBundle\Entity\DTO\ProgramYearStewardDTO;
 use Ilios\CoreBundle\Entity\DTO\SchoolDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionDescriptionDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionDTO;
+use Ilios\CoreBundle\Entity\DTO\SessionLearningMaterialDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionTypeDTO;
 use Ilios\CoreBundle\Entity\DTO\TermDTO;
 use Ilios\CoreBundle\Entity\DTO\VocabularyDTO;
@@ -57,6 +60,7 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof CompetencyDTO
                 || $subject instanceof CourseDTO
                 || $subject instanceof CourseClerkshipTypeDTO
+                || $subject instanceof CourseLearningMaterialDTO
                 || $subject instanceof CurriculumInventoryAcademicLevelDTO
                 || $subject instanceof CurriculumInventoryInstitutionDTO
                 || $subject instanceof CurriculumInventoryReportDTO
@@ -65,6 +69,7 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof DepartmentDTO
                 || $subject instanceof IlmSessionDTO
                 || $subject instanceof InstructorGroupDTO
+                || $subject instanceof LearningMaterialDTO
                 || $subject instanceof LearningMaterialStatusDTO
                 || $subject instanceof MeshConceptDTO
                 || $subject instanceof MeshDescriptorDTO
@@ -79,6 +84,7 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof SchoolDTO
                 || $subject instanceof SessionDTO
                 || $subject instanceof SessionDescriptionDTO
+                || $subject instanceof SessionLearningMaterialDTO
                 || $subject instanceof SessionTypeDTO
                 || $subject instanceof TermDTO
                 || $subject instanceof VocabularyDTO

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/GreenlightViewDTOVoter.php
@@ -29,6 +29,7 @@ use Ilios\CoreBundle\Entity\DTO\MeshTreeDTO;
 use Ilios\CoreBundle\Entity\DTO\ObjectiveDTO;
 use Ilios\CoreBundle\Entity\DTO\ProgramDTO;
 use Ilios\CoreBundle\Entity\DTO\ProgramYearDTO;
+use Ilios\CoreBundle\Entity\DTO\ProgramYearStewardDTO;
 use Ilios\CoreBundle\Entity\DTO\SchoolDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionDescriptionDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionDTO;
@@ -74,6 +75,7 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof ObjectiveDTO
                 || $subject instanceof ProgramDTO
                 || $subject instanceof ProgramYearDTO
+                || $subject instanceof ProgramYearStewardDTO
                 || $subject instanceof SchoolDTO
                 || $subject instanceof SessionDTO
                 || $subject instanceof SessionDescriptionDTO

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/IlmSession.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/IlmSession.php
@@ -33,12 +33,7 @@ class IlmSession extends AbstractVoter
             case self::EDIT:
             case self::CREATE:
             case self::DELETE:
-                return $this->permissionChecker->canUpdateSession(
-                    $user,
-                    $subject->getSession()->getId(),
-                    $subject->getSession()->getCourse()->getId(),
-                    $subject->getSession()->getCourse()->getSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateSession($user, $subject->getSession());
                 break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/IngestionException.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/IngestionException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\IngestionExceptionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class IngestionException extends AbstractVoter
+{
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof IngestionExceptionInterface
+            && in_array($attribute, [self::VIEW]);
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return $user->performsNonLearnerFunction();
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/LearningMaterial.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/LearningMaterial.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\CoreBundle\Entity\LearningMaterialInterface;
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Class LearningMaterial
+ */
+class LearningMaterial extends AbstractVoter
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof LearningMaterialInterface && in_array($attribute, array(
+                self::VIEW, self::CREATE, self::EDIT, self::DELETE
+            ));
+    }
+
+    /**
+     * @param string $attribute
+     * @param LearningMaterialInterface $learningMaterial
+     * @param TokenInterface $token
+     * @return bool
+     */
+    protected function voteOnAttribute($attribute, $learningMaterial, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return true;
+                break;
+            case self::CREATE:
+            case self::EDIT:
+            case self::DELETE:
+                return $user->performsNonLearnerFunction();
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/Objective.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/Objective.php
@@ -74,12 +74,7 @@ class Objective extends AbstractVoter
         /* @var ProgramYearInterface $programYear */
         $programYear = $objective->getProgramYears()->first(); // there should ever only be one
 
-        return $this->permissionChecker->canUpdateProgramYear(
-            $user,
-            $programYear->getId(),
-            $programYear->getProgram()->getId(),
-            $programYear->getProgram()->getSchool()->getId()
-        );
+        return $this->permissionChecker->canUpdateProgramYear($user, $programYear);
     }
 
     /**
@@ -94,12 +89,7 @@ class Objective extends AbstractVoter
         /* @var SessionInterface $session */
         $session = $objective->getSessions()->first(); // there should ever only be one
 
-        return $this->permissionChecker->canUpdateSession(
-            $user,
-            $session->getId(),
-            $session->getCourse()->getId(),
-            $session->getCourse()->getSchool()->getId()
-        );
+        return $this->permissionChecker->canUpdateSession($user, $session);
     }
 
     /**
@@ -112,10 +102,6 @@ class Objective extends AbstractVoter
         /* @var CourseInterface $course */
         $course = $objective->getCourses()->first(); // there should ever only be one
 
-        return $this->permissionChecker->canUpdateCourse(
-            $user,
-            $course->getId(),
-            $course->getSchool()->getId()
-        );
+        return $this->permissionChecker->canUpdateCourse($user, $course);
     }
 }

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/Offering.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/Offering.php
@@ -34,12 +34,7 @@ class Offering extends AbstractVoter
             case self::EDIT:
             case self::CREATE:
             case self::DELETE:
-                return $this->permissionChecker->canUpdateSession(
-                    $user,
-                    $subject->getSession()->getId(),
-                    $subject->getSession()->getCourse()->getId(),
-                    $subject->getSession()->getCourse()->getSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateSession($user, $subject->getSession());
                 break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/PendingUserUpdate.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/PendingUserUpdate.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\PendingUserUpdateInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class PendingUserUpdate extends AbstractVoter
+{
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof PendingUserUpdateInterface
+            && in_array(
+                $attribute,
+                [self::VIEW, self::EDIT, self::DELETE]
+            );
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return $user->performsNonLearnerFunction();
+                break;
+            case self::EDIT:
+                return $this->permissionChecker->canUpdateUser($user, $subject->getUser()->getSchool()->getId());
+                break;
+            case self::DELETE:
+                return $this->permissionChecker->canUpdateUser($user, $subject->getUser()->getSchool()->getId());
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/ProgramYear.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/ProgramYear.php
@@ -13,7 +13,7 @@ class ProgramYear extends AbstractVoter
         return $subject instanceof ProgramYearInterface
             && in_array(
                 $attribute,
-                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE, self::UNLOCK, self::UNARCHIVE]
             );
     }
 
@@ -32,28 +32,20 @@ class ProgramYear extends AbstractVoter
                 return true;
                 break;
             case self::EDIT:
-                return $this->permissionChecker->canUpdateProgramYear(
-                    $user,
-                    $subject->getId(),
-                    $subject->getProgram()->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateProgramYear($user, $subject);
                 break;
             case self::CREATE:
-                return $this->permissionChecker->canCreateProgramYear(
-                    $user,
-                    $subject->getProgram()->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canCreateProgramYear($user, $subject->getProgram());
                 break;
             case self::DELETE:
-                return $this->permissionChecker->canDeleteProgramYear(
-                    $user,
-                    $subject->getId(),
-                    $subject->getProgram()->getId(),
-                    $subject->getSchool()->getId()
-                );
-            break;
+                return $this->permissionChecker->canDeleteProgramYear($user, $subject);
+                break;
+            case self::UNLOCK:
+                return $this->permissionChecker->canUnlockProgramYear($user, $subject);
+                break;
+            case self::UNARCHIVE:
+                return $this->permissionChecker->canUnarchiveProgramYear($user, $subject);
+                break;
         }
 
         return false;

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/ProgramYearSteward.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/ProgramYearSteward.php
@@ -34,12 +34,7 @@ class ProgramYearSteward extends AbstractVoter
             case self::EDIT:
             case self::CREATE:
             case self::DELETE:
-                return $this->permissionChecker->canUpdateProgramYear(
-                    $user,
-                    $subject->getProgramYear()->getId(),
-                    $subject->getProgram()->getId(),
-                    $subject->getProgramOwningSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateProgramYear($user, $subject->getProgramYear());
                 break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/ProgramYearSteward.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/ProgramYearSteward.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\ProgramYearStewardInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class ProgramYearSteward extends AbstractVoter
+{
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof ProgramYearStewardInterface
+            && in_array(
+                $attribute,
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+            );
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return true;
+                break;
+            case self::EDIT:
+            case self::CREATE:
+            case self::DELETE:
+                return $this->permissionChecker->canUpdateProgramYear(
+                    $user,
+                    $subject->getProgramYear()->getId(),
+                    $subject->getProgram()->getId(),
+                    $subject->getProgramOwningSchool()->getId()
+                );
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/Session.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/Session.php
@@ -32,27 +32,13 @@ class Session extends AbstractVoter
                 return true;
                 break;
             case self::EDIT:
-                return $this->permissionChecker->canUpdateSession(
-                    $user,
-                    $subject->getId(),
-                    $subject->getCourse()->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateSession($user, $subject);
                 break;
             case self::CREATE:
-                return $this->permissionChecker->canCreateSession(
-                    $user,
-                    $subject->getCourse()->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canCreateSession($user, $subject->getCourse());
                 break;
             case self::DELETE:
-                return $this->permissionChecker->canDeleteSession(
-                    $user,
-                    $subject->getId(),
-                    $subject->getCourse()->getId(),
-                    $subject->getSchool()->getId()
-                );
+                return $this->permissionChecker->canDeleteSession($user, $subject);
                 break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/SessionDescription.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/SessionDescription.php
@@ -34,12 +34,7 @@ class SessionDescription extends AbstractVoter
             case self::EDIT:
             case self::CREATE:
             case self::DELETE:
-                return $this->permissionChecker->canUpdateSession(
-                    $user,
-                    $subject->getSession()->getId(),
-                    $subject->getSession()->getCourse()->getId(),
-                    $subject->getSession()->getCourse()->getSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateSession($user, $subject->getSession());
                 break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/SessionLearningMaterial.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/SessionLearningMaterial.php
@@ -34,12 +34,7 @@ class SessionLearningMaterial extends AbstractVoter
             case self::EDIT:
             case self::CREATE:
             case self::DELETE:
-                return $this->permissionChecker->canUpdateSession(
-                    $user,
-                    $subject->getSession()->getId(),
-                    $subject->getSession()->getCourse()->getId(),
-                    $subject->getSession()->getCourse()->getSchool()->getId()
-                );
+                return $this->permissionChecker->canUpdateSession($user, $subject->getSession());
                 break;
         }
 

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/SessionLearningMaterial.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/SessionLearningMaterial.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\SessionLearningMaterialInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class SessionLearningMaterial extends AbstractVoter
+{
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof SessionLearningMaterialInterface
+            && in_array(
+                $attribute,
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+            );
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return true;
+                break;
+            case self::EDIT:
+            case self::CREATE:
+            case self::DELETE:
+                return $this->permissionChecker->canUpdateSession(
+                    $user,
+                    $subject->getSession()->getId(),
+                    $subject->getSession()->getCourse()->getId(),
+                    $subject->getSession()->getCourse()->getSchool()->getId()
+                );
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/RelationshipVoter/User.php
+++ b/src/Ilios/AuthenticationBundle/RelationshipVoter/User.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Ilios\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
+use Ilios\CoreBundle\Entity\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class User extends AbstractVoter
+{
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof UserInterface
+            && in_array(
+                $attribute,
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+            );
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return $user->isTheUser($subject) || $user->performsNonLearnerFunction();
+                break;
+            case self::CREATE:
+                return $this->permissionChecker->canCreateUser($user, $subject->getSchool()->getId());
+                break;
+            case self::EDIT:
+                return $this->permissionChecker->canUpdateUser(
+                    $user,
+                    $subject->getSchool()->getId()
+                );
+                break;
+            case self::DELETE:
+                return $this->permissionChecker->canDeleteUser(
+                    $user,
+                    $subject->getSchool()->getId()
+                );
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Ilios/AuthenticationBundle/Service/PermissionChecker.php
+++ b/src/Ilios/AuthenticationBundle/Service/PermissionChecker.php
@@ -128,6 +128,12 @@ class PermissionChecker
     const CAN_UPDATE_LEARNER_GROUPS = 'canUpdateLearnerGroups';
     /** @var string */
     const CAN_DELETE_LEARNER_GROUPS = 'canDeleteLearnerGroups';
+    /** @var string */
+    const CAN_CREATE_USERS = 'canCreateUser';
+    /** @var string */
+    const CAN_UPDATE_USERS = 'canUpdateUser';
+    /** @var string */
+    const CAN_DELETE_USERS = 'canDeleteUser';
 
     /**
      * @var SchoolManager
@@ -1063,6 +1069,48 @@ class PermissionChecker
         if ($this->hasPermission(
             $schoolId,
             PermissionChecker::CAN_CREATE_LEARNER_GROUPS,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function canUpdateUser(SessionUserInterface $sessionUser, int $schoolId): bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+        if ($this->hasPermission(
+            $schoolId,
+            PermissionChecker::CAN_UPDATE_USERS,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function canDeleteUser(SessionUserInterface $sessionUser, int $schoolId): bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+        if ($this->hasPermission(
+            $schoolId,
+            PermissionChecker::CAN_DELETE_USERS,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function canCreateUser(SessionUserInterface $sessionUser, int $schoolId): bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+        if ($this->hasPermission(
+            $schoolId,
+            PermissionChecker::CAN_CREATE_USERS,
             $rolesInSchool
         )) {
             return true;

--- a/src/Ilios/AuthenticationBundle/Service/PermissionChecker.php
+++ b/src/Ilios/AuthenticationBundle/Service/PermissionChecker.php
@@ -5,8 +5,14 @@ namespace Ilios\AuthenticationBundle\Service;
 use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
 use Ilios\AuthenticationBundle\Classes\UserRoles;
 
+use Ilios\CoreBundle\Entity\CohortInterface;
+use Ilios\CoreBundle\Entity\CourseInterface;
 use Ilios\CoreBundle\Entity\DTO\SchoolDTO;
 use Ilios\CoreBundle\Entity\Manager\SchoolManager;
+use Ilios\CoreBundle\Entity\ProgramInterface;
+use Ilios\CoreBundle\Entity\ProgramYearInterface;
+use Ilios\CoreBundle\Entity\SchoolInterface;
+use Ilios\CoreBundle\Entity\SessionInterface;
 
 class PermissionChecker
 {
@@ -15,11 +21,19 @@ class PermissionChecker
     /** @var string */
     const CAN_DELETE_ALL_COURSES = 'canDeleteAllCourses';
     /** @var string */
+    const CAN_UNLOCK_ALL_COURSES = 'canUnlockAllCourses';
+    /** @var string */
+    const CAN_UNARCHIVE_ALL_COURSES = 'canUnarchiveAllCourses';
+    /** @var string */
     const CAN_CREATE_COURSES = 'canCreateCourses';
     /** @var string */
     const CAN_UPDATE_THEIR_COURSES = 'canUpdateTheirCourses';
     /** @var string */
     const CAN_DELETE_THEIR_COURSES = 'canDeleteTheirCourses';
+    /** @var string */
+    const CAN_UNLOCK_THEIR_COURSES = 'canUnlockTheirCourses';
+    /** @var string */
+    const CAN_UNARCHIVE_THEIR_COURSES = 'canUnarchiveTheirCourses';
     /** @var string */
     const CAN_UPDATE_ALL_SESSIONS = 'canUpdateAllSessions';
     /** @var string */
@@ -57,11 +71,19 @@ class PermissionChecker
     /** @var string */
     const CAN_DELETE_ALL_PROGRAM_YEARS = 'canDeleteAllProgramYears';
     /** @var string */
+    const CAN_UNLOCK_ALL_PROGRAM_YEARS = 'canUnlockAllProgramYears';
+    /** @var string */
+    const CAN_UNARCHIVE_ALL_PROGRAM_YEARS = 'canUnarchiveAllProgramYears';
+    /** @var string */
     const CAN_CREATE_PROGRAM_YEARS = 'canCreateProgramYears';
     /** @var string */
     const CAN_UPDATE_THEIR_PROGRAM_YEARS = 'canUpdateTheirProgramYears';
     /** @var string */
     const CAN_DELETE_THEIR_PROGRAM_YEARS = 'canDeleteTheirProgramYears';
+    /** @var string */
+    const CAN_UNLOCK_THEIR_PROGRAM_YEARS = 'canUnlockTheirProgramYears';
+    /** @var string */
+    const CAN_UNARCHIVE_THEIR_PROGRAM_YEARS = 'canUnarchiveTheirProgramYears';
     /** @var string */
     const CAN_UPDATE_ALL_COHORTS = 'canUpdateAllCohorts';
     /** @var string */
@@ -167,9 +189,13 @@ class PermissionChecker
             $arr[self::CAN_UPDATE_ALL_COURSES] = $allRoles;
             $arr[self::CAN_CREATE_COURSES] = $allRoles;
             $arr[self::CAN_DELETE_ALL_COURSES] = $allRoles;
+            $arr[self::CAN_UNLOCK_ALL_COURSES] = $allRoles;
+            $arr[self::CAN_UNARCHIVE_ALL_COURSES] = $allRoles;
 
             $arr[self::CAN_UPDATE_THEIR_COURSES] = $allRoles;
             $arr[self::CAN_DELETE_THEIR_COURSES] = $allRoles;
+            $arr[self::CAN_UNLOCK_THEIR_COURSES] = $allRoles;
+            $arr[self::CAN_UNARCHIVE_THEIR_COURSES] = $allRoles;
 
             $arr[self::CAN_UPDATE_ALL_SESSIONS] = $allRoles;
             $arr[self::CAN_CREATE_SESSIONS] = $allRoles;
@@ -200,9 +226,13 @@ class PermissionChecker
             $arr[self::CAN_UPDATE_ALL_PROGRAM_YEARS] = $allRoles;
             $arr[self::CAN_CREATE_PROGRAM_YEARS] = $allRoles;
             $arr[self::CAN_DELETE_ALL_PROGRAM_YEARS] = $allRoles;
+            $arr[self::CAN_UNLOCK_ALL_PROGRAM_YEARS] = $allRoles;
+            $arr[self::CAN_UNARCHIVE_ALL_PROGRAM_YEARS] = $allRoles;
 
             $arr[self::CAN_UPDATE_THEIR_PROGRAM_YEARS] = $allRoles;
             $arr[self::CAN_DELETE_THEIR_PROGRAM_YEARS] = $allRoles;
+            $arr[self::CAN_UNLOCK_THEIR_PROGRAM_YEARS] = $allRoles;
+            $arr[self::CAN_UNARCHIVE_THEIR_PROGRAM_YEARS] = $allRoles;
 
             $arr[self::CAN_UPDATE_ALL_COHORTS] = $allRoles;
             $arr[self::CAN_CREATE_COHORTS] = $allRoles;
@@ -280,19 +310,23 @@ class PermissionChecker
         return $hasPermission;
     }
 
-    public function canUpdateCourse(SessionUserInterface $sessionUser, int $courseId, int $schoolId): bool
+    public function canUpdateCourse(SessionUserInterface $sessionUser, CourseInterface $course): bool
     {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+        if ($course->isLocked() || $course->isArchived()) {
+            return false;
+        }
+
+        $rolesInSchool = $sessionUser->rolesInSchool($course->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $course->getSchool()->getId(),
             PermissionChecker::CAN_UPDATE_ALL_COURSES,
             $rolesInSchool
         )) {
             return true;
         }
-        $rolesInCourse = $sessionUser->rolesInCourse($courseId);
+        $rolesInCourse = $sessionUser->rolesInCourse($course->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $course->getSchool()->getId(),
             PermissionChecker::CAN_UPDATE_THEIR_COURSES,
             $rolesInCourse
         )) {
@@ -302,19 +336,23 @@ class PermissionChecker
         return false;
     }
 
-    public function canDeleteCourse(SessionUserInterface $sessionUser, int $courseId, int $schoolId): bool
+    public function canDeleteCourse(SessionUserInterface $sessionUser, CourseInterface $course): bool
     {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+        if ($course->isLocked() || $course->isArchived()) {
+            return false;
+        }
+
+        $rolesInSchool = $sessionUser->rolesInSchool($course->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $course->getSchool()->getId(),
             PermissionChecker::CAN_DELETE_ALL_COURSES,
             $rolesInSchool
         )) {
             return true;
         }
-        $rolesInCourse = $sessionUser->rolesInCourse($courseId);
+        $rolesInCourse = $sessionUser->rolesInCourse($course->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $course->getSchool()->getId(),
             PermissionChecker::CAN_DELETE_THEIR_COURSES,
             $rolesInCourse
         )) {
@@ -324,11 +362,11 @@ class PermissionChecker
         return false;
     }
 
-    public function canCreateCourse(SessionUserInterface $sessionUser, int $schoolId): bool
+    public function canCreateCourse(SessionUserInterface $sessionUser, SchoolInterface $school): bool
     {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+        $rolesInSchool = $sessionUser->rolesInSchool($school->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $school->getId(),
             PermissionChecker::CAN_CREATE_COURSES,
             $rolesInSchool
         )) {
@@ -338,73 +376,117 @@ class PermissionChecker
         return false;
     }
 
-    public function canUpdateSession(
-        SessionUserInterface $sessionUser,
-        int $sessionId,
-        int $courseId,
-        int $schoolId
-    ): bool {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+    public function canUnlockCourse(SessionUserInterface $sessionUser, CourseInterface $course): bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($course->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $course->getSchool()->getId(),
+            PermissionChecker::CAN_UNLOCK_ALL_COURSES,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+        $rolesInCourse = $sessionUser->rolesInCourse($course->getId());
+        if ($this->hasPermission(
+            $course->getSchool()->getId(),
+            PermissionChecker::CAN_UNLOCK_THEIR_COURSES,
+            $rolesInCourse
+        )) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function canUnarchiveCourse(SessionUserInterface $sessionUser, CourseInterface $course): bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($course->getSchool()->getId());
+        if ($this->hasPermission(
+            $course->getSchool()->getId(),
+            PermissionChecker::CAN_UNARCHIVE_ALL_COURSES,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+        $rolesInCourse = $sessionUser->rolesInCourse($course->getId());
+        if ($this->hasPermission(
+            $course->getSchool()->getId(),
+            PermissionChecker::CAN_UNARCHIVE_THEIR_COURSES,
+            $rolesInCourse
+        )) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function canUpdateSession(SessionUserInterface $sessionUser, SessionInterface $session): bool
+    {
+        if ($session->getCourse()->isLocked() || $session->getCourse()->isArchived()) {
+            return false;
+        }
+        $rolesInSchool = $sessionUser->rolesInSchool($session->getSchool()->getId());
+        if ($this->hasPermission(
+            $session->getSchool()->getId(),
             PermissionChecker::CAN_UPDATE_ALL_SESSIONS,
             $rolesInSchool
         )) {
             return true;
         }
-        $rolesInSession = $sessionUser->rolesInSession($sessionId);
+        $rolesInSession = $sessionUser->rolesInSession($session->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $session->getSchool()->getId(),
             PermissionChecker::CAN_UPDATE_THEIR_SESSIONS,
             $rolesInSession
         )) {
             return true;
         }
 
-        return $this->canUpdateCourse($sessionUser, $courseId, $schoolId);
+        return $this->canUpdateCourse($sessionUser, $session->getCourse());
     }
 
-    public function canDeleteSession(
-        SessionUserInterface $sessionUser,
-        int $sessionId,
-        int $courseId,
-        int $schoolId
-    ): bool {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+    public function canDeleteSession(SessionUserInterface $sessionUser, SessionInterface $session): bool
+    {
+        if ($session->getCourse()->isLocked() || $session->getCourse()->isArchived()) {
+            return false;
+        }
+
+        $rolesInSchool = $sessionUser->rolesInSchool($session->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $session->getSchool()->getId(),
             PermissionChecker::CAN_DELETE_ALL_SESSIONS,
             $rolesInSchool
         )) {
             return true;
         }
-        $rolesInSession = $sessionUser->rolesInSession($sessionId);
+        $rolesInSession = $sessionUser->rolesInSession($session->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $session->getSchool()->getId(),
             PermissionChecker::CAN_DELETE_THEIR_SESSIONS,
             $rolesInSession
         )) {
             return true;
         }
 
-        return $this->canUpdateCourse($sessionUser, $courseId, $schoolId);
+        return $this->canUpdateCourse($sessionUser, $session->getCourse());
     }
 
-    public function canCreateSession(
-        SessionUserInterface $sessionUser,
-        int $courseId,
-        int $schoolId
-    ): bool {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+    public function canCreateSession(SessionUserInterface $sessionUser, CourseInterface $course): bool
+    {
+        if ($course->isLocked() || $course->isArchived()) {
+            return false;
+        }
+
+        $rolesInSchool = $sessionUser->rolesInSchool($course->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $course->getSchool()->getId(),
             PermissionChecker::CAN_CREATE_SESSIONS,
             $rolesInSchool
         )) {
             return true;
         }
 
-        return $this->canUpdateCourse($sessionUser, $courseId, $schoolId);
+        return $this->canUpdateCourse($sessionUser, $course);
     }
 
     public function canUpdateSessionType(SessionUserInterface $sessionUser, int $schoolId): bool
@@ -551,142 +633,204 @@ class PermissionChecker
         return false;
     }
 
-    public function canUpdateProgramYear(
-        SessionUserInterface $sessionUser,
-        int $programYearId,
-        int $programId,
-        int $schoolId
-    ) : bool {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+    public function canUpdateProgramYear(SessionUserInterface $sessionUser, ProgramYearInterface $programYear) : bool
+    {
+        if ($programYear->isLocked() || $programYear->isArchived()) {
+            return false;
+        }
+
+        $rolesInSchool = $sessionUser->rolesInSchool($programYear->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $programYear->getSchool()->getId(),
             PermissionChecker::CAN_UPDATE_ALL_PROGRAM_YEARS,
             $rolesInSchool
         )) {
             return true;
         }
-        $rolesInProgramYear = $sessionUser->rolesInProgramYear($programYearId);
+        $rolesInProgramYear = $sessionUser->rolesInProgramYear($programYear->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $programYear->getSchool()->getId(),
             PermissionChecker::CAN_UPDATE_THEIR_PROGRAM_YEARS,
             $rolesInProgramYear
         )) {
             return true;
         }
 
-        return $this->canUpdateProgram($sessionUser, $programId, $schoolId);
+        return $this->canUpdateProgram(
+            $sessionUser,
+            $programYear->getProgram()->getId(),
+            $programYear->getSchool()->getId()
+        );
     }
 
-    public function canDeleteProgramYear(
-        SessionUserInterface $sessionUser,
-        int $programYearId,
-        int $programId,
-        int $schoolId
-    ) : bool {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+    public function canDeleteProgramYear(SessionUserInterface $sessionUser, ProgramYearInterface $programYear) : bool
+    {
+        if ($programYear->isLocked() || $programYear->isArchived()) {
+            return false;
+        }
+
+        $rolesInSchool = $sessionUser->rolesInSchool($programYear->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $programYear->getSchool()->getId(),
             PermissionChecker::CAN_DELETE_ALL_PROGRAM_YEARS,
             $rolesInSchool
         )) {
             return true;
         }
-        $rolesInProgramYear = $sessionUser->rolesInProgramYear($programYearId);
+        $rolesInProgramYear = $sessionUser->rolesInProgramYear($programYear->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $programYear->getSchool()->getId(),
             PermissionChecker::CAN_DELETE_THEIR_PROGRAM_YEARS,
             $rolesInProgramYear
         )) {
             return true;
         }
 
-        return $this->canUpdateProgram($sessionUser, $programId, $schoolId);
+        return $this->canUpdateProgram(
+            $sessionUser,
+            $programYear->getProgram()->getId(),
+            $programYear->getSchool()->getId()
+        );
     }
 
-    public function canCreateProgramYear(
-        SessionUserInterface $sessionUser,
-        int $programId,
-        int $schoolId
-    ) : bool {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+    public function canCreateProgramYear(SessionUserInterface $sessionUser, ProgramInterface $program): bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($program->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $program->getSchool()->getId(),
             PermissionChecker::CAN_CREATE_PROGRAM_YEARS,
             $rolesInSchool
         )) {
             return true;
         }
 
-        return $this->canUpdateProgram($sessionUser, $programId, $schoolId);
+        return $this->canUpdateProgram($sessionUser, $program->getId(), $program->getSchool()->getId());
     }
 
-    public function canUpdateCohort(
-        SessionUserInterface $sessionUser,
-        int $cohortId,
-        int $programId,
-        int $schoolId
-    ) : bool {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+    public function canUnlockProgramYear(SessionUserInterface $sessionUser, ProgramYearInterface $programYear) : bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($programYear->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $programYear->getSchool()->getId(),
+            PermissionChecker::CAN_UNLOCK_ALL_PROGRAM_YEARS,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+        $rolesInProgramYear = $sessionUser->rolesInProgramYear($programYear->getId());
+        if ($this->hasPermission(
+            $programYear->getSchool()->getId(),
+            PermissionChecker::CAN_UNLOCK_THEIR_PROGRAM_YEARS,
+            $rolesInProgramYear
+        )) {
+            return true;
+        }
+
+        return $this->canUpdateProgram(
+            $sessionUser,
+            $programYear->getProgram()->getId(),
+            $programYear->getSchool()->getId()
+        );
+    }
+
+    public function canUnarchiveProgramYear(SessionUserInterface $sessionUser, ProgramYearInterface $programYear) : bool
+    {
+        $rolesInSchool = $sessionUser->rolesInSchool($programYear->getSchool()->getId());
+        if ($this->hasPermission(
+            $programYear->getSchool()->getId(),
+            PermissionChecker::CAN_UNARCHIVE_ALL_PROGRAM_YEARS,
+            $rolesInSchool
+        )) {
+            return true;
+        }
+        $rolesInProgramYear = $sessionUser->rolesInProgramYear($programYear->getId());
+        if ($this->hasPermission(
+            $programYear->getSchool()->getId(),
+            PermissionChecker::CAN_UNARCHIVE_THEIR_PROGRAM_YEARS,
+            $rolesInProgramYear
+        )) {
+            return true;
+        }
+
+        return $this->canUpdateProgram(
+            $sessionUser,
+            $programYear->getProgram()->getId(),
+            $programYear->getSchool()->getId()
+        );
+    }
+
+    public function canUpdateCohort(SessionUserInterface $sessionUser, CohortInterface $cohort): bool
+    {
+        if ($cohort->getProgramYear()->isLocked() || $cohort->getProgramYear()->isArchived()) {
+            return false;
+        }
+
+        $rolesInSchool = $sessionUser->rolesInSchool($cohort->getSchool()->getId());
+        if ($this->hasPermission(
+            $cohort->getSchool()->getId(),
             PermissionChecker::CAN_UPDATE_ALL_COHORTS,
             $rolesInSchool
         )) {
             return true;
         }
-        $rolesInCohort = $sessionUser->rolesInCohort($cohortId);
+        $rolesInCohort = $sessionUser->rolesInCohort($cohort->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $cohort->getSchool()->getId(),
             PermissionChecker::CAN_UPDATE_THEIR_COHORTS,
             $rolesInCohort
         )) {
             return true;
         }
 
-        return $this->canUpdateProgram($sessionUser, $programId, $schoolId);
+        return $this->canUpdateProgram($sessionUser, $cohort->getProgram()->getId(), $cohort->getSchool()->getId());
     }
 
-    public function canDeleteCohort(
-        SessionUserInterface $sessionUser,
-        int $cohortId,
-        int $programId,
-        int $schoolId
-    ) : bool {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+    public function canDeleteCohort(SessionUserInterface $sessionUser, CohortInterface $cohort): bool
+    {
+        if ($cohort->getProgramYear()->isLocked() || $cohort->getProgramYear()->isArchived()) {
+            return false;
+        }
+
+        $rolesInSchool = $sessionUser->rolesInSchool($cohort->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $cohort->getSchool()->getId(),
             PermissionChecker::CAN_DELETE_ALL_COHORTS,
             $rolesInSchool
         )) {
             return true;
         }
-        $rolesInCohort = $sessionUser->rolesInCohort($cohortId);
+        $rolesInCohort = $sessionUser->rolesInCohort($cohort->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $cohort->getSchool()->getId(),
             PermissionChecker::CAN_DELETE_THEIR_COHORTS,
             $rolesInCohort
         )) {
             return true;
         }
 
-        return $this->canUpdateProgram($sessionUser, $programId, $schoolId);
+        return $this->canUpdateProgram($sessionUser, $cohort->getProgram()->getId(), $cohort->getSchool()->getId());
     }
 
-    public function canCreateCohort(
-        SessionUserInterface $sessionUser,
-        int $programId,
-        int $schoolId
-    ) : bool {
-        $rolesInSchool = $sessionUser->rolesInSchool($schoolId);
+    public function canCreateCohort(SessionUserInterface $sessionUser, ProgramYearInterface $programYear): bool
+    {
+        if ($programYear->isLocked() || $programYear->isArchived()) {
+            return false;
+        }
+
+        $rolesInSchool = $sessionUser->rolesInSchool($programYear->getSchool()->getId());
         if ($this->hasPermission(
-            $schoolId,
+            $programYear->getSchool()->getId(),
             PermissionChecker::CAN_CREATE_COHORTS,
             $rolesInSchool
         )) {
             return true;
         }
 
-        return $this->canUpdateProgram($sessionUser, $programId, $schoolId);
+        return $this->canUpdateProgram(
+            $sessionUser,
+            $programYear->getProgram()->getId(),
+            $programYear->getSchool()->getId()
+        );
     }
 
     public function canUpdateSchoolConfig(SessionUserInterface $sessionUser, int $schoolId) : bool

--- a/tests/AuthenticationBundle/RelationshipVoter/AuthenticationTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/AuthenticationTest.php
@@ -1,0 +1,132 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\Authentication as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\Authentication;
+use Ilios\CoreBundle\Entity\School;
+use Ilios\CoreBundle\Entity\User;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class AuthenticationTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(Authentication::class);
+    }
+
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Authentication::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Authentication::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
+    }
+
+    public function testCanEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Authentication::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Authentication::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Authentication::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Authentication::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Authentication::class);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(Authentication::class);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/CohortTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/CohortTest.php
@@ -7,6 +7,7 @@ use Ilios\AuthenticationBundle\Service\PermissionChecker;
 use Ilios\CoreBundle\Entity\Program;
 use Ilios\CoreBundle\Entity\Cohort;
 use Ilios\CoreBundle\Entity\DTO\CohortDTO;
+use Ilios\CoreBundle\Entity\ProgramYear;
 use Ilios\CoreBundle\Entity\School;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
@@ -36,13 +37,6 @@ class CohortTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(Cohort::class);
-        $entity->shouldReceive('getId')->andReturn(1);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canUpdateCohort')->andReturn(true);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
@@ -52,13 +46,6 @@ class CohortTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(Cohort::class);
-        $entity->shouldReceive('getId')->andReturn(1);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canUpdateCohort')->andReturn(false);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
@@ -68,13 +55,6 @@ class CohortTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(Cohort::class);
-        $entity->shouldReceive('getId')->andReturn(1);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canDeleteCohort')->andReturn(true);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
@@ -84,13 +64,6 @@ class CohortTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(Cohort::class);
-        $entity->shouldReceive('getId')->andReturn(1);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canDeleteCohort')->andReturn(false);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
@@ -100,12 +73,8 @@ class CohortTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(Cohort::class);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
+        $programYear = m::mock(ProgramYear::class);
+        $entity->shouldReceive('getProgramYear')->andReturn($programYear);
         $this->permissionChecker->shouldReceive('canCreateCohort')->andReturn(true);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
@@ -115,12 +84,8 @@ class CohortTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(Cohort::class);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
+        $programYear = m::mock(ProgramYear::class);
+        $entity->shouldReceive('getProgramYear')->andReturn($programYear);
         $this->permissionChecker->shouldReceive('canCreateCohort')->andReturn(false);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");

--- a/tests/AuthenticationBundle/RelationshipVoter/CourseLearningMaterialTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/CourseLearningMaterialTest.php
@@ -1,0 +1,123 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\CourseLearningMaterial as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\Course;
+use Ilios\CoreBundle\Entity\CourseLearningMaterial;
+use Ilios\CoreBundle\Entity\School;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class CourseLearningMaterialTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(CourseLearningMaterial::class);
+    }
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(CourseLearningMaterial::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(CourseLearningMaterial::class);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $entity->shouldReceive('getCourse')->andReturn($course);
+        $school->shouldReceive('getId')->andReturn(1);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(CourseLearningMaterial::class);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(CourseLearningMaterial::class);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(CourseLearningMaterial::class);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(CourseLearningMaterial::class);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(CourseLearningMaterial::class);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateCourse')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
@@ -6,8 +6,12 @@ use Ilios\AuthenticationBundle\Classes\SessionUserInterface;
 use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
 use Ilios\AuthenticationBundle\RelationshipVoter\ElevatedPermissionsViewDTOVoter as Voter;
 use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\DTO\AuthenticationDTO;
+use Ilios\CoreBundle\Entity\DTO\IngestionExceptionDTO;
 use Ilios\CoreBundle\Entity\DTO\LearnerGroupDTO;
 use Ilios\CoreBundle\Entity\DTO\OfferingDTO;
+use Ilios\CoreBundle\Entity\DTO\PendingUserUpdateDTO;
+use Ilios\CoreBundle\Entity\DTO\UserDTO;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -29,8 +33,12 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
     public function dtoProvider()
     {
         return [
+            [AuthenticationDTO::class],
+            [IngestionExceptionDTO::class],
             [LearnerGroupDTO::class],
             [OfferingDTO::class],
+            [PendingUserUpdateDTO::class],
+            [UserDTO::class],
         ];
     }
 

--- a/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -31,6 +31,7 @@ use Ilios\CoreBundle\Entity\DTO\MeshTreeDTO;
 use Ilios\CoreBundle\Entity\DTO\ObjectiveDTO;
 use Ilios\CoreBundle\Entity\DTO\ProgramDTO;
 use Ilios\CoreBundle\Entity\DTO\ProgramYearDTO;
+use Ilios\CoreBundle\Entity\DTO\ProgramYearStewardDTO;
 use Ilios\CoreBundle\Entity\DTO\SchoolDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionDescriptionDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionDTO;
@@ -84,6 +85,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [ObjectiveDTO::class],
             [ProgramDTO::class],
             [ProgramYearDTO::class],
+            [ProgramYearStewardDTO::class],
             [SchoolDTO::class],
             [SessionDTO::class],
             [SessionDescriptionDTO::class],
@@ -96,6 +98,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
     /**
      * @dataProvider canViewDTOProvider
      * @covers GreenlightViewDTOVoter::voteOnAttribute()
+     * @param string $class The fully qualified class name.
      */
     public function testCanViewDTO($class)
     {

--- a/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -13,6 +13,7 @@ use Ilios\CoreBundle\Entity\DTO\CohortDTO;
 use Ilios\CoreBundle\Entity\DTO\CompetencyDTO;
 use Ilios\CoreBundle\Entity\DTO\CourseClerkshipTypeDTO;
 use Ilios\CoreBundle\Entity\DTO\CourseDTO;
+use Ilios\CoreBundle\Entity\DTO\CourseLearningMaterialDTO;
 use Ilios\CoreBundle\Entity\DTO\CurriculumInventoryAcademicLevelDTO;
 use Ilios\CoreBundle\Entity\DTO\CurriculumInventoryInstitutionDTO;
 use Ilios\CoreBundle\Entity\DTO\CurriculumInventoryReportDTO;
@@ -21,6 +22,7 @@ use Ilios\CoreBundle\Entity\DTO\CurriculumInventorySequenceDTO;
 use Ilios\CoreBundle\Entity\DTO\DepartmentDTO;
 use Ilios\CoreBundle\Entity\DTO\IlmSessionDTO;
 use Ilios\CoreBundle\Entity\DTO\InstructorGroupDTO;
+use Ilios\CoreBundle\Entity\DTO\LearningMaterialDTO;
 use Ilios\CoreBundle\Entity\DTO\LearningMaterialStatusDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshConceptDTO;
 use Ilios\CoreBundle\Entity\DTO\MeshDescriptorDTO;
@@ -35,6 +37,7 @@ use Ilios\CoreBundle\Entity\DTO\ProgramYearStewardDTO;
 use Ilios\CoreBundle\Entity\DTO\SchoolDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionDescriptionDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionDTO;
+use Ilios\CoreBundle\Entity\DTO\SessionLearningMaterialDTO;
 use Ilios\CoreBundle\Entity\DTO\SessionTypeDTO;
 use Ilios\CoreBundle\Entity\DTO\TermDTO;
 use Ilios\CoreBundle\Entity\DTO\VocabularyDTO;
@@ -67,6 +70,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [CompetencyDTO::class],
             [CourseDTO::class],
             [CourseClerkshipTypeDTO::class],
+            [CourseLearningMaterialDTO::class],
             [CurriculumInventoryAcademicLevelDTO::class],
             [CurriculumInventoryInstitutionDTO::class],
             [CurriculumInventoryReportDTO::class],
@@ -75,6 +79,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [DepartmentDTO::class],
             [IlmSessionDTO::class],
             [InstructorGroupDTO::class],
+            [LearningMaterialDTO::class],
             [LearningMaterialStatusDTO::class],
             [MeshConceptDTO::class],
             [MeshDescriptorDTO::class],
@@ -89,6 +94,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [SchoolDTO::class],
             [SessionDTO::class],
             [SessionDescriptionDTO::class],
+            [SessionLearningMaterialDTO::class],
             [SessionTypeDTO::class],
             [TermDTO::class],
             [VocabularyDTO::class],

--- a/tests/AuthenticationBundle/RelationshipVoter/IngestionExceptionTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/IngestionExceptionTest.php
@@ -1,0 +1,44 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\IngestionException as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\IngestionException;
+use Ilios\CoreBundle\Entity\School;
+use Ilios\CoreBundle\Entity\User;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class IngestionExceptionTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(IngestionException::class, [AbstractVoter::VIEW]);
+    }
+
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(IngestionException::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(IngestionException::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/LearningMaterialTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/LearningMaterialTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\LearningMaterial as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\LearningMaterial;
+use Ilios\CoreBundle\Entity\LearningMaterialInterface;
+
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class LearningMaterialTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(LearningMaterialInterface::class);
+    }
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterial::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanCreateLearningMaterial()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterial::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreateLearningMaterial()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterial::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+
+    public function testCanEditLearningMaterial()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterial::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEditLearningMaterial()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterial::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDeleteLearningMaterial()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterial::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDeleteLearningMaterial()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(LearningMaterial::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/PendingUserUpdateTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/PendingUserUpdateTest.php
@@ -1,0 +1,107 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\PendingUserUpdate as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\PendingUserUpdate;
+use Ilios\CoreBundle\Entity\School;
+use Ilios\CoreBundle\Entity\User;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class PendingUserUpdateTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(
+            PendingUserUpdate::class,
+            [AbstractVoter::VIEW, AbstractVoter::DELETE, AbstractVoter::EDIT]
+        );
+    }
+
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(PendingUserUpdate::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(PendingUserUpdate::class);
+        $token->getUser()->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
+    }
+
+    public function testCanEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(PendingUserUpdate::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(PendingUserUpdate::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(PendingUserUpdate::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(PendingUserUpdate::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $user = m::mock(User::class);
+        $user->shouldReceive('getSchool')->andReturn($school);
+        $entity->shouldReceive('getUser')->andReturn($user);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/ProgramYearStewardTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/ProgramYearStewardTest.php
@@ -1,0 +1,146 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\ProgramYearSteward as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\Program;
+use Ilios\CoreBundle\Entity\ProgramYear;
+use Ilios\CoreBundle\Entity\ProgramYearSteward;
+use Ilios\CoreBundle\Entity\School;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class ProgramYearStewardTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(ProgramYearSteward::class);
+    }
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(ProgramYearSteward::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(ProgramYearSteward::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $programYear = m::mock(ProgramYear::class);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramYear')->andReturn($programYear);
+        $program = m::mock(Program::class);
+        $program->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgram')->andReturn($program);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramOwningSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(ProgramYearSteward::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $programYear = m::mock(ProgramYear::class);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramYear')->andReturn($programYear);
+        $program = m::mock(Program::class);
+        $program->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgram')->andReturn($program);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramOwningSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(ProgramYearSteward::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $programYear = m::mock(ProgramYear::class);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramYear')->andReturn($programYear);
+        $program = m::mock(Program::class);
+        $program->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgram')->andReturn($program);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramOwningSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(ProgramYearSteward::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $programYear = m::mock(ProgramYear::class);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramYear')->andReturn($programYear);
+        $program = m::mock(Program::class);
+        $program->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgram')->andReturn($program);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramOwningSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(ProgramYearSteward::class);
+        $programYear = m::mock(ProgramYear::class);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramYear')->andReturn($programYear);
+        $program = m::mock(Program::class);
+        $program->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgram')->andReturn($program);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramOwningSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(ProgramYearSteward::class);
+        $programYear = m::mock(ProgramYear::class);
+        $programYear->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramYear')->andReturn($programYear);
+        $program = m::mock(Program::class);
+        $program->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgram')->andReturn($program);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getProgramOwningSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/ProgramYearTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/ProgramYearTest.php
@@ -36,13 +36,6 @@ class ProgramYearTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(ProgramYear::class);
-        $entity->shouldReceive('getId')->andReturn(1);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(true);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
@@ -52,13 +45,6 @@ class ProgramYearTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(ProgramYear::class);
-        $entity->shouldReceive('getId')->andReturn(1);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canUpdateProgramYear')->andReturn(false);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
@@ -68,13 +54,6 @@ class ProgramYearTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(ProgramYear::class);
-        $entity->shouldReceive('getId')->andReturn(1);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canDeleteProgramYear')->andReturn(true);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
@@ -84,13 +63,6 @@ class ProgramYearTest extends AbstractBase
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(ProgramYear::class);
-        $entity->shouldReceive('getId')->andReturn(1);
-        $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canDeleteProgramYear')->andReturn(false);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
@@ -101,11 +73,7 @@ class ProgramYearTest extends AbstractBase
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(ProgramYear::class);
         $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
         $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canCreateProgramYear')->andReturn(true);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
@@ -116,11 +84,7 @@ class ProgramYearTest extends AbstractBase
         $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(ProgramYear::class);
         $program = m::mock(Program::class);
-        $program->shouldReceive('getId')->andReturn(1);
         $entity->shouldReceive('getProgram')->andReturn($program);
-        $school = m::mock(School::class);
-        $school->shouldReceive('getId')->andReturn(1);
-        $entity->shouldReceive('getSchool')->andReturn($school);
         $this->permissionChecker->shouldReceive('canCreateProgramYear')->andReturn(false);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");

--- a/tests/AuthenticationBundle/RelationshipVoter/SessionLearningMaterialTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/SessionLearningMaterialTest.php
@@ -1,0 +1,142 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\SessionLearningMaterial as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\Course;
+use Ilios\CoreBundle\Entity\SessionLearningMaterial;
+use Ilios\CoreBundle\Entity\Session;
+use Ilios\CoreBundle\Entity\School;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class SessionLearningMaterialTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(SessionLearningMaterial::class);
+    }
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(SessionLearningMaterial::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(SessionLearningMaterial::class);
+        $session = m::mock(Session::class);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSession')->andReturn($session);
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(SessionLearningMaterial::class);
+        $session = m::mock(Session::class);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSession')->andReturn($session);
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(SessionLearningMaterial::class);
+        $session = m::mock(Session::class);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSession')->andReturn($session);
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(SessionLearningMaterial::class);
+        $session = m::mock(Session::class);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSession')->andReturn($session);
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(SessionLearningMaterial::class);
+        $session = m::mock(Session::class);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSession')->andReturn($session);
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(SessionLearningMaterial::class);
+        $session = m::mock(Session::class);
+        $session->shouldReceive('getId')->andReturn(1);
+        $course = m::mock(Course::class);
+        $course->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSession')->andReturn($session);
+        $session->shouldReceive('getCourse')->andReturn($course);
+        $course->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateSession')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+}

--- a/tests/AuthenticationBundle/RelationshipVoter/UserTest.php
+++ b/tests/AuthenticationBundle/RelationshipVoter/UserTest.php
@@ -1,0 +1,134 @@
+<?php
+namespace Tests\AuthenticationBundle\RelationshipVoter;
+
+use Ilios\AuthenticationBundle\RelationshipVoter\AbstractVoter;
+use Ilios\AuthenticationBundle\RelationshipVoter\User as Voter;
+use Ilios\AuthenticationBundle\Service\PermissionChecker;
+use Ilios\CoreBundle\Entity\User;
+use Ilios\CoreBundle\Entity\School;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class UserTest extends AbstractBase
+{
+    public function setup()
+    {
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testAllowsRootFullAccess()
+    {
+        $this->checkRootEntityAccess(User::class);
+    }
+
+
+    public function testCanView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(User::class);
+        $user->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        $user->shouldReceive('isTheUser')->with($entity)->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewYourself()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(User::class);
+        $user->shouldNotReceive('performsNonLearnerFunction');
+        $user->shouldReceive('isTheUser')->with($entity)->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotView()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $entity = m::mock(User::class);
+        $user->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $user->shouldReceive('isTheUser')->with($entity)->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
+    }
+
+    public function testCanEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(User::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Edit allowed");
+    }
+
+    public function testCanNotEdit()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(User::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canUpdateUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::EDIT]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
+    }
+
+    public function testCanDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(User::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canDeleteUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Delete allowed");
+    }
+
+    public function testCanNotDelete()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(User::class);
+        $entity->shouldReceive('getId')->andReturn(1);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canDeleteUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::DELETE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
+    }
+
+    public function testCanCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(User::class);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canCreateUser')->andReturn(true);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "Create allowed");
+    }
+
+    public function testCanNotCreate()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $entity = m::mock(User::class);
+        $school = m::mock(School::class);
+        $school->shouldReceive('getId')->andReturn(1);
+        $entity->shouldReceive('getSchool')->andReturn($school);
+        $this->permissionChecker->shouldReceive('canCreateUser')->andReturn(false);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::CREATE]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
+    }
+}


### PR DESCRIPTION
refs #1950 

this batch adds new perms and checks for:

- users and associates
- learning materials and associates
- program year stewards

it also adds permissions and checks for lockable and archivable entities and sub-entities.
