### PR TITLE
Cleanup orphaned objectives onFlush

### DIFF
--- a/app/Resources/DoctrineMigrations/Version20180617000000.php
+++ b/app/Resources/DoctrineMigrations/Version20180617000000.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Remove parent/child relationships from Orphaned Objectives
+ */
+final class Version20180617000000 extends AbstractMigration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $related = 'SELECT objective_id FROM objective WHERE ' .
+          'objective_id NOT IN (SELECT objective_id FROM program_year_x_objective) ' .
+          'AND objective_id NOT IN (SELECT objective_id FROM course_x_objective) ' .
+          'AND objective_id NOT IN (SELECT objective_id FROM session_x_objective) ';
+
+        $this->addSql("DELETE FROM objective_x_objective WHERE objective_id IN (${related})");
+        $this->addSql("DELETE FROM objective_x_objective WHERE parent_objective_id IN (${related})");
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/Objective.php
+++ b/src/Ilios/CoreBundle/Entity/Objective.php
@@ -279,6 +279,7 @@ class Objective implements ObjectiveInterface
     {
         if (!$this->children->contains($child)) {
             $this->children->add($child);
+            $child->addParent($this);
         }
     }
 
@@ -287,7 +288,10 @@ class Objective implements ObjectiveInterface
      */
     public function removeChild(ObjectiveInterface $child)
     {
-        $this->children->removeElement($child);
+        if ($this->children->contains($child)) {
+            $this->children->removeElement($child);
+            $child->removeParent($this);
+        }
     }
 
     /**

--- a/src/Ilios/CoreBundle/Entity/ObjectiveInterface.php
+++ b/src/Ilios/CoreBundle/Entity/ObjectiveInterface.php
@@ -52,7 +52,7 @@ interface ObjectiveInterface extends
     public function removeParent(ObjectiveInterface $parent);
 
     /**
-     * @return ArrayCollection|ObjectiveInterface
+     * @return ObjectiveInterface[]
      */
     public function getParents();
 
@@ -72,7 +72,7 @@ interface ObjectiveInterface extends
     public function removeChild(ObjectiveInterface $child);
 
     /**
-     * @return ArrayCollection|ObjectiveInterface[]
+     * @return ObjectiveInterface[]
      */
     public function getChildren();
 

--- a/src/Ilios/CoreBundle/EventListener/RemoveOrphanedObjectives.php
+++ b/src/Ilios/CoreBundle/EventListener/RemoveOrphanedObjectives.php
@@ -37,7 +37,7 @@ class RemoveOrphanedObjectives
                     $courses = $objective->getCourses();
                     $sessions = $objective->getSessions();
                     /** @var IdentifiableEntityInterface[] $allLinks */
