### PR TITLE
Attempt to sign in users sooner

### DIFF
--- a/src/Ilios/AuthenticationBundle/Service/AuthenticationInterface.php
+++ b/src/Ilios/AuthenticationBundle/Service/AuthenticationInterface.php
@@ -4,6 +4,7 @@ namespace Ilios\AuthenticationBundle\Service;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Ilios\CoreBundle\Entity\UserInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 interface AuthenticationInterface
 {
@@ -31,4 +32,14 @@ interface AuthenticationInterface
      * @return array
      */
     public function getPublicConfigurationInformation(Request $request);
+
+    /**
+     * Attempt to authenticate the user and send either an empty Response
+     * or a redirect response for SSO auth.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function createAuthenticationResponse(Request $request): Response;
 }

--- a/src/Ilios/AuthenticationBundle/Service/CasAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/CasAuthentication.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 use Ilios\CoreBundle\Entity\Manager\AuthenticationManager;
 use Ilios\AuthenticationBundle\Traits\AuthenticationService;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -146,5 +147,13 @@ class CasAuthentication implements AuthenticationInterface
         $configuration['casLoginUrl'] = $this->casManager->getLoginUrl();
 
         return $configuration;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createAuthenticationResponse(Request $request): Response
+    {
+        return new Response();
     }
 }

--- a/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/FormAuthentication.php
@@ -5,6 +5,7 @@ namespace Ilios\AuthenticationBundle\Service;
 use Ilios\AuthenticationBundle\Classes\SessionUser;
 use Ilios\CoreBundle\Entity\Manager\UserManager;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -176,5 +177,13 @@ class FormAuthentication implements AuthenticationInterface
         $configuration['type'] = 'form';
 
         return $configuration;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createAuthenticationResponse(Request $request): Response
+    {
+        return new Response();
     }
 }

--- a/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/LdapAuthentication.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 use Ilios\CoreBundle\Entity\Manager\AuthenticationManager;
 use Ilios\AuthenticationBundle\Traits\AuthenticationService;
+use Symfony\Component\HttpFoundation\Response;
 
 class LdapAuthentication implements AuthenticationInterface
 {
@@ -161,5 +162,13 @@ class LdapAuthentication implements AuthenticationInterface
         $configuration['type'] = 'ldap';
 
         return $configuration;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createAuthenticationResponse(Request $request): Response
+    {
+        return new Response();
     }
 }

--- a/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
+++ b/src/Ilios/AuthenticationBundle/Service/ShibbolethAuthentication.php
@@ -4,11 +4,13 @@ namespace Ilios\AuthenticationBundle\Service;
 
 use Ilios\CoreBundle\Service\Config;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 use Ilios\CoreBundle\Entity\Manager\AuthenticationManager;
 use Ilios\AuthenticationBundle\Traits\AuthenticationService;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class ShibbolethAuthentication
@@ -173,5 +175,22 @@ class ShibbolethAuthentication implements AuthenticationInterface
         $configuration['loginUrl'] = $url . $this->loginPath;
 
         return $configuration;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createAuthenticationResponse(Request $request): Response
+    {
+        $applicationId = $request->server->get('Shib-Application-ID');
+        if (!$applicationId) {
+            $configuration = $this->getPublicConfigurationInformation($request);
+            $url = $configuration['loginUrl'] . "?target=" . $request->getRequestUri();
+            return RedirectResponse::create(
+                $url
+            );
+        }
+
+        return new Response();
     }
 }


### PR DESCRIPTION
Instead of waiting for the frontend to redirect users who need to be
authenticated by shibboleth we can redirect them as soon as they request
the index.html page. Doing this removes the need for the browser to
render our javascript twice.

Needs:
- [x] Test on an actual shibboleth server
- [x] See if there is a similar speedup to be had for CAS