### PR TITLE
Non-learners get materials from draft events

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/UserRepository.php
@@ -820,7 +820,7 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         $sessionIds = array_keys($sessions);
 
 
-        $sessionMaterials = $this->getLearningMaterialsForSessions($sessionIds, $this->_em);
+        $sessionMaterials = $this->getSessionLearningMaterialsForPublishedSessions($sessionIds, $this->_em);
 
         $sessionUserMaterials = array_map(function (array $arr) use ($factory, $sessions) {
             $arr['firstOfferingDate'] = $sessions[$arr['sessionId']]['firstOfferingDate'];
@@ -828,7 +828,7 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             return $factory->create($arr);
         }, $sessionMaterials);
 
-        $courseMaterials = $this->getLearningMaterialsForCourses($sessionIds, $this->_em);
+        $courseMaterials = $this->getCourseLearningMaterialsForPublishedSessions($sessionIds, $this->_em);
 
         $courseUserMaterials = array_map(function (array $arr) use ($factory) {
             return $factory->create($arr);

--- a/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
+++ b/tests/IliosApiBundle/Endpoints/SchooleventsTest.php
@@ -174,7 +174,11 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[3]['equipmentRequired'], 'equipmentRequired is correct for event 3');
         $this->assertTrue($events[3]['supplemental'], 'supplemental is correct for event 3');
         $this->assertArrayNotHasKey('attendanceRequired', $events[3], 'attendanceRequired is correct for event 3');
-        $this->assertEquals(count($events[3]['learningMaterials']), 0, 'Event 3 has no learning materials');
+        $this->assertEquals(
+            7,
+            count($events[3]['learningMaterials']),
+            'Event 3 has the correct number of learning materials'
+        );
 
         $this->assertEquals($events[4]['offering'], 7);
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate']);
@@ -184,7 +188,11 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[4]['equipmentRequired'], 'equipmentRequired is correct for event 4');
         $this->assertTrue($events[4]['supplemental'], 'supplemental is correct for event 4');
         $this->assertArrayNotHasKey('attendanceRequired', $events[4], 'attendanceRequired is correct for event 4');
-        $this->assertEquals(count($events[4]['learningMaterials']), 0, 'Event 4 has no learning materials');
+        $this->assertEquals(
+            7,
+            count($events[4]['learningMaterials']),
+            'Event 4 has the correct number of learning materials'
+        );
 
         $this->assertEquals($events[5]['ilmSession'], 1);
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate']);
@@ -221,7 +229,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[8]['equipmentRequired'], 'equipmentRequired is correct for event 8');
         $this->assertFalse($events[8]['supplemental'], 'supplemental is correct for event 8');
         $this->assertArrayNotHasKey('attendanceRequired', $events[8], 'attendanceRequired is correct for event 8');
-        $this->assertEquals(count($events[8]['learningMaterials']), 0, 'Event 8 has no learning materials');
+        $this->assertEquals(0, count($events[8]['learningMaterials']), 'Event 8 has no learning materials');
 
         $this->assertEquals($events[9]['offering'], 1);
         $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate']);
@@ -267,7 +275,11 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertFalse($events[10]['equipmentRequired'], 'equipmentRequired is correct for event 10');
         $this->assertTrue($events[10]['supplemental'], 'supplemental is correct for event 10');
         $this->assertArrayNotHasKey('attendanceRequired', $events[10], 'attendanceRequired is correct for event 10');
-        $this->assertEquals(count($events[10]['learningMaterials']), 0, 'Event 8 has no learning materials');
+        $this->assertEquals(
+            7,
+            count($events[10]['learningMaterials']),
+            'Event 10 has the correct number of learning materials'
+        );
 
 
         foreach ($events as $event) {
@@ -290,6 +302,26 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[0]['offering'], $offerings[5]['id']);
     }
 
