### PR TITLE
Warmup cache better in docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,5 +13,6 @@ phpunit.xml.dist
 .travis.yml
 docker-composer.yml
 Dockerfile
-app/config/parameters.yml
+docs
+*.xml.dist
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,12 @@ RUN \
 
 RUN chown -R www-data:www-data /var/www/ilios
 
-# launch apache httpd as a foreground service
+RUN su - www-data -s /bin/sh -c "/var/www/ilios/bin/console assets:install"
+
+# add our own entrypoint scripts
+COPY ./docker/ilios-entrypoint /usr/local/bin/
+ENTRYPOINT ["ilios-entrypoint"]
+
 CMD ["apache2-foreground"]
 
 # http is typically port 80

--- a/docker/ilios-entrypoint
+++ b/docker/ilios-entrypoint
@@ -1,0 +1,13 @@
+#!/bin/sh
+# started with https://github.com/docker-library/php/blob/d97098c8c6af46ae1211e65ff052278ab39ba45c/7.2/stretch/apache/docker-php-entrypoint
+set -e
+
+# We need to warmup the cache in addition to starting apache
+su - www-data -s /bin/sh -c '/var/www/ilios/bin/console cache:warmup'
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- apache2-foreground "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Instead of doing the cache warmup during the build phase this changes our setup to do it during the run phase. This ensure that we have final access to the filesystem as well as any outside services that we need.

Since #2252 removed the cache steps out of the composer scripts this makes our containers much smaller and easier to work with.