### PR TITLE
Add health checks

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -45,6 +45,7 @@ class AppKernel extends Kernel
             new Ilios\ApiBundle\IliosApiBundle(),
             new Http\HttplugBundle\HttplugBundle(),
             new Happyr\GoogleAnalyticsBundle\HappyrGoogleAnalyticsBundle(),
+            new Liip\MonitorBundle\LiipMonitorBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -126,3 +126,15 @@ httplug:
 happyr_google_analytics:
     tracking_id: 'INJECTED FROM Config IN TrackApiUsageListener'
     http_message_factory: 'httplug.message_factory'
+
+liip_monitor:
+    enable_controller: true
+    checks:
+      php_extensions: [apcu, mbstring, ldap, xml, dom, mysqli, mysqlnd, pdo, zip]
+      php_version:
+        7.2: ">="
+      readable_directory: ["%kernel.cache_dir%"]
+      writable_directory: ["%kernel.cache_dir%"]
+      disk_usage:
+        path: '%env(ILIOS_FILE_SYSTEM_STORAGE_PATH)%'
+      doctrine_dbal: [default]

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -28,6 +28,10 @@ ilios_core_downloadcurriculuminventoryreport:
     requirements:
         token: '^[a-zA-Z0-9]{64}$'
 
+_monitor:
+    resource: "@LiipMonitorBundle/Resources/config/routing.xml"
+    prefix: /ilios/health
+
 ilios_web:
     resource: '@IliosWebBundle/Resources/config/routing.yml'
     prefix:   /

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "happyr/google-analytics-bundle": "^4.0",
         "ilios/mesh-parser": "^2.0",
         "incenteev/composer-parameter-handler": "^2.0",
+        "liip/monitor-bundle": "^2.6",
         "nelmio/cors-bundle": "^1.5",
         "ocramius/proxy-manager": "^2.0.0",
         "php-http/guzzle6-adapter": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcc37758cbb7180619386c097bccf59e",
+    "content-hash": "ca532404d8d26d01469e7fb52bd848d4",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2245,6 +2245,86 @@
                 "sql"
             ],
             "time": "2014-01-12T16:20:24+00:00"
+        },
+        {
+            "name": "liip/monitor-bundle",
+            "version": "2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/liip/LiipMonitorBundle.git",
+                "reference": "6e46cdb73ea7600a4b947f1a3eaba09c4c4e6556"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/liip/LiipMonitorBundle/zipball/6e46cdb73ea7600a4b947f1a3eaba09c4c4e6556",
+                "reference": "6e46cdb73ea7600a4b947f1a3eaba09c4c4e6556",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4|^7.0",
+                "symfony/framework-bundle": "~2.7|~3.0|^4.0",
+                "zendframework/zenddiagnostics": "^1.0.2"
+            },
+            "require-dev": {
+                "doctrine/doctrine-migrations-bundle": "~1.0",
+                "doctrine/migrations": "~1.0",
+                "guzzlehttp/guzzle": "~3.8|~4.0|~5.0|~6.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^1.0|^2.0",
+                "phpunit/phpunit": "^4.8.35|^6.0",
+                "sensiolabs/security-checker": "~1.3|~2.0|~3.0|~4.0",
+                "swiftmailer/swiftmailer": "~5.4",
+                "symfony/asset": "^2.0|^3.0|^4.0",
+                "symfony/browser-kit": "^2.0|^3.0|^4.0",
+                "symfony/expression-language": "~2.3|~3.0|^4.0",
+                "symfony/finder": "^2.0|^3.0|^4.0",
+                "symfony/templating": "^2.0|^3.0|^4.0",
+                "symfony/twig-bundle": "^2.0|^3.0|^4.0"
+            },
+            "suggest": {
+                "sensio/distribution-bundle": "To be able to use the composer ScriptHandler",
+                "symfony/expression-language": "To use the Expression check"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liip\\MonitorBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Liip AG",
+                    "homepage": "http://www.liip.ch/"
+                },
+                {
+                    "name": "Alvaro Videla",
+                    "email": "alvaro.videla@liip.ch"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://github.com/liip/LiipMonitorBundle/contributors"
+                },
+                {
+                    "name": "Kevin Bond",
+                    "homepage": "http://zenstruck.com/"
+                }
+            ],
+            "description": "Liip Monitor Bundle",
+            "keywords": [
+                "check",
+                "health",
+                "monitor",
+                "monitoring"
+            ],
+            "time": "2017-12-18T13:22:14+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4626,6 +4706,69 @@
                 "zf2"
             ],
             "time": "2017-07-11T19:17:22+00:00"
+        },
+        {
+            "name": "zendframework/zenddiagnostics",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/ZendDiagnostics.git",
+                "reference": "d27aa064c5185c5830e917ffe48284b0995eed13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/ZendDiagnostics/zipball/d27aa064c5185c5830e917ffe48284b0995eed13",
+                "reference": "d27aa064c5185c5830e917ffe48284b0995eed13",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6|^7.0"
+            },
+            "require-dev": {
+                "doctrine/migrations": "^1.0",
+                "guzzle/http": "^3.0",
+                "guzzle/plugin-mock": "^3.0",
+                "mikey179/vfsstream": "^1.6",
+                "php-amqplib/php-amqplib": "^2.0",
+                "phpunit/phpunit": "^4.7|^5.0",
+                "predis/predis": "^1.0",
+                "sensiolabs/security-checker": "^1.3",
+                "symfony/yaml": "^2.7|^3.0|^4.0",
+                "zendframework/zend-loader": "^2.0"
+            },
+            "suggest": {
+                "doctrine/migrations": "Required by Check\\DoctrineMigration",
+                "ext-bcmath": "Required by Check\\CpuPerformance",
+                "guzzle/http": "Required by Check\\GuzzleHttpService",
+                "predis/predis": "Required by Check\\Redis",
+                "sensiolabs/security-checker": "Required by Check\\SecurityAdvisory",
+                "symfony/yaml": "Required by Check\\YamlFile",
+                "videlalvaro/php-amqplib": "Required by Check\\RabbitMQ"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "ZendDiagnostics\\": "src/",
+                    "ZendDiagnosticsTest\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A set of components for performing diagnostic tests in PHP applications",
+            "homepage": "https://github.com/zendframework/ZendDiagnostics",
+            "keywords": [
+                "diagnostics",
+                "php",
+                "test"
+            ],
+            "time": "2017-12-13T08:36:13+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Allows us to manually and programmatically check the health of a server.

Humans can check a running server by visiting http://server.com/ilios/health
Machines can get a plain HTTP response (either 200 OK, or 502 Bad Gateway) at http://server.com/ilios/health/http_status_checks

Fixes #2109

There is much room for expansion here we can create groups and check lots of other things, but for now this handles the basics.