### PR TITLE
Enable the http2 module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN \
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable opcache \
     # enable modules
-    && a2enmod rewrite socache_shmcb mpm_prefork \
+    && a2enmod rewrite socache_shmcb mpm_prefork http2 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge libldap2-dev zlib1g-dev libicu-dev -y \
     && apt-get autoremove -y


### PR DESCRIPTION
This allows for symfony to push assets out with the index.html page
instead of waiting for the browser to find and request them.