### PR TITLE
Remove deprecated Symfony RoleInterface

### DIFF
--- a/src/AppBundle/Entity/UserRole.php
+++ b/src/AppBundle/Entity/UserRole.php
@@ -5,15 +5,12 @@ namespace AppBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use AppBundle\Traits\UsersEntity;
 use AppBundle\Annotation as IS;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 use AppBundle\Traits\IdentifiableEntity;
 use AppBundle\Traits\TitledEntity;
 use AppBundle\Traits\StringableIdEntity;
-use AppBundle\Entity\UserInterface;
 
 /**
  * Class UserRole
@@ -99,13 +96,5 @@ class UserRole implements UserRoleInterface
             $this->users->removeElement($user);
             $user->removeRole($this);
         }
-    }
-
-    /**
-     * @return string
-     */
-    public function getRole()
-    {
-        return 'ROLE_' . $this->title;
     }
 }

--- a/src/AppBundle/Entity/UserRoleInterface.php
+++ b/src/AppBundle/Entity/UserRoleInterface.php
@@ -2,12 +2,9 @@
 
 namespace AppBundle\Entity;
 
-use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Collections\ArrayCollection;
 use AppBundle\Traits\IdentifiableEntityInterface;
 use AppBundle\Traits\TitledEntityInterface;
 use AppBundle\Traits\UsersEntityInterface;
-use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * Interface UserRoleInterface
@@ -15,7 +12,6 @@ use Symfony\Component\Security\Core\Role\RoleInterface;
 interface UserRoleInterface extends
     IdentifiableEntityInterface,
     TitledEntityInterface,
-    RoleInterface,
     LoggableEntityInterface,
     UsersEntityInterface
 {

--- a/tests/AppBundle/Entity/UserRoleTest.php
+++ b/tests/AppBundle/Entity/UserRoleTest.php
@@ -73,10 +73,4 @@ class UserRoleTest extends EntityBase
     {
         $this->entityCollectionSetTest('user', 'User', false, false, 'addRole');
     }
-
-    public function testGetRole()
-    {
-        $this->object->setTitle('test');
-        $this->assertEquals('ROLE_test', $this->object->getRole());
-    }
 }


### PR DESCRIPTION
We're no longer using this for authorization so it can just be dropped.