### PR TITLE
correctly calculate event duration if offerings are configured to be counted as one.

### DIFF
--- a/src/Ilios/CoreBundle/Entity/Manager/CurriculumInventoryReportManager.php
+++ b/src/Ilios/CoreBundle/Entity/Manager/CurriculumInventoryReportManager.php
@@ -464,7 +464,7 @@ class CurriculumInventoryReportManager extends BaseManager
             if (!array_key_exists($row['event_id'], $rhett)) {
                 $rhett[$row['event_id']] = $row;
             } else {
-                if (array_key_exists($row['event_id'], $sessionIds)) {
+                if (in_array($row['event_id'], $sessionIds)) {
                     if ($rhett[$row['event_id']]['duration'] < $row['duration']) {
                         $rhett[$row['event_id']]['duration'] = $row['duration'];
                     }
@@ -544,7 +544,7 @@ class CurriculumInventoryReportManager extends BaseManager
             if (!array_key_exists($row['event_id'], $rhett)) {
                 $rhett[$row['event_id']] = $row;
             } else {
-                if (array_key_exists($row['event_id'], $sessionIds)) {
+                if (in_array($row['event_id'], $sessionIds)) {
                     if ($rhett[$row['event_id']]['duration'] < $row['duration']) {
                         $rhett[$row['event_id']]['duration'] = $row['duration'];
                     }

--- a/tests/CoreBundle/Entity/Manager/CurriculumInventoryReportManagerTest.php
+++ b/tests/CoreBundle/Entity/Manager/CurriculumInventoryReportManagerTest.php
@@ -433,7 +433,7 @@ class CurriculumInventoryReportManagerTest extends TestCase
         $this->assertEquals(4, count($events));
         $this->assertEquals(2880, $events[10]['duration']);
         $this->assertEquals(90, $events[20]['duration']);
-        $this->assertEquals(4320, $events[30]['duration']);
+        $this->assertEquals(2880, $events[30]['duration']);
         $this->assertEquals(0, $events[40]['duration']);
     }
 
@@ -496,7 +496,7 @@ class CurriculumInventoryReportManagerTest extends TestCase
         $this->assertEquals(5, count($events));
         $this->assertEquals(1440, $events[10]['duration']);
         $this->assertEquals(90, $events[20]['duration']);
-        $this->assertEquals(4320, $events[30]['duration']);
+        $this->assertEquals(2880, $events[30]['duration']);
         $this->assertEquals(0, $events[40]['duration']);
         $this->assertEquals(2970, $events[50]['duration']);
     }


### PR DESCRIPTION
fixes #2206