### PR TITLE
Add a setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,12 +1,25 @@
 #!/usr/bin/env php
 <?php
 
+Commands::checkForAppENV();
 Commands::isComposerInstalled();
 Commands::install();
 
 class Commands
 {
 
+    public static function checkForAppENV()
+    {
+        if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
+            self::writeError("Missing `APP_ENV` environmental variable. Please see <docs>");
+            exit(1);
+        }
+        $env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'];
+        if ($env !== 'prod') {
+            self::writeError("`APP_ENV` should be set to 'prod' it is set to ${env}");
+            exit(1);
+        }
+    }
     public static function isComposerInstalled()
     {
         exec('composer --version  2>&1', $output, $returnValue);
@@ -16,6 +29,7 @@ class Commands
                 break;
             case 127:
                 self::writeError("Unable to find `composer` command. See https://getcomposer.org/ for help installing it.");
+                exit(1);
                 break;
         }
     }
@@ -45,22 +59,23 @@ class Commands
                 foreach($output as $message) {
                     self::output($message);
                 }
+                exit(1);
                 break;
         }
     }
 
     private static function output($message)
     {
-        fwrite(STDOUT, "\n${message} \n");
+        fwrite(STDOUT, "${message} \n");
     }
 
     private static function writeError($message)
     {
-        fwrite(STDERR, "\n\033[31m Error: \033[0m ${message} \n");
+        fwrite(STDERR, "\n\033[31m Error: \033[0m ${message} \n\n");
     }
 
     private static function writeSuccess($message)
     {
-        fwrite(STDOUT, "\n\033[32m Success: \033[0m ${message} \n");
+        self::output("\033[32m Success: \033[0m ${message}");
     }
 }

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,66 @@
+#!/usr/bin/env php
+<?php
+
+Commands::isComposerInstalled();
+Commands::install();
+
+class Commands
+{
+
+    public static function isComposerInstalled()
+    {
+        exec('composer --version  2>&1', $output, $returnValue);
+        switch ($returnValue) {
+            case 0:
+                self::writeSuccess('Composer is installed');
+                break;
+            case 127:
+                self::writeError("Unable to find `composer` command. See https://getcomposer.org/ for help installing it.");
+                break;
+        }
+    }
+
+    public static function install()
+    {
+        $workingDir = realpath(__DIR__ . '/../');
+        $options = [
+            "--working-dir ${workingDir}",
+            '--prefer-dist',
+            '--no-dev',
+            '--no-progress',
+            '--no-interaction',
+            '--no-suggest',
+            '--classmap-authoritative'
+        ];
+        $flags = implode(' ', $options);
+        self::output('Installing Dependencies');
+
+        exec("composer install ${flags}  2>&1", $output, $returnValue);
+        switch ($returnValue) {
+            case 0:
+                self::writeSuccess('Dependencies Installed');
+                break;
+            default:
+                self::writeError("There was a problem installing dependencies.");
+                foreach($output as $message) {
+                    self::output($message);
+                }
+                break;
+        }
+    }
+
+    private static function output($message)
+    {
+        fwrite(STDOUT, "\n${message} \n");
+    }
+
+    private static function writeError($message)
+    {
+        fwrite(STDERR, "\n\033[31m Error: \033[0m ${message} \n");
+    }
+
+    private static function writeSuccess($message)
+    {
+        fwrite(STDOUT, "\n\033[32m Success: \033[0m ${message} \n");
+    }
+}

--- a/bin/setup
+++ b/bin/setup
@@ -5,6 +5,7 @@ Commands::checkForAppENV();
 Commands::isComposerInstalled();
 Commands::install();
 Commands::clearAndWarmUpCache();
