### PR TITLE
Re-organize the index.html template to load faster

### DIFF
--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -2,7 +2,6 @@
 
 namespace App\Controller;
 
-use Http\Discovery\Exception\NotFoundException;
 use App\Service\Filesystem;
 use App\Service\AuthenticationInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -173,7 +172,7 @@ class IndexController extends Controller
      * @param string $path
      * @return array
      */
-    public function extractOptions($path)
+    protected function extractOptions($path)
     {
         $contents = $this->fs->readFile($path);
         $json = json_decode($contents);
@@ -194,7 +193,8 @@ class IndexController extends Controller
         $links = array_map(function ($obj) {
             return [
                 'rel' => $obj->rel,
-                'preload' => $obj->rel === 'stylesheet',
+                'isStyleSheet' => $obj->rel === 'stylesheet',
+                'isNotStyleSheet' => $obj->rel !== 'stylesheet',
                 'href' => ltrim($obj->href, '/'),
                 'sizes' => property_exists($obj, 'sizes')?$obj->sizes:null,
                 'type' => property_exists($obj, 'type')?$obj->type:null,

--- a/templates/index/webindex.html.twig
+++ b/templates/index/webindex.html.twig
@@ -33,23 +33,12 @@
     {% endfor %}
 
     {% for l in links %}
-        {% if l.preload %}
-            <link rel="{{ l.rel }}" href="{{ preload(asset(l.href), { as: 'style' }) }}" type="{{  l.type }}" sizes="{{  l.sizes }}"  />
-        {% else %}
+        {% if l.isNotStyleSheet %}
             <link rel="{{ l.rel }}" href="{{ l.href }}" type="{{  l.type }}" sizes="{{  l.sizes }}"  />
         {% endif %}
     {% endfor %}
-    <link rel="stylesheet" href="{{ preload(asset('theme-overrides/custom.css'), { as: 'style'}) }}" />
 </head>
 <body>
-
-{% for n in noScripts %}
-    <noscript>
-        {% autoescape false %}
-        {{ n.htmlContent }}
-        {% endautoescape %}
-    </noscript>
-{% endfor %}
 
 {% for d in divs %}
     <div id="{{ d.id }}" class="{{ d.class }}">
@@ -59,10 +48,27 @@
     </div>
 {% endfor %}
 
+{% for l in links %}
+    {% if l.isStyleSheet %}
+        <link rel="{{ l.rel }}" href="{{ preload(asset(l.href), { as: 'style' }) }}" type="{{  l.type }}" sizes="{{  l.sizes }}"  />
+   {% endif %}
+{% endfor %}
+<link rel="stylesheet" href="{{ preload(asset('theme-overrides/custom.css'), { as: 'style'}) }}" />
+
+{% for n in noScripts %}
+    <noscript>
+        {% autoescape false %}
+            {{ n.htmlContent }}
+        {% endautoescape %}
+    </noscript>
+{% endfor %}
+
+
+
 
 {% for s in scripts %}
     {% if s.src %}
-        <script src="{{ preload(asset(s.src), { as: 'script' }) }}"></script>
+        <script defer src="{{ preload(asset(s.src), { as: 'script' }) }}"></script>
     {% else %}
         <script>
             {% autoescape false %}


### PR DESCRIPTION
By moving style sheets and defering the loading of scripts it ensures
that our loading indicator is parsed and rendered as quickly as
possible. Otherwise the browser would block rendering while the styles
were fetched and parsed.