### PR TITLE
Prevent caching failure responses

### DIFF
--- a/src/Classes/LocalCachingFilesystemDecorator.php
+++ b/src/Classes/LocalCachingFilesystemDecorator.php
@@ -97,10 +97,13 @@ class LocalCachingFilesystemDecorator implements FilesystemInterface
         if ($this->cacheEnabled && $this->cacheFileSystem->has($path)) {
             return $this->cacheFileSystem->read($path);
         }
-        $string = $this->remoteFileSystem->read($path);
-        $this->cacheFileSystem->put($path, $string);
+        $result = $this->remoteFileSystem->read($path);
 
-        return $string;
+        if ($result !== false) {
+            $this->cacheFileSystem->put($path, $result);
+        }
+
+        return $result;
     }
 
     /**
@@ -112,7 +115,11 @@ class LocalCachingFilesystemDecorator implements FilesystemInterface
             return $this->cacheFileSystem->readStream($path);
         }
         $resource = $this->remoteFileSystem->readStream($path);
-        $this->cacheFileSystem->putStream($path, $resource);
+
+        if ($resource !== false) {
+            $this->cacheFileSystem->putStream($path, $resource);
+        }
+
 
         return $resource;
     }

--- a/tests/Classes/LocalCachingFilesystemDecoratorTest.php
+++ b/tests/Classes/LocalCachingFilesystemDecoratorTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace App\Tests\Classes;
+
+use App\Classes\LocalCachingFilesystemDecorator;
+use League\Flysystem\FilesystemInterface;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Mockery as m;
+
+/**
+ * Class LocalCachingFilesystemDecoratorTest
+ * @package App\Tests\Classes
+ */
+class LocalCachingFilesystemDecoratorTest extends TestCase
+{
+    /**
+     * @var m\MockInterface
+     */
+    private $cacheFileSystem;
+
+    /**
+     * @var m\MockInterface
+     */
+    private $remoteFileSystem;
+
+    /**
+     * @var LocalCachingFilesystemDecorator
+     */
+    private $subject;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->cacheFileSystem = m::mock(FilesystemInterface::class);
+        $this->remoteFileSystem = m::mock(FilesystemInterface::class);
+        $this->subject = new LocalCachingFilesystemDecorator(
+            $this->cacheFileSystem,
+            $this->remoteFileSystem
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDown() : void
+    {
+        unset($this->cacheFileSystem);
+        unset($this->remoteFileSystem);
+        unset($this->subject);
+    }
+
+    public function testReadDoesNotCacheFailures()
+    {
+        $path = __FILE__;
+        $this->remoteFileSystem->shouldReceive('read')->with($path)->andReturn(false);
+        $this->cacheFileSystem->shouldReceive('has')->with($path)->andReturn(false);
+        $this->cacheFileSystem->shouldNotReceive('put');
+
+        $result = $this->subject->read($path);
+        $this->assertFalse($result);
+    }
+
+    public function testReadStreamDoesNotCacheFailures()
+    {
+        $path = __FILE__;
+        $this->remoteFileSystem->shouldReceive('readStream')->with($path)->andReturn(false);
+        $this->cacheFileSystem->shouldReceive('has')->with($path)->andReturn(false);
+        $this->cacheFileSystem->shouldNotReceive('putStream');
+
+        $result = $this->subject->readStream($path);
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
If the remote file system returned false we were caching that, php
turned it into a string and we stored it to return to users.