### PR TITLE
Allow finalized CI reports to be rolled over

### DIFF
--- a/src/AppBundle/Controller/CurriculumInventoryReportController.php
+++ b/src/AppBundle/Controller/CurriculumInventoryReportController.php
@@ -123,7 +123,7 @@ class CurriculumInventoryReportController extends ApiController
             throw new NotFoundHttpException(sprintf('The resource \'%s\' was not found.', $id));
         }
 
-        if (! $this->authorizationChecker->isGranted([AbstractVoter::CREATE], $report)) {
+        if (! $this->authorizationChecker->isGranted([AbstractVoter::ROLLOVER], $report)) {
             throw $this->createAccessDeniedException('Unauthorized access!');
         }
 

--- a/src/AppBundle/RelationshipVoter/AbstractVoter.php
+++ b/src/AppBundle/RelationshipVoter/AbstractVoter.php
@@ -43,6 +43,11 @@ abstract class AbstractVoter extends SymfonyVoter
     const ARCHIVE = 'archive';
 
     /**
+     * @var string
+     */
+    const ROLLOVER = 'rollover';
+
+    /**
      * @var PermissionChecker
      */
     protected $permissionChecker;

--- a/src/AppBundle/RelationshipVoter/CurriculumInventoryReport.php
+++ b/src/AppBundle/RelationshipVoter/CurriculumInventoryReport.php
@@ -13,7 +13,7 @@ class CurriculumInventoryReport extends AbstractVoter
         return $subject instanceof CurriculumInventoryReportInterface
             && in_array(
                 $attribute,
-                [self::CREATE, self::VIEW, self::EDIT, self::DELETE]
+                [self::CREATE, self::VIEW, self::EDIT, self::DELETE, self::ROLLOVER]
             );
     }
 
@@ -28,8 +28,10 @@ class CurriculumInventoryReport extends AbstractVoter
             return true;
         }
 
-        if ($subject->getExport()) {
-            return false;
+        if (self::ROLLOVER !== $attribute) {
+            if ($subject->getExport()) {
+                return false;
+            }
         }
 
         if ($user->isRoot()) {
@@ -38,6 +40,7 @@ class CurriculumInventoryReport extends AbstractVoter
 
         switch ($attribute) {
             case self::CREATE:
+            case self::ROLLOVER:
                 return $this->permissionChecker->canCreateCurriculumInventoryReport(
                     $user,
                     $subject->getSchool()->getId()

--- a/tests/AppBundle/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/AppBundle/Endpoints/CurriculumInventoryReportTest.php
@@ -427,4 +427,35 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
         $this->assertSame((int) $overrides['year'], (int) $newReport['year']);
         $this->assertNotSame((int) $report['year'], (int) $newReport['year']);
     }
+
+
+    public function testRolloverExportedCurriculumInventoryReport()
+    {
+        $dataLoader = $this->getDataLoader();
+        $reports = $dataLoader->getAll();
+        $report = $reports[1];
+        $this->assertArrayHasKey('export', $report);
+
+        $this->createJsonRequest(
+            'POST',
+            $this->getUrl(
+                'ilios_api_curriculuminventoryreport_rollover',
+                [
+                    'version' => 'v1',
+                    'object' => 'curriculuminventoryreports',
+                    'id' => $report['id'],
+                ]
+            ),
+            null,
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+        $this->assertJsonResponse($response, Response::HTTP_CREATED);
+        $data = json_decode($response->getContent(), true)['curriculumInventoryReports'];
+        $newReport = $data[0];
+
+        // compare reports
+        $this->assertSame($report['name'], $newReport['name']);
+        $this->assertSame($report['description'], $newReport['description']);
+    }
 }


### PR DESCRIPTION
Our permissions didn't account for rolling over a finalized report. I
created a special action type for rolling over the original report and
re-organized the Voter a bit.

Fixes #2228