### PR TITLE
show years, not urls in --year option description for ilios:import-mesh-universe command.

### DIFF
--- a/src/Command/ImportMeshUniverseCommand.php
+++ b/src/Command/ImportMeshUniverseCommand.php
@@ -73,7 +73,8 @@ class ImportMeshUniverseCommand extends Command
                 'year',
                 'y',
                 InputOption::VALUE_REQUIRED,
-                'The MeSH descriptors publication year. Acceptable values are '.implode(', ', self::YEARS)
+                'The MeSH descriptors publication year. Acceptable values are '
+                . implode(', ', array_keys(self::YEARS)) . '.'
             );
     }
 


### PR DESCRIPTION
fixes #2300 

```
$ bin/console ilios:import-mesh-universe --help
Description:
  Imports the MeSH universe into Ilios.

Usage:
  ilios:import-mesh-universe [options]
  ilios:maintenance:import-mesh-universe

Options:
  -u, --url=URL         The MeSH descriptors URL.
  -p, --path=PATH       The MeSH descriptors file path.
  -y, --year=YEAR       The MeSH descriptors publication year. Acceptable values are 2017, 2018.
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -e, --env=ENV         The Environment name. [default: "prod"]
      --no-debug        Switches off debug mode.
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

```