### PR TITLE
Find events by session Id

### DIFF
--- a/src/Controller/SchooleventController.php
+++ b/src/Controller/SchooleventController.php
@@ -2,6 +2,8 @@
 
 namespace App\Controller;
 
+use App\Entity\Manager\SessionManager;
+use App\Entity\SessionInterface;
 use App\RelationshipVoter\AbstractVoter;
 use App\Classes\SchoolEvent;
 use App\Entity\Manager\SchoolManager;
@@ -28,18 +30,19 @@ class SchooleventController extends Controller
      * @param string $id of the school
      * @param Request $request
      * @param SchoolManager $schoolManager
+     * @param SessionManager $sessionManager
      * @param AuthorizationCheckerInterface $authorizationChecker
      * @param TokenStorageInterface $tokenStorage
      * @param SerializerInterface $serializer
      *
      * @return Response
-     * @throws \Exception
      */
     public function getAction(
         $version,
         $id,
         Request $request,
         SchoolManager $schoolManager,
+        SessionManager $sessionManager,
         AuthorizationCheckerInterface $authorizationChecker,
         TokenStorageInterface $tokenStorage,
         SerializerInterface $serializer
@@ -50,18 +53,30 @@ class SchooleventController extends Controller
             throw new NotFoundHttpException(sprintf('The school \'%s\' was not found.', $id));
         }
 
-        $fromTimestamp = $request->get('from');
-        $toTimestamp = $request->get('to');
-        $from = DateTime::createFromFormat('U', $fromTimestamp);
-        $to = DateTime::createFromFormat('U', $toTimestamp);
+        if ($sessionId = $request->get('session')) {
+            /** @var SessionInterface $session */
+            $session = $sessionManager->findOneBy(['id' => $sessionId]);
 
-        if (!$from) {
-            throw new InvalidInputWithSafeUserMessageException("?from is missing or is not a valid timestamp");
+            if (!$session) {
+                throw new NotFoundHttpException(sprintf('The session \'%s\' was not found.', $id));
+            }
+            $events = $schoolManager->findSessionEventsForSchool($school->getId(), $sessionId);
+        } else {
+            $fromTimestamp = $request->get('from');
+            $toTimestamp = $request->get('to');
+            $from = DateTime::createFromFormat('U', $fromTimestamp);
+            $to = DateTime::createFromFormat('U', $toTimestamp);
+
+            if (!$from) {
+                throw new InvalidInputWithSafeUserMessageException("?from is missing or is not a valid timestamp");
+            }
+            if (!$to) {
+                throw new InvalidInputWithSafeUserMessageException("?to is missing or is not a valid timestamp");
+            }
+            $events = $schoolManager->findEventsForSchool($school->getId(), $from, $to);
         }
-        if (!$to) {
-            throw new InvalidInputWithSafeUserMessageException("?to is missing or is not a valid timestamp");
-        }
-        $events = $schoolManager->findEventsForSchool($school->getId(), $from, $to);
+
+
 
         $events = array_filter($events, function ($entity) use ($authorizationChecker) {
             return $authorizationChecker->isGranted(AbstractVoter::VIEW, $entity);

--- a/src/Entity/Manager/SchoolManager.php
+++ b/src/Entity/Manager/SchoolManager.php
@@ -44,6 +44,19 @@ class SchoolManager extends BaseManager
     }
 
     /**
+     * @param int $schoolId
+     * @param int $sessionId
+     * @return SchoolEvent[]
+     * @throws \Exception
+     */
+    public function findSessionEventsForSchool(int $schoolId, int $sessionId) : array
+    {
+        /** @var SchoolRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->findSessionEventsForSchool($schoolId, $sessionId);
+    }
+
+    /**
      * Finds and adds instructors to a given list of calendar events.
      *
      * @param CalendarEvent[] $events

--- a/src/Entity/Manager/UserManager.php
+++ b/src/Entity/Manager/UserManager.php
@@ -86,6 +86,21 @@ class UserManager extends BaseManager
     }
 
     /**
+     * Find all of the events for a user in a session
+     *
+     * @param integer $userId
+     * @param integer $sessionId
+     * @return UserEvent[]
+     * @throws \Exception
+     */
+    public function findSessionEventsForUser(int $userId, int $sessionId) : array
+    {
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->findSessionEventsForUser($userId, $sessionId);
+    }
+
+    /**
      * Finds and adds instructors to a given list of calendar events.
      *
      * @param CalendarEvent[] $events

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -673,6 +673,52 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEquals('8', $lms[6]['sessionLearningMaterial']);
     }
 
+    public function testGetEventsBySessionForCourseDirector()
+    {
+        $userId = 2;
+        $sessionId = 3;
+
+        $events = $this->getEventsForSessionId(
+            $userId,
+            $sessionId,
+            $this->getTokenForUser($userId)
+        );
+
+        $this->assertEquals(3, count($events), 'Expected events returned');
+        $this->assertEquals(
+            $sessionId,
+            $events[0]['session']
+        );
+        $this->assertEquals(6, $events[0]['offering']);
+        $this->assertEquals($sessionId, $events[0]['session']);
+        $this->assertEquals(7, $events[1]['offering']);
+        $this->assertEquals($sessionId, $events[1]['session']);
+        $this->assertEquals(8, $events[2]['offering']);
+        $this->assertEquals($sessionId, $events[2]['session']);
+    }
+
+    public function testGetEventsBySessionForLearner()
+    {
+        $userId = 5;
+        $sessionId = 1;
+
+        $events = $this->getEventsForSessionId(
+            $userId,
+            $sessionId,
+            $this->getTokenForUser($userId)
+        );
+
+        $this->assertEquals(2, count($events), 'Expected events returned');
+        $this->assertEquals(
+            $sessionId,
+            $events[0]['session']
+        );
+        $this->assertEquals(1, $events[0]['offering']);
+        $this->assertEquals($sessionId, $events[0]['session']);
+        $this->assertEquals(2, $events[1]['offering']);
+        $this->assertEquals($sessionId, $events[1]['session']);
+    }
+
     /**
      * @param int $userId
      * @param int $from
@@ -687,6 +733,42 @@ class UsereventTest extends AbstractEndpointTest
             'id' => $userId,
             'from' => $from,
             'to' => $to,
+        ];
+        $url = $this->getUrl(
+            'ilios_api_userevents',
+            $parameters
+        );
+        $this->createJsonRequest(
+            'GET',
+            $url,
+            null,
+            $userToken
+        );
+
+        $response = $this->client->getResponse();
+
+        if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
+            $this->fail("Unable to load url: {$url}");
+        }
+
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+
+        return json_decode($response->getContent(), true)['userEvents'];
+    }
+
+    /**
+     * @param int $userId
+     * @param int $from
+     * @param int $to
+     * @param string|null $userToken
+     * @return array
+     */
+    protected function getEventsForSessionId($userId, $sessionId, $userToken)
+    {
+        $parameters = [
+            'version' => 'v1',
+            'id' => $userId,
+            'session' => $sessionId,
         ];
         $url = $this->getUrl(
             'ilios_api_userevents',


### PR DESCRIPTION
For both schools and users when we have a session id (as we do in pre / post requisites) this filter allows us to find the right events without needing access to the sessions endpoint to discover the offerings first.