### PR TITLE
Add pre/post requisite information to events

### DIFF
--- a/src/Classes/CalendarEvent.php
+++ b/src/Classes/CalendarEvent.php
@@ -211,6 +211,20 @@ class CalendarEvent
     public $competencies = array();
 
     /**
+     * @var []
+     * @IS\Expose
+     * @IS\Type("entityCollection")
+     */
+    public $postrequisiteSession;
+
+    /**
+     * @var []
+     * @IS\Expose
+     * @IS\Type("entityCollection")
+     */
+    public $prerequisiteSessions = array();
+
+    /**
      * Clean out all the data for draft or scheduled events
      *
      * This information is not available to un-privileged users
@@ -252,6 +266,7 @@ class CalendarEvent
             $this->sessionObjectives = [];
             $this->courseObjectives = [];
             $this->competencies = [];
+            $this->prerequisiteSessions = [];
         }
     }
 

--- a/src/Controller/SchooleventController.php
+++ b/src/Controller/SchooleventController.php
@@ -84,7 +84,7 @@ class SchooleventController extends Controller
 
         $result = $schoolManager->addInstructorsToEvents($events);
         $result = $schoolManager->addMaterialsToEvents($result);
-        $result = $schoolManager->addObjectivesAndCompetenciesToEvents($result);
+        $result = $schoolManager->addSessionDataToEvents($result);
 
         $sessionUser = $tokenStorage->getToken()->getUser();
 

--- a/src/Controller/UsereventController.php
+++ b/src/Controller/UsereventController.php
@@ -90,7 +90,7 @@ class UsereventController extends AbstractController
 
         $result = $manager->addInstructorsToEvents($events);
         $result = $manager->addMaterialsToEvents($result);
-        $result = $manager->addObjectivesAndCompetenciesToEvents($result);
+        $result = $manager->addSessionDataToEvents($result);
 
         // Remove all draft data when not viewing your own events
         // or if the requesting user does not have elevated privileges

--- a/src/Entity/Manager/SchoolManager.php
+++ b/src/Entity/Manager/SchoolManager.php
@@ -91,10 +91,10 @@ class SchoolManager extends BaseManager
      * @return CalendarEvent[]
      * @throws \Exception
      */
-    public function addObjectivesAndCompetenciesToEvents(array $events)
+    public function addSessionDataToEvents(array $events)
     {
         /** @var SchoolRepository $repository */
         $repository = $this->getRepository();
-        return $repository->addObjectivesAndCompetenciesToEvents($events);
+        return $repository->addSessionDataToEvents($events);
     }
 }

--- a/src/Entity/Manager/UserManager.php
+++ b/src/Entity/Manager/UserManager.php
@@ -121,11 +121,11 @@ class UserManager extends BaseManager
      * @return CalendarEvent[]
      * @throws \Exception
      */
-    public function addObjectivesAndCompetenciesToEvents(array $events)
+    public function addSessionDataToEvents(array $events)
     {
         /** @var UserRepository $repository */
         $repository = $this->getRepository();
-        return $repository->addObjectivesAndCompetenciesToEvents($events);
+        return $repository->addSessionDataToEvents($events);
     }
 
     /**

--- a/src/Entity/Repository/SchoolRepository.php
+++ b/src/Entity/Repository/SchoolRepository.php
@@ -214,18 +214,21 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
     ) {
         $qb = $this->_em->createQueryBuilder();
         $what = 'c.id as courseId, s.id AS sessionId, ' .
-          'o.id, o.startDate, o.endDate, o.room, o.updatedAt, o.updatedAt AS offeringUpdatedAt, ' .
-          's.updatedAt AS sessionUpdatedAt, s.title, st.calendarColor, st.title as sessionTypeTitle, ' .
-          's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
-          's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, s.instructionalNotes, ' .
-          'c.publishedAsTbd as coursePublishedAsTbd, c.published as coursePublished, c.title as courseTitle, ' .
-          'c.externalId as courseExternalId, sd.description AS sessionDescription';
+            'o.id, o.startDate, o.endDate, o.room, o.updatedAt, o.updatedAt AS offeringUpdatedAt, ' .
+            's.updatedAt AS sessionUpdatedAt, s.title, st.calendarColor, st.title as sessionTypeTitle, ' .
+            's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
+            's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, s.instructionalNotes, ' .
+            'c.publishedAsTbd as coursePublishedAsTbd, c.published as coursePublished, c.title as courseTitle, ' .
+            'c.externalId as courseExternalId, sd.description AS sessionDescription, ' .
+            'ps.id as postrequisiteSessionId, ps.title as postrequisiteSessionTitle';
+
         $qb->addSelect($what)->from('App\Entity\School', 'school');
         $qb->join('school.courses', 'c');
         $qb->join('c.sessions', 's');
         $qb->join('s.offerings', 'o');
         $qb->leftJoin('s.sessionType', 'st');
         $qb->leftJoin('s.sessionDescription', 'sd');
+        $qb->leftJoin('s.postrequisite', 'ps');
 
         $qb->andWhere($qb->expr()->eq('school.id', ':school_id'));
         $qb->andWhere($qb->expr()->orX(
@@ -267,7 +270,9 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
             's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
             's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, s.instructionalNotes, ' .
             'c.publishedAsTbd as coursePublishedAsTbd, c.published as coursePublished, c.title as courseTitle, ' .
-            'c.externalId as courseExternalId, sd.description AS sessionDescription';
+            'c.externalId as courseExternalId, sd.description AS sessionDescription, ' .
+            'ps.id as postrequisiteSessionId, ps.title as postrequisiteSessionTitle';
+
         $qb->addSelect($what)->from('App\Entity\School', 'school');
 
         $qb->join('school.courses', 'c');
@@ -275,6 +280,7 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
         $qb->join('s.ilmSession', 'ilm');
         $qb->leftJoin('s.sessionType', 'st');
         $qb->leftJoin('s.sessionDescription', 'sd');
+        $qb->leftJoin('s.postrequisite', 'ps');
 
         $qb->where($qb->expr()->andX(
             $qb->expr()->eq('school.id', ':school_id'),
@@ -318,9 +324,9 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
      * @param CalendarEvent[] $events
      * @return CalendarEvent[]
      */
