### PR TITLE
Switch mockery back to stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
   "require-dev": {
     "fzaninotto/faker": "@stable",
     "liip/test-fixtures-bundle": "~1.0.0-RC1",
-    "mockery/mockery": "1.2.0",
+    "mockery/mockery": "@stable",
     "squizlabs/php_codesniffer": "@stable",
     "symfony/debug-pack": "^1.0",
     "symfony/profiler-pack": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9f50f8d2c0319d8395e423bdea0f9d0",
+    "content-hash": "754d16aaa645322397b256b3ba39fd99",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.100.6",
+            "version": "3.100.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "4b3732bfc8c60e5c816dd3b1175b5a7f7231d98d"
+                "reference": "25233e0cde3fe5e5723c136c6ac66fb7c66e9115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4b3732bfc8c60e5c816dd3b1175b5a7f7231d98d",
-                "reference": "4b3732bfc8c60e5c816dd3b1175b5a7f7231d98d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/25233e0cde3fe5e5723c136c6ac66fb7c66e9115",
+                "reference": "25233e0cde3fe5e5723c136c6ac66fb7c66e9115",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-06-18T18:13:15+00:00"
+            "time": "2019-06-19T19:57:46+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -8432,16 +8432,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "100633629bf76d57430b86b7098cd6beb996a35a"
+                "reference": "0eb0b48c3f07b3b89f5169ce005b7d05b18cf1d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/100633629bf76d57430b86b7098cd6beb996a35a",
-                "reference": "100633629bf76d57430b86b7098cd6beb996a35a",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/0eb0b48c3f07b3b89f5169ce005b7d05b18cf1d2",
+                "reference": "0eb0b48c3f07b3b89f5169ce005b7d05b18cf1d2",
                 "shasum": ""
             },
             "require": {
@@ -8450,7 +8450,7 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5.7.10|~6.5|~7.0"
+                "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
             },
             "type": "library",
             "extra": {
@@ -8493,7 +8493,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2018-10-02T21:52:37+00:00"
+            "time": "2019-02-13T09:37:52+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -9264,6 +9264,7 @@
         "firebase/php-jwt": 0,
         "fzaninotto/faker": 0,
         "liip/test-fixtures-bundle": 5,
+        "mockery/mockery": 0,
         "squizlabs/php_codesniffer": 0
     },
     "prefer-stable": false,

--- a/tests/Classes/SessionUserTest.php
+++ b/tests/Classes/SessionUserTest.php
@@ -6,8 +6,8 @@ use App\Classes\SessionUser;
 use App\Entity\Manager\UserManager;
 use App\Entity\School;
 use App\Entity\UserInterface;
+use App\Tests\TestCase;
 use Mockery as m;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
 /**
  * Class SessionUserTest
@@ -15,8 +15,6 @@ use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
  */
 class SessionUserTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /**
      * @var m\MockInterface
      */

--- a/tests/Controller/DirectoryControllerTest.php
+++ b/tests/Controller/DirectoryControllerTest.php
@@ -9,7 +9,7 @@ use App\Entity\Manager\UserManager;
 use App\Entity\UserInterface;
 use App\Service\Directory;
 use App\Controller\DirectoryController;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use App\Tests\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Mockery as m;
@@ -19,8 +19,6 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class DirectoryControllerTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /**
      * @var DirectoryController
      */

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -6,7 +6,7 @@ use App\Classes\SessionUserInterface;
 use App\Controller\Search;
 use App\Service\PermissionChecker;
 use App\Service\Search as SearchService;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use App\Tests\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Mockery as m;
@@ -16,8 +16,6 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class SearchControllerTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /**
      * @var Search
      */

--- a/tests/Entity/Manager/CurriculumInventoryReportManagerTest.php
+++ b/tests/Entity/Manager/CurriculumInventoryReportManagerTest.php
@@ -15,8 +15,6 @@ use App\Tests\TestCase;
  */
 class CurriculumInventoryReportManagerTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /**
      * @var m\MockInterface
      */

--- a/tests/RelationshipVoter/AbstractBase.php
+++ b/tests/RelationshipVoter/AbstractBase.php
@@ -3,15 +3,13 @@ namespace App\Tests\RelationshipVoter;
 
 use App\Classes\SessionUserInterface;
 use App\RelationshipVoter\AbstractVoter;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use App\Tests\TestCase;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class AbstractBase extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /** @var  m\MockInterface */
     protected $permissionChecker;
 

--- a/tests/Service/AuthenticationFactoryTest.php
+++ b/tests/Service/AuthenticationFactoryTest.php
@@ -6,14 +6,13 @@ use App\Service\FormAuthentication;
 use App\Service\LdapAuthentication;
 use App\Service\ShibbolethAuthentication;
 use App\Service\Config;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use App\Tests\TestCase;
 use Mockery as m;
 
 use App\Service\AuthenticationFactory;
 
 class AuthenticationFactoryTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     protected $config;
     protected $cas;
     protected $form;

