### PR TITLE
Read ENV variables from $_ENV as well as $_SERVER

### DIFF
--- a/src/Ilios/CoreBundle/Service/Config.php
+++ b/src/Ilios/CoreBundle/Service/Config.php
@@ -64,16 +64,21 @@ class Config
     protected function getValueFromEnv($name)
     {
         $envName = 'ILIOS_' .  s($name)->underscored()->toUpperCase();
-        if (isset($_SERVER[$envName])) {
+        $result = null;
+        if (isset($_ENV[$envName])) {
+            $result = $_ENV[$envName];
+        }
+        if ($result === null && isset($_SERVER[$envName])) {
             $result = $_SERVER[$envName];
+        }
+        if ($result !== null) {
             $lowerCaseResult = strtolower($result);
             if (in_array($lowerCaseResult, ['null', 'false', 'true'])) {
                 $result = json_decode($lowerCaseResult);
             }
-            return $result;
         }
 
-        return null;
+        return $result;
     }
 
     /**

--- a/tests/CoreBundle/Service/ConfigTest.php
+++ b/tests/CoreBundle/Service/ConfigTest.php
@@ -22,10 +22,10 @@ class ConfigTest extends TestCase
         $value = '123Test';
         $key = 'random-key-99';
         $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
-        $_SERVER[$envKey] = $value;
+        $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertEquals($value, $result);
-        unset($_SERVER[$envKey]);
+        unset($_ENV[$envKey]);
     }
 
     public function testPullsFromDBIfNoEnv()
@@ -46,10 +46,10 @@ class ConfigTest extends TestCase
         $value = 'false';
         $key = 'random-key-99';
         $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
-        $_SERVER[$envKey] = $value;
+        $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertTrue($result === false);
-        unset($_SERVER[$envKey]);
+        unset($_ENV[$envKey]);
     }
 
     public function testConvertsStringTrueToBooleanTrue()
@@ -59,10 +59,10 @@ class ConfigTest extends TestCase
         $value = 'true';
         $key = 'random-key-99';
         $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
-        $_SERVER[$envKey] = $value;
+        $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertTrue($result === true);
-        unset($_SERVER[$envKey]);
+        unset($_ENV[$envKey]);
     }
 
     public function testConvertsStringNullToNullNull()
@@ -71,9 +71,10 @@ class ConfigTest extends TestCase
         $config = new Config($manager);
         $key = 'random-key-99';
         $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
-        $_SERVER[$envKey] = 'null';
+        $_ENV[$envKey] = 'null';
         $manager->shouldReceive('getValue')->with($key)->once();
         $config->get($key);
+        unset($_ENV[$envKey]);
     }
 
     public function testConvertsUpercaseStringFalseToBooleanFalse()
@@ -83,10 +84,10 @@ class ConfigTest extends TestCase
         $value = 'FALSE';
         $key = 'random-key-99';
         $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
-        $_SERVER[$envKey] = $value;
+        $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertTrue($result === false);
-        unset($_SERVER[$envKey]);
+        unset($_ENV[$envKey]);
     }
 
     public function testConvertsUpercaseStringTrueToBooleanTrue()
@@ -96,10 +97,10 @@ class ConfigTest extends TestCase
         $value = 'TRUE';
         $key = 'random-key-99';
         $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
-        $_SERVER[$envKey] = $value;
+        $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertTrue($result === true);
-        unset($_SERVER[$envKey]);
+        unset($_ENV[$envKey]);
     }
 
     public function testConvertsUpercaseStringNullToNullNull()
@@ -108,8 +109,24 @@ class ConfigTest extends TestCase
         $config = new Config($manager);
         $key = 'random-key-99';
         $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
-        $_SERVER[$envKey] = 'NULL';
+        $_ENV[$envKey] = 'NULL';
         $manager->shouldReceive('getValue')->with($key)->once();
         $config->get($key);
+        unset($_ENV[$envKey]);
+    }
+
+    public function testLooksInServerIfNotInEnv()
+    {
+        $manager = m::mock(ApplicationConfigManager::class);
+        $config = new Config($manager);
+        $value = '123Test';
+        $key = 'random-key-99';
+        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $_ENV[$envKey] = $value;
+        $_SERVER[$envKey] = 'bad';
+        $result = $config->get($key);
+        $this->assertEquals($value, $result);
+        unset($_SERVER[$envKey]);
+        unset($_ENV[$envKey]);
     }
 }


### PR DESCRIPTION
Reading only from $_SERVER doesn't work for variables which are part of the execution context on the machine. We need to check in $_ENV as well.  $_ENV is not always filled however, depending on the way the script was called so we also need to check in $_SERVER.

Fixes #2056