### PR TITLE
Drop support for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,35 +6,21 @@ matrix:
   fast_finish: true
   allow_failures: 
   exclude:
-  - php: '7.1'
   - php: '7.2'
   include:
-  - php: '7.1'
-    env: TEST_EVERYTHING_ELSE=true
   - php: '7.2'
     env: TEST_EVERYTHING_ELSE=true
-  - php: '7.1'
-    env: TEST_PHPUNIT_API1=true
   - php: '7.2'
     env: TEST_PHPUNIT_API1=true
-  - php: '7.1'
-    env: TEST_PHPUNIT_API2=true
   - php: '7.2'
     env: TEST_PHPUNIT_API2=true
-  - php: '7.1'
-    env: TEST_PHPUNIT_API3=true
   - php: '7.2'
     env: TEST_PHPUNIT_API3=true
-  - php: '7.1'
-    env: TEST_PHPUNIT_API4=true
   - php: '7.2'
     env: TEST_PHPUNIT_API4=true
-  - php: '7.1'
-    env: TEST_PHPUNIT_API5=true
   - php: '7.2'
     env: TEST_PHPUNIT_API5=true
 php:
-- '7.1'
 - '7.2'
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         ]
     },
     "require": {
-        "php": ">= 7.1",
+        "php": ">= 7.2",
         "ext-apcu": "*",
         "alchemy/zippy": "^0.4.8",
         "danielstjules/stringy": "^3.1",
@@ -80,7 +80,7 @@
     },
     "config": {
       "platform": {
-        "php": "7.1.0"
+        "php": "7.2.0"
       },
       "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9caef4a9ec8822216831ad2839f9079",
+    "content-hash": "fcc37758cbb7180619386c097bccf59e",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2431,33 +2431,34 @@
         },
         {
             "name": "ocramius/proxy-manager",
-            "version": "2.1.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/ProxyManager.git",
-                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7"
+                "reference": "81d53b2878f1d1c40ad27270e64b51798485dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
-                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/81d53b2878f1d1c40ad27270e64b51798485dfc5",
+                "reference": "81d53b2878f1d1c40ad27270e64b51798485dfc5",
                 "shasum": ""
             },
             "require": {
-                "ocramius/package-versions": "^1.1.1",
-                "php": "^7.1.0",
-                "zendframework/zend-code": "^3.1.0"
+                "ocramius/package-versions": "^1.1.3",
+                "php": "^7.2.0",
+                "zendframework/zend-code": "^3.3.0"
             },
             "require-dev": {
-                "couscous/couscous": "^1.5.2",
+                "couscous/couscous": "^1.6.1",
                 "ext-phar": "*",
-                "humbug/humbug": "dev-master@DEV",
-                "nikic/php-parser": "^3.0.4",
+                "humbug/humbug": "1.0.0-RC.0@RC",
+                "nikic/php-parser": "^3.1.1",
+                "padraic/phpunit-accelerator": "dev-master@DEV",
                 "phpbench/phpbench": "^0.12.2",
-                "phpstan/phpstan": "^0.6.4",
-                "phpunit/phpunit": "^5.6.4",
-                "phpunit/phpunit-mock-objects": "^3.4.1",
-                "squizlabs/php_codesniffer": "^2.7.0"
+                "phpstan/phpstan": "dev-master#856eb10a81c1d27c701a83f167dc870fd8f4236a as 0.9.999",
+                "phpstan/phpstan-phpunit": "dev-master#5629c0a1f4a9c417cb1077cf6693ad9753895761",
+                "phpunit/phpunit": "^6.4.3",
+                "squizlabs/php_codesniffer": "^2.9.1"
             },
             "suggest": {
                 "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
@@ -2496,7 +2497,7 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "time": "2017-05-04T11:12:50+00:00"
+            "time": "2017-11-16T23:22:31+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -6559,11 +6560,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 7.1",
+        "php": ">= 7.2",
         "ext-apcu": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.0"
+        "php": "7.2.0"
     }
 }

--- a/docs/ilios_php_version_policy.md
+++ b/docs/ilios_php_version_policy.md
@@ -8,14 +8,13 @@ At any given time, the Ilios application will only be supported on the very late
  
 #### Policy Example
 
-For example, the current version of PHP is v7.1.  When PHP v7.2 is released, we will continue to ensure the Ilios code will work on PHP 7.1 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 7.2 going forward.
+For example, the current version of PHP is v7.2.  When PHP v7.3 is released, we will continue to ensure the Ilios code will work on PHP 7.2 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 7.3 going forward.
 
 ### Currently Supported Versions of PHP
 
 Based on the policy above, Ilios is currently compatible with the following versions of PHP:
 
-* PHP 7.0
-* PHP 7.1 (Recommended)
+* PHP 7.2
  
 ### Up-To-Date PHP Repositories for CentOS and RHEL
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ Ilios 3 uses a Symfony (PHP/SQL) backend to serve its API, so these tools and th
 
 * CentOS 7 - Any modern Linux should work, but we recommend Redhat (RHEL, CentOS, or Fedora) or Ubuntu
 * MySQL using the InnoDB database engine (v5.5 or later required, 5.6+ recommended)
-* PHP v7.0+ REQUIRED, v7.1 RECOMMENDED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
+* PHP v7.2+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
 
 NOTE: Several institutions have successfully deployed Ilios using Microsoft IIS on Windows as their webserver, but we do not recommend it as we do not have alot of experience with it ourselves and we've only ever support Ilios on Linux systems.  That being said, if you MUST use IIS for Windows and are having trouble getting Ilios running properly, please contact the [Ilios Project Support Team](https://iliosproject.org) at support@iliosproject.org if you have any problems and we might be able to help you out!
 


### PR DESCRIPTION
As indicated in the Ilios version policy we may drop support for a minor
version of PHP 90 days after the new version is released. PHP 7.2 was
released on November 30th 2017 and PHP 7.2 is now available in the IUS
repository.

Composer update after changing our minimum version also updates:

| Production Changes     | From  | To    | Compare                                                        |
|------------------------|-------|-------|----------------------------------------------------------------|
| ocramius/proxy-manager | 2.1.1 | 2.2.0 | Ocramius/ProxyManager@2.1.1...2.2.0 |