### PR TITLE
Send the correct headers with PNG files

### DIFF
--- a/src/AppBundle/Controller/IndexController.php
+++ b/src/AppBundle/Controller/IndexController.php
@@ -113,6 +113,11 @@ class IndexController extends Controller
         if ($extension === 'svg') {
             $response->headers->set('Content-Type', 'image/svg+xml');
         }
+        if ($extension === 'png') {
+            //PNG files are already compressed and we don't gzip them again
+            $response->headers->remove('Content-Encoding');
+            $response->headers->set('Content-Type', 'image/png');
+        }
         if ($versionedStaticFile) {
             //cache for one year
             $response->setMaxAge(60 * 60 * 24 * 365);


### PR DESCRIPTION
Fixes issue where favicon icons do not load in some browsers because we were sending the wrong content type and an incorrect encoding header.