-    public function addObjectivesAndCompetenciesToEvents(array $events)
+    public function addSessionDataToEvents(array $events)
     {
-        return $this->attachObjectivesAndCompetenciesToEvents($events, $this->_em);
+        return $this->attachSessionDataToEvents($events, $this->_em);
     }
 
     /**

--- a/src/Entity/Repository/UserRepository.php
+++ b/src/Entity/Repository/UserRepository.php
@@ -339,7 +339,8 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
             's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, s.instructionalNotes, ' .
             'c.publishedAsTbd as coursePublishedAsTbd, c.published as coursePublished, c.title AS courseTitle, ' .
-            'sd.description AS sessionDescription, st.title AS sessionTypeTitle, c.externalId AS courseExternalId';
+            'sd.description AS sessionDescription, st.title AS sessionTypeTitle, c.externalId AS courseExternalId, ' .
+            'ps.id as postrequisiteSessionId, ps.title as postrequisiteSessionTitle';
         $qb->addSelect($what)->from('App\Entity\User', 'u');
         foreach ($joins as $key => $statement) {
             $qb->leftJoin($statement, $key);
@@ -348,6 +349,7 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         $qb->leftJoin('s.course', 'c');
         $qb->leftJoin('s.sessionType', 'st');
         $qb->leftJoin('s.sessionDescription', 'sd');
+        $qb->leftJoin('s.postrequisite', 'ps');
 
 
         $qb->andWhere($qb->expr()->eq('u.id', ':user_id'));
@@ -385,7 +387,8 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
             's.publishedAsTbd as sessionPublishedAsTbd, s.published as sessionPublished, ' .
             's.attireRequired, s.equipmentRequired, s.supplemental, s.attendanceRequired, s.instructionalNotes, ' .
             'c.publishedAsTbd as coursePublishedAsTbd, c.published as coursePublished, c.title as courseTitle,' .
-            'sd.description AS sessionDescription, st.title AS sessionTypeTitle, c.externalId AS courseExternalId';
+            'sd.description AS sessionDescription, st.title AS sessionTypeTitle, c.externalId AS courseExternalId, ' .
+            'ps.id as postrequisiteSessionId, ps.title as postrequisiteSessionTitle';
 
         $qb->addSelect($what)->from('App\Entity\User', 'u');
 
@@ -396,6 +399,7 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
         $qb->leftJoin('s.course', 'c');
         $qb->leftJoin('s.sessionType', 'st');
         $qb->leftJoin('s.sessionDescription', 'sd');
+        $qb->leftJoin('s.postrequisite', 'ps');
 
         $qb->where($qb->expr()->andX(
             $qb->expr()->eq('u.id', ':user_id'),
@@ -891,9 +895,9 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
      * @param CalendarEvent[] $events
      * @return CalendarEvent[]
      */
