### PR TITLE
Fixup users and environments in Docker build

### DIFF
--- a/docker/ilios-entrypoint
+++ b/docker/ilios-entrypoint
@@ -3,7 +3,7 @@
 set -e
 
 # We need to warmup the cache in addition to starting apache
-su - www-data -s /bin/sh -c '/var/www/ilios/bin/console cache:warmup'
+sudo -E -u www-data /var/www/ilios/bin/console cache:warmup
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then


### PR DESCRIPTION
Environmental variables do not survive the su -c -s process and I
couldn't see a way to make that work so instead I reorganized our docker
build a bit and added sudo to use in the entrypoint to clear the cache
as the right user