### PR TITLE
Add a monitor to check ILIOS_SECRET

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,6 +126,6 @@ jobs:
   - PHPUnit_api_5
   steps:
     - script: docker build -t ilios-php-apache-test .
-    - script: docker run -d --name ilios-php-apache-test ilios-php-apache-test
+    - script: docker run -d --name ilios-php-apache-test -e "ILIOS_SECRET=TravisSecret" ilios-php-apache-test
     - script: docker ps | grep -q ilios-php-apache-test
     - script: docker exec ilios-php-apache-test php /var/www/ilios/bin/console monitor:health

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -306,5 +306,10 @@ services:
       tags:
       - { name: liip_monitor.check, group: production }
 
+    App\Monitor\NoDefaultSecret:
+      autoconfigure: false
+      tags:
+        - { name: liip_monitor.check, group: default }
+
     League\Flysystem\FilesystemInterface:
       factory: ['@App\Service\FilesystemFactory', getFilesystem]

--- a/src/Monitor/NoDefaultSecret.php
+++ b/src/Monitor/NoDefaultSecret.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Monitor;
+
+use ZendDiagnostics\Check\CheckInterface;
+use ZendDiagnostics\Result\Failure;
+use ZendDiagnostics\Result\ResultInterface;
+use ZendDiagnostics\Result\Success;
+use ZendDiagnostics\Result\Warning;
+
+class NoDefaultSecret implements CheckInterface
+{
+    /**
+     * Perform the actual check and return a ResultInterface
+     *
+     * @return ResultInterface
+     */
+    public function check()
+    {
+        $secret = getenv('ILIOS_SECRET', true);
+        if (!$secret) {
+            return new Warning("'ILIOS_SECRET' is not set");
+        }
+
+        $badSecrets = array_map('strtolower', [
+            'NotSecretChangeMe',
+            'ThisTokenIsNotSoSecretChangeIt',
+            'ST@G1nGS3CRET12345',
+            'PR0DUCT10nS3CRET12345',
+        ]);
+
+        if (in_array(trim(strtolower($secret)), $badSecrets)) {
+            return new Failure(
+                "\nILIOS_SECRET: Set to a ${secret}. This isn't safe and should be changed"
+            );
+        }
+
+        return new Success('ILIOS_SECRET not set do a default value');
+    }
+
+    /**
+     * Return a label describing this test instance.
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return 'No Default Secret';
+    }
+}


### PR DESCRIPTION
We provide several default values for this in code and documentation, we
need to check to be sure those aren't being used.

Fixes #1734