### PR TITLE
Add Missing Event Details

### DIFF
--- a/src/Ilios/ApiBundle/Controller/SchooleventController.php
+++ b/src/Ilios/ApiBundle/Controller/SchooleventController.php
@@ -29,18 +29,18 @@ class SchooleventController extends Controller
      * @param Request $request
      * @param SchoolManager $schoolManager
      * @param UserManager $userManager
-     * @param AuthorizationCheckerInterface $authorizationChecker,
-     * @param TokenStorageInterface $tokenStorage,
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param TokenStorageInterface $tokenStorage
      * @param SerializerInterface $serializer
      *
      * @return Response
+     * @throws \Exception
      */
     public function getAction(
         $version,
         $id,
         Request $request,
         SchoolManager $schoolManager,
-        UserManager $userManager,
         AuthorizationCheckerInterface $authorizationChecker,
         TokenStorageInterface $tokenStorage,
         SerializerInterface $serializer
@@ -68,8 +68,8 @@ class SchooleventController extends Controller
             return $authorizationChecker->isGranted(AbstractVoter::VIEW, $entity);
         });
 
-        $result = $userManager->addInstructorsToEvents($events);
-        $result = $userManager->addMaterialsToEvents($result);
+        $result = $schoolManager->addInstructorsToEvents($events);
+        $result = $schoolManager->addMaterialsToEvents($result);
 
         $sessionUser = $tokenStorage->getToken()->getUser();
 

--- a/src/Ilios/ApiBundle/Controller/UsereventController.php
+++ b/src/Ilios/ApiBundle/Controller/UsereventController.php
@@ -34,6 +34,7 @@ class UsereventController extends AbstractController
      * @param TokenStorageInterface $tokenStorage
      *
      * @return Response
