### PR TITLE
add session/course objectives and related competencies to calendar-events

### DIFF
--- a/src/Ilios/ApiBundle/Controller/SchooleventController.php
+++ b/src/Ilios/ApiBundle/Controller/SchooleventController.php
@@ -70,6 +70,8 @@ class SchooleventController extends Controller
 
         $result = $schoolManager->addInstructorsToEvents($events);
         $result = $schoolManager->addMaterialsToEvents($result);
+        $result = $schoolManager->addObjectivesAndCompetenciesToEvents($result);
+
 
         $sessionUser = $tokenStorage->getToken()->getUser();
 

--- a/src/Ilios/ApiBundle/Controller/SchooleventController.php
+++ b/src/Ilios/ApiBundle/Controller/SchooleventController.php
@@ -72,7 +72,6 @@ class SchooleventController extends Controller
         $result = $schoolManager->addMaterialsToEvents($result);
         $result = $schoolManager->addObjectivesAndCompetenciesToEvents($result);
 
-
         $sessionUser = $tokenStorage->getToken()->getUser();
 
         //Un-privileged users get less data

--- a/src/Ilios/ApiBundle/Controller/UsereventController.php
+++ b/src/Ilios/ApiBundle/Controller/UsereventController.php
@@ -77,6 +77,7 @@ class UsereventController extends AbstractController
 
         $result = $manager->addInstructorsToEvents($events);
         $result = $manager->addMaterialsToEvents($result);
+        $result = $manager->addObjectivesAndCompetenciesToEvents($result);
 
         // Remove all draft data when not viewing your own events
         // or if the requesting user does not have elevated privileges

