### PR TITLE
Link config to the correct school

### DIFF
--- a/src/Command/SetSchoolConfigValueCommand.php
+++ b/src/Command/SetSchoolConfigValueCommand.php
@@ -88,6 +88,7 @@ class SetSchoolConfigValueCommand extends Command
         if (!$config) {
             $config = $this->schoolConfigManager->create();
             $config->setName($name);
+            $config->setSchool($school);
         }
         $config->setValue($value);
 

--- a/tests/Command/SetSchoolConfigValueCommandTest.php
+++ b/tests/Command/SetSchoolConfigValueCommandTest.php
@@ -70,6 +70,7 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
         $this->schoolManager->shouldReceive('findOneBy')->once()->with(['id' => '1'])->andReturn($mockSchool);
         $mockConfig = m::mock(SchoolConfig::class);
         $mockConfig->shouldReceive('setValue')->with('bar')->once();
+        $mockConfig->shouldReceive('setSchool')->with($mockSchool)->once();
         $mockConfig->shouldReceive('setName')->with('foo')->once();
         $this->schoolConfigManager
             ->shouldReceive('findOneBy')


### PR DESCRIPTION
School config values, when saved, must be linked to a school. Our
command was failing to do this.