### PR TITLE
Fix handling of empty cohort

### DIFF
--- a/src/Controller/ProgramYearController.php
+++ b/src/Controller/ProgramYearController.php
@@ -33,6 +33,18 @@ class ProgramYearController extends ApiController
         $class = $manager->getClass() . '[]';
 
         $json = $this->extractJsonFromRequest($request, $object, 'POST');
+        $obj = json_decode($json);
+        $arr = is_array($obj) ? $obj : [$obj];
+        // remove empty cohorts since we will be creating them later
+        $cleanData = array_map(function ($obj) {
+            if (empty($obj->cohort)) {
+                unset($obj->cohort);
+            }
+
+            return $obj;
+        }, $arr);
+        $json = json_encode($cleanData);
+
         $serializer = $this->getSerializer();
         $entities = $serializer->deserialize($json, $class, 'json');
         $this->validateAndAuthorizeEntities($entities, AbstractVoter::CREATE);

--- a/tests/Endpoints/ProgramYearTest.php
+++ b/tests/Endpoints/ProgramYearTest.php
@@ -185,6 +185,15 @@ class ProgramYearTest extends ReadWriteEndpointTest
         );
     }
 
+    public function testPostWithNullCohort()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->create();
+        $postData = $dataLoader->create();
+        $postData['cohort'] = null;
+        $this->postTest($data, $postData);
+    }
+
     public function testRejectUnprivilegedPut()
     {
         $dataLoader = $this->getDataLoader();


### PR DESCRIPTION
When a program year is saved without a cohort (as it almost always is)
we need to handle null value the same way we handle no value. When
saving the frontend sends a `null` value here and I don't think we want
to allow program year cohort to be actually unset as it would be if we
allowed a null value for cohort in the validator.

Fixes #2260 

