### PR TITLE
d/l action for program year objectives mapping.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -3,7 +3,7 @@ imports:
     - { resource: services.yml }
 
 parameters:
-    ilios_api_version: v1.31
+    ilios_api_version: v1.32
 
 framework:
     #esi:             ~

--- a/src/Ilios/ApiBundle/Controller/ProgramYearController.php
+++ b/src/Ilios/ApiBundle/Controller/ProgramYearController.php
@@ -116,6 +116,7 @@ class ProgramYearController extends ApiController
             foreach (['program_year_objective', 'mapped_course_objective'] as $key) {
                 $row[$key] = strip_tags($row[$key]);
             }
+            $row['matriculation_year'] = $row['matriculation_year'] . ' - ' . ($row['matriculation_year'] + 1);
         });
 
         $serializer = new Serializer([new ObjectNormalizer()], [new CsvEncoder()]);

--- a/src/Ilios/ApiBundle/Resources/config/special-routes.yml
+++ b/src/Ilios/ApiBundle/Resources/config/special-routes.yml
@@ -360,6 +360,15 @@ ilios_api_programyears_put:
         object: "programyears"
         id: '\d+'
 
+ilios_api_programyears_downloadobjectivesmapping:
+    path: /{version}/{object}/{id}/downloadobjectivesmapping
+    defaults: { _controller: IliosApiBundle:ProgramYear:downloadCourseObjectivesReport, id: 0 }
+    methods: [GET]
+    requirements:
+        version: "%ilios_api_valid_api_versions%"
+        object: 'programyears'
+        id: '(?i)[a-z0-9\-]+'
+
 ilios_api_usermadereminders_410:
     path:     /{version}/{object}/{id}
     defaults: { _controller: IliosApiBundle:UserMadeReminder:fourTen, id: 0 }

--- a/src/Ilios/CoreBundle/Entity/Manager/ProgramYearManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/ProgramYearManager.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Ilios\CoreBundle\Entity\Manager;
+
+use Ilios\CoreBundle\Entity\Repository\ProgramYearRepository;
+
+/**
+ * Class ProgramYearManager
+ * @package Ilios\CoreBundle\Entity\Manager
+ */
+class ProgramYearManager extends BaseManager
+{
+    /**
+     * @param int $programYearId
+     * @return array
+     * @throws \Exception
+     */
+    public function getProgramYearObjectiveToCourseObjectivesMapping($programYearId): array
+    {
+        /** @var ProgramYearRepository $repo */
+        $repo = $this->getRepository();
+        return $repo->getProgramYearObjectiveToCourseObjectivesMapping($programYearId);
+    }
+}

--- a/src/Ilios/CoreBundle/Entity/Repository/ProgramYearRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/ProgramYearRepository.php
@@ -191,7 +191,7 @@ class ProgramYearRepository extends EntityRepository implements DTORepositoryInt
     {
         $qb = $this->_em->createQueryBuilder();
         $qb->select(
-            "p.title AS program_title, py.startYear AS program_year, pyo.title AS program_year_objective," .
+            "p.title AS program_title, py.startYear AS matriculation_year, pyo.title AS program_year_objective," .
                 "cmp.title AS competency, c.title AS course_title, c.externalId AS course_shortname," .
                 "co.title AS mapped_course_objective"
         )

--- a/src/Ilios/CoreBundle/Entity/Repository/ProgramYearRepository.php
+++ b/src/Ilios/CoreBundle/Entity/Repository/ProgramYearRepository.php
@@ -182,4 +182,32 @@ class ProgramYearRepository extends EntityRepository implements DTORepositoryInt
 
         return $qb;
     }
+
+    /**
+     * @param int $programYearId
+     * @return array
+     */
+    public function getProgramYearObjectiveToCourseObjectivesMapping($programYearId): array
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select(
+            "p.title AS program_title, py.startYear AS program_year, pyo.title AS program_year_objective," .
+                "cmp.title AS competency, c.title AS course_title, c.externalId AS course_shortname," .
+                "co.title AS mapped_course_objective"
+        )
+            ->from('IliosCoreBundle:ProgramYear', 'py')
+            ->join('py.program', 'p')
+            ->join('py.objectives', 'pyo')
+            ->leftJoin('pyo.competency', 'cmp')
+            ->leftJoin('pyo.children', 'co')
+            ->leftJoin('co.courses', 'c')
+            ->where($qb->expr()->eq('py.id', ':id'))
+            ->orderBy('pyo.id', 'ASC')
+            ->addOrderBy('cmp.id', 'ASC')
+            ->addOrderBy('c.id', 'ASC')
+            ->addOrderBy('co.id', 'ASC')
+            ->setParameter(':id', $programYearId);
+
+        return $qb->getQuery()->getArrayResult();
+    }
 }

