### PR TITLE
Add course id to events

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,7 +6,7 @@ imports:
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
-    ilios_api_version: v1.36
+    ilios_api_version: v1.37
     ilios_api_valid_endpoints: >-
       aamcmethods,aamcpcrses,aamcresourcetypes,academicyears,applicationconfigs,assessmentoptions,authentications,
       cohorts,competencies,courses,courseclerkshiptypes,courselearningmaterials,curriculuminventoryacademiclevels,curriculuminventoryexports,

--- a/src/Classes/CalendarEvent.php
+++ b/src/Classes/CalendarEvent.php
@@ -151,8 +151,10 @@ class CalendarEvent
 
     /**
      * @var int
+     * @IS\Expose
+     * @IS\Type("integer")
      */
-    public $courseId;
+    public $course;
 
     /**
      * @var string

--- a/src/Traits/CalendarEventRepository.php
+++ b/src/Traits/CalendarEventRepository.php
@@ -50,7 +50,7 @@ trait CalendarEventRepository
         $event->sessionDescription = $arr['sessionDescription'];
         $event->instructionalNotes = $arr['instructionalNotes'];
         $event->session = $arr['sessionId'];
-        $event->courseId = $arr['courseId'];
+        $event->course = $arr['courseId'];
         $event->attireRequired = $arr['attireRequired'];
         $event->equipmentRequired = $arr['equipmentRequired'];
         $event->supplemental = $arr['supplemental'];
@@ -95,7 +95,7 @@ trait CalendarEventRepository
         $event->courseExternalId = $arr['courseExternalId'];
         $event->sessionDescription = $arr['sessionDescription'];
         $event->session = $arr['sessionId'];
-        $event->courseId = $arr['courseId'];
+        $event->course = $arr['courseId'];
         $event->attireRequired = $arr['attireRequired'];
         $event->equipmentRequired = $arr['equipmentRequired'];
         $event->supplemental = $arr['supplemental'];
@@ -245,7 +245,7 @@ trait CalendarEventRepository
     public function attachSessionDataToEvents(array $events, EntityManager $em)
     {
         $sessionIds = array_unique(array_column($events, 'session'));
-        $courseIds = array_unique(array_column($events, 'courseId'));
+        $courseIds = array_unique(array_column($events, 'course'));
         $competencyIds = [];
 
         $qb = $em->createQueryBuilder();
@@ -364,8 +364,8 @@ trait CalendarEventRepository
             if (array_key_exists($event->session, $sessionObjectives)) {
                 $event->sessionObjectives = array_values($sessionObjectives[$event->session]);
             }
-            if (array_key_exists($event->courseId, $courseObjectives)) {
-                $event->courseObjectives = array_values($courseObjectives[$event->courseId]);
+            if (array_key_exists($event->course, $courseObjectives)) {
+                $event->courseObjectives = array_values($courseObjectives[$event->course]);
             }
 
             $listsOfCompetencyIds = array_merge(
@@ -456,7 +456,7 @@ trait CalendarEventRepository
         for ($i =0, $n = count($events); $i < $n; $i++) {
             $event = $events[$i];
             $sessionId = $event->session;
-            $courseId = $event->courseId;
+            $courseId = $event->course;
             $sessionLms = array_key_exists($sessionId, $groupedSessionLms) ? $groupedSessionLms[$sessionId] : [];
             $courseLms = array_key_exists($courseId, $groupedCourseLms) ? $groupedCourseLms[$courseId] : [];
             $lms = array_merge($sessionLms, $courseLms);

--- a/tests/Classes/SessionEventTest.php
+++ b/tests/Classes/SessionEventTest.php
@@ -23,7 +23,7 @@ class SchoolEventTest extends TestCase
         $calendarEvent->attireRequired = true;
         $calendarEvent->color = '#fff';
         $calendarEvent->courseExternalId = 12;
-        $calendarEvent->courseId = 17;
+        $calendarEvent->course = 17;
         $calendarEvent->courseTitle = 'Test Event';
         $calendarEvent->endDate = new \DateTime();
         $calendarEvent->equipmentRequired = true;
@@ -38,6 +38,7 @@ class SchoolEventTest extends TestCase
         $this->assertSame($calendarEvent->color, $schoolEvent->color);
         $this->assertSame($calendarEvent->courseExternalId, $schoolEvent->courseExternalId);
         $this->assertSame($calendarEvent->courseTitle, $schoolEvent->courseTitle);
+        $this->assertSame($calendarEvent->course, $schoolEvent->course);
         $this->assertSame($calendarEvent->endDate, $schoolEvent->endDate);
         $this->assertSame($calendarEvent->equipmentRequired, $schoolEvent->equipmentRequired);
         $this->assertSame($calendarEvent->instructionalNotes, $schoolEvent->instructionalNotes);

--- a/tests/Classes/UserEventTest.php
+++ b/tests/Classes/UserEventTest.php
@@ -67,7 +67,7 @@ class UserEventTest extends TestCase
         $calendarEvent->attireRequired = true;
         $calendarEvent->color = '#fff';
         $calendarEvent->courseExternalId = 12;
-        $calendarEvent->courseId = 17;
+        $calendarEvent->course = 17;
         $calendarEvent->courseTitle = 'Test Event';
         $calendarEvent->endDate = new \DateTime();
         $calendarEvent->equipmentRequired = true;
@@ -82,6 +82,7 @@ class UserEventTest extends TestCase
         $this->assertSame($calendarEvent->color, $userEvent->color);
         $this->assertSame($calendarEvent->courseExternalId, $userEvent->courseExternalId);
         $this->assertSame($calendarEvent->courseTitle, $userEvent->courseTitle);
+        $this->assertSame($calendarEvent->course, $userEvent->course);
         $this->assertSame($calendarEvent->endDate, $userEvent->endDate);
         $this->assertSame($calendarEvent->equipmentRequired, $userEvent->equipmentRequired);
         $this->assertSame($calendarEvent->instructionalNotes, $userEvent->instructionalNotes);

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -116,6 +116,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[0]['startDate'], $offerings[2]['startDate']);
         $this->assertEquals($events[0]['endDate'], $offerings[2]['endDate']);
         $this->assertEquals($events[0]['courseTitle'], $courses[0]['title']);
+        $this->assertEquals($events[0]['course'], $courses[0]['id']);
         $this->assertTrue($events[0]['attireRequired'], 'attireRequired is correct for event 0');
         $this->assertTrue($events[0]['equipmentRequired'], 'equipmentRequired is correct for event 0');
         $this->assertTrue($events[0]['supplemental'], 'supplemental is correct for event 0');
@@ -154,6 +155,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[1]['startDate'], $offerings[3]['startDate']);
         $this->assertEquals($events[1]['endDate'], $offerings[3]['endDate']);
         $this->assertEquals($events[1]['courseTitle'], $courses[0]['title']);
+        $this->assertEquals($events[1]['course'], $courses[0]['id']);
         $this->assertTrue($events[1]['attireRequired'], 'attireRequired is correct for event 1');
         $this->assertTrue($events[1]['equipmentRequired'], 'equipmentRequired is correct for event 1');
         $this->assertTrue($events[1]['supplemental'], 'supplemental is correct for event 1');
@@ -178,6 +180,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[2]['startDate'], $offerings[4]['startDate']);
         $this->assertEquals($events[2]['endDate'], $offerings[4]['endDate']);
         $this->assertEquals($events[2]['courseTitle'], $courses[0]['title']);
+        $this->assertEquals($events[2]['course'], $courses[0]['id']);
         $this->assertTrue($events[2]['attireRequired'], 'attireRequired is correct for event 2');
         $this->assertTrue($events[2]['equipmentRequired'], 'equipmentRequired is correct for event 2');
         $this->assertTrue($events[2]['supplemental'], 'supplemental is correct for event 2');
@@ -201,6 +204,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[3]['startDate'], $offerings[5]['startDate']);
         $this->assertEquals($events[3]['endDate'], $offerings[5]['endDate']);
         $this->assertEquals($events[3]['courseTitle'], $courses[1]['title']);
+        $this->assertEquals($events[3]['course'], $courses[1]['id']);
         $this->assertFalse($events[3]['attireRequired'], 'attireRequired is correct for event 3');
         $this->assertFalse($events[3]['equipmentRequired'], 'equipmentRequired is correct for event 3');
         $this->assertTrue($events[3]['supplemental'], 'supplemental is correct for event 3');
@@ -225,6 +229,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate']);
         $this->assertEquals($events[4]['endDate'], $offerings[6]['endDate']);
         $this->assertEquals($events[4]['courseTitle'], $courses[1]['title']);
+        $this->assertEquals($events[4]['course'], $courses[1]['id']);
         $this->assertFalse($events[4]['attireRequired'], 'attireRequired is correct for event 4');
         $this->assertFalse($events[4]['equipmentRequired'], 'equipmentRequired is correct for event 4');
         $this->assertTrue($events[4]['supplemental'], 'supplemental is correct for event 4');
@@ -248,6 +253,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[5]['ilmSession'], 1);
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate']);
         $this->assertEquals($events[5]['courseTitle'], $courses[1]['title']);
+        $this->assertEquals($events[5]['course'], $courses[1]['id']);
         $this->assertFalse($events[5]['attireRequired'], 'attireRequired is correct for event 5');
         $this->assertFalse($events[5]['equipmentRequired'], 'equipmentRequired is correct for event 5');
         $this->assertFalse($events[5]['supplemental'], 'supplemental is correct for event 5');
@@ -264,6 +270,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[6]['ilmSession'], 2);
         $this->assertEquals($events[6]['startDate'], $ilmSessions[1]['dueDate']);
         $this->assertEquals($events[6]['courseTitle'], $courses[1]['title']);
+        $this->assertEquals($events[6]['course'], $courses[1]['id']);
         $this->assertFalse($events[6]['attireRequired'], 'attireRequired is correct for event 6');
         $this->assertFalse($events[6]['equipmentRequired'], 'equipmentRequired is correct for event 6');
         $this->assertFalse($events[6]['supplemental'], 'supplemental is correct for event 6');
@@ -280,6 +287,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[7]['ilmSession'], 3);
         $this->assertEquals($events[7]['startDate'], $ilmSessions[2]['dueDate']);
         $this->assertEquals($events[7]['courseTitle'], $courses[1]['title']);
+        $this->assertEquals($events[7]['course'], $courses[1]['id']);
         $this->assertFalse($events[7]['attireRequired'], 'attireRequired is correct for event 7');
         $this->assertFalse($events[7]['equipmentRequired'], 'equipmentRequired is correct for event 7');
         $this->assertFalse($events[7]['supplemental'], 'supplemental is correct for event 7');
@@ -296,6 +304,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[8]['ilmSession'], 4);
         $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate']);
         $this->assertEquals($events[8]['courseTitle'], $courses[1]['title']);
+        $this->assertEquals($events[8]['course'], $courses[1]['id']);
         $this->assertFalse($events[8]['attireRequired'], 'attireRequired is correct for event 8');
         $this->assertFalse($events[8]['equipmentRequired'], 'equipmentRequired is correct for event 8');
         $this->assertFalse($events[8]['supplemental'], 'supplemental is correct for event 8');
@@ -313,6 +322,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate']);
         $this->assertEquals($events[9]['endDate'], $offerings[0]['endDate']);
         $this->assertEquals($events[9]['courseTitle'], $courses[0]['title']);
+        $this->assertEquals($events[9]['course'], $courses[0]['id']);
         $this->assertFalse($events[9]['attireRequired'], 'attireRequired is correct for event 9');
         $this->assertArrayNotHasKey('equipmentRequired', $events[9], 'equipmentRequired is correct for event 9');
         $this->assertFalse($events[9]['supplemental'], 'supplemental is correct for event 9');
@@ -358,6 +368,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($events[10]['startDate'], $offering->getStartDate()->format('c'));
         $this->assertEquals($events[10]['endDate'], $offering->getEndDate()->format('c'));
         $this->assertEquals($events[10]['courseTitle'], $courses[1]['title']);
+        $this->assertEquals($events[10]['course'], $courses[1]['id']);
         $this->assertFalse($events[10]['attireRequired'], 'attireRequired is correct for event 10');
         $this->assertFalse($events[10]['equipmentRequired'], 'equipmentRequired is correct for event 10');
         $this->assertTrue($events[10]['supplemental'], 'supplemental is correct for event 10');

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -155,6 +155,7 @@ class UsereventTest extends AbstractEndpointTest
             'endDate is correct for event 0'
         );
         $this->assertEquals($events[0]['courseTitle'], $courses[0]['title'], 'title is correct for event 0');
+        $this->assertEquals($events[0]['course'], $courses[0]['id'], 'id is correct for event 0');
         $this->assertEquals(
             $events[0]['courseExternalId'],
             $courses[0]['externalId'],
@@ -210,6 +211,7 @@ class UsereventTest extends AbstractEndpointTest
         );
         $this->assertEquals($events[1]['endDate'], $offerings[3]['endDate'], 'endDate is correct for event 1');
         $this->assertEquals($events[1]['courseTitle'], $courses[0]['title'], 'title is correct for event 1');
+        $this->assertEquals($events[1]['course'], $courses[0]['id'], 'id is correct for event 1');
         $this->assertEquals(
             $events[1]['courseExternalId'],
             $courses[0]['externalId'],
@@ -264,6 +266,7 @@ class UsereventTest extends AbstractEndpointTest
         );
         $this->assertEquals($events[2]['endDate'], $offerings[4]['endDate'], 'endDate is correct for event 2');
         $this->assertEquals($events[2]['courseTitle'], $courses[0]['title'], 'title is correct for event 2');
+        $this->assertEquals($events[2]['course'], $courses[0]['id'], 'id is correct for event 2');
         $this->assertEquals(
             $events[2]['courseExternalId'],
             $courses[0]['externalId'],
@@ -314,6 +317,7 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEquals($events[3]['startDate'], $offerings[5]['startDate'], 'startDate is correct for event 3');
         $this->assertEquals($events[3]['endDate'], $offerings[5]['endDate'], 'endDate is correct for event 3');
         $this->assertEquals($events[3]['courseTitle'], $courses[1]['title'], 'title is correct for event 3');
+        $this->assertEquals($events[3]['course'], $courses[1]['id'], 'id is correct for event 3');
         $this->assertEquals(
             $events[3]['courseExternalId'],
             $courses[1]['externalId'],
@@ -362,6 +366,7 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate'], 'startDate is correct for event 4');
         $this->assertEquals($events[4]['endDate'], $offerings[6]['endDate'], 'endDate is correct for event 4');
         $this->assertEquals($events[4]['courseTitle'], $courses[1]['title'], 'title is correct for event 4');
+        $this->assertEquals($events[4]['course'], $courses[1]['id'], 'id is correct for event 4');
         $this->assertEquals(
             $events[4]['courseExternalId'],
             $courses[1]['externalId'],
@@ -409,6 +414,7 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEquals($events[5]['ilmSession'], 1, 'ilmSession is correct for 5');
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate'], 'dueDate is correct for 5');
         $this->assertEquals($events[5]['courseTitle'], $courses[1]['title'], 'title is correct for 5');
+        $this->assertEquals($events[5]['course'], $courses[1]['id'], 'id is correct for 5');
         $this->assertEquals(
             $events[5]['courseExternalId'],
             $courses[1]['externalId'],
@@ -448,7 +454,8 @@ class UsereventTest extends AbstractEndpointTest
 
         $this->assertEquals($events[6]['ilmSession'], 2, 'ilmSession is correct for event 6');
         $this->assertEquals($events[6]['startDate'], $ilmSessions[1]['dueDate'], 'dueDate is correct for event 6');
-        $this->assertEquals($events[6]['courseTitle'], $courses[1]['title'], 'ilmSession is correct for event 6');
+        $this->assertEquals($events[6]['courseTitle'], $courses[1]['title'], 'title is correct for event 6');
+        $this->assertEquals($events[6]['course'], $courses[1]['id'], 'id is correct for event 6');
         $this->assertEquals(
             $events[6]['courseExternalId'],
             $courses[1]['externalId'],
@@ -488,6 +495,7 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEquals($events[7]['ilmSession'], 3, 'ilmSession is correct for event 7');
         $this->assertEquals($events[7]['startDate'], $ilmSessions[2]['dueDate'], 'dueDate is correct for event 7');
         $this->assertEquals($events[7]['courseTitle'], $courses[1]['title'], 'title is correct for event 7');
+        $this->assertEquals($events[7]['course'], $courses[1]['id'], 'id is correct for event 7');
         $this->assertEquals(
             $events[7]['courseExternalId'],
             $courses[1]['externalId'],
@@ -527,6 +535,7 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEquals($events[8]['ilmSession'], 4, 'ilmSession is correct for event 8');
         $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate'], 'dueDate is correct for event 8');
         $this->assertEquals($events[8]['courseTitle'], $courses[1]['title'], 'title is correct for event 8');
+        $this->assertEquals($events[8]['course'], $courses[1]['id'], 'id is correct for event 8');
         $this->assertEquals(
             $events[8]['courseExternalId'],
             $courses[1]['externalId'],
@@ -569,6 +578,11 @@ class UsereventTest extends AbstractEndpointTest
             $events[9]['sessionTypeTitle'],
             $sessionTypes[0]['title'],
             'session type title is correct for event 9'
+        );
+        $this->assertEquals(
+            $events[9]['course'],
+            $courses[0]['id'],
+            'course id correct for event 9'
         );
         $this->assertEquals(
             $events[9]['courseExternalId'],
@@ -635,6 +649,11 @@ class UsereventTest extends AbstractEndpointTest
             $events[10]['instructionalNotes'],
             $sessions[2]['instructionalNotes'],
             'instructional notes is correct for event 10'
+        );
+        $this->assertEquals(
+            $events[10]['course'],
+            $courses[1]['id'],
+            'course id correct for event 10'
         );
         $this->assertEquals(
             $events[10]['courseExternalId'],


### PR DESCRIPTION
Since students cannot access a session we need a way to get to the
course id without loading the session first.

Needed for https://github.com/ilios/common/pull/650