### PR TITLE
Shorten the path to commands

### DIFF
--- a/src/Command/AddDirectoryUserCommand.php
+++ b/src/Command/AddDirectoryUserCommand.php
@@ -61,7 +61,8 @@ class AddDirectoryUserCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:directory:add-user')
+            ->setName('ilios:add-directory-user')
+            ->setAliases(['ilios:directory:add-user'])
             ->setDescription('Add a user to ilios.')
             ->addArgument(
                 'campusId',

--- a/src/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Command/AddNewStudentsToSchoolCommand.php
@@ -69,7 +69,8 @@ class AddNewStudentsToSchoolCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:directory:add-students')
+            ->setName('ilios:add-students')
+            ->setAliases(['ilios:directory:add-students'])
             ->setDescription('Add students found by a directory filter into a school.')
             ->addArgument(
                 'schoolId',

--- a/src/Command/AddRootUserCommand.php
+++ b/src/Command/AddRootUserCommand.php
@@ -18,7 +18,7 @@ class AddRootUserCommand extends Command
     /**
      * @var string
      */
-    const COMMAND_NAME = 'ilios:maintenance:add-root-user';
+    const COMMAND_NAME = 'ilios:add-root-user';
 
     /**
      * @var UserManager
@@ -38,6 +38,7 @@ class AddRootUserCommand extends Command
     {
         $this
             ->setName(self::COMMAND_NAME)
+            ->setAliases(['ilios:maintenance:add-root-user'])
             ->setDescription('Grants root-level privileges to a given user.')
             ->addArgument(
                 'userId',

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -71,7 +71,10 @@ class AddUserCommand extends Command
      */
     protected function configure()
     {
-        $this->setName('ilios:maintenance:add-user')->setDescription('Add a user to ilios.');
+        $this
+            ->setName('ilios:add-user')
+            ->setAliases(['ilios:maintenance:add-user'])
+            ->setDescription('Add a user to ilios.');
         $userOptions = [
             'schoolId',
             'firstName',

--- a/src/Command/AuditLogExportCommand.php
+++ b/src/Command/AuditLogExportCommand.php
@@ -4,7 +4,6 @@ namespace App\Command;
 
 use App\Entity\Manager\AuditLogManager;
 use Psr\Log\LoggerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -49,7 +48,8 @@ class AuditLogExportCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:export-audit-log')
+            ->setName('ilios:export-audit-log')
+            ->setAliases(['ilios:maintenance:export-audit-log'])
             ->setDescription('Exports audit log entries in a given time range and, optionally, deletes them.')
             ->addOption(
                 'delete',

--- a/src/Command/CleanupStringsCommand.php
+++ b/src/Command/CleanupStringsCommand.php
@@ -91,7 +91,8 @@ class CleanupStringsCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:cleanup-strings')
+            ->setName('ilios:cleanup-strings')
+            ->setAliases(['ilios:maintenance:cleanup-strings'])
             ->setDescription('Purify HTML strings in the database to only contain allowed elements')
             ->addOption(
                 'objective-title',

--- a/src/Command/CreateUserTokenCommand.php
+++ b/src/Command/CreateUserTokenCommand.php
@@ -46,7 +46,8 @@ class CreateUserTokenCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:create-user-token')
+            ->setName('ilios:create-user-token')
+            ->setAliases(['ilios:maintenance:create-user-token'])
             ->setDescription('Create a new API token for a user.')
             ->addArgument(
                 'userId',

--- a/src/Command/CrossingGuardCommand.php
+++ b/src/Command/CrossingGuardCommand.php
@@ -35,7 +35,9 @@ class CrossingGuardCommand extends Command
      */
     protected function configure()
     {
-        $this->setName('ilios:maintenance:crossing-guard')
+        $this
+            ->setName('ilios:crossing-guard')
+            ->setAliases(['ilios:maintenance:crossing-guard'])
             ->setDescription('Enable, disable, and check the status of the crossing guard.')
             ->addArgument(
                 'action',

--- a/src/Command/FindUserCommand.php
+++ b/src/Command/FindUserCommand.php
@@ -36,7 +36,8 @@ class FindUserCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:directory:find-user')
+            ->setName('ilios:find-user')
+            ->setAliases(['ilios:directory:find-user'])
             ->setDescription('Find a user in the directory.')
             ->addArgument(
                 'searchTerms',

--- a/src/Command/FixLearningMaterialMimeTypesCommand.php
+++ b/src/Command/FixLearningMaterialMimeTypesCommand.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Helper\ProgressBar;
 
 use App\Entity\Manager\LearningMaterialManager;
 use App\Service\IliosFileSystem;
-use Symfony\Component\Debug\Exception\ContextErrorException;
 
 /**
  * Cleanup incorrectly stored mime types for learning materials.
@@ -44,7 +43,8 @@ class FixLearningMaterialMimeTypesCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:fix-mime-types')
+            ->setName('ilios:fix-mime-types')
+            ->setAliases(['ilios:maintenance:fix-mime-types'])
             ->setDescription('Cleanup incorrectly stored mime types for learning materials.');
     }
 

--- a/src/Command/GenerateEndpointTestCommand.php
+++ b/src/Command/GenerateEndpointTestCommand.php
@@ -57,6 +57,7 @@ class GenerateEndpointTestCommand extends Command
     {
         $this
             ->setName('ilios:generate:endpoint-test')
+            ->setHidden(true)
             ->setDescription('Creates basic test for an endpoint.')
             ->addArgument(
                 'entityShortcut',

--- a/src/Command/GenerateSwaggerApiDefinitionYamlCommand.php
+++ b/src/Command/GenerateSwaggerApiDefinitionYamlCommand.php
@@ -56,6 +56,7 @@ class GenerateSwaggerApiDefinitionYamlCommand extends Command
     {
         $this
             ->setName('ilios:generate:swagger-definition')
+            ->setHidden(true)
             ->setDescription('Creates standard swagger definition yaml file for an entity.')
             ->addArgument(
                 'entityShortcut',

--- a/src/Command/GenerateSwaggerApiPathYamlCommand.php
+++ b/src/Command/GenerateSwaggerApiPathYamlCommand.php
@@ -38,6 +38,7 @@ class GenerateSwaggerApiPathYamlCommand extends Command
     {
         $this
             ->setName('ilios:generate:swagger-path')
+            ->setHidden(true)
             ->setDescription('Creates standard swagger path yaml file for an endpoint.')
             ->addArgument(
                 'endpointName',

--- a/src/Command/ImportMeshUniverseCommand.php
+++ b/src/Command/ImportMeshUniverseCommand.php
@@ -54,7 +54,8 @@ class ImportMeshUniverseCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:import-mesh-universe')
+            ->setName('ilios:import-mesh-universe')
+            ->setAliases(['ilios:maintenance:import-mesh-universe'])
             ->setDescription('Imports the MeSH universe into Ilios.')
             ->addOption(
                 'url',

--- a/src/Command/InstallFirstUserCommand.php
+++ b/src/Command/InstallFirstUserCommand.php
@@ -99,7 +99,8 @@ class InstallFirstUserCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:setup:first-user')
+            ->setName('ilios:setup-first-user')
+            ->setAliases(['ilios:setup:first-user'])
             ->setDescription('Creates a first user account with root privileges.')
             ->addOption(
                 'school',

--- a/src/Command/InvalidateUserTokenCommand.php
+++ b/src/Command/InvalidateUserTokenCommand.php
@@ -44,7 +44,8 @@ class InvalidateUserTokenCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:invalidate-user-tokens')
+            ->setName('ilios:invalidate-user-tokens')
+            ->setAliases(['ilios:maintenance:invalidate-user-tokens'])
             ->setDescription('Invalidate all user tokens issued before now.')
             ->addArgument(
                 'userId',

--- a/src/Command/ListConfigValuesCommand.php
+++ b/src/Command/ListConfigValuesCommand.php
@@ -39,7 +39,8 @@ class ListConfigValuesCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:list-config-values')
+            ->setName('ilios:list-config-values')
+            ->setAliases(['ilios:maintenance:list-config-values'])
             ->setDescription('Read configuration values from the DB');
     }
 

--- a/src/Command/ListRootUsersCommand.php
+++ b/src/Command/ListRootUsersCommand.php
@@ -17,7 +17,7 @@ class ListRootUsersCommand extends Command
     /**
      * @var string
      */
-    const COMMAND_NAME = 'ilios:maintenance:list-root-users';
+    const COMMAND_NAME = 'ilios:list-root-users';
 
     /**
      * @var UserManager
@@ -37,6 +37,7 @@ class ListRootUsersCommand extends Command
     {
         $this
             ->setName(self::COMMAND_NAME)
+            ->setAliases(['ilios:maintenance:list-root-users'])
             ->setDescription('Lists all users with root-level privileges.');
     }
 

--- a/src/Command/ListSchoolConfigValuesCommand.php
+++ b/src/Command/ListSchoolConfigValuesCommand.php
@@ -48,7 +48,8 @@ class ListSchoolConfigValuesCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:list-school-config-values')
+            ->setName('ilios:list-school-config-values')
+            ->setAliases(['ilios:maintenance:list-school-config-values'])
             ->setDescription('Read school configuration values from the DB')
             //required arguments
             ->addArgument(

--- a/src/Command/MigrateIlios2LearningMaterialsCommand.php
+++ b/src/Command/MigrateIlios2LearningMaterialsCommand.php
@@ -53,7 +53,9 @@ class MigrateIlios2LearningMaterialsCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:setup:migrate-learning-materials')
+            ->setName('ilios:migrate-learning-materials')
+            ->setAliases(['ilios:setup:migrate-learning-materials'])
+            ->setHidden(true)
             ->setDescription('Migrate Ilios2 Learning Materials to Ilios3 Structure')
             ->addArgument(
                 'pathToIlios2',

--- a/src/Command/RemoveRootUserCommand.php
+++ b/src/Command/RemoveRootUserCommand.php
@@ -18,7 +18,7 @@ class RemoveRootUserCommand extends Command
     /**
      * @var string
      */
-    const COMMAND_NAME = 'ilios:maintenance:remove-root-user';
+    const COMMAND_NAME = 'ilios:remove-root-user';
 
     /**
      * @var UserManager
@@ -38,6 +38,7 @@ class RemoveRootUserCommand extends Command
     {
         $this
             ->setName(self::COMMAND_NAME)
+            ->setAliases(['ilios:maintenance:remove-root-user'])
             ->setDescription('Revokes root-level privileges from a given user.')
             ->addArgument(
                 'userId',

--- a/src/Command/RolloverCourseCommand.php
+++ b/src/Command/RolloverCourseCommand.php
@@ -37,7 +37,8 @@ class RolloverCourseCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:rollover-course')
+            ->setName('ilios:rollover-course')
+            ->setAliases(['ilios:maintenance:rollover-course'])
             ->setDescription('Roll over a course to a new year using its course_id')
             //required arguments
             ->addArgument(

--- a/src/Command/RolloverCurriculumInventoryReportCommand.php
+++ b/src/Command/RolloverCurriculumInventoryReportCommand.php
@@ -44,7 +44,8 @@ class RolloverCurriculumInventoryReportCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:rollover-ci-report')
+            ->setName('ilios:rollover-ci-report')
+            ->setAliases(['ilios:maintenance:rollover-ci-report'])
             ->setDescription('Rolls over (copies) a given curriculum inventory report.')
             //required arguments
             ->addArgument(

--- a/src/Command/SendChangeAlertsCommand.php
+++ b/src/Command/SendChangeAlertsCommand.php
@@ -88,7 +88,8 @@ class SendChangeAlertsCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:messaging:send-change-alerts')
+            ->setName('ilios:send-change-alerts')
+            ->setAliases(['ilios:messaging:send-change-alerts'])
             ->setDescription('Sends out change alert message to configured email recipients.')
             ->addOption(
                 'dry-run',

--- a/src/Command/SendTeachingRemindersCommand.php
+++ b/src/Command/SendTeachingRemindersCommand.php
@@ -76,7 +76,8 @@ class SendTeachingRemindersCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:messaging:send-teaching-reminders')
+            ->setName('ilios:send-teaching-reminders')
+            ->setAliases(['ilios:messaging:send-teaching-reminders'])
             ->setDescription('Sends teaching reminders to educators.')
             ->addArgument(
                 'sender',

--- a/src/Command/SetConfigValueCommand.php
+++ b/src/Command/SetConfigValueCommand.php
@@ -38,7 +38,8 @@ class SetConfigValueCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:set-config-value')
+            ->setName('ilios:set-config-value')
+            ->setAliases(['ilios:maintenance:set-config-value'])
             ->setDescription('Set a configuration value in the DB')
             //required arguments
             ->addArgument(

--- a/src/Command/SetSchoolConfigValueCommand.php
+++ b/src/Command/SetSchoolConfigValueCommand.php
@@ -47,7 +47,8 @@ class SetSchoolConfigValueCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:set-school-config-value')
+            ->setName('ilios:set-school-config-value')
+            ->setAliases(['ilios:maintenance:set-school-config-value'])
             ->setDescription('Set a configuration value in the DB')
             //required arguments
             ->addArgument(

--- a/src/Command/SetupAuthenticationCommand.php
+++ b/src/Command/SetupAuthenticationCommand.php
@@ -39,7 +39,8 @@ class SetupAuthenticationCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:setup:authentication')
+            ->setName('ilios:setup-authentication')
+            ->setAliases(['ilios:setup:authentication'])
             ->setDescription('Sets up authentication.');
     }
 

--- a/src/Command/SyncAllUsersCommand.php
+++ b/src/Command/SyncAllUsersCommand.php
@@ -68,7 +68,8 @@ class SyncAllUsersCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:directory:sync-users')
+            ->setName('ilios:sync-users')
+            ->setAliases(['ilios:directory:sync-users'])
             ->setDescription('Sync all users against the directory by their campus ID.');
     }
 

--- a/src/Command/SyncFormerStudentsCommand.php
+++ b/src/Command/SyncFormerStudentsCommand.php
@@ -55,7 +55,8 @@ class SyncFormerStudentsCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:directory:sync-former-students')
+            ->setName('ilios:sync-former-students')
+            ->setAliases(['ilios:directory:sync-former-students'])
             ->setDescription('Sync former students from the directory.')
             ->addArgument(
                 'filter',

--- a/src/Command/SyncUserCommand.php
+++ b/src/Command/SyncUserCommand.php
@@ -61,7 +61,8 @@ class SyncUserCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:directory:sync-user')
+            ->setName('ilios:sync-user')
+            ->setAliases(['ilios:directory:sync-user'])
             ->setDescription('Sync a user from the directory.')
             ->addArgument(
                 'userId',

--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -114,7 +114,8 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:update-frontend')
+            ->setName('ilios:update-frontend')
+            ->setAliases(['ilios:maintenance:update-frontend'])
             ->setDescription('Updates the frontend to the latest version.')
             ->addOption(
                 'staging-build',

--- a/src/Command/ValidateLearningMaterialPathsCommand.php
+++ b/src/Command/ValidateLearningMaterialPathsCommand.php
@@ -45,7 +45,8 @@ class ValidateLearningMaterialPathsCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ilios:maintenance:validate-learning-materials')
+            ->setName('ilios:validate-learning-materials')
+            ->setAliases(['ilios:maintenance:validate-learning-materials'])
             ->setDescription('Validate file paths for learning materials');
     }
 

--- a/tests/Command/AddDirectoryUserCommandTest.php
+++ b/tests/Command/AddDirectoryUserCommandTest.php
@@ -15,7 +15,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-    const COMMAND_NAME = 'ilios:directory:add-user';
+    const COMMAND_NAME = 'ilios:add-directory-user';
     
     protected $userManager;
     protected $authenticationManager;

--- a/tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
 class AddNewStudentsToSchoolCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:directory:add-students';
+    const COMMAND_NAME = 'ilios:add-students';
     
     protected $userManager;
     protected $userRoleManager;

--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 class AddUserCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:add-user';
+    const COMMAND_NAME = 'ilios:add-user';
 
     protected $userManager;
     protected $authenticationManager;

--- a/tests/Command/AuditLogExportCommandTest.php
+++ b/tests/Command/AuditLogExportCommandTest.php
@@ -42,7 +42,7 @@ class AuditLogExportCommandTest extends KernelTestCase
         $command = new AuditLogExportCommand($this->logger, $this->auditLogManager);
         $application->add($command);
 
-        $command = $application->find('ilios:maintenance:export-audit-log');
+        $command = $application->find('ilios:export-audit-log');
         $this->commandTester = new CommandTester($command);
     }
 

--- a/tests/Command/CleanupStringsCommandTest.php
+++ b/tests/Command/CleanupStringsCommandTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 class CleanupStringsCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:cleanup-strings';
+    const COMMAND_NAME = 'ilios:cleanup-strings';
     
     protected $purifier;
     protected $em;

--- a/tests/Command/CreateUserTokenCommandTest.php
+++ b/tests/Command/CreateUserTokenCommandTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 class CreateUserTokenCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:create-user-token';
+    const COMMAND_NAME = 'ilios:create-user-token';
     
     protected $userManager;
     protected $commandTester;

--- a/tests/Command/CrossingGuardCommandTest.php
+++ b/tests/Command/CrossingGuardCommandTest.php
@@ -14,7 +14,7 @@ use Mockery as m;
 class CrossingGuardCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:crossing-guard';
+    const COMMAND_NAME = 'ilios:crossing-guard';
 
     protected $crossingGuard;
     protected $commandTester;

--- a/tests/Command/FindUserCommandTest.php
+++ b/tests/Command/FindUserCommandTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 class FindUserCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:directory:find-user';
+    const COMMAND_NAME = 'ilios:find-user';
     
     protected $commandTester;
     protected $directory;

--- a/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
+++ b/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\File\File;
 class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:fix-mime-types';
+    const COMMAND_NAME = 'ilios:fix-mime-types';
     
     protected $iliosFileSystem;
     protected $learningMaterialManager;

--- a/tests/Command/ImportMeshUniverseCommandTest.php
+++ b/tests/Command/ImportMeshUniverseCommandTest.php
@@ -38,7 +38,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     /**
      * @var string
      */
-    const COMMAND_NAME = 'ilios:maintenance:import-mesh-universe';
+    const COMMAND_NAME = 'ilios:import-mesh-universe';
 
     /**
      * @inheritdoc

--- a/tests/Command/InstallFirstUserCommandTest.php
+++ b/tests/Command/InstallFirstUserCommandTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 class InstallFirstUserCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:setup:first-user';
+    const COMMAND_NAME = 'ilios:setup-first-user';
 
     protected $userManager;
     protected $authenticationManager;

--- a/tests/Command/InvalidateUserTokenCommandTest.php
+++ b/tests/Command/InvalidateUserTokenCommandTest.php
@@ -15,7 +15,7 @@ use \DateTime;
 class InvalidateUserTokenCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:invalidate-user-tokens';
+    const COMMAND_NAME = 'ilios:invalidate-user-tokens';
     
     protected $userManager;
     protected $authenticationManager;

--- a/tests/Command/ListConfigValuesCommandTest.php
+++ b/tests/Command/ListConfigValuesCommandTest.php
@@ -12,7 +12,7 @@ use Mockery as m;
 class ListConfigValuesCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:list-config-values';
+    const COMMAND_NAME = 'ilios:list-config-values';
     
     protected $commandTester;
     protected $applicationConfigManager;

--- a/tests/Command/ListSchoolConfigValuesCommandTest.php
+++ b/tests/Command/ListSchoolConfigValuesCommandTest.php
@@ -13,7 +13,7 @@ use Mockery as m;
 class ListSchoolConfigValuesCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:list-school-config-values';
+    const COMMAND_NAME = 'ilios:list-school-config-values';
     
     protected $commandTester;
     protected $schoolManager;

--- a/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
+++ b/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:setup:migrate-learning-materials';
+    const COMMAND_NAME = 'ilios:migrate-learning-materials';
     
     protected $symfonyFileSystem;
     protected $iliosFileSystem;

--- a/tests/Command/RolloverCourseCommandTest.php
+++ b/tests/Command/RolloverCourseCommandTest.php
@@ -16,7 +16,7 @@ use Mockery as m;
 class RolloverCourseCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:rollover-course';
+    const COMMAND_NAME = 'ilios:rollover-course';
 
     /**
      * @var m\MockInterface

--- a/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
+++ b/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
@@ -16,7 +16,7 @@ use Mockery as m;
 class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:rollover-ci-report';
+    const COMMAND_NAME = 'ilios:rollover-ci-report';
 
     /**
      * @var m\MockInterface

--- a/tests/Command/SendChangeAlertsCommandTest.php
+++ b/tests/Command/SendChangeAlertsCommandTest.php
@@ -37,7 +37,7 @@ use Mockery as m;
 class SendChangeAlertsCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:messaging:send-change-alerts';
+    const COMMAND_NAME = 'ilios:send-change-alerts';
 
     /**
      * @var m\MockInterface

--- a/tests/Command/SendTeachingRemindersCommandTest.php
+++ b/tests/Command/SendTeachingRemindersCommandTest.php
@@ -31,7 +31,7 @@ use Mockery as m;
 class SendTeachingRemindersCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:messaging:send-teaching-reminders';
+    const COMMAND_NAME = 'ilios:send-teaching-reminders';
 
     /**
      * @var OfferingManager

--- a/tests/Command/SetConfigValueCommandTest.php
+++ b/tests/Command/SetConfigValueCommandTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 class SetConfigValueCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:set-config-value';
+    const COMMAND_NAME = 'ilios:set-config-value';
     
     protected $commandTester;
     protected $applicationConfigManager;

--- a/tests/Command/SetSchoolConfigValueCommandTest.php
+++ b/tests/Command/SetSchoolConfigValueCommandTest.php
@@ -14,7 +14,7 @@ use Mockery as m;
 class SetSchoolConfigValueCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:set-school-config-value';
+    const COMMAND_NAME = 'ilios:set-school-config-value';
     
     protected $commandTester;
     protected $schoolManager;

--- a/tests/Command/SetupAuthenticationCommandTest.php
+++ b/tests/Command/SetupAuthenticationCommandTest.php
@@ -16,7 +16,7 @@ use Mockery as m;
 class SetupAuthenticationCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:setup:authentication';
+    const COMMAND_NAME = 'ilios:setup-authentication';
 
     protected $applicationConfigManager;
     protected $questionHelper;

--- a/tests/Command/SyncAllUsersCommandTest.php
+++ b/tests/Command/SyncAllUsersCommandTest.php
@@ -18,7 +18,7 @@ use Mockery as m;
 class SyncAllUsersCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:directory:sync-users';
+    const COMMAND_NAME = 'ilios:sync-users';
     
     protected $userManager;
     protected $authenticationManager;

--- a/tests/Command/SyncFormerStudentsCommandTest.php
+++ b/tests/Command/SyncFormerStudentsCommandTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
 class SyncFormerStudentsCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:directory:sync-former-students';
+    const COMMAND_NAME = 'ilios:sync-former-students';
     
     protected $userManager;
     protected $userRoleManager;

--- a/tests/Command/SyncUserCommandTest.php
+++ b/tests/Command/SyncUserCommandTest.php
@@ -20,7 +20,7 @@ use Mockery as m;
 class SyncUserCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:directory:sync-user';
+    const COMMAND_NAME = 'ilios:sync-user';
     
     protected $userManager;
     protected $authenticationManager;

--- a/tests/Command/UpdateFrontendCommandTest.php
+++ b/tests/Command/UpdateFrontendCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Finder\Finder;
 class UpdateFrontendCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:update-frontend';
+    const COMMAND_NAME = 'ilios:update-frontend';
     const TEST_API_VERSION = '33.14-test';
     
     protected $commandTester;

--- a/tests/Command/ValidateLearningMaterialPathsCommandTest.php
+++ b/tests/Command/ValidateLearningMaterialPathsCommandTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    const COMMAND_NAME = 'ilios:maintenance:validate-learning-materials';
+    const COMMAND_NAME = 'ilios:validate-learning-materials';
     
     protected $iliosFileSystem;
     protected $learningMaterialManager;


### PR DESCRIPTION
We don't need these to be so heavily name spaced. I went ahead and
aliased the original command name to ease the documentation transition,
but we can drop that at some point in the near future.