### PR TITLE
Don't allow empty term or vocabulary titles

### DIFF
--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -131,7 +131,7 @@ class Term implements TermInterface
     /**
      * @var string
      *
-     * @ORM\Column(type="string", length=200, nullable=true)
+     * @ORM\Column(type="string", length=200, nullable=false)
      *
      * @Assert\NotBlank
      * @Assert\Type(type="string")

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -133,6 +133,7 @@ class Term implements TermInterface
      *
      * @ORM\Column(type="string", length=200, nullable=true)
      *
+     * @Assert\NotBlank
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,

--- a/src/Entity/Vocabulary.php
+++ b/src/Entity/Vocabulary.php
@@ -53,7 +53,7 @@ class Vocabulary implements VocabularyInterface
     /**
      * @var string
      *
-     * @ORM\Column(type="string", length=200, nullable=true)
+     * @ORM\Column(type="string", length=200, nullable=false)
      *
      * @Assert\NotBlank
      * @Assert\Type(type="string")

--- a/src/Entity/Vocabulary.php
+++ b/src/Entity/Vocabulary.php
@@ -55,6 +55,7 @@ class Vocabulary implements VocabularyInterface
      *
      * @ORM\Column(type="string", length=200, nullable=true)
      *
+     * @Assert\NotBlank
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,

--- a/src/Migrations/Version20190201190000.php
+++ b/src/Migrations/Version20190201190000.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190201190000 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql("UPDATE term SET title=CONCAT('(No Title Provided)_', term_id) WHERE title='' OR title IS NULL");
+        $this->addSql("UPDATE vocabulary SET title=CONCAT('(No Title Provided)_', vocabulary_id) WHERE title='' OR title IS NULL");
+        $this->addSql('ALTER TABLE term CHANGE title title VARCHAR(200) NOT NULL');
+        $this->addSql('ALTER TABLE vocabulary CHANGE title title VARCHAR(200) NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE term CHANGE title title VARCHAR(200) DEFAULT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE vocabulary CHANGE title title VARCHAR(200) DEFAULT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -408,6 +408,27 @@ abstract class AbstractEndpointTest extends WebTestCase
     }
 
     /**
+     * Test POSTing bad data to the API
+     * @param array $data
+     * @param int $code
+     */
+    protected function badPutTest(array $data, $id, $code = Response::HTTP_BAD_REQUEST)
+    {
+        $endpoint = $this->getPluralName();
+        $responseKey = $this->getCamelCasedPluralName();
+        $this->createJsonRequest(
+            'PUT',
+            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => $endpoint, 'id' => $id]),
+            json_encode([$responseKey => [$data]]),
+            $this->getAuthenticatedUserToken()
+        );
+
+        $response = $this->client->getResponse();
+
+        $this->assertJsonResponse($response, $code);
+    }
+
+    /**
      * When relational data is sent to the API ensure it
      * is recorded on the non-owning side of the relationship
      *

--- a/tests/Endpoints/TermTest.php
+++ b/tests/Endpoints/TermTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Endpoints;
 
 use App\Tests\ReadWriteEndpointTest;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Term API endpoint Test.
@@ -106,5 +107,20 @@ class TermTest extends ReadWriteEndpointTest
             'terms',
             $postData
         );
+    }
+
+    public function testCannotSaveTermWithEmptyTitle()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->create();
+        $data['title'] = '';
+        $this->createJsonRequest(
+            'POST',
+            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'terms']),
+            json_encode(['term' => $data]),
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+        $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
     }
 }

--- a/tests/Endpoints/TermTest.php
+++ b/tests/Endpoints/TermTest.php
@@ -109,18 +109,35 @@ class TermTest extends ReadWriteEndpointTest
         );
     }
 
-    public function testCannotSaveTermWithEmptyTitle()
+    public function testCannotCreateTermWithEmptyTitle()
     {
         $dataLoader = $this->getDataLoader();
         $data = $dataLoader->create();
         $data['title'] = '';
-        $this->createJsonRequest(
-            'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'terms']),
-            json_encode(['term' => $data]),
-            $this->getAuthenticatedUserToken()
-        );
-        $response = $this->client->getResponse();
-        $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
+        $this->badPostTest($data);
+    }
+
+    public function testCannotCreateTermWithNoTitle()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->create();
+        unset($data['title']);
+        $this->badPostTest($data);
+    }
+
+    public function testCannotSaveTermWithEmptyTitle()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->getOne();
+        $data['title'] = '';
+        $this->badPutTest($data, $data['id']);
+    }
+
+    public function testCannotSaveTermWithNoTitle()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->getOne();
+        unset($data['title']);
+        $this->badPutTest($data, $data['id']);
     }
 }

--- a/tests/Endpoints/VocabularyTest.php
+++ b/tests/Endpoints/VocabularyTest.php
@@ -63,18 +63,35 @@ class VocabularyTest extends ReadWriteEndpointTest
         ];
     }
 
-    public function testCannotSaveVocabularyWithEmptyTitle()
+    public function testCannotCreateWithEmptyTitle()
     {
         $dataLoader = $this->getDataLoader();
         $data = $dataLoader->create();
         $data['title'] = '';
-        $this->createJsonRequest(
-            'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'vocabularies']),
-            json_encode(['vocabulary' => $data]),
-            $this->getAuthenticatedUserToken()
-        );
-        $response = $this->client->getResponse();
-        $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
+        $this->badPostTest($data);
+    }
+
+    public function testCannotCreateWithNoTitle()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->create();
+        unset($data['title']);
+        $this->badPostTest($data);
+    }
+
+    public function testCannotSaveWithEmptyTitle()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->getOne();
+        $data['title'] = '';
+        $this->badPutTest($data, $data['id']);
+    }
+
+    public function testCannotSaveWithNoTitle()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->getOne();
+        unset($data['title']);
+        $this->badPutTest($data, $data['id']);
     }
 }

--- a/tests/Endpoints/VocabularyTest.php
+++ b/tests/Endpoints/VocabularyTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Endpoints;
 
 use App\Tests\ReadWriteEndpointTest;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Vocabulary API endpoint Test.
@@ -60,5 +61,20 @@ class VocabularyTest extends ReadWriteEndpointTest
             'active' => [[0], ['active' => true]],
             'notActive' => [[1], ['active' => false]],
         ];
+    }
+
+    public function testCannotSaveVocabularyWithEmptyTitle()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->create();
+        $data['title'] = '';
+        $this->createJsonRequest(
+            'POST',
+            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'vocabularies']),
+            json_encode(['vocabulary' => $data]),
+            $this->getAuthenticatedUserToken()
+        );
+        $response = $this->client->getResponse();
+        $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
     }
 }


### PR DESCRIPTION
Changes the validations and the DB structure to disallow this.

Fixes #2329 