--- a/src/Ilios/CoreBundle/Classes/CalendarEvent.php
+++ b/src/Ilios/CoreBundle/Classes/CalendarEvent.php
@@ -183,6 +183,27 @@ class CalendarEvent
     public $sessionTypeTitle;
 
     /**
+     * @var array
+     * @IS\Expose
+     * @IS\Type("entityCollection")
+     */
+    public $sessionObjectives = array();
+
+    /**
+     * @var array
+     * @IS\Expose
+     * @IS\Type("entityCollection")
+     */
+    public $courseObjectives = array();
+
+    /**
+     * @var array
+     * @IS\Expose
+     * @IS\Type("entityCollection")
+     */
+    public $competencies = array();
+
+    /**
      * Clean out all the data for draft or scheduled events
      *
      * This information is not available to un-privileged users
@@ -207,6 +228,9 @@ class CalendarEvent
 
             $this->instructors = [];
             $this->learningMaterials = [];
+            $this->sessionObjectives = [];
+            $this->courseObjectives = [];
+            $this->competencies = [];
         }
     }
 

--- a/src/Ilios/CoreBundle/Entity/Manager/SchoolManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/SchoolManager.php
@@ -70,4 +70,18 @@ class SchoolManager extends BaseManager
         $repository = $this->getRepository();
         return $repository->addMaterialsToEvents($events, $this->factory);
     }
+
+    /**
+     * Finds and adds course- and session-objectives and their competencies to a given list of calendar events.
+     *
+     * @param CalendarEvent[] $events
+     * @return CalendarEvent[]
+     * @throws \Exception
+     */
+    public function addObjectivesAndCompetenciesToEvents(array $events)
+    {
+        /** @var SchoolRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->addObjectivesAndCompetenciesToEvents($events);
+    }
 }

--- a/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/UserManager.php
@@ -100,6 +100,20 @@ class UserManager extends BaseManager
     }
 
     /**
+     * Finds and adds course- and session-objectives and their competencies to a given list of calendar events.
+     *
+     * @param CalendarEvent[] $events
+     * @return CalendarEvent[]
+     * @throws \Exception
+     */
+    public function addObjectivesAndCompetenciesToEvents(array $events)
+    {
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->addObjectivesAndCompetenciesToEvents($events);
+    }
+
+    /**
      * @param array $campusIdFilter an array of the campusIDs to include in our search if empty then all users
      *
      * @return ArrayCollection

--- a/src/Ilios/CoreBundle/Entity/Repository/SchoolRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/SchoolRepository.php
@@ -283,6 +283,17 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
     }
 
     /**
+     * Finds and adds course- and session-objectives and their competencies to a given list of calendar events.
+     *
+     * @param CalendarEvent[] $events
+     * @return CalendarEvent[]
+     */
+    public function addObjectivesAndCompetenciesToEvents(array $events)
+    {
+        return $this->attachObjectivesAndCompetenciesToEvents($events, $this->_em);
+    }
+
+    /**
      * @param QueryBuilder $qb
      * @param array $criteria
      * @param array $orderBy

--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -856,6 +856,16 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         return $this->attachMaterialsToEvents($events, $factory, $this->_em);
     }
 
+    /**
+     * Finds and adds course- and session-objectives and their competencies to a given list of calendar events.
+     *
+     * @param CalendarEvent[] $events
+     * @return CalendarEvent[]
+     */
+    public function addObjectivesAndCompetenciesToEvents(array $events)
+    {
+        return $this->attachObjectivesAndCompetenciesToEvents($events, $this->_em);
+    }
 
     /**
      * Returns a list of ids of schools directed by the given user.

--- a/src/Ilios/CoreBundle/Traits/CalendarEventRepository.php
+++ b/src/Ilios/CoreBundle/Traits/CalendarEventRepository.php
@@ -268,7 +268,7 @@ trait CalendarEventRepository
         $results = $qb->getQuery()->getArrayResult();
         $courseObjectives =  [];
         foreach ($results as $result) {
-            if (! array_key_exists($result['course_id'], $sessionObjectives)) {
+            if (! array_key_exists($result['course_id'], $courseObjectives)) {
                 $courseObjectives[$result['course_id']] = [];
             }
             $courseObjectives[$result['course_id']][] = [

--- a/src/Ilios/CoreBundle/Traits/CalendarEventRepository.php
+++ b/src/Ilios/CoreBundle/Traits/CalendarEventRepository.php
@@ -220,7 +220,7 @@ trait CalendarEventRepository
      * Adds course- and session-objectives and their competencies to a given list of events.
      * @param array $events A list of events
      * @param EntityManager $em
-     * @return array The events list with instructors added.
+     * @return array The events list with objectives and competencies added.
      */
     public function attachObjectivesAndCompetenciesToEvents(array $events, EntityManager $em)
     {

--- a/tests/CoreBundle/DataLoader/CompetencyData.php
+++ b/tests/CoreBundle/DataLoader/CompetencyData.php
@@ -10,7 +10,7 @@ class CompetencyData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 1,
-            'title' => $this->faker->text,
+            'title' => 'first competency',
             'active' => true,
             'school' => "1",
             'objectives' => [],
@@ -21,7 +21,7 @@ class CompetencyData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 2,
-            'title' => $this->faker->text,
+            'title' => 'second competency',
             'active' => false,
             'school' => "1",
             'objectives' => [],

--- a/tests/CoreBundle/DataLoader/ObjectiveData.php
+++ b/tests/CoreBundle/DataLoader/ObjectiveData.php
@@ -10,7 +10,7 @@ class ObjectiveData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 1,
-            'title' => $this->faker->text,
+            'title' => 'first objective',
             'position' => 0,
             'competency' => '3',
             'courses' => [],
@@ -28,7 +28,7 @@ class ObjectiveData extends AbstractDataLoader
             'position' => 0,
             'courses' => ['1', '2', '4'],
             'programYears' => ['1'],
-            'sessions' => ['1'],
+            'sessions' => [],
             'parents' => ['1'],
             'children' => ['3', '6'],
             'meshDescriptors' => ['abc1'],
@@ -37,7 +37,7 @@ class ObjectiveData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 3,
-            'title' => $this->faker->text,
+            'title' => 'third objective',
             'position' => 0,
             'courses' => [],
             'programYears' => [],
@@ -51,7 +51,7 @@ class ObjectiveData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 4,
-            'title' => $this->faker->text,
+            'title' => 'fourth objective',
             'position' => 0,
             'courses' => ["2"],
             'programYears' => [],
@@ -64,7 +64,7 @@ class ObjectiveData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 5,
-            'title' => $this->faker->text,
+            'title' => 'fifth objective',
             'position' => 0,
             'courses' => ["3"],
             'programYears' => [],
@@ -77,7 +77,7 @@ class ObjectiveData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 6,
-            'title' => $this->faker->text,
+            'title' =>'sixth objective',
             'position' => 0,
             'courses' => [],
             'programYears' => [],
@@ -90,7 +90,7 @@ class ObjectiveData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 7,
-            'title' => $this->faker->text,
+            'title' => 'seventh objective',
             'position' => 0,
             'courses' => [],
             'programYears' => [],
@@ -103,7 +103,7 @@ class ObjectiveData extends AbstractDataLoader
         );
         $arr[] = array(
             'id' => 8,
-            'title' => $this->faker->text,
+            'title' => 'eighth objective',
             'position' => 0,
             'courses' => [],
             'programYears' => ['5'],

--- a/tests/CoreBundle/DataLoader/SessionData.php
+++ b/tests/CoreBundle/DataLoader/SessionData.php
@@ -19,7 +19,7 @@ class SessionData extends AbstractDataLoader
             'course' => '1',
             'sessionDescription' => '1',
             'terms' => ['2', '5'],
-            'objectives' => ['2', '3'],
+            'objectives' => ['3'],
             'meshDescriptors' => ['abc1'],
             'learningMaterials' => ['1'],
             'offerings' => ['1', '2'],

--- a/tests/IliosApiBundle/Endpoints/ObjectiveTest.php
+++ b/tests/IliosApiBundle/Endpoints/ObjectiveTest.php
@@ -71,7 +71,7 @@ class ObjectiveTest extends ReadWriteEndpointTest
             'competency' => [[0], ['competency' => 3]],
             'courses' => [[1, 3], ['courses' => [2]]],
             'programYears' => [[0, 1], ['programYears' => [1]]],
-            'sessions' => [[1, 2], ['sessions' => [1]]],
+            'sessions' => [[2], ['sessions' => [1]]],
 //            'parents' => [[2, 5], ['parents' => [2]]],
 //            'children' => [[1], ['children' => [3]]],
 //            'meshDescriptors' => [[6], ['meshDescriptors' => ['abc3']]],

--- a/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
+++ b/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
@@ -128,7 +128,8 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals(2, $events[0]['courseObjectives'][0]['id']);
         $this->assertEquals('second objective', $events[0]['courseObjectives'][0]['title']);
         $this->assertEquals(0, $events[0]['courseObjectives'][0]['position']);
-        $this->assertEquals(3, $events[0]['courseObjectives'][0]['competency']);
+        $this->assertEquals(1, count($events[0]['courseObjectives'][0]['competencies']));
+        $this->assertEquals(3, $events[0]['courseObjectives'][0]['competencies'][0]);
         $this->assertEquals(2, count($events[0]['competencies']));
         $this->assertEquals(3, $events[0]['competencies'][0]['id']);
         $this->assertEquals('third competency', $events[0]['competencies'][0]['title']);
@@ -240,13 +241,14 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals(3, $events[9]['sessionObjectives'][0]['id']);
         $this->assertEquals('third objective', $events[9]['sessionObjectives'][0]['title']);
         $this->assertEquals(0, $events[9]['sessionObjectives'][0]['position']);
-        $this->assertEquals(3, $events[9]['sessionObjectives'][0]['competency']);
-
+        $this->assertEquals(1, count($events[9]['sessionObjectives'][0]['competencies']));
+        $this->assertEquals(3, $events[9]['sessionObjectives'][0]['competencies'][0]);
         $this->assertEquals(1, count($events[9]['courseObjectives']));
         $this->assertEquals(2, $events[9]['courseObjectives'][0]['id']);
         $this->assertEquals('second objective', $events[9]['courseObjectives'][0]['title']);
         $this->assertEquals(0, $events[9]['courseObjectives'][0]['position']);
-        $this->assertEquals(3, $events[9]['courseObjectives'][0]['competency']);
+        $this->assertEquals(1, count($events[9]['courseObjectives'][0]['competencies']));
+        $this->assertEquals(3, $events[9]['courseObjectives'][0]['competencies'][0]);
         $this->assertEquals(2, count($events[9]['competencies']));
         $this->assertEquals(3, $events[9]['competencies'][0]['id']);
         $this->assertEquals('third competency', $events[9]['competencies'][0]['title']);

--- a/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
+++ b/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
@@ -123,6 +123,19 @@ class SchooleventsTest extends AbstractEndpointTest
             9,
             'Event 0 has the correct number of learning materials'
         );
+        $this->assertEquals(0, count($events[0]['sessionObjectives']));
+        $this->assertEquals(1, count($events[0]['courseObjectives']));
+        $this->assertEquals(2, $events[0]['courseObjectives'][0]['id']);
+        $this->assertEquals('second objective', $events[0]['courseObjectives'][0]['title']);
+        $this->assertEquals(0, $events[0]['courseObjectives'][0]['position']);
+        $this->assertEquals(3, $events[0]['courseObjectives'][0]['competency']);
+        $this->assertEquals(2, count($events[0]['competencies']));
+        $this->assertEquals(3, $events[0]['competencies'][0]['id']);
+        $this->assertEquals('third competency', $events[0]['competencies'][0]['title']);
+        $this->assertEquals(1, $events[0]['competencies'][0]['parent']);
+        $this->assertEquals(1, $events[0]['competencies'][1]['id']);
+        $this->assertEquals('first competency', $events[0]['competencies'][1]['title']);
+        $this->assertEquals(null, $events[0]['competencies'][1]['parent']);
 
         $this->assertEquals($events[1]['offering'], 4);
         $this->assertEquals($events[1]['startDate'], $offerings[3]['startDate']);
@@ -223,6 +236,25 @@ class SchooleventsTest extends AbstractEndpointTest
             10,
             'Event 9 has the correct number of learning materials'
         );
