### PR TITLE
Add PHP 7.3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
   allow_failures:
   exclude:
   - php: '7.2'
+  - php: '7.3'
   include:
   - php: '7.2'
     env: TEST_EVERYTHING_ELSE=true
@@ -22,8 +23,23 @@ matrix:
     env: TEST_PHPUNIT_API5=true
   - php: '7.2'
     env: TEST_CONTAINER_BUILD=true
+  - php: '7.3'
+    env: TEST_EVERYTHING_ELSE=true
+  - php: '7.3'
+    env: TEST_PHPUNIT_API1=true
+  - php: '7.3'
+    env: TEST_PHPUNIT_API2=true
+  - php: '7.3'
+    env: TEST_PHPUNIT_API3=true
+  - php: '7.3'
+    env: TEST_PHPUNIT_API4=true
+  - php: '7.3'
+    env: TEST_PHPUNIT_API5=true
+  - php: '7.3'
+    env: TEST_CONTAINER_BUILD=true
 php:
 - '7.2'
+- '7.3'
 env:
   global:
   - ILIOS_DATABASE_URL=mysql://travis@127.0.0.1/ilios


### PR DESCRIPTION
Start testing against this released version as we're officially
supporting it now.