### PR TITLE
Remove annotation reset from tests

### DIFF
--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -67,9 +67,6 @@ abstract class AbstractEndpointTest extends WebTestCase
         unset($this->client);
         unset($this->fixtures);
         unset($this->faker);
-        // Until https://github.com/doctrine/annotations/pull/135
-        // is merged we need to keep the registry clean ourselves
-        AnnotationRegistry::reset();
     }
 
     /**


### PR DESCRIPTION
We're up to date on doctrine/annotations now and can remove this
workaround