### PR TITLE
Include display name in user search

### DIFF
--- a/src/Entity/Repository/UserRepository.php
+++ b/src/Entity/Repository/UserRepository.php
@@ -61,6 +61,7 @@ class UserRepository extends EntityRepository implements DTORepositoryInterface
                 $qb->expr()->like('u.firstName', "?{$key}"),
                 $qb->expr()->like('u.lastName', "?{$key}"),
                 $qb->expr()->like('u.middleName', "?{$key}"),
+                $qb->expr()->like('u.displayName', "?{$key}"),
                 $qb->expr()->like('u.email', "?{$key}"),
                 $qb->expr()->like('u.preferredEmail', "?{$key}"),
                 $qb->expr()->like('u.campusId', "?{$key}"),

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -29,6 +29,7 @@ class Index extends ElasticSearchBase
                 'firstName' => $user->firstName,
                 'lastName' => $user->lastName,
                 'middleName' => $user->middleName,
+                'displayName' => $user->displayName,
                 'email' => $user->email,
                 'campusId' => $user->campusId,
                 'username' => $user->username,

--- a/tests/DataLoader/UserData.php
+++ b/tests/DataLoader/UserData.php
@@ -53,7 +53,7 @@ class UserData extends AbstractDataLoader
             'lastName' => 'first',
             'middleName' => 'first',
             'firstName' => 'first',
-            'displayName' => $this->faker->name,
+            'displayName' => 'disnom',
             'email' => 'first@example.com',
             'preferredEmail' => $this->faker->email,
             'phone' => '415-555-0123',

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -162,6 +162,7 @@ class UserTest extends ReadWriteEndpointTest
             ['newuser', [1]],
             ['1111@school', [0]],
             ['', [0, 1, 2, 3, 4]],
+            ['disnom', [1]],
         ];
     }
 


### PR DESCRIPTION
For both DB and elastic searches the display name needs to be included
for a match.