--- a/src/Ilios/CoreBundle/Resources/config/services.yml
+++ b/src/Ilios/CoreBundle/Resources/config/services.yml
@@ -177,6 +177,10 @@ services:
         public: true
         arguments:
             $class: 'Ilios\CoreBundle\Entity\PendingUserUpdate'
+    Ilios\CoreBundle\Entity\Manager\ProgramYearManager:
+        public: true
+        arguments:
+            $class: 'Ilios\CoreBundle\Entity\ProgramYear'
     Ilios\CoreBundle\Entity\Manager\ProgramYearStewardManager:
         public: true
         arguments:

--- a/tests/CoreBundle/DataLoader/CourseData.php
+++ b/tests/CoreBundle/DataLoader/CourseData.php
@@ -15,7 +15,7 @@ class CourseData extends AbstractDataLoader
             'year' => 2016,
             'startDate' => "2016-09-04T00:00:00+00:00",
             'endDate' => "2017-01-01T00:00:00+00:00",
-            'externalId' => $this->faker->text(10),
+            'externalId' => 'first',
             'locked' => false,
             'archived' => false,
             'publishedAsTbd' => false,
@@ -35,12 +35,12 @@ class CourseData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 2,
-            'title' => $this->faker->text(25),
+            'title' => 'course 2',
             'level' => 1,
             'year' => 2012,
             'startDate' => "2013-09-01T00:00:00+00:00",
             'endDate' => "2013-12-14T00:00:00+00:00",
-            'externalId' => $this->faker->text(10),
+            'externalId' => 'second',
             'locked' => false,
             'archived' => false,
             'publishedAsTbd' => false,
@@ -60,7 +60,7 @@ class CourseData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 3,
-            'title' => $this->faker->text(25),
+            'title' => 'third',
             'level' => 1,
             'year' => 2012,
             'startDate' => "2013-09-01T00:00:00+00:00",
@@ -84,12 +84,12 @@ class CourseData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 4,
-            'title' => $this->faker->text(25),
+            'title' => 'fourth course',
             'level' => 3,
             'year' => 2013,
             'startDate' => "2013-09-01T00:00:00+00:00",
             'endDate' => "2013-12-14T00:00:00+00:00",
-            'externalId' => $this->faker->text(10),
+            'externalId' => 'fourth',
             'locked' => false,
             'archived' => false,
             'publishedAsTbd' => false,
@@ -109,12 +109,12 @@ class CourseData extends AbstractDataLoader
 
         $arr[] = array(
             'id' => 5,
-            'title' => $this->faker->text(25),
+            'title' => 'fifth Course',
             'level' => 3,
             'year' => 2013,
             'startDate' => "2017-02-14T00:00:00+00:00",
             'endDate' => "2017-02-17T00:00:00+00:00",
-            'externalId' => $this->faker->text(10),
+            'externalId' => 'fifth',
             'locked' => true,
             'archived' => true,
             'publishedAsTbd' => true,


### PR DESCRIPTION
fixes #2192 

this is the reporting query that runs for a given program year objective.

```sql
SELECT p.title AS program_title, py.start_year AS matriculation_year, pyo.title AS program_year_objective,
  cmp.title AS competency, c.title AS course_title, c.external_id AS course_shortname, co.title AS mapped_course_objective
FROM program_year py
JOIN program p ON py.program_id = p.program_id
JOIN program_year_x_objective pyxo ON py.program_year_id = pyxo.program_year_id
LEFT JOIN objective pyo ON pyxo.objective_id = pyo.objective_id
LEFT JOIN competency cmp ON pyo.competency_id = cmp.competency_id
LEFT JOIN objective_x_objective oxo ON pyo.objective_id = oxo.parent_objective_id
LEFT JOIN objective co ON oxo.objective_id = co.objective_id
LEFT JOIN course_x_objective cxo ON cxo.objective_id = co.objective_id
LEFT JOIN course c ON c.course_id = cxo.course_id
WHERE py.program_year_id = ?;
```