### PR TITLE
Correctly bump API and reset objectives

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,7 +6,7 @@ imports:
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
-    ilios_api_version: v1.35
+    ilios_api_version: v1.36
     ilios_api_valid_endpoints: >-
       aamcmethods,aamcpcrses,aamcresourcetypes,academicyears,applicationconfigs,assessmentoptions,authentications,
       cohorts,competencies,courses,courseclerkshiptypes,courselearningmaterials,curriculuminventoryacademiclevels,curriculuminventoryexports,

--- a/src/Migrations/Version20190307000000.php
+++ b/src/Migrations/Version20190307000000.php
@@ -6,22 +6,17 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
 /**
- * Add active flag to objective table
+ * Reset objective active to true in case it was changed accidentally
  */
-final class Version20190225000000 extends AbstractMigration
+final class Version20190307000000 extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-
-        $this->addSql('ALTER TABLE objective ADD active TINYINT(1) NOT NULL');
         $this->addSql('UPDATE objective SET active=1');
     }
 
     public function down(Schema $schema) : void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-
-        $this->addSql('ALTER TABLE objective DROP active');
     }
 }


### PR DESCRIPTION
This API bump is happening after a release, any changes saved by users
to objectives would have included a null active status which would put
the DB into a state that probably wasn't intended. Changing this back to
active seems less likely to cause issues as any change to inactive would
have been intentional and repeatable.