-    public function addObjectivesAndCompetenciesToEvents(array $events)
+    public function addSessionDataToEvents(array $events)
     {
-        return $this->attachObjectivesAndCompetenciesToEvents($events, $this->_em);
+        return $this->attachSessionDataToEvents($events, $this->_em);
     }
 
     /**

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -144,6 +144,11 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals(1, $events[0]['competencies'][1]['id']);
         $this->assertEquals('first competency', $events[0]['competencies'][1]['title']);
         $this->assertEquals(null, $events[0]['competencies'][1]['parent']);
+        $this->assertEquals($events[1]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[1]['prerequisiteSessions']);
 
         $this->assertEquals($events[1]['offering'], 4);
         $this->assertEquals($events[1]['startDate'], $offerings[3]['startDate']);
@@ -164,6 +169,11 @@ class SchooleventsTest extends AbstractEndpointTest
             $sessions[1]['instructionalNotes'],
             'instructional notes is correct for event 1'
         );
+        $this->assertEquals($events[1]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[1]['prerequisiteSessions']);
 
         $this->assertEquals($events[2]['offering'], 5);
         $this->assertEquals($events[2]['startDate'], $offerings[4]['startDate']);
@@ -183,6 +193,11 @@ class SchooleventsTest extends AbstractEndpointTest
             $sessions[1]['instructionalNotes'],
             'instructional notes is correct for event 2'
         );
+        $this->assertEquals($events[2]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[2]['prerequisiteSessions']);
 
         $this->assertEquals($events[3]['offering'], 6);
         $this->assertEquals($events[3]['startDate'], $offerings[5]['startDate']);
@@ -202,6 +217,11 @@ class SchooleventsTest extends AbstractEndpointTest
             $sessions[2]['instructionalNotes'],
             'instructional notes is correct for event 3'
         );
+        $this->assertEquals($events[3]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[3]['prerequisiteSessions']);
 
         $this->assertEquals($events[4]['offering'], 7);
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate']);
@@ -221,6 +241,11 @@ class SchooleventsTest extends AbstractEndpointTest
             $sessions[2]['instructionalNotes'],
             'instructional notes is correct for event 4'
         );
+        $this->assertEquals($events[4]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[4]['prerequisiteSessions']);
 
         $this->assertEquals($events[5]['ilmSession'], 1);
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate']);
@@ -235,6 +260,8 @@ class SchooleventsTest extends AbstractEndpointTest
             $events[5],
             'instructional notes is correct for event 5'
         );
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[5]);
+        $this->assertEmpty($events[5]['prerequisiteSessions']);
 
         $this->assertEquals($events[6]['ilmSession'], 2);
         $this->assertEquals($events[6]['startDate'], $ilmSessions[1]['dueDate']);
@@ -249,6 +276,8 @@ class SchooleventsTest extends AbstractEndpointTest
             $events[6],
             'instructional notes is correct for event 6'
         );
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[6]);
+        $this->assertEmpty($events[6]['prerequisiteSessions']);
 
         $this->assertEquals($events[7]['ilmSession'], 3);
         $this->assertEquals($events[7]['startDate'], $ilmSessions[2]['dueDate']);
@@ -263,6 +292,8 @@ class SchooleventsTest extends AbstractEndpointTest
             $events[7],
             'instructional notes is correct for event 7'
         );
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[7]);
+        $this->assertEmpty($events[7]['prerequisiteSessions']);
 
         $this->assertEquals($events[8]['ilmSession'], 4);
         $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate']);
@@ -277,6 +308,8 @@ class SchooleventsTest extends AbstractEndpointTest
             $events[8],
             'instructional notes is correct for event 8'
         );
+        $this->assertEmpty($events[8]['prerequisiteSessions']);
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[8]);
 
         $this->assertEquals($events[9]['offering'], 1);
         $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate']);
@@ -316,7 +349,8 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals(1, $events[9]['competencies'][1]['id']);
         $this->assertEquals('first competency', $events[9]['competencies'][1]['title']);
         $this->assertEquals(null, $events[9]['competencies'][1]['parent']);
-
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[9]);
+        $this->assertEmpty($events[9]['prerequisiteSessions']);
 
         /** @var OfferingInterface $offering */
         $offering = $this->fixtures->getReference('offerings8');
@@ -332,6 +366,11 @@ class SchooleventsTest extends AbstractEndpointTest
             count($events[10]['learningMaterials']),
             'Event 10 has the correct number of learning materials'
         );
+        $this->assertEquals($events[10]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[10]['prerequisiteSessions']);
 
 
         foreach ($events as $event) {

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -196,6 +196,11 @@ class UsereventTest extends AbstractEndpointTest
             $events[0]['attendanceRequired'],
             'attendanceRequired is correct for event 0'
         );
