### PR TITLE
Fix route for download of competencies

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -500,15 +500,13 @@ ilios_api_programyears_put:
     id: '\d+'
 
 ilios_api_programyears_downloadobjectivesmapping:
-  path: /{version}/{object}/{id}/downloadobjectivesmapping
+  path: /api/{version}/{object}/{id}/downloadobjectivesmapping
   controller: App\Controller\ProgramYearController::downloadCourseObjectivesReportAction
-  defaults:
-    id: 0
   methods: [GET]
   requirements:
     version: "%ilios_api_valid_api_versions%"
     object: 'programyears'
-    id: '(?i)[a-z0-9\-]+'
+    id: '\d+'
 
 ilios_api_usermadereminders_410:
   path:     /api/{version}/{object}/{id}


### PR DESCRIPTION
Was just missing the /api, but I cleaned up some other issues as well.

Fixes ilios/frontend#4107