### PR TITLE
Create blocking migration command

### DIFF
--- a/src/Command/LockingMigrationCommand.php
+++ b/src/Command/LockingMigrationCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\IliosFileSystem;
+use Doctrine\Bundle\MigrationsBundle\Command\MigrationsMigrateDoctrineCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Uses a lock to ensure that only one migration can run
+ * This allows migrations to be done when containers boot without
+ * worrying about too many running at the same time.
+ *
+ * Class LockingMigrationCommand
+ */
+class LockingMigrationCommand extends MigrationsMigrateDoctrineCommand
+{
+    const LOCK_NAME = 'database-migration.lock';
+
+    /**
+     * @var IliosFileSystem
+     */
+    private $fileSystem;
+
+    public function __construct(IliosFileSystem $fileSystem)
+    {
+        parent::__construct();
+        $this->fileSystem = $fileSystem;
+    }
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('ilios:migrate-database');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    {
+        try {
+            $this->fileSystem->waitForLock(self::LOCK_NAME);
+
+            return parent::execute($input, $output);
+        } finally {
+            $this->fileSystem->releaseLock(self::LOCK_NAME);
+        }
+    }
+}

--- a/src/Service/IliosFileSystem.php
+++ b/src/Service/IliosFileSystem.php
@@ -198,4 +198,16 @@ class IliosFileSystem
 
         return $this->fileSystem->exists($fullPath);
     }
+
+    /**
+     * Wait for and then acquire a lock
+     * @param string $name
+     */
+    public function waitForLock($name)
+    {
+        while ($this->hasLock($name)) {
+            usleep(250);
+        }
+        $this->createLock($name);
+    }
 }

--- a/tests/Service/IliosFileSystemTest.php
+++ b/tests/Service/IliosFileSystemTest.php
@@ -210,7 +210,7 @@ class IliosFileSystemTest extends TestCase
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
         $lockFileDir = dirname($lockFilePath);
-        $this->mockFileSystem->shouldReceive('exists')->with($lockFilePath)->andReturn(true);
+        $this->mockFileSystem->shouldReceive('exists')->with($lockFilePath)->andReturn(false);
         $this->mockFileSystem->shouldReceive('touch')->with($lockFilePath);
         $this->mockFileSystem->shouldReceive('mkdir')->with($lockFileDir);
         $this->iliosFileSystem->createLock($name);
@@ -241,6 +241,17 @@ class IliosFileSystemTest extends TestCase
         $this->mockFileSystem->shouldReceive('exists')->with($lockFilePath)->andReturn(false);
         $status = $this->iliosFileSystem->hasLock($name);
         $this->assertFalse($status);
+    }
+
+    public function testWaitForLock()
+    {
+        $name = 'test.lock';
+        $lockFilePath = $this->getTestFileLock($name);
+        $lockFileDir = dirname($lockFilePath);
+        $this->mockFileSystem->shouldReceive('exists')->with($lockFilePath)->andReturn(false);
+        $this->mockFileSystem->shouldReceive('touch')->with($lockFilePath);
+        $this->mockFileSystem->shouldReceive('mkdir')->with($lockFileDir);
+        $this->iliosFileSystem->waitForLock($name);
     }
 
     public function testConvertsUnsafeFileNames()


### PR DESCRIPTION
This will allow migrations to be run on multiple instances at once
without actually having any conflicts. The first to run will keep the
lock and any others will wait for it to be released before checking and
finding no new migrations.