### PR TITLE
Add error capture configuration

### DIFF
--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Service\Config;
 use App\Service\Filesystem;
 use App\Service\AuthenticationInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -32,19 +33,27 @@ class IndexController extends Controller
     private $authentication;
 
     /**
+     * @var Config
+     */
+    private $config;
+
+    /**
      * IndexController constructor.
      * @param Filesystem $fs
      * @param EngineInterface $templatingEngine
      * @param AuthenticationInterface $authentication
+     * @param Config $config
      */
     public function __construct(
         Filesystem $fs,
         EngineInterface $templatingEngine,
-        AuthenticationInterface $authentication
+        AuthenticationInterface $authentication,
+        Config $config
     ) {
         $this->fs = $fs;
         $this->templatingEngine = $templatingEngine;
         $this->authentication = $authentication;
+        $this->config = $config;
     }
 
     /**
@@ -236,6 +245,7 @@ class IndexController extends Controller
             'styles' => $styles,
             'noScripts' => $noScripts,
             'divs' => $divs,
+            'errorCaptureEnabled' => $this->config->get('errorCaptureEnabled')
         ];
 
         return $options;

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -13,6 +13,7 @@ class Config
         'cas_authentication_verify_ssl',
         'enable_tracking',
         'requireSecureConnection',
+        'errorCaptureEnabled',
     ];
 
     /**

--- a/templates/index/webindex.html.twig
+++ b/templates/index/webindex.html.twig
@@ -11,6 +11,7 @@
  * - $styles:  Array of style tags to create
  * - $noScripts:  Array of noscript tags to create
  * - $divs:  Array of divs to create
+ * - $errorCaptureEnabled:  Boolean global errorCaptureEnabled option
  */
 #}
 
@@ -20,8 +21,9 @@
     {% for m in metas %}
         <meta {% if m.httpequiv %} http-equiv="{{ m.httpequiv }}" {% endif %} {% if m.charset %} charset="{{ m.charset }}" {% endif %} {% if m.name %} name="{{ m.name }}" {% endif %} {% if m.content %} content="{{ m.content }}" {% endif %} />
     {% endfor %}
-    <meta name='iliosconfig-api-name-space'content='api/v1'>
-    <meta name='iliosconfig-api-host'content=''>
+    <meta name='iliosconfig-api-name-space' content='api/v1'>
+    <meta name='iliosconfig-api-host' content=''>
+    <meta name='iliosconfig-error-capture-enabled' content="{{ errorCaptureEnabled ? 'true':'false' }}">
     <title>Ilios</title>
 
     {% for s in styles %}

--- a/tests/Service/ConfigTest.php
+++ b/tests/Service/ConfigTest.php
@@ -77,7 +77,7 @@ class ConfigTest extends TestCase
         unset($_ENV[$envKey]);
     }
 
-    public function testConvertsUpercaseStringFalseToBooleanFalse()
+    public function testConvertsUppercaseStringFalseToBooleanFalse()
     {
         $manager = m::mock(ApplicationConfigManager::class);
         $config = new Config($manager);
@@ -90,7 +90,7 @@ class ConfigTest extends TestCase
         unset($_ENV[$envKey]);
     }
 
-    public function testConvertsUpercaseStringTrueToBooleanTrue()
+    public function testConvertsUppercaseStringTrueToBooleanTrue()
     {
         $manager = m::mock(ApplicationConfigManager::class);
         $config = new Config($manager);
@@ -103,7 +103,7 @@ class ConfigTest extends TestCase
         unset($_ENV[$envKey]);
     }
 
-    public function testConvertsUpercaseStringNullToNullNull()
+    public function testConvertsUppercaseStringNullToNullNull()
     {
         $manager = m::mock(ApplicationConfigManager::class);
         $config = new Config($manager);
@@ -115,7 +115,7 @@ class ConfigTest extends TestCase
         unset($_ENV[$envKey]);
     }
 
-    public function testDoesnOverwriteEnvWithServer()
+    public function testDoesNotOverwriteEnvWithServer()
     {
         $manager = m::mock(ApplicationConfigManager::class);
         $config = new Config($manager);


### PR DESCRIPTION
Allows applications to be configured to send errors to the centralized
logging service.