+Commands::checkRequirements();
 
 class Commands
 {
@@ -68,25 +69,41 @@ class Commands
     public static function clearAndWarmUpCache()
     {
         self::output('Clearing and warming up the cache');
-        self::runSymfonyCommand('cache:clear --no-warmup', 'Cache Cleared Successfully');
-        self::runSymfonyCommand('cache:warmup', 'Cache Warmed Up Successfully');
+        self::runSymfonyCommand('cache:clear --no-warmup', 'Cache Cleared Successfully', 'Error clearing cache');
+        self::runSymfonyCommand('cache:warmup', 'Cache Warmed Up Successfully', 'Error warming up cache');
     }
 
-    public static function runSymfonyCommand($cmd, $successMessage)
+    public static function runSymfonyCommand($cmd, $successMessage, $errorMessage)
     {
-        exec(__DIR__ . "/console ${cmd}  2>&1", $output, $returnValue);
+        $path = __DIR__ . "/console ${cmd}";
+        exec("${path}  2>&1", $output, $returnValue);
         switch ($returnValue) {
             case 0:
                 self::writeSuccess($successMessage);
                 break;
             default:
-                self::writeError("There was an error:");
-                foreach($output as $message) {
-                    self::output($message);
-                }
+                self::writeError($errorMessage);
+                self::output("Run\n `${path}`\nto see what went wrong");
                 exit(1);
                 break;
         }
+    }
+
+    public static function checkRequirements()
+    {
+        self::output("Checking system requirements");
+        $path = realpath(__DIR__ . '/../vendor/bin/requirements-checker');
+        exec("${path}  2>&1", $output, $returnValue);
+        if ($returnValue !== 0) {
+            self::writeError("System does not meet requirements");
+            self::output("Run\n${path}\nto see why");
+            exit(1);
+        }
+        self::runSymfonyCommand(
+            'monitor:health  --group=default --group=production',
+            'Health Check Passed',
+            'Health Check Failed.'
+        );
     }
 
     private static function output($message)

--- a/bin/setup
+++ b/bin/setup
@@ -5,6 +5,7 @@ Commands::checkForAppENV();
 Commands::isComposerInstalled();
 Commands::install();
 Commands::clearAndWarmUpCache();
+Commands::assetsInstall();
 Commands::checkRequirements();
 
 class Commands
@@ -71,6 +72,12 @@ class Commands
         self::output('Clearing and warming up the cache');
         self::runSymfonyCommand('cache:clear --no-warmup', 'Cache Cleared Successfully', 'Error clearing cache');
         self::runSymfonyCommand('cache:warmup', 'Cache Warmed Up Successfully', 'Error warming up cache');
+    }
+
+    public static function assetsInstall()
+    {
+        self::output('Installing Web Assets');
+        self::runSymfonyCommand('assets:install', 'Assets Successfully', 'Error Installing Assets');
     }
 
     public static function runSymfonyCommand($cmd, $successMessage, $errorMessage)

--- a/bin/setup
+++ b/bin/setup
@@ -4,6 +4,7 @@
 Commands::checkForAppENV();
 Commands::isComposerInstalled();
 Commands::install();
+Commands::clearAndWarmUpCache();
 
 class Commands
 {
@@ -64,6 +65,30 @@ class Commands
         }
     }
 