+     * @throws \Exception
      */
     public function getAction(
         $version,

--- a/src/Ilios/ApiBundle/Resources/swagger/definitions/CalendarEvent.yml
+++ b/src/Ilios/ApiBundle/Resources/swagger/definitions/CalendarEvent.yml
@@ -75,6 +75,10 @@ CalendarEvent:
    description: Is attendance required at this session
    type: boolean
    readOnly: true
+  sessions:
+   description: ID of the session which this event belongs to
+   type: integer
+   readOnly: true
   learningMaterials:
    description: Attached learning materials.
    type: array

--- a/src/Ilios/CoreBundle/Classes/CalendarEvent.php
+++ b/src/Ilios/CoreBundle/Classes/CalendarEvent.php
@@ -144,6 +144,8 @@ abstract class CalendarEvent
 
     /**
      * @var int
+     * @IS\Expose
+     * @IS\Type("boolean")
      */
     public $sessionId;
 

--- a/src/Ilios/CoreBundle/Classes/CalendarEvent.php
+++ b/src/Ilios/CoreBundle/Classes/CalendarEvent.php
@@ -11,7 +11,7 @@ use Ilios\CoreBundle\Entity\LearningMaterialStatusInterface;
  *
  *@IS\DTO
  */
-abstract class CalendarEvent
+class CalendarEvent
 {
     /**
      * @var string

--- a/src/Ilios/CoreBundle/Classes/CalendarEvent.php
+++ b/src/Ilios/CoreBundle/Classes/CalendarEvent.php
@@ -147,7 +147,7 @@ class CalendarEvent
      * @IS\Expose
      * @IS\Type("boolean")
      */
-    public $sessionId;
+    public $session;
 
     /**
      * @var int

--- a/src/Ilios/CoreBundle/Classes/CalendarEvent.php
+++ b/src/Ilios/CoreBundle/Classes/CalendarEvent.php
@@ -153,6 +153,34 @@ abstract class CalendarEvent
     public $courseId;
 
     /**
+     * @var string
+     * @IS\Expose
+     * @IS\Type("string")
+     */
+    public $courseExternalId;
+
+    /**
+     * @var string
+     * @IS\Expose
+     * @IS\Type("string")
+     */
+    public $sessionTitle;
+
+    /**
+     * @var string
+     * @IS\Expose
+     * @IS\Type("string")
+     */
+    public $sessionDescription;
+
+    /**
+     * @var string
+     * @IS\Expose
+     * @IS\Type("string")
+     */
+    public $sessionTypeTitle;
+
+    /**
      * Clean out all the data for draft or scheduled events
      *
      * This information is not available to un-privileged users
@@ -170,6 +198,10 @@ abstract class CalendarEvent
             $this->equipmentRequired = null;
             $this->supplemental = null;
             $this->attendanceRequired = null;
+            $this->courseExternalId = null;
+            $this->sessionDescription = null;
+            $this->sessionTitle = null;
+            $this->sessionTypeTitle = null;
 
             $this->instructors = [];
             $this->learningMaterials = [];

--- a/src/Ilios/CoreBundle/Classes/UserEvent.php
+++ b/src/Ilios/CoreBundle/Classes/UserEvent.php
@@ -17,46 +17,4 @@ class UserEvent extends CalendarEvent
      * @IS\Type("integer")
      */
     public $user;
-
-    /**
-     * @var string
-     * @IS\Expose
-     * @IS\Type("string")
-     */
-    public $courseExternalId;
-
-    /**
-     * @var string
-     * @IS\Expose
-     * @IS\Type("string")
-     */
-    public $sessionTitle;
-
-    /**
-     * @var string
-     * @IS\Expose
-     * @IS\Type("string")
-     */
-    public $sessionDescription;
-
-    /**
-     * @var string
-     * @IS\Expose
-     * @IS\Type("string")
-     */
-    public $sessionTypeTitle;
-
-    /**
-     * @inheritdoc
-     */
-    public function clearDataForDraftOrScheduledEvent()
-    {
-        parent::clearDataForDraftOrScheduledEvent();
-        if (!$this->isPublished || $this->isScheduled) {
-            $this->courseExternalId = null;
-            $this->sessionDescription = null;
-            $this->sessionTitle = null;
-            $this->sessionTypeTitle = null;
-        }
-    }
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/SchoolManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/SchoolManager.php
@@ -2,7 +2,11 @@
 
 namespace Ilios\CoreBundle\Entity\Manager;
 
+use Ilios\CoreBundle\Classes\CalendarEvent;
 use Ilios\CoreBundle\Classes\SchoolEvent;
+use Ilios\CoreBundle\Entity\Repository\SchoolRepository;
+use Ilios\CoreBundle\Service\UserMaterialFactory;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * Class SchoolManager
@@ -10,13 +14,60 @@ use Ilios\CoreBundle\Classes\SchoolEvent;
 class SchoolManager extends BaseManager
 {
     /**
+     * @var UserMaterialFactory
+     */
+    protected $factory;
+
+    /**
+     * @param RegistryInterface $registry
+     * @param string $class
+     * @param UserMaterialFactory $factory
+     */
+    public function __construct(RegistryInterface $registry, $class, UserMaterialFactory $factory)
+    {
+        parent::__construct($registry, $class);
+        $this->factory = $factory;
+    }
+
+    /**
      * @param int $schoolId
      * @param \DateTime $from
      * @param \DateTime $to
      * @return SchoolEvent[]
+     * @throws \Exception
      */
     public function findEventsForSchool($schoolId, \DateTime $from, \DateTime $to)
     {
-        return $this->getRepository()->findEventsForSchool($schoolId, $from, $to);
+        /** @var SchoolRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->findEventsForSchool($schoolId, $from, $to);
+    }
+
+    /**
+     * Finds and adds instructors to a given list of calendar events.
+     *
+     * @param CalendarEvent[] $events
+     * @return CalendarEvent[]
+     * @throws \Exception
+     */
+    public function addInstructorsToEvents(array $events)
+    {
+        /** @var SchoolRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->addInstructorsToEvents($events);
+    }
+
+    /**
+     * Finds and adds learning materials to a given list of user events.
+     *
+     * @param CalendarEvent[] $events
+     * @return CalendarEvent[]
+     * @throws \Exception
+     */
+    public function addMaterialsToEvents(array $events)
+    {
+        /** @var SchoolRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->addMaterialsToEvents($events, $this->factory);
     }
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
@@ -37,11 +37,14 @@ class UserManager extends BaseManager
      * @param array $campusIds
      *
      * @return UserDTO[]
+     * @throws \Exception
      */
     public function findAllMatchingDTOsByCampusIds(
         array $campusIds
     ) {
-        return $this->getRepository()->findAllMatchingDTOsByCampusIds($campusIds);
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->findAllMatchingDTOsByCampusIds($campusIds);
     }
 
     /**
@@ -52,6 +55,7 @@ class UserManager extends BaseManager
      * @param array $criteria
      *
      * @return UserInterface[]
+     * @throws \Exception
      */
     public function findUsersByQ(
         $q,
@@ -60,7 +64,9 @@ class UserManager extends BaseManager
         $offset = null,
         array $criteria = array()
     ) {
-        return $this->getRepository()->findByQ($q, $orderBy, $limit, $offset, $criteria);
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->findByQ($q, $orderBy, $limit, $offset, $criteria);
     }
 
     /**
@@ -70,10 +76,13 @@ class UserManager extends BaseManager
      * @param \DateTime $from
      * @param \DateTime $to
      * @return UserEvent[]
+     * @throws \Exception
      */
     public function findEventsForUser($userId, \DateTime $from, \DateTime $to)
     {
-        return $this->getRepository()->findEventsForUser($userId, $from, $to);
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->findEventsForUser($userId, $from, $to);
     }
 
     /**
@@ -81,20 +90,26 @@ class UserManager extends BaseManager
      *
      * @param CalendarEvent[] $events
      * @return CalendarEvent[]
+     * @throws \Exception
      */
     public function addInstructorsToEvents(array $events)
     {
-        return $this->getRepository()->addInstructorsToEvents($events);
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->addInstructorsToEvents($events);
     }
 
     /**
      * @param array $campusIdFilter an array of the campusIDs to include in our search if empty then all users
      *
      * @return ArrayCollection
+     * @throws \Exception
      */
     public function findUsersWhoAreNotFormerStudents(array $campusIdFilter = array())
     {
-        return $this->getRepository()->findUsersWhoAreNotFormerStudents($campusIdFilter);
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->findUsersWhoAreNotFormerStudents($campusIdFilter);
     }
 
     /**
@@ -103,18 +118,24 @@ class UserManager extends BaseManager
      * @param $includeSyncIgnore
      *
      * @return array
+     * @throws \Exception
      */
     public function getAllCampusIds($includeDisabled = true, $includeSyncIgnore = true)
     {
-        return $this->getRepository()->getAllCampusIds($includeDisabled, $includeSyncIgnore);
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->getAllCampusIds($includeDisabled, $includeSyncIgnore);
     }
 
     /**
      * Reset the examined flags on every user
+     * @throws \Exception
      */
     public function resetExaminedFlagForAllUsers()
     {
-        return $this->getRepository()->resetExaminedFlagForAllUsers();
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->resetExaminedFlagForAllUsers();
     }
 
     /**
@@ -123,10 +144,13 @@ class UserManager extends BaseManager
      * @param integer $userId
      * @param array $criteria
      * @return UserMaterial[]
+     * @throws \Exception
      */
     public function findMaterialsForUser($userId, $criteria)
     {
-        return $this->getRepository()->findMaterialsForUser($userId, $this->factory, $criteria);
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->findMaterialsForUser($userId, $this->factory, $criteria);
     }
 
     /**
@@ -134,10 +158,13 @@ class UserManager extends BaseManager
      *
      * @param UserEvent[] $events
      * @return UserEvent[]
+     * @throws \Exception
      */
     public function addMaterialsToEvents(array $events)
     {
-        return $this->getRepository()->addMaterialsToEvents($events, $this->factory);
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->addMaterialsToEvents($events, $this->factory);
     }
 
     /**

--- a/src/Ilios/CoreBundle/Traits/CalendarEventRepository.php
+++ b/src/Ilios/CoreBundle/Traits/CalendarEventRepository.php
@@ -1,0 +1,358 @@
+<?php
+
+namespace Ilios\CoreBundle\Traits;
+
+use Doctrine\ORM\EntityManager;
+use Ilios\CoreBundle\Classes\CalendarEvent;
+use Ilios\CoreBundle\Classes\UserMaterial;
+use Ilios\CoreBundle\Service\UserMaterialFactory;
+
+/**
+ * Class CalendarEventRepository
+ *
+ * Loads CalendarEvents
+ */
+trait CalendarEventRepository
+{
+    /**
+     * Convert offerings into CalendarEvent() objects
+     * @param integer $userId
+     * @param array $results
+     *
+     * @return CalendarEvent[]
+     */
+    protected function createEventObjectsForOfferings($userId, array $results)
+    {
+        return array_map(function ($arr) use ($userId) {
+            $event = new CalendarEvent();
+            $event->name = $arr['title'];
+            $event->startDate = $arr['startDate'];
+            $event->endDate = $arr['endDate'];
+            $event->offering = $arr['id'];
+            $event->location = $arr['room'];
+            $event->color = $arr['calendarColor'];
+            $event->lastModified = max($arr['offeringUpdatedAt'], $arr['sessionUpdatedAt']);
+            $event->isPublished = $arr['sessionPublished']  && $arr['coursePublished'];
+            $event->isScheduled = $arr['sessionPublishedAsTbd'] || $arr['coursePublishedAsTbd'];
+            $event->courseTitle = $arr['courseTitle'];
+            $event->sessionTypeTitle = $arr['sessionTypeTitle'];
+            $event->courseExternalId = $arr['courseExternalId'];
+            $event->sessionDescription = $arr['sessionDescription'];
+            $event->sessionId = $arr['sessionId'];
+            $event->courseId = $arr['courseId'];
+            $event->attireRequired = $arr['attireRequired'];
+            $event->equipmentRequired = $arr['equipmentRequired'];
+            $event->supplemental = $arr['supplemental'];
+            $event->attendanceRequired = $arr['attendanceRequired'];
+            return $event;
+        }, $results);
+    }
+
+    /**
+     * Convert IlmSessions into CalendarEvent() objects
+     * @param integer $userId
+     * @param array $results
+     * @return CalendarEvent[]
+     */
+    protected function createEventObjectsForIlmSessions($userId, array $results)
+    {
+        return array_map(function ($arr) use ($userId) {
+            $event = new CalendarEvent();
+            $event->user = $userId;
+            $event->name = $arr['title'];
+            $event->startDate = $arr['dueDate'];
+            $endDate = new \DateTime();
+            $endDate->setTimestamp($event->startDate->getTimestamp());
+            $event->endDate = $endDate->modify('+15 minutes');
+            $event->ilmSession = $arr['id'];
+            $event->color = $arr['calendarColor'];
+            $event->lastModified = $arr['updatedAt'];
+            $event->isPublished = $arr['sessionPublished']  && $arr['coursePublished'];
+            $event->isScheduled = $arr['sessionPublishedAsTbd'] || $arr['coursePublishedAsTbd'];
+            $event->courseTitle = $arr['courseTitle'];
+            $event->sessionTypeTitle = $arr['sessionTypeTitle'];
+            $event->courseExternalId = $arr['courseExternalId'];
+            $event->sessionDescription = $arr['sessionDescription'];
+            $event->sessionId = $arr['sessionId'];
+            $event->courseId = $arr['courseId'];
+            $event->attireRequired = $arr['attireRequired'];
+            $event->equipmentRequired = $arr['equipmentRequired'];
+            $event->supplemental = $arr['supplemental'];
+            $event->attendanceRequired = $arr['attendanceRequired'];
+            return $event;
+        }, $results);
+    }
+
+    /**
+     * Retrieves a list of instructors associated with given offerings.
+     *
+     * @param array $ids A list of offering ids.
+     * @return array A map of instructor lists, keyed off by offering ids.
+     */
+    protected function getInstructorsForOfferings(array $ids, EntityManager $em)
+    {
+        if (empty($ids)) {
+            return [];
+        }
+
+        $qb = $em->createQueryBuilder();
+        $qb->select('o.id AS oId, u.id AS userId, u.firstName, u.lastName')
+            ->from('IliosCoreBundle:User', 'u');
+        $qb->leftJoin('u.instructedOfferings', 'o');
+        $qb->where(
+            $qb->expr()->in('o.id', ':offerings')
+        );
+        $qb->setParameter(':offerings', $ids);
+        $instructedOfferings = $qb->getQuery()->getArrayResult();
+
+
+        $qb = $em->createQueryBuilder();
+        $qb->select('o.id AS oId, u.id AS userId, u.firstName, u.lastName')
+            ->from('IliosCoreBundle:User', 'u');
+        $qb->leftJoin('u.instructorGroups', 'ig');
+        $qb->leftJoin('ig.offerings', 'o');
+        $qb->where(
+            $qb->expr()->in('o.id', ':offerings')
+        );
+        $qb->setParameter(':offerings', $ids);
+        $groupOfferings = $qb->getQuery()->getArrayResult();
+
+        $results = array_merge($instructedOfferings, $groupOfferings);
+
+        $offeringInstructors = [];
+        foreach ($results as $result) {
+            if (! array_key_exists($result['oId'], $offeringInstructors)) {
+                $offeringInstructors[$result['oId']] = [];
+            }
+            $offeringInstructors[$result['oId']][$result['userId']] = $result['firstName'] . ' ' . $result['lastName'];
+        }
+        return $offeringInstructors;
+    }
+
+    /**
+     * Retrieves a list of instructors associated with given ILM sessions.
+     *
+     * @param array $ids A list of ILM session ids.
+     * @param EntityManager $em
+     * @return array A map of instructor lists, keyed off by ILM sessions ids.
+     */
+    protected function getInstructorsForIlmSessions(array $ids, EntityManager $em)
+    {
+        if (empty($ids)) {
+            return [];
+        }
+
+        $qb = $em->createQueryBuilder();
+        $qb->select('ilm.id AS ilmId, u.id AS userId, u.firstName, u.lastName')
+            ->from('IliosCoreBundle:User', 'u');
+        $qb->leftJoin('u.instructorIlmSessions', 'ilm');
+        $qb->where(
+            $qb->expr()->in('ilm.id', ':ilms')
+        );
+        $qb->setParameter(':ilms', $ids);
+        $instructedIlms = $qb->getQuery()->getArrayResult();
+
+        $qb = $em->createQueryBuilder();
+        $qb->select('ilm.id AS ilmId, u.id AS userId, u.firstName, u.lastName')
+            ->from('IliosCoreBundle:User', 'u');
+        $qb->leftJoin('u.instructorGroups', 'ig');
+        $qb->leftJoin('ig.ilmSessions', 'ilm');
+        $qb->where(
+            $qb->expr()->in('ilm.id', ':ilms')
+        );
+        $qb->setParameter(':ilms', $ids);
+        $groupIlms = $qb->getQuery()->getArrayResult();
+
+        $results = array_merge($instructedIlms, $groupIlms);
+
+        $ilmInstructors = [];
+        foreach ($results as $result) {
+            if (! array_key_exists($result['ilmId'], $ilmInstructors)) {
+                $ilmInstructors[$result['ilmId']] = [];
+            }
+            $ilmInstructors[$result['ilmId']][$result['userId']] = $result['firstName'] . ' ' . $result['lastName'];
+        }
+        return $ilmInstructors;
+    }
+
+    /**
+     * Adds instructors to a given list of events.
+     * @param array $events A list of events
+     * @param EntityManager $em
+     * @return array The events list with instructors added.
+     */
+    public function attachInstructorsToEvents(array $events, EntityManager $em)
+    {
+        $offeringIds = array_map(function ($event) {
+            return $event->offering;
+        }, array_filter($events, function ($event) {
+            return $event->offering;
+        }));
+
+        $ilmIds = array_map(function ($event) {
+            return $event->ilmSession;
+        }, array_filter($events, function ($event) {
+            return $event->ilmSession;
+        }));
+
+        // array-filtering throws off the array index.
+        // set this right again.
+        $events = array_values($events);
+
+        $offeringInstructors = $this->getInstructorsForOfferings($offeringIds, $em);
+        $ilmInstructors = $this->getInstructorsForIlmSessions($ilmIds, $em);
+
+        for ($i = 0, $n = count($events); $i < $n; $i++) {
+            if ($events[$i]->offering) { // event maps to offering
+                if (array_key_exists($events[$i]->offering, $offeringInstructors)) {
+                    $events[$i]->instructors = array_values($offeringInstructors[$events[$i]->offering]);
+                }
+            } elseif ($events[$i]->ilmSession) { // event maps to ILM session
+                if (array_key_exists($events[$i]->ilmSession, $ilmInstructors)) {
+                    $events[$i]->instructors = array_values($ilmInstructors[$events[$i]->ilmSession]);
+                }
+            }
+        }
+        return $events;
+    }
+
+    /**
+     * Finds and adds learning materials to a given list of calendar events.
+     *
+     * @param CalendarEvent[] $events
+     * @param UserMaterialFactory $factory
+     * @param EntityManager $em
+     * @return CalendarEvent[]
+     */
+    public function attachMaterialsToEvents(array $events, UserMaterialFactory $factory, EntityManager $em)
+    {
+        $sessionIds = array_map(function (CalendarEvent $event) {
+            return $event->sessionId;
+        }, $events);
+
+        $sessionIds = array_values(array_unique($sessionIds));
+
+        $sessionMaterials = $this->getLearningMaterialsForSessions($sessionIds, $em);
+
+        $sessionUserMaterials = array_map(function (array $arr) use ($factory) {
+            return $factory->create($arr);
+        }, $sessionMaterials);
+
+        $courseMaterials = $this->getLearningMaterialsForCourses($sessionIds, $em);
+
+        $courseUserMaterials = array_map(function (array $arr) use ($factory) {
+            return $factory->create($arr);
+        }, $courseMaterials);
+
+
+
+        //sort materials by id for consistency
+        $sortFn = function (UserMaterial $a, UserMaterial $b) {
+            return $a->id - $b->id;
+        };
+
+        usort($sessionUserMaterials, $sortFn);
+        usort($courseUserMaterials, $sortFn);
+
+        // group materials by session or course
+        $groupedSessionLms = [];
+        $groupedCourseLms = [];
+        for ($i = 0, $n = count($sessionUserMaterials); $i < $n; $i++) {
+            $lm = $sessionUserMaterials[$i];
+            $id = $lm->session;
+            if (! array_key_exists($id, $groupedSessionLms)) {
+                $groupedSessionLms[$id] = [];
+            }
+            $groupedSessionLms[$id][] = $lm;
+        }
+        for ($i = 0, $n = count($courseUserMaterials); $i < $n; $i++) {
+            $lm = $courseUserMaterials[$i];
+            $id = $lm->course;
+            if (! array_key_exists($id, $groupedCourseLms)) {
+                $groupedCourseLms[$id] = [];
+            }
+            $groupedCourseLms[$id][] = $lm;
+        }
+
+        for ($i =0, $n = count($events); $i < $n; $i++) {
+            $event = $events[$i];
+            $sessionId = $event->sessionId;
+            $courseId = $event->courseId;
+            $sessionLms = array_key_exists($sessionId, $groupedSessionLms) ? $groupedSessionLms[$sessionId] : [];
+            $courseLms = array_key_exists($courseId, $groupedCourseLms) ? $groupedCourseLms[$courseId] : [];
+            $lms = array_merge($sessionLms, $courseLms);
+            $event->learningMaterials = $lms;
+        }
+        return $events;
+    }
+
+    /**
+     * Get a set of learning materials based on session
+     *
+     * @param array $sessionIds
+     *
+     * @param EntityManager $em
+     * @return array
+     */
+    protected function getLearningMaterialsForSessions(
+        array $sessionIds,
+        EntityManager $em
+    ) {
+
+        $qb = $em->createQueryBuilder();
+        $what = 's.title as sessionTitle, s.id as sessionId, ' .
+            'c.id as courseId, c.title as courseTitle, ' .
+            'slm.id as slmId, slm.position, slm.notes, slm.required, slm.publicNotes, slm.startDate, slm.endDate, ' .
+            'lm.id, lm.title, lm.description, lm.originalAuthor, lm.token, ' .
+            'lm.citation, lm.link, lm.filename, lm.filesize, lm.mimetype, lms.id AS status';
+        $qb->select($what)->from('IliosCoreBundle:Session', 's');
+        $qb->join('s.learningMaterials', 'slm');
+        $qb->join('slm.learningMaterial', 'lm');
+        $qb->join('lm.status', 'lms');
+        $qb->join('s.course', 'c');
+
+        $qb->andWhere($qb->expr()->in('s.id', ':sessions'));
+        $qb->andWhere($qb->expr()->eq('s.published', 1));
+        $qb->andWhere($qb->expr()->eq('s.publishedAsTbd', 0));
+        $qb->andWhere($qb->expr()->eq('c.published', 1));
+        $qb->andWhere($qb->expr()->eq('c.publishedAsTbd', 0));
+        $qb->setParameter(':sessions', $sessionIds);
+        $qb->distinct();
+
+        return $qb->getQuery()->getArrayResult();
+    }
+
+    /**
+     * Get a set of course learning materials based on sessionIds
+     *
+     * @param array $sessionIds
+     *
+     * @param EntityManager $em
+     * @return array
+     */
+    protected function getLearningMaterialsForCourses(
+        array $sessionIds,
+        EntityManager $em
+    ) {
+
+        $qb = $em->createQueryBuilder();
+        $what = 'c.title as courseTitle, c.id as courseId, c.startDate as firstOfferingDate, ' .
+            'clm.id as clmId, clm.position, clm.notes, clm.required, clm.publicNotes, clm.startDate, clm.endDate, ' .
+            'lm.id, lm.title, lm.description, lm.originalAuthor, lm.token, ' .
+            'lm.citation, lm.link, lm.filename, lm.filesize, lm.mimetype, lms.id AS status';
+        $qb->select($what)->from('IliosCoreBundle:Session', 's');
+        $qb->join('s.course', 'c');
+        $qb->join('c.learningMaterials', 'clm');
+        $qb->join('clm.learningMaterial', 'lm');
+        $qb->join('lm.status', 'lms');
+
+
+        $qb->andWhere($qb->expr()->in('s.id', ':sessions'));
+        $qb->andWhere($qb->expr()->eq('c.published', 1));
+        $qb->andWhere($qb->expr()->eq('c.publishedAsTbd', 0));
+        $qb->setParameter(':sessions', $sessionIds);
+        $qb->distinct();
+
+        return $qb->getQuery()->getArrayResult();
+    }
+}

--- a/src/Ilios/CoreBundle/Traits/CalendarEventRepository.php
+++ b/src/Ilios/CoreBundle/Traits/CalendarEventRepository.php
@@ -38,7 +38,7 @@ trait CalendarEventRepository
             $event->sessionTypeTitle = $arr['sessionTypeTitle'];
             $event->courseExternalId = $arr['courseExternalId'];
             $event->sessionDescription = $arr['sessionDescription'];
-            $event->sessionId = $arr['sessionId'];
+            $event->session = $arr['sessionId'];
             $event->courseId = $arr['courseId'];
             $event->attireRequired = $arr['attireRequired'];
             $event->equipmentRequired = $arr['equipmentRequired'];
@@ -73,7 +73,7 @@ trait CalendarEventRepository
             $event->sessionTypeTitle = $arr['sessionTypeTitle'];
             $event->courseExternalId = $arr['courseExternalId'];
             $event->sessionDescription = $arr['sessionDescription'];
-            $event->sessionId = $arr['sessionId'];
+            $event->session = $arr['sessionId'];
             $event->courseId = $arr['courseId'];
             $event->attireRequired = $arr['attireRequired'];
             $event->equipmentRequired = $arr['equipmentRequired'];
@@ -227,7 +227,7 @@ trait CalendarEventRepository
     public function attachMaterialsToEvents(array $events, UserMaterialFactory $factory, EntityManager $em)
     {
         $sessionIds = array_map(function (CalendarEvent $event) {
-            return $event->sessionId;
+            return $event->session;
         }, $events);
 
         $sessionIds = array_values(array_unique($sessionIds));
@@ -276,7 +276,7 @@ trait CalendarEventRepository
 
         for ($i =0, $n = count($events); $i < $n; $i++) {
             $event = $events[$i];
-            $sessionId = $event->sessionId;
+            $sessionId = $event->session;
             $courseId = $event->courseId;
             $sessionLms = array_key_exists($sessionId, $groupedSessionLms) ? $groupedSessionLms[$sessionId] : [];
             $courseLms = array_key_exists($courseId, $groupedCourseLms) ? $groupedCourseLms[$courseId] : [];

--- a/tests/CoreBundle/Entity/Manager/SchoolManagerTest.php
+++ b/tests/CoreBundle/Entity/Manager/SchoolManagerTest.php
@@ -2,6 +2,7 @@
 namespace Tests\CoreBundle\Entity\Manager;
 
 use Ilios\CoreBundle\Entity\Manager\SchoolManager;
+use Ilios\CoreBundle\Service\UserMaterialFactory;
 use Mockery as m;
 use Tests\CoreBundle\TestCase;
 
@@ -28,7 +29,7 @@ class SchoolManagerTest extends TestCase
             ->mock();
         
         $entity = m::mock($class);
-        $manager = new SchoolManager($registry, $class);
+        $manager = new SchoolManager($registry, $class, m::mock(UserMaterialFactory::class));
         $manager->delete($entity);
     }
 }


### PR DESCRIPTION
Adds the data we need to render events without making another trip to the API and without needing access to endpoints that students cannot access.

WIP:
- [x] Set data on SchoolEvents that is present on user events
- [x] Consolidate user and school event object creation to avoid dupliaction
- [ ] Is there a way to provide objective data here? (maybe not because we need the competency which is only linked to the program year objective).
- [x] Rename `sessionId` to `session` to match `offering` and `ilmSession` syntactically