+        $this->assertEquals([
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ], $events[0]['postrequisiteSession']);
+        $this->assertEmpty($events[0]['prerequisiteSessions']);
 
         $this->assertEquals($events[1]['offering'], 4, 'offering is correct for event 1');
         $this->assertEquals(
@@ -246,6 +251,11 @@ class UsereventTest extends AbstractEndpointTest
             $events[1]['attendanceRequired'],
             'attendanceRequired is correct for event 1'
         );
+        $this->assertEquals($events[2]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[2]['prerequisiteSessions']);
 
         $this->assertEquals($events[2]['offering'], 5, 'offering is correct for event 2');
         $this->assertEquals(
@@ -296,6 +306,11 @@ class UsereventTest extends AbstractEndpointTest
             $events[2]['attendanceRequired'],
             'attendanceRequired is correct for event 2'
         );
+        $this->assertEquals($events[2]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[2]['prerequisiteSessions']);
 
         $this->assertEquals($events[3]['offering'], 6, 'offering is correct for event 3');
         $this->assertEquals($events[3]['startDate'], $offerings[5]['startDate'], 'startDate is correct for event 3');
@@ -339,6 +354,11 @@ class UsereventTest extends AbstractEndpointTest
             $events[3],
             'attendanceRequired is correct for event 3'
         );
+        $this->assertEquals($events[3]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[3]['prerequisiteSessions']);
 
         $this->assertEquals($events[4]['offering'], 7, 'offering is correct for event 4');
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate'], 'startDate is correct for event 4');
@@ -382,6 +402,11 @@ class UsereventTest extends AbstractEndpointTest
             $events[4],
             'attendanceRequired is correct for event 4'
         );
+        $this->assertEquals($events[4]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[4]['prerequisiteSessions']);
 
         $this->assertEquals($events[5]['ilmSession'], 1, 'ilmSession is correct for 5');
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate'], 'dueDate is correct for 5');
@@ -420,6 +445,8 @@ class UsereventTest extends AbstractEndpointTest
             $events[5],
             'attendanceRequired is correct for event 5'
         );
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[5]);
+        $this->assertEmpty($events[5]['prerequisiteSessions']);
 
         $this->assertEquals($events[6]['ilmSession'], 2, 'ilmSession is correct for event 6');
         $this->assertEquals($events[6]['startDate'], $ilmSessions[1]['dueDate'], 'dueDate is correct for event 6');
@@ -457,6 +484,8 @@ class UsereventTest extends AbstractEndpointTest
             $events[6],
             'attendanceRequired is correct for event 6'
         );
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[6]);
+        $this->assertEmpty($events[6]['prerequisiteSessions']);
 
         $this->assertEquals($events[7]['ilmSession'], 3, 'ilmSession is correct for event 7');
         $this->assertEquals($events[7]['startDate'], $ilmSessions[2]['dueDate'], 'dueDate is correct for event 7');
@@ -494,6 +523,8 @@ class UsereventTest extends AbstractEndpointTest
             $events[7],
             'attendanceRequired is correct for event 7'
         );
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[7]);
+        $this->assertEmpty($events[7]['prerequisiteSessions']);
 
         $this->assertEquals($events[8]['ilmSession'], 4, 'ilmSession is correct for event 8');
         $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate'], 'dueDate is correct for event 8');
@@ -531,6 +562,8 @@ class UsereventTest extends AbstractEndpointTest
             $events[8],
             'attendanceRequired is correct for event 8'
         );
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[8]);
+        $this->assertEmpty($events[8]['prerequisiteSessions']);
 
         $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate'], 'startDate is correct for event 9');
         $this->assertEquals($events[9]['endDate'], $offerings[0]['endDate'], 'endDate is correct for event 9');
@@ -577,6 +610,8 @@ class UsereventTest extends AbstractEndpointTest
             $events[9],
             'attendanceRequired is correct for event 9'
         );
+        $this->assertArrayNotHasKey('postrequisiteSession', $events[9]);
+        $this->assertEmpty($events[9]['prerequisiteSessions']);
 
         /** @var OfferingInterface $offering */
         $offering = $this->fixtures->getReference('offerings8');
@@ -623,6 +658,11 @@ class UsereventTest extends AbstractEndpointTest
             $events[10],
             'attendanceRequired is correct for event 10'
         );
+        $this->assertEquals($events[10]['postrequisiteSession'], [
+            'id' => 4,
+            'title' => $sessions[3]['title']
+        ]);
+        $this->assertEmpty($events[10]['prerequisiteSessions']);
 
         foreach ($events as $event) {
             $this->assertEquals($userId, $event['user']);


### PR DESCRIPTION
In order to link events in the calendar we need this information and the
session itself isn't available to unprivileged users.