+    public function testPrivilegedUsersGetsEventsForUnpublishedSessions()
+    {
+        $school = $this->container->get(SchoolData::class)->getOne();
+        $events = $this->getEvents($school['id'], 0, 100000000000);
+
+        $event = $events[3];
+        $this->assertFalse($event['isPublished']);
+        $this->assertFalse($event['isScheduled']);
+        $lms = $event['learningMaterials'];
+
+        $this->assertEquals(7, count($lms));
+        $this->assertEquals('2', $lms[0]['sessionLearningMaterial']);
+        $this->assertEquals('3', $lms[1]['sessionLearningMaterial']);
+        $this->assertEquals('4', $lms[2]['sessionLearningMaterial']);
+        $this->assertEquals('5', $lms[3]['sessionLearningMaterial']);
+        $this->assertEquals('6', $lms[4]['sessionLearningMaterial']);
+        $this->assertEquals('7', $lms[5]['sessionLearningMaterial']);
+        $this->assertEquals('8', $lms[6]['sessionLearningMaterial']);
+    }
+
     protected function getEvents($schoolId, $from, $to, $userId = null)
     {
         $parameters = [
@@ -303,7 +335,7 @@ class SchooleventsTest extends AbstractEndpointTest
             $parameters
         );
 
-        $userToken = isset($userId) ? $this->getTokenForUser($userId): $this->getAuthenticatedUserToken();
+        $userToken = isset($userId) ? $this->getTokenForUser($userId) : $this->getAuthenticatedUserToken();
         $this->createJsonRequest(
             'GET',
             $url,

--- a/tests/IliosApiBundle/Endpoints/UsereventTest.php
+++ b/tests/IliosApiBundle/Endpoints/UsereventTest.php
@@ -295,7 +295,11 @@ class UsereventTest extends AbstractEndpointTest
             $sessionTypes[1]['title'],
             'session type title is correct for event 3'
         );
-        $this->assertEquals(count($events[3]['learningMaterials']), 0, 'Event 3 has no learning materials');
+        $this->assertEquals(
+            7,
+            count($events[3]['learningMaterials']),
+            'Event 3 has the correct number of learning materials'
+        );
 
         $this->assertFalse(
             $events[3]['attireRequired'],
@@ -329,7 +333,11 @@ class UsereventTest extends AbstractEndpointTest
             $sessionTypes[1]['title'],
             'session type title is correct for event 4'
         );
-        $this->assertEquals(count($events[4]['learningMaterials']), 0, 'Event 4 has no learning materials');
+        $this->assertEquals(
+            7,
+            count($events[4]['learningMaterials']),
+            'Event 4 has the correct number of learning materials'
+        );
 
         $this->assertFalse(
             $events[4]['attireRequired'],
@@ -583,6 +591,30 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEquals($events[0]['startDate'], $offerings[5]['startDate']);
         $this->assertEquals($events[0]['endDate'], $offerings[5]['endDate']);
         $this->assertEquals($events[0]['offering'], $offerings[5]['id']);
+    }
+
+    public function testPrivilegedUsersGetsEventsForUnpublishedSessions()
+    {
+        $userId = 2;
+        $events = $this->getEvents(
+            $userId,
+            0,
+            100000000000,
+            $this->getTokenForUser($userId)
+        );
+        $event = $events[3];
+        $this->assertFalse($event['isPublished']);
+        $this->assertFalse($event['isScheduled']);
+        $lms = $event['learningMaterials'];
+
+        $this->assertEquals(7, count($lms));
+        $this->assertEquals('2', $lms[0]['sessionLearningMaterial']);
+        $this->assertEquals('3', $lms[1]['sessionLearningMaterial']);
+        $this->assertEquals('4', $lms[2]['sessionLearningMaterial']);
+        $this->assertEquals('5', $lms[3]['sessionLearningMaterial']);
+        $this->assertEquals('6', $lms[4]['sessionLearningMaterial']);
+        $this->assertEquals('7', $lms[5]['sessionLearningMaterial']);
+        $this->assertEquals('8', $lms[6]['sessionLearningMaterial']);
     }
 
     /**


### PR DESCRIPTION
Anyone with elevated privileges should have access to the materials in
draft sessions and courses. We're already controlling this in the
controllers, but we needed to return a full graph of materials.

Fixes #2186