### PR TITLE
Fix Session Timestamp test

### DIFF
--- a/tests/Endpoints/SessionTest.php
+++ b/tests/Endpoints/SessionTest.php
@@ -143,7 +143,7 @@ class SessionTest extends ReadWriteEndpointTest
     {
         $dataLoader = $this->getContainer()->get(IlmSessionData::class);
         $data = $dataLoader->getOne();
-        $data['instructors'] = ["1", "2"];
+        $data['hours'] += 5;
         $this->relatedTimeStampUpdateTest($data['session'], 'ilmsessions', 'ilmSession', $data);
     }
 


### PR DESCRIPTION
Fixed this test to do what it says, update the ILM instead of updating
the instructors as we already have a test for that.