### PR TITLE
Improve our health checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ script:
 - if [ "$TEST_CONTAINER_BUILD" = true ]; then (docker build -t ilios-php-apache-test .) fi
 - if [ "$TEST_CONTAINER_BUILD" = true ]; then (docker run -d --name ilios-php-apache-test ilios-php-apache-test) fi
 - if [ "$TEST_CONTAINER_BUILD" = true ]; then (docker ps | grep -q ilios-php-apache-test) fi
+- if [ "$TEST_CONTAINER_BUILD" = true ]; then (docker exec ilios-php-apache-test php /var/www/ilios/bin/console monitor:health) fi
 notifications:
   slack:
     secure: Aw/KYBBltksyk0cPOyB9ZGjtmtYWkcns5AgsZmv1FiTUT2BYVc06yQ0LGQGQDHeNs7Zi8l0BtxhJv0gtwdnYydvwiUckR3ZRjTV7//1ni8XzzyO612ArwVKA1LHTVKm8zy3PcW3XobKtI0QlQZ/jPJ2yk8nbcXJ7XnCXyFq7OyI=

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -140,7 +140,14 @@ liip_monitor:
             "7.2": ">="
           readable_directory: ["%kernel.cache_dir%"]
           writable_directory: ["%kernel.cache_dir%"]
+#          Disabled for now as create_function throws warnings we should re-enabled once we move to SymfonyFlex where there is an update
+#          symfony_requirements:
+#            file:  '%kernel.root_dir%/../var/SymfonyRequirements.php'
           disk_usage:
             path: '%env(ILIOS_FILE_SYSTEM_STORAGE_PATH)%'
+          security_advisory:
         production:
           doctrine_dbal: [default]
+          doctrine_migrations:
+            migrations_with_doctrine_bundle:
+              connection: default

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -131,12 +131,16 @@ happyr_google_analytics:
 
 liip_monitor:
     enable_controller: true
+    default_group: default
     checks:
-      php_extensions: [apcu, mbstring, ldap, xml, dom, mysqli, mysqlnd, pdo, zip]
-      php_version:
-        7.2: ">="
-      readable_directory: ["%kernel.cache_dir%"]
-      writable_directory: ["%kernel.cache_dir%"]
-      disk_usage:
-        path: '%env(ILIOS_FILE_SYSTEM_STORAGE_PATH)%'
-      doctrine_dbal: [default]
+      groups:
+        default:
+          php_extensions: [apcu, mbstring, ldap, xml, dom, mysqli, mysqlnd, pdo, zip, json, zlib]
+          php_version:
+            7.2: ">="
+          readable_directory: ["%kernel.cache_dir%"]
+          writable_directory: ["%kernel.cache_dir%"]
+          disk_usage:
+            path: '%env(ILIOS_FILE_SYSTEM_STORAGE_PATH)%'
+        production:
+          doctrine_dbal: [default]

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -135,9 +135,9 @@ liip_monitor:
     checks:
       groups:
         default:
-          php_extensions: [apcu, mbstring, ldap, xml, dom, mysqli, mysqlnd, pdo, zip, json, zlib]
+          php_extensions: [apcu, mbstring, ldap, xml, dom, mysqlnd, pdo, zip, json, zlib]
           php_version:
-            7.2: ">="
+            "7.2": ">="
           readable_directory: ["%kernel.cache_dir%"]
           writable_directory: ["%kernel.cache_dir%"]
           disk_usage:

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
     "require": {
         "php": ">= 7.2",
         "ext-apcu": "*",
+        "ext-json": "*",
+        "ext-zlib": "*",
         "alchemy/zippy": "^0.4.8",
         "danielstjules/stringy": "^3.1",
         "doctrine/doctrine-bundle": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b3de93744c943306949fa262bfa9a7fd",
+    "content-hash": "73b0ec5c617ab67543a777c1d8e9c167",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -7023,7 +7023,9 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">= 7.2",
-        "ext-apcu": "*"
+        "ext-apcu": "*",
+        "ext-json": "*",
+        "ext-zlib": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
This groups and expands our automated health checks (and composer extension requirements). The end result is that we can visit `/ilios/health/http_status_checks?group=default&group=production` and get a status code if everything checks out.