+    public static function clearAndWarmUpCache()
+    {
+        self::output('Clearing and warming up the cache');
+        self::runSymfonyCommand('cache:clear --no-warmup', 'Cache Cleared Successfully');
+        self::runSymfonyCommand('cache:warmup', 'Cache Warmed Up Successfully');
+    }
+
+    public static function runSymfonyCommand($cmd, $successMessage)
+    {
+        exec(__DIR__ . "/console ${cmd}  2>&1", $output, $returnValue);
+        switch ($returnValue) {
+            case 0:
+                self::writeSuccess($successMessage);
+                break;
+            default:
+                self::writeError("There was an error:");
+                foreach($output as $message) {
+                    self::output($message);
+                }
+                exit(1);
+                break;
+        }
+    }
+
     private static function output($message)
     {
         fwrite(STDOUT, "${message} \n");
@@ -71,7 +96,7 @@ class Commands
 
     private static function writeError($message)
     {
-        fwrite(STDERR, "\n\033[31m Error: \033[0m ${message} \n\n");
+        fwrite(STDERR, "\n\033[31m Error: \033[0m ${message} \n");
     }
 
     private static function writeSuccess($message)

--- a/composer.json
+++ b/composer.json
@@ -85,11 +85,6 @@
   },
   "scripts": {
     "auto-scripts": {
-      "cache:clear": "symfony-cmd",
-      "assets:install %PUBLIC_DIR%": "symfony-cmd",
-      "monitor:health": "symfony-cmd",
-      "requirements-checker": "script",
-      "security-checker security:check": "script"
     },
     "ilios-scripts": [
       "App\\Composer\\MigrateParameters::migrate"

--- a/docs/install.md
+++ b/docs/install.md
@@ -66,54 +66,9 @@ sudo -u apache git checkout tags/$(git fetch --tags; git describe --tags `git re
 ```
 5. Run the following command to build the packages and its dependencies.  This step assumes you have PHP 7.2+ and Composer installed on your system:
 ```bash
-sudo -u apache APP_ENV=prod composer install --no-dev --optimize-autoloader
-```  
-This will install the required PHP Symfony packages and their dependencies.  When the process nears completion, you will be prompted with the following configuration setting options.  You should set them as noted:
-```bash
-#Set this to your database host's IP address or hostname
-database_host: 127.0.0.1
- 
-#3306 is the default for MySQL but your db port may be different
-database_port: 3306
- 
-#enter the name of your database where your Ilios data resides 
-database_name: ilios
- 
-#enter the name of the user login name you use for accessing the database 
-database_user: ilios_user
- 
-#this should be set to YOUR database password
-database_password: 3x@mp73P@$$w0rd
- 
-# Set the version of your MySQL database server software
-database_mysql_version: 5.6
- 
-#default values, set to your values if different
-mailer_transport: smtp
-mailer_host: 127.0.0.1
-mailer_user: null
-mailer_password: null
- 
-#en = 'english', enter your desired language ISO abbreviation, if different
-locale: en
- 
-#The value for 'secret' should be a long string of random characters and letters of your choosing.  If you are 
-#running in a load-balanced environment, these need to be the same on all the webservers in
-#the group. IMPORTANT:  You MUST change this to your own value as using the default value would
-#be EXTREMELY dangerous in a production enviroment!
-secret: ThisCanBeWhateverYouLike,JustMakeSureYouChangeIt!
+sudo -u apache bin/setup
 ```
-
-That should complete the first-time configuration of the parameters.yml file.  If you need to update these values, you can do so at anytime by editing the file directly, but you will need to clear the Symfony cache after making any changes by running the following console command from the root of the Ilios application:
-```
-sudo -u apache bin/console cache:clear --env=prod
-```
-
-
-6. Lastly, update the auto-loader to account for any new classes/classmap packages:
-```
-sudo -u apache APP_ENV=prod composer dump-autoload --no-dev --classmap-authoritative
-```
+This will install the required PHP Symfony packages and their dependencies and check your system for any issues.
 
 Congratulations! Once you've the completed the above steps, the latest codebase will have been built and deployed!
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -38,7 +38,7 @@ If you use git to manage your Ilios you can update the code by checking it out u
 
  ```bash
 cd YOUR_ILIOS_APPLICATION_ROOT
-sudo -u apache APP_ENV=prod composer install --no-dev --optimize-autoloader
+sudo -u apache bin/setup
 ```
 
 4. Execute any pending database migrations.
@@ -46,14 +46,6 @@ sudo -u apache APP_ENV=prod composer install --no-dev --optimize-autoloader
  ```bash
 cd YOUR_ILIOS_APPLICATION_ROOT
 sudo -u apache bin/console doctrine:migrations:migrate --env=prod --no-interaction
-```
-
-5. Clear your application cache.
-
- ```bash
-cd YOUR_ILIOS_APPLICATION_ROOT
-sudo -u apache bin/console cache:clear --no-warmup --env=prod
-sudo -u apache bin/console cache:warmup --env=prod
 ```
 
 ## Version-specific steps


### PR DESCRIPTION
In order to improve documentation and make the experience for users simpler I have added `bin/setup` which handles the tedium of installing and setting up ilios.

This allowed me to remove the `auto-scripts` from composer that cause issues in our docker build and it will allow us to do tests and provide links to setup documentation.