+        $this->assertEquals(1, count($events[9]['sessionObjectives']));
+        $this->assertEquals(3, $events[9]['sessionObjectives'][0]['id']);
+        $this->assertEquals('third objective', $events[9]['sessionObjectives'][0]['title']);
+        $this->assertEquals(0, $events[9]['sessionObjectives'][0]['position']);
+        $this->assertEquals(3, $events[9]['sessionObjectives'][0]['competency']);
+
+        $this->assertEquals(1, count($events[9]['courseObjectives']));
+        $this->assertEquals(2, $events[9]['courseObjectives'][0]['id']);
+        $this->assertEquals('second objective', $events[9]['courseObjectives'][0]['title']);
+        $this->assertEquals(0, $events[9]['courseObjectives'][0]['position']);
+        $this->assertEquals(3, $events[9]['courseObjectives'][0]['competency']);
+        $this->assertEquals(2, count($events[9]['competencies']));
+        $this->assertEquals(3, $events[9]['competencies'][0]['id']);
+        $this->assertEquals('third competency', $events[9]['competencies'][0]['title']);
+        $this->assertEquals(1, $events[9]['competencies'][0]['parent']);
+        $this->assertEquals(1, $events[9]['competencies'][1]['id']);
+        $this->assertEquals('first competency', $events[9]['competencies'][1]['title']);
+        $this->assertEquals(null, $events[9]['competencies'][1]['parent']);
+
 
         /** @var OfferingInterface $offering */
         $offering = $this->fixtures->getReference('offerings8');


### PR DESCRIPTION
fixes #2173 

this adds it to both school- and user-events.

each event has now three new attributes - `sessionObjectives`, `courseObjectives` and `competencies`.

- Items in the `sessionObjectives` and `courseObjectives` collections have the same structure - `id`, `title`, `position` and `competenies` (that's the competency ids as lookup-keys)

- items in the `competencies` collection have the following structure: `id`, `title`, and `parent` (parent competency id, which is `NULL` for domains). this list contains all linked competencies and their parent domains.
