### PR TITLE
Re-organize the .env.dist file

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -2,27 +2,38 @@
 # Copy this file to .env file for development, create environment variables when deploying to production
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
-###> symfony/framework-bundle ###
+# Setup the symfony environment
 APP_ENV=dev
-ILIOS_SECRET=f106e47b06a45247ea18c53d201esdf6a8de8bc
-#TRUSTED_PROXIES=127.0.0.1,127.0.0.2
-#TRUSTED_HOSTS=localhost,example.com
-###< symfony/framework-bundle ###
+APP_DEBUG=true
+ILIOS_LOCALE=en
+ILIOS_SECRET='f106e47b06a45247ea18c53d201esdf6a8de8bc'
 
-###> doctrine/doctrine-bundle ###
+# Required Ilios vars
+
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
-# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
-# Configure your db driver and server_version in config/packages/doctrine.yaml
-DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
-###< doctrine/doctrine-bundle ###
+ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
 
-###> nelmio/cors-bundle ###
-CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?$
-###< nelmio/cors-bundle ###
+ILIOS_DATABASE_MYSQL_VERSION=5.7
 
-###> symfony/swiftmailer-bundle ###
 # For Gmail as a transport, use: "gmail://username:password@localhost"
 # For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
 # Delivery is disabled by default via "null://localhost"
 ILIOS_MAILER_URL=null://localhost
-###< symfony/swiftmailer-bundle ###
+
+# Where on the file system to store upload learning materials
+ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+
+ILIOS_ENABLE_TRACKING=false
+
+# These options will override the data in the application_config database table
+# They aren't required, but can make it easier to develop locally against a production database
+#ILIOS_AUTHENTICATION_TYPE=form
+#ILIOS_REQUIRE_SECURE_CONNECTION=false
+
+#ILIOS_LDAP_DIRECTORY_URL='ldaps://directory.example.com'
+#ILIOS_LDAP_DIRECTORY_USER='uid=Ilios,ou=applications,dc=example,dc=com'
+#ILIOS_LDAP_DIRECTORY_PASSWORD='P@55w0rd'
+#ILIOS_LDAP_DIRECTORY_SEARCH_BASE='ou=people,dc=example,dc=com'
+#ILIOS_LDAP_DIRECTORY_CAMPUS_ID_PROPERTY=idNumber
+#ILIOS_LDAP_DIRECTORY_USERNAME_PROPERTY=eduPersonPrincipalName
+


### PR DESCRIPTION
These are the defaults we want to make it easy to use. Since we override
most of the default ENV variables and call them ILIOS_* I pulled the
sections out of their flex chunks. I also added all of the local
database overrides that I tend to use myself.