--- a/tests/Service/ChangeAlertHandlerTest.php
+++ b/tests/Service/ChangeAlertHandlerTest.php
@@ -4,10 +4,7 @@ namespace App\Tests\Service;
 use App\Entity\Alert;
 use App\Entity\AlertChangeType;
 use App\Entity\AlertChangeTypeInterface;
-use App\Entity\AlertInterface;
 use App\Entity\Course;
-use App\Entity\InstructorGroup;
-use App\Entity\LearnerGroup;
 use App\Entity\Manager\AlertChangeTypeManager;
 use App\Entity\Manager\AlertManager;
 use App\Entity\Manager\UserManager;
@@ -25,8 +22,6 @@ use App\Tests\TestCase;
  */
 class ChangeAlertHandlerTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /**
      * @var m\MockInterface
      */

--- a/tests/Service/ConfigTest.php
+++ b/tests/Service/ConfigTest.php
@@ -13,8 +13,6 @@ use function Stringy\create as s;
  */
 class ConfigTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     public function testPullsFromENVFirst()
     {
         $manager = m::mock(ApplicationConfigManager::class);

--- a/tests/Service/CurriculumInventory/Export/AggregatorTest.php
+++ b/tests/Service/CurriculumInventory/Export/AggregatorTest.php
@@ -8,7 +8,7 @@ use App\Entity\Manager\CurriculumInventoryReportManager;
 use App\Entity\Program;
 use App\Service\Config;
 use App\Service\CurriculumInventory\Export\Aggregator;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use App\Tests\TestCase;
 use Mockery as m;
 
 /**
@@ -17,8 +17,6 @@ use Mockery as m;
  */
 class AggregatorTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /**
      * @var m\MockInterface
      */

--- a/tests/Service/CurriculumInventory/ExporterTest.php
+++ b/tests/Service/CurriculumInventory/ExporterTest.php
@@ -4,8 +4,8 @@ namespace App\Tests\Service\CurriculumInventory;
 use App\Service\CurriculumInventory\Export\Aggregator;
 use App\Service\CurriculumInventory\Export\XmlPrinter;
 use App\Service\CurriculumInventory\Exporter;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
+use App\Tests\TestCase;
 use Mockery as m;
 
 /**
@@ -13,8 +13,6 @@ use Mockery as m;
  */
 class ExporterTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /**
      * @covers \App\Service\CurriculumInventory\Exporter::__construct
      */

--- a/tests/Service/DefaultPermissionMatrixTest.php
+++ b/tests/Service/DefaultPermissionMatrixTest.php
@@ -7,8 +7,8 @@ use App\Classes\UserRoles;
 use App\Service\DefaultPermissionMatrix;
 use App\Entity\DTO\SchoolDTO;
 use App\Entity\Manager\SchoolManager;
+use App\Tests\TestCase;
 use Mockery as m;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
 /**
  * Class DefaultPermissionMatrixTest
@@ -17,8 +17,6 @@ use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
  */
 class DefaultPermissionMatrixTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /**
      * @var DefaultPermissionMatrix
      */

--- a/tests/Service/DirectoryTest.php
+++ b/tests/Service/DirectoryTest.php
@@ -10,8 +10,6 @@ use App\Tests\TestCase;
 
 class DirectoryTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     protected $ldapManager;
     protected $config;
     protected $obj;

--- a/tests/Service/FilesystemFactoryTest.php
+++ b/tests/Service/FilesystemFactoryTest.php
@@ -5,15 +5,12 @@ namespace App\Tests\Service;
 use App\Classes\LocalCachingFilesystemDecorator;
 use App\Service\Config;
 use App\Service\FilesystemFactory;
-use League\Flysystem\Adapter\Local;
+use App\Tests\TestCase;
 use League\Flysystem\FilesystemInterface;
 use Mockery as m;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
 class FilesystemFactoryTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /** @var m\Mock */
     private $config;
 

--- a/tests/Service/FormAuthenticationTest.php
+++ b/tests/Service/FormAuthenticationTest.php
@@ -7,7 +7,7 @@ use App\Service\SessionUserProvider;
 use App\Entity\Manager\AuthenticationManager;
 use App\Entity\Manager\UserManager;
 use App\Entity\UserInterface;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use App\Tests\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Mockery as m;
 
@@ -17,8 +17,6 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 class FormAuthenticationTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     protected $authManager;
     protected $userManager;
     protected $encoder;

--- a/tests/Service/IliosFileSystemTest.php
+++ b/tests/Service/IliosFileSystemTest.php
@@ -2,7 +2,6 @@
 namespace App\Tests\Service;
 
 use App\Entity\LearningMaterialInterface;
-use App\Service\Config;
 use League\Flysystem\Filesystem;
 use Mockery as m;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFileSystem;
@@ -13,7 +12,6 @@ use App\Tests\TestCase;
 
 class IliosFileSystemTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     /**
      *
      * @var IliosFileSystem

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -8,15 +8,13 @@ use App\Entity\DTO\CourseDTO;
 use App\Entity\DTO\UserDTO;
 use App\Entity\User;
 use App\Service\Index;
+use App\Tests\TestCase;
 use Elasticsearch\Client;
 use Ilios\MeSH\Model\Descriptor;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Mockery as m;
 
 class IndexTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     public function testSetup()
     {
         $obj1 = $this->createWithHost();

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -4,7 +4,7 @@ namespace App\Tests\Service;
 use App\Classes\SessionUserInterface;
 use App\Service\PermissionChecker;
 use App\Service\SessionUserProvider;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use App\Tests\TestCase;
 use Firebase\JWT\JWT;
 use DateTime;
 use Mockery as m;
@@ -13,8 +13,6 @@ use App\Service\JsonWebTokenManager;
 
 class JsonWebTokenManagerTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /** @var JsonWebTokenManager */
     protected $obj;
     protected $permissionChecker;

--- a/tests/Service/LdapAuthenticationTest.php
+++ b/tests/Service/LdapAuthenticationTest.php
@@ -8,7 +8,7 @@ use App\Entity\AuthenticationInterface;
 use App\Entity\Manager\AuthenticationManager;
 use App\Entity\UserInterface;
 use App\Service\Config;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use App\Tests\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Mockery as m;
 
@@ -17,8 +17,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class LdapAuthenticationTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     protected $authManager;
     protected $jwtManager;
     protected $sessionUserProvider;

--- a/tests/Service/LdapManagerTest.php
+++ b/tests/Service/LdapManagerTest.php
@@ -2,14 +2,12 @@
 namespace App\Tests\Service;
 
 use App\Service\Config;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use App\Service\LdapManager;
+use App\Tests\TestCase;
 use Mockery as m;
 
 class LdapManagerTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     public function testConstructor()
     {
         $config = m::mock(Config::class);

--- a/tests/Service/LoggerQueueTest.php
+++ b/tests/Service/LoggerQueueTest.php
@@ -12,8 +12,6 @@ use App\Tests\TestCase;
  */
 class LoggerQueueTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     public function testFlush()
     {
         $action = 'create';

--- a/tests/Service/PermissionCheckerTest.php
+++ b/tests/Service/PermissionCheckerTest.php
@@ -6,15 +6,13 @@ use App\Classes\Capabilities;
 use App\Classes\PermissionMatrixInterface;
 use App\Classes\SessionUserInterface;
 use App\Service\PermissionChecker;
-use App\Entity\CohortInterface;
 use App\Entity\CourseInterface;
 use App\Entity\ProgramInterface;
 use App\Entity\ProgramYearInterface;
-use App\Entity\SchoolConfigInterface;
 use App\Entity\SchoolInterface;
 use App\Entity\SessionInterface;
+use App\Tests\TestCase;
 use Mockery as m;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
 /**
  * Class PermissionCheckerTest
@@ -22,8 +20,6 @@ use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
  */
 class PermissionCheckerTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     /**
      * @var PermissionChecker
      */

--- a/tests/Service/SearchTest.php
+++ b/tests/Service/SearchTest.php
@@ -1,16 +1,13 @@
 <?php
 namespace App\Tests\Service;
 
-use App\Service\Config;
 use App\Service\Search;
+use App\Tests\TestCase;
 use Elasticsearch\Client;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Mockery as m;
 
 class SearchTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     public function testSetup()
     {
         $obj1 = $this->createWithHost();

--- a/tests/Service/ShibbolethAuthenticationTest.php
+++ b/tests/Service/ShibbolethAuthenticationTest.php
@@ -8,8 +8,8 @@ use App\Entity\AuthenticationInterface;
 use App\Entity\Manager\AuthenticationManager;
 use App\Entity\UserInterface;
 use App\Service\Config;
+use App\Tests\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Mockery as m;
 
@@ -21,8 +21,6 @@ use Symfony\Component\HttpFoundation\ServerBag;
 
 class ShibbolethAuthenticationTest extends TestCase
 {
-    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     protected $authManager;
     protected $jwtManager;
     protected $logger;


### PR DESCRIPTION
Unlocking this dependency to get back to regular updates.

Hoping a dependency update has fixed this issue, otherwise this PR will be a reminder to investigate.