### PR TITLE
Allow learning materials to be overwritten

### DIFF
--- a/src/Service/IliosFileSystem.php
+++ b/src/Service/IliosFileSystem.php
@@ -58,7 +58,7 @@ class IliosFileSystem
     {
         $relativePath = $this->getLearningMaterialFilePath($file);
         $stream = fopen($file->getPathname(), 'r+');
-        $this->fileSystem->writeStream($relativePath, $stream);
+        $this->fileSystem->putStream($relativePath, $stream);
         fclose($stream);
 
         return $relativePath;

--- a/tests/Service/IliosFileSystemTest.php
+++ b/tests/Service/IliosFileSystemTest.php
@@ -54,7 +54,7 @@ class IliosFileSystemTest extends TestCase
         $path = __FILE__;
         $file = m::mock(File::class)
             ->shouldReceive('getPathname')->andReturn($path)->getMock();
-        $this->fileSystem->shouldReceive('writeStream');
+        $this->fileSystem->shouldReceive('putStream');
         $this->iliosFileSystem->storeLearningMaterialFile($file);
     }
 


### PR DESCRIPTION
The same file can be uploaded many times and it should work, using put
instead of write here allows that to happen.

Fixes ilios/frontend#4421