### PR TITLE
Remove createCIReportInAnySchool from JWT

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/JsonWebTokenManager.php
+++ b/src/Ilios/AuthenticationBundle/Service/JsonWebTokenManager.php
@@ -90,12 +90,6 @@ class JsonWebTokenManager
         $arr = $this->decode($jwt);
         return $arr['can_create_or_update_user_in_any_school'];
     }
-
-    public function getCanCreateCIReportInAnySchoolFromToken($jwt)
-    {
-        $arr = $this->decode($jwt);
-        return $arr['can_create_curriculum_inventory_report_in_any_school'];
-    }
     
     protected function decode($jwt)
     {
@@ -108,6 +102,7 @@ class JsonWebTokenManager
      * @param  SessionUserInterface $sessionUser
      * @param string $timeToLive PHP DateInterval notation for the length of time the token shoud be valid
      * @return string
+     * @throws \Exception
      */
     public function createJwtFromSessionUser(SessionUserInterface $sessionUser, $timeToLive = 'PT8H')
     {
@@ -125,8 +120,6 @@ class JsonWebTokenManager
         $expires = clone $now;
         $expires->add($interval);
         $canCreateOrUpdateUserInAnySchool = $this->permissionChecker->canCreateOrUpdateUsersInAnySchool($sessionUser);
-        $canCreateCIReportInAnySchool = $this->permissionChecker
-            ->canCreateCurriculumInventoryReportInAnySchool($sessionUser);
 
         $arr = array(
             'iss' => self::TOKEN_ISS,
@@ -137,7 +130,6 @@ class JsonWebTokenManager
             'is_root' => $sessionUser->isRoot(),
             'performs_non_learner_function' => $sessionUser->performsNonLearnerFunction(),
             'can_create_or_update_user_in_any_school' => $canCreateOrUpdateUserInAnySchool,
-            'can_create_curriculum_inventory_report_in_any_school' => $canCreateCIReportInAnySchool,
         );
 
         return JWT::encode($arr, $this->jwtKey);

--- a/tests/AuthenticationBundle/Service/JsonWebTokenManagerTest.php
+++ b/tests/AuthenticationBundle/Service/JsonWebTokenManagerTest.php
@@ -68,8 +68,6 @@ class JsonWebTokenManagerTest extends TestCase
         $sessionUser->shouldReceive('performsNonLearnerFunction')->once()->andReturn(true);
         $this->permissionChecker->shouldReceive('canCreateOrUpdateUsersInAnySchool')
             ->with($sessionUser)->once()->andReturn(true);
-        $this->permissionChecker->shouldReceive('canCreateCurriculumInventoryReportInAnySchool')
-            ->with($sessionUser)->once()->andReturn(true);
 
         $jwt = $this->obj->createJwtFromSessionUser($sessionUser);
         
@@ -77,7 +75,6 @@ class JsonWebTokenManagerTest extends TestCase
         $this->assertSame(true, $this->obj->getPerformsNonLearnerFunctionFromToken($jwt));
         $this->assertSame(true, $this->obj->getIsRootFromToken($jwt));
         $this->assertSame(true, $this->obj->getCanCreateOrUpdateUserInAnySchoolFromToken($jwt));
-        $this->assertSame(true, $this->obj->getCanCreateCIReportInAnySchoolFromToken($jwt));
     }
     
     public function testCreateJwtFromSessionUserWhichExpiresNextWeek()
@@ -88,8 +85,6 @@ class JsonWebTokenManagerTest extends TestCase
         $sessionUser->shouldReceive('isRoot')->once()->andReturn(true);
         $sessionUser->shouldReceive('performsNonLearnerFunction')->once()->andReturn(true);
         $this->permissionChecker->shouldReceive('canCreateOrUpdateUsersInAnySchool')
-            ->with($sessionUser)->once()->andReturn(true);
-        $this->permissionChecker->shouldReceive('canCreateCurriculumInventoryReportInAnySchool')
             ->with($sessionUser)->once()->andReturn(true);
         
         $jwt = $this->obj->createJwtFromSessionUser($sessionUser, 'P1W');
@@ -108,8 +103,6 @@ class JsonWebTokenManagerTest extends TestCase
         $sessionUser->shouldReceive('performsNonLearnerFunction')->once()->andReturn(true);
         $this->permissionChecker->shouldReceive('canCreateOrUpdateUsersInAnySchool')
             ->with($sessionUser)->once()->andReturn(true);
-        $this->permissionChecker->shouldReceive('canCreateCurriculumInventoryReportInAnySchool')
-            ->with($sessionUser)->once()->andReturn(true);
         
         $jwt = $this->obj->createJwtFromSessionUser($sessionUser, 'P400D');
         $now = new DateTime();
@@ -127,8 +120,6 @@ class JsonWebTokenManagerTest extends TestCase
         $sessionUser->shouldReceive('performsNonLearnerFunction')->once()->andReturn(false);
         $this->permissionChecker->shouldReceive('canCreateOrUpdateUsersInAnySchool')
             ->with($sessionUser)->once()->andReturn(false);
-        $this->permissionChecker->shouldReceive('canCreateCurriculumInventoryReportInAnySchool')
-            ->with($sessionUser)->once()->andReturn(false);
 
         $jwt = $this->obj->createJwtFromSessionUser($sessionUser);
 
@@ -136,7 +127,6 @@ class JsonWebTokenManagerTest extends TestCase
         $this->assertSame(false, $this->obj->getIsRootFromToken($jwt));
         $this->assertSame(false, $this->obj->getPerformsNonLearnerFunctionFromToken($jwt));
         $this->assertSame(false, $this->obj->getCanCreateOrUpdateUserInAnySchoolFromToken($jwt));
-        $this->assertSame(false, $this->obj->getCanCreateCIReportInAnySchoolFromToken($jwt));
     }
     
     protected function buildToken(array $values = array(), $secretKey = 'ilios.jwt.key.secret')


### PR DESCRIPTION
We don't need this in the token anymore as we're not using it to build
the navigation in the frontend.

Refs ilios/frontend#3778