### PR TITLE
Modify the way we generate update timestamp

### DIFF
--- a/src/Service/Timestamper.php
+++ b/src/Service/Timestamper.php
@@ -48,7 +48,7 @@ class Timestamper
     {
         if (count($this->entities)) {
             $om = $this->registry->getManager();
-            $now = new \DateTime();
+            $now = \DateTime::createFromFormat('U', time());
             foreach ($this->entities as $class => $ids) {
                 $qb = $om->createQueryBuilder();
                 $qb->update($class, 'c')

--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests;
 
+use App\Service\Timestamper;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use DateTime;
@@ -57,6 +58,7 @@ abstract class AbstractEndpointTest extends WebTestCase
         $fixtures = array_merge($authFixtures, $testFixtures);
         $this->fixtures = $this->loadFixtures($fixtures)->getReferenceRepository();
         ClockMock::register(__CLASS__);
+        ClockMock::register(Timestamper::class);
     }
 
     public function tearDown()


### PR DESCRIPTION
By using the time() builtin the ClockMock in our tests can work more
effectively to change the time.

https://symfony.com/blog/new-in-symfony-2-8-clock-mocking-and-time-sensitive-tests#clock-mocking