### PR TITLE
Bind common parameters

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,6 +26,12 @@ services:
         public: false       # Allows optimizing the container by removing unused services; this also means
                             # fetching services directly from the container via $container->get() won't work.
                             # The best practice is to be explicit about your dependencies anyway.
+        bind:
+          $environment: '%kernel.environment%'
+          $kernelCacheDir: '%kernel.cache_dir%'
+          $apiVersion: '%ilios_api_version%'
+          $kernelRootDirectory: '%kernel.root_dir%'
+          $kernelProjectDir: '%kernel.project_dir%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
@@ -49,20 +55,9 @@ services:
 
     App\Controller\ExceptionController:
       public: true
-      arguments:
-        $environment: '%kernel.environment%'
 
     App\Controller\SwaggerDocsController:
       public: true
-      arguments:
-        $kernelRootDir: '%kernel.root_dir%'
-
-    App\Command\UpdateFrontendCommand:
-      arguments:
-        $kernelCacheDir: '%kernel.cache_dir%'
-        $kernelProjectDir: '%kernel.project_dir%'
-        $apiVersion: '%ilios_api_version%'
-        $environment: '%kernel.environment%'
 
     App\Entity\Manager\AlertManager:
       public: true
@@ -220,8 +215,6 @@ services:
       public: true
 
     App\Service\DataimportFileLocator:
-      arguments:
-        $kernelRootDirectory: '%kernel.root_dir%'
       public: true
 
     App\Service\Filesystem:
@@ -229,10 +222,6 @@ services:
 
     App\Service\Directory:
       public: true
-
-    App\Service\TemporaryFileSystem:
-      arguments:
-        $kernelRootDirectory: '%kernel.root_dir%'
 
     App\Service\LoggerQueue:
       public: true
@@ -256,10 +245,6 @@ services:
     App\Service\CrossingGuard:
       tags:
       - { name: kernel.event_listener, event: kernel.request, priority: 256 }
-
-    App\Service\SwaggerDocBuilder:
-      arguments:
-        $apiVersion: '%ilios_api_version%'
 
     App\Service\JsonWebTokenManager:
       public: true
@@ -302,8 +287,6 @@ services:
 
     App\Monitor\Frontend:
       autoconfigure: false
-      arguments:
-        $kernelCacheDir: '%kernel.cache_dir%'
       tags:
       - { name: liip_monitor.check, group: production }
 

--- a/src/Controller/SwaggerDocsController.php
+++ b/src/Controller/SwaggerDocsController.php
@@ -26,17 +26,17 @@ class SwaggerDocsController extends AbstractController
     /**
      * @var string
      */
-    protected $kernelRootDir;
+    protected $kernelRootDirectory;
 
     /**
      * SwaggerDocsController constructor.
      * @param SwaggerDocBuilder $builder
-     * @param string $kernelRootDir
+     * @param string $kernelRootDirectory
      */
-    public function __construct(SwaggerDocBuilder $builder, $kernelRootDir)
+    public function __construct(SwaggerDocBuilder $builder, $kernelRootDirectory)
     {
         $this->builder = $builder;
-        $this->kernelRootDir = $kernelRootDir;
+        $this->kernelRootDirectory = $kernelRootDirectory;
     }
 
     /**
@@ -64,7 +64,7 @@ class SwaggerDocsController extends AbstractController
     public function uiAction(Request $request, $fileName)
     {
         $fileName = empty($fileName)?'index.html':$fileName;
-        $swaggerDistDir = $this->kernelRootDir . '/../vendor/swagger-api/swagger-ui/dist';
+        $swaggerDistDir = $this->kernelRootDirectory . '/../vendor/swagger-api/swagger-ui/dist';
         $filePath = "${swaggerDistDir}/${fileName}";
 
         if (!is_readable($filePath)) {


### PR DESCRIPTION
Symfony now gives us the option to use the variable name in services as
a constant injector and bind it in our services definition.