### PR TITLE
Convert audit_log objectId to be a varchar instead of an integer

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20180326223500.php
+++ b/app/Resources/DoctrineMigrations/Version20180326223500.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Convert audit_log objectId to be a varchar instead of an integer
+ */
+class Version20180326223500 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE audit_log CHANGE objectId objectId VARCHAR(255) NOT NULL');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE audit_log CHANGE objectId objectId INT NOT NULL');
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/AuditLog.php
+++ b/src/Ilios/CoreBundle/Entity/AuditLog.php
@@ -60,9 +60,9 @@ class AuditLog implements AuditLogInterface
     /**
      * @var int
      *
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type="string", length=255)
      *
-     * @Assert\Type(type="integer")
+     * @Assert\Type(type="string")
      * @Assert\NotBlank()
      */
     protected $objectId;
@@ -157,18 +157,18 @@ class AuditLog implements AuditLogInterface
     /**
      * Set objectId
      *
-     * @param integer $objectId
+     * @param string $objectId
      *
      */
     public function setObjectId($objectId)
     {
-        $this->objectId = (int) $objectId;
+        $this->objectId = $objectId;
     }
 
     /**
      * Get objectId
      *
-     * @return integer
+     * @return string
      */
     public function getObjectId()
     {

--- a/src/Ilios/CoreBundle/Entity/AuditLogInterface.php
+++ b/src/Ilios/CoreBundle/Entity/AuditLogInterface.php
@@ -43,14 +43,14 @@ interface AuditLogInterface extends
     /**
      * Set objectId
      *
-     * @param integer $objectId
+     * @param string $objectId
      */
     public function setObjectId($objectId);
 
     /**
      * Get objectId
      *
-     * @return integer
+     * @return string
      */
     public function getObjectId();
 

--- a/tests/CoreBundle/Entity/AuditLogTest.php
+++ b/tests/CoreBundle/Entity/AuditLogTest.php
@@ -33,7 +33,7 @@ class AuditLogTest extends EntityBase
         $this->validateNotBlanks($notBlank);
 
         $this->object->setAction('test');
-        $this->object->setObjectId(1);
+        $this->object->setObjectId('1');
         $this->object->setObjectClass('test');
         $this->object->setValuesChanged('test');
         $this->validate(0);
@@ -69,10 +69,9 @@ class AuditLogTest extends EntityBase
      * @covers \Ilios\CoreBundle\Entity\AuditLog::setObjectId
      * @covers \Ilios\CoreBundle\Entity\AuditLog::getObjectId
      */
-    public function testSetObjectIdForcesInt()
+    public function testSetObjectIdString()
     {
-        $this->object->setObjectId('');
-        $this->assertSame(0, $this->object->getObjectId());
+        $this->basicSetTest('objectId', 'string');
     }
 
     /**


### PR DESCRIPTION
This allows entities with a string ID like AAMC Resource Type to be
logged.

Fixes #2095