-                    $allLinks = $programYears->toArray() + $courses->toArray() + $sessions->toArray();
+                    $allLinks = array_merge($programYears->toArray(), $courses->toArray(), $sessions->toArray());
                     //ensure that this Objective is only linked to the deleted entity
                     if (count($allLinks) === 0 ||
                         (count($allLinks) === 1 && $allLinks[0]->getId() === $entity->getId())

--- a/src/Ilios/CoreBundle/EventListener/RemoveOrphanedObjectives.php
+++ b/src/Ilios/CoreBundle/EventListener/RemoveOrphanedObjectives.php
@@ -1,0 +1,73 @@
+<?php
+namespace Ilios\CoreBundle\EventListener;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\UnitOfWork;
+use Ilios\CoreBundle\Entity\CourseInterface;
+use Ilios\CoreBundle\Entity\Objective;
+use Ilios\CoreBundle\Entity\ProgramYearInterface;
+use Ilios\CoreBundle\Entity\SessionInterface;
+use Ilios\CoreBundle\Traits\IdentifiableEntityInterface;
+
+/**
+ * Doctrine event listener.
+ * When a ProgramYear, Course, or Session is deleted cleanup any newly orphaned objectives.
+ */
+class RemoveOrphanedObjectives
+{
+    /**
+     * @param OnFlushEventArgs $eventArgs
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function onFlush(OnFlushEventArgs $eventArgs)
+    {
+        $em = $eventArgs->getEntityManager();
+        $uow = $em->getUnitOfWork();
+
+        foreach ($uow->getScheduledEntityDeletions() as $entity) {
+            if (
+                $entity instanceof ProgramYearInterface ||
+                $entity instanceof CourseInterface ||
+                $entity instanceof SessionInterface
+            ) {
+                $objectives = $entity->getObjectives();
+                foreach ($objectives as $objective) {
+                    $programYears = $objective->getProgramYears();
+                    $courses = $objective->getCourses();
+                    $sessions = $objective->getSessions();
+                    /** @var IdentifiableEntityInterface[] $allLinks */
+                    $allLinks = $programYears->toArray() + $courses->toArray() + $sessions->toArray();
+                    //ensure that this Objective is only linked to the deleted entity
+                    if (count($allLinks) === 0 ||
+                        (count($allLinks) === 1 && $allLinks[0]->getId() === $entity->getId())
+                    ) {
+                        $this->removeLinks($uow, $em, $objective);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param UnitOfWork $uow
+     * @param EntityManager $em
+     * @param Objective $objective
+     * @throws \Doctrine\ORM\ORMException
+     */
+    protected function removeLinks(UnitOfWork $uow, EntityManager $em, Objective $objective)
+    {
+        $objective->setParents(new ArrayCollection());
+        $objective->setCompetency(null);
+        foreach ($objective->getChildren() as $child) {
+            $child->removeParent($objective);
+            $em->persist($child);
+            $classMetadata = $em->getClassMetadata(Objective::class);
+            $uow->computeChangeSet($classMetadata, $child);
+        }
+        $em->persist($objective);
+        $classMetadata = $em->getClassMetadata(Objective::class);
+        $uow->computeChangeSet($classMetadata, $objective);
+    }
+}

--- a/src/Ilios/CoreBundle/EventListener/RemoveOrphanedObjectives.php
+++ b/src/Ilios/CoreBundle/EventListener/RemoveOrphanedObjectives.php
@@ -27,8 +27,7 @@ class RemoveOrphanedObjectives
         $uow = $em->getUnitOfWork();
 
         foreach ($uow->getScheduledEntityDeletions() as $entity) {
-            if (
-                $entity instanceof ProgramYearInterface ||
+            if ($entity instanceof ProgramYearInterface ||
                 $entity instanceof CourseInterface ||
                 $entity instanceof SessionInterface
             ) {

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -38,6 +38,10 @@ services:
         tags:
           - { name: doctrine.event_listener, event: onFlush }
 
+    Ilios\CoreBundle\EventListener\RemoveOrphanedObjectives:
+        tags:
+          - { name: doctrine.event_listener, event: onFlush }
+
     Ilios\CoreBundle\Service\Config:
         public: true
 

--- a/tests/CoreBundle/Entity/ObjectiveTest.php
+++ b/tests/CoreBundle/Entity/ObjectiveTest.php
@@ -143,7 +143,7 @@ class ObjectiveTest extends EntityBase
      */
     public function testAddChild()
     {
-        $this->entityCollectionAddTest('children', 'Objective', 'getChildren', 'addChild');
+        $this->entityCollectionAddTest('children', 'Objective', 'getChildren', 'addChild', 'addParent');
     }
 
     /**
@@ -151,7 +151,7 @@ class ObjectiveTest extends EntityBase
      */
     public function testRemoveChild()
     {
-        $this->entityCollectionRemoveTest('children', 'Objective', 'getChildren', 'addChild', 'removeChild');
+        $this->entityCollectionRemoveTest('children', 'Objective', 'getChildren', 'addChild', 'removeChild', 'removeParent');
     }
 
     /**
@@ -160,7 +160,7 @@ class ObjectiveTest extends EntityBase
      */
     public function testGetChildren()
     {
-        $this->entityCollectionSetTest('children', 'Objective', 'getChildren', 'setChildren', false);
+        $this->entityCollectionSetTest('children', 'Objective', 'getChildren', 'setChildren', 'addParent');
     }
 
     /**

--- a/tests/CoreBundle/Entity/ObjectiveTest.php
+++ b/tests/CoreBundle/Entity/ObjectiveTest.php
@@ -151,7 +151,14 @@ class ObjectiveTest extends EntityBase
      */
     public function testRemoveChild()
     {
-        $this->entityCollectionRemoveTest('children', 'Objective', 'getChildren', 'addChild', 'removeChild', 'removeParent');
+        $this->entityCollectionRemoveTest(
+            'children',
+            'Objective',
+            'getChildren',
+            'addChild',
+            'removeChild',
+            'removeParent'
+        );
     }
 
     /**

--- a/tests/IliosApiBundle/Endpoints/CourseTest.php
+++ b/tests/IliosApiBundle/Endpoints/CourseTest.php
@@ -646,18 +646,18 @@ class CourseTest extends ReadWriteEndpointTest
         }
         $newObjectives = $this->postMany('objectives', 'objectives', $create);
 
-        $getObjectives = function($id) use ($self) {
+        $getObjectives = function ($id) use ($self) {
             return $self->getOne('objectives', 'objectives', $id);
         };
         $objectives = array_map($getObjectives, array_column($newObjectives, 'id'));
-        foreach($objectives as $arr) {
+        foreach ($objectives as $arr) {
             $this->assertNotEmpty($arr['parents'], 'parents have been created');
             $this->assertNotEmpty($arr['children'], 'children have been created');
             $this->assertArrayHasKey('competency', $arr);
         }
         $this->deleteTest($id);
         $objectives = array_map($getObjectives, array_column($newObjectives, 'id'));
-        foreach($objectives as $arr) {
+        foreach ($objectives as $arr) {
             $this->assertEmpty($arr['parents'], 'parents have been removed');
             $this->assertEmpty($arr['children'], 'children have been removed');
             $this->assertArrayNotHasKey('competency', $arr);

--- a/tests/IliosApiBundle/Endpoints/ObjectiveTest.php
+++ b/tests/IliosApiBundle/Endpoints/ObjectiveTest.php
@@ -42,7 +42,7 @@ class ObjectiveTest extends ReadWriteEndpointTest
             'programYears' => ['programYears', [2]],
             'sessions' => ['sessions', [2]],
             'parents' => ['parents', [2]],
-            'children' => ['children', [4], $skipped = true],
+            'children' => ['children', [4]],
             'meshDescriptors' => ['meshDescriptors', ['abc2']],
             'ancestor' => ['ancestor', 1, $skipped = true],
             'descendants' => ['descendants', [2], $skipped = true],

--- a/tests/IliosApiBundle/Endpoints/ProgramYearTest.php
+++ b/tests/IliosApiBundle/Endpoints/ProgramYearTest.php
@@ -245,18 +245,18 @@ class ProgramYearTest extends ReadWriteEndpointTest
         }
         $newObjectives = $this->postMany('objectives', 'objectives', $create);
 
-        $getObjectives = function($id) use ($self) {
+        $getObjectives = function ($id) use ($self) {
             return $self->getOne('objectives', 'objectives', $id);
         };
         $objectives = array_map($getObjectives, array_column($newObjectives, 'id'));
-        foreach($objectives as $arr) {
+        foreach ($objectives as $arr) {
             $this->assertNotEmpty($arr['parents'], 'parents have been created');
             $this->assertNotEmpty($arr['children'], 'children have been created');
             $this->assertArrayHasKey('competency', $arr);
         }
         $this->deleteTest($id);
         $objectives = array_map($getObjectives, array_column($newObjectives, 'id'));
-        foreach($objectives as $arr) {
+        foreach ($objectives as $arr) {
             $this->assertEmpty($arr['parents'], 'parents have been removed');
             $this->assertEmpty($arr['children'], 'children have been removed');
             $this->assertArrayNotHasKey('competency', $arr);

--- a/tests/IliosApiBundle/Endpoints/SessionTest.php
+++ b/tests/IliosApiBundle/Endpoints/SessionTest.php
@@ -4,6 +4,7 @@ namespace Tests\IliosApiBundle\Endpoints;
 
 use Tests\CoreBundle\DataLoader\IlmSessionData;
 use Tests\CoreBundle\DataLoader\LearningMaterialData;
+use Tests\CoreBundle\DataLoader\ObjectiveData;
 use Tests\CoreBundle\DataLoader\SessionDescriptionData;
 use Tests\CoreBundle\DataLoader\SessionLearningMaterialData;
 use Tests\IliosApiBundle\ReadWriteEndpointTest;
@@ -225,5 +226,46 @@ class SessionTest extends ReadWriteEndpointTest
         $postData = $data;
         $postData['sessionDescription'] = null;
         $this->postTest($data, $postData);
+    }
+
+    public function testRemoveLinksFromOrphanedObjectives()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->getOne();
+        $id = $data['id'];
+        $self = $this;
+
+        //create data we an depend on
+        $dataLoader = $this->container->get(ObjectiveData::class);
+        $create = [];
+        for ($i = 0; $i < 2; $i++) {
+            $arr = $dataLoader->create();
+            $arr['parents'] = ['1'];
+            $arr['children'] = ['7', '8'];
+            $arr['competency'] = 1;
+            $arr['programYears'] = [];
+            $arr['courses'] = [];
+            $arr['sessions'] = [$id];
+            unset($arr['id']);
+            $create[] = $arr;
+        }
+        $newObjectives = $this->postMany('objectives', 'objectives', $create);
+
+        $getObjectives = function($id) use ($self) {
+            return $self->getOne('objectives', 'objectives', $id);
+        };
+        $objectives = array_map($getObjectives, array_column($newObjectives, 'id'));
+        foreach($objectives as $arr) {
+            $this->assertNotEmpty($arr['parents'], 'parents have been created');
+            $this->assertNotEmpty($arr['children'], 'children have been created');
+            $this->assertArrayHasKey('competency', $arr);
+        }
+        $this->deleteTest($id);
+        $objectives = array_map($getObjectives, array_column($newObjectives, 'id'));
+        foreach($objectives as $arr) {
+            $this->assertEmpty($arr['parents'], 'parents have been removed');
+            $this->assertEmpty($arr['children'], 'children have been removed');
+            $this->assertArrayNotHasKey('competency', $arr);
+        }
     }
 }

--- a/tests/IliosApiBundle/Endpoints/SessionTest.php
+++ b/tests/IliosApiBundle/Endpoints/SessionTest.php
@@ -251,18 +251,18 @@ class SessionTest extends ReadWriteEndpointTest
         }
         $newObjectives = $this->postMany('objectives', 'objectives', $create);
 
-        $getObjectives = function($id) use ($self) {
+        $getObjectives = function ($id) use ($self) {
             return $self->getOne('objectives', 'objectives', $id);
         };
         $objectives = array_map($getObjectives, array_column($newObjectives, 'id'));
-        foreach($objectives as $arr) {
+        foreach ($objectives as $arr) {
             $this->assertNotEmpty($arr['parents'], 'parents have been created');
             $this->assertNotEmpty($arr['children'], 'children have been created');
             $this->assertArrayHasKey('competency', $arr);
         }
         $this->deleteTest($id);
         $objectives = array_map($getObjectives, array_column($newObjectives, 'id'));
-        foreach($objectives as $arr) {
+        foreach ($objectives as $arr) {
             $this->assertEmpty($arr['parents'], 'parents have been removed');
             $this->assertEmpty($arr['children'], 'children have been removed');
             $this->assertArrayNotHasKey('competency', $arr);


### PR DESCRIPTION
When a ProgramYear, Course, or Session is deleted we also need to clean
up those objective's parents and children so that we don't have a tree
with no links.

Fixes #2178