### PR TITLE
Remove types from our search index

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         volumes:
             - ./:/var/www/ilios:delegated
     elasticsearch:
-        image: elasticsearch:6.5.4
+        image: elasticsearch:6.7.1
         environment:
             - http.cors.enabled=true
             - http.cors.allow-origin=http://localhost:1358

--- a/src/Classes/ElasticSearchBase.php
+++ b/src/Classes/ElasticSearchBase.php
@@ -18,9 +18,10 @@ class ElasticSearchBase
      */
     protected $enabled = false;
 
-    const COURSE_INDEX = 'ilios-public-courses';
-    const MESH_INDEX = 'ilios-public-mesh';
-    const USER_INDEX = 'ilios-private-users';
+    const PUBLIC_CURRICULUM_INDEX = 'ilios-public-curriculum';
+    const PRIVATE_USER_INDEX = 'ilios-private-users';
+    const PUBLIC_MESH_INDEX = 'ilios-public-mesh';
+    const SESSION_ID_PREFIX = 'session_';
 
     /**
      * Search constructor.

--- a/src/Classes/IndexableCourse.php
+++ b/src/Classes/IndexableCourse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Classes;
+
+class IndexableCourse
+{
+    public $courseDTO;
+    public $school;
+    public $clerkshipType;
+    public $courseDirectors = [];
+    public $courseAdministrators = [];
+    public $courseTerms = [];
+    public $courseObjectives = [];
+    public $courseMeshDescriptors = [];
+    public $courseLearningMaterials = [];
+    public $sessions = [];
+}

--- a/src/Command/PopulateIndexCommand.php
+++ b/src/Command/PopulateIndexCommand.php
@@ -106,10 +106,10 @@ class PopulateIndexCommand extends Command
         $progressBar = new ProgressBar($output, count($allIds));
         $progressBar->setMessage('Adding Courses...');
         $progressBar->start();
-        $chunks = array_chunk($allIds, 500);
+        $chunks = array_chunk($allIds, 100);
         foreach ($chunks as $ids) {
-            $dtos = $this->courseManager->findDTOsBy(['id' => $ids]);
-            $this->index->indexCourses($dtos);
+            $indexes = $this->courseManager->getCourseIndexesFor($ids);
+            $this->index->indexCourses($indexes);
             $progressBar->advance(count($ids));
         }
         $progressBar->setMessage(count($allIds) . " Courses Added!");

--- a/src/Entity/DTO/CourseDTO.php
+++ b/src/Entity/DTO/CourseDTO.php
@@ -209,23 +209,4 @@ class CourseDTO
         $this->sessions = [];
         $this->descendants = [];
     }
-
-    public static function createSearchIndexDTOFromEntity(CourseInterface $course) : CourseDTO
-    {
-        $dto = new CourseDTO(
-            $course->getId(),
-            $course->getTitle(),
-            $course->getLevel(),
-            $course->getYear(),
-            $course->getStartDate(),
-            $course->getEndDate(),
-            $course->getExternalId(),
-            $course->isLocked(),
-            $course->isArchived(),
-            $course->isPublishedAsTbd(),
-            $course->isPublished()
-        );
-
-        return $dto;
-    }
 }

--- a/src/Entity/Manager/CourseManager.php
+++ b/src/Entity/Manager/CourseManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity\Manager;
 
+use App\Classes\IndexableCourse;
 use App\Entity\CourseInterface;
 use App\Entity\Repository\CourseRepository;
 use App\Entity\UserInterface;
@@ -68,5 +69,19 @@ class CourseManager extends BaseManager
         /** @var CourseRepository $repository */
         $repository = $this->getRepository();
         return $repository->isUserInstructingInCourse($userId, $courseId);
+    }
+
+    /**
+     * Create course index objects for a set of courses
+     *
+     * @param array $courseIds
+     *
+     * @return IndexableCourse[]
+     */
+    public function getCourseIndexesFor(array $courseIds)
+    {
+        /** @var CourseRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->getCourseIndexesFor($courseIds);
     }
 }

--- a/src/Entity/Repository/CourseRepository.php
+++ b/src/Entity/Repository/CourseRepository.php
@@ -79,7 +79,8 @@ class CourseRepository extends EntityRepository implements DTORepositoryInterfac
 
         foreach ($qb->getQuery()->getResult() as $arr) {
             $courseDTOs[$arr['courseId']]->school = (int)$arr['schoolId'];
-            $courseDTOs[$arr['courseId']]->clerkshipType = $arr['clerkshipTypeId'] ? (int)$arr['clerkshipTypeId'] : null;
+            $courseDTOs[$arr['courseId']]->clerkshipType =
+                $arr['clerkshipTypeId'] ? (int)$arr['clerkshipTypeId'] : null;
             $courseDTOs[$arr['courseId']]->ancestor = $arr['ancestorId'] ? (int)$arr['ancestorId'] : null;
         }
 
@@ -217,7 +218,7 @@ EOL;
      * Finds all courses associated with a given user.
      * A user can be associated as either course director, learner or instructor with a given course.
      *
-     * @param integer $user
+     * @param integer $userId
      * @param array $criteria
      * @param array|null $orderBy
      * @param null $limit
@@ -231,9 +232,7 @@ EOL;
         array $orderBy = null,
         $limit = null,
         $offset = null
-    )
-    {
-
+    ) {
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata('App\Entity\Course', 'c');
         $meta = $this->_em->getClassMetadata('App\Entity\Course');

--- a/src/Entity/Repository/CourseRepository.php
+++ b/src/Entity/Repository/CourseRepository.php
@@ -1,7 +1,10 @@
 <?php
+
 namespace App\Entity\Repository;
 
+use App\Classes\IndexableCourse;
 use App\Entity\Course;
+use App\Entity\Session;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
@@ -75,9 +78,9 @@ class CourseRepository extends EntityRepository implements DTORepositoryInterfac
             ->setParameter('courseIds', $courseIds);
 
         foreach ($qb->getQuery()->getResult() as $arr) {
-            $courseDTOs[$arr['courseId']]->school = (int) $arr['schoolId'];
-            $courseDTOs[$arr['courseId']]->clerkshipType = $arr['clerkshipTypeId']?(int)$arr['clerkshipTypeId']:null;
-            $courseDTOs[$arr['courseId']]->ancestor = $arr['ancestorId']?(int)$arr['ancestorId']:null;
+            $courseDTOs[$arr['courseId']]->school = (int)$arr['schoolId'];
+            $courseDTOs[$arr['courseId']]->clerkshipType = $arr['clerkshipTypeId'] ? (int)$arr['clerkshipTypeId'] : null;
+            $courseDTOs[$arr['courseId']]->ancestor = $arr['ancestorId'] ? (int)$arr['ancestorId'] : null;
         }
 
         $related = [
@@ -149,7 +152,7 @@ class CourseRepository extends EntityRepository implements DTORepositoryInterfac
      */
     public function isUserInstructingInCourse($userId, $courseId)
     {
-        $sql =<<<EOL
+        $sql = <<<EOL
 SELECT
   oxi.user_id
 FROM
@@ -204,8 +207,8 @@ EOL;
         $stmt->bindValue("user_id", $userId);
         $stmt->bindValue("course_id", $courseId);
         $stmt->execute();
-        $rows =  $stmt->fetchAll();
-        $isInstructing = ! empty($rows);
+        $rows = $stmt->fetchAll();
+        $isInstructing = !empty($rows);
         $stmt->closeCursor();
         return $isInstructing;
     }
@@ -228,7 +231,8 @@ EOL;
         array $orderBy = null,
         $limit = null,
         $offset = null
-    ) {
+    )
+    {
 
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata('App\Entity\Course', 'c');
@@ -238,7 +242,7 @@ EOL;
             $orderBy = ['id' => 'ASC'];
         }
 
-        $sql =<<<EOL
+        $sql = <<<EOL
 SELECT * FROM (
   SELECT c.* FROM course c
     JOIN course_director cd ON cd.course_id = c.course_id
@@ -321,7 +325,7 @@ EOL;
         $sqlFragments = [];
         foreach ($criteria as $name => $value) {
             $i++;
-            if (! $meta->hasField($name)) {
+            if (!$meta->hasField($name)) {
                 throw new \Exception(sprintf('"%s" is not a property of the Course entity.', $name));
             }
 
@@ -341,7 +345,7 @@ EOL;
         if (is_array($orderBy)) {
             $sqlFragments = [];
             foreach ($orderBy as $sort => $order) {
-                if (! $meta->hasField($sort)) {
+                if (!$meta->hasField($sort)) {
                     throw new \Exception(sprintf('"%s" is not a property of the Course entity.', $sort));
                 }
                 $column = $meta->getColumnName($sort);
@@ -367,10 +371,10 @@ EOL;
         }
 
         if (isset($limit)) {
-            $query->setParameter('limit', (int) $limit);
+            $query->setParameter('limit', (int)$limit);
         }
         if (isset($offset)) {
-            $query->setParameter('offset', (int) $offset);
+            $query->setParameter('offset', (int)$offset);
         }
         return $query->getResult();
     }
@@ -566,5 +570,242 @@ EOL;
         }
 
         return $qb;
+    }
+
+    /**
+     * Create course index objects for a set of courses
+     *
+     * @param array $courseIds
+     *
+     * @return IndexableCourse[]
+     */
+    public function getCourseIndexesFor(array $courseIds)
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select(
+            'c.id AS id, c.title AS title, c.level AS level, c.year AS year, ' .
+            'c.startDate AS startDate, c.endDate AS endDate, c.externalId AS externalId, ' .
+            'c.locked AS locked, c.archived AS archived, c.publishedAsTbd AS publishedAsTbd, ' .
+            'c.published AS published, s.title as school, cl.title as clerkshipType'
+        )
+            ->from(Course::class, 'c')
+            ->join('c.school', 's')
+            ->leftJoin('c.clerkshipType', 'cl')
+            ->where($qb->expr()->in('c.id', ':courseIds'))
+            ->setParameter('courseIds', $courseIds);
+
+        /** @var IndexableCourse[] $indexableCourses */
+        $indexableCourses = [];
+        foreach ($qb->getQuery()->getResult(AbstractQuery::HYDRATE_ARRAY) as $arr) {
+            $index = new IndexableCourse();
+            $index->courseDTO = new CourseDTO(
+                $arr['id'],
+                $arr['title'],
+                $arr['level'],
+                $arr['year'],
+                $arr['startDate'],
+                $arr['endDate'],
+                $arr['externalId'],
+                $arr['locked'],
+                $arr['archived'],
+                $arr['publishedAsTbd'],
+                $arr['published']
+            );
+            $index->school = $arr['school'];
+            $index->clerkshipType = $arr['clerkshipType'] ? $arr['clerkshipType'] : null;
+
+            $indexableCourses[$arr['id']] = $index;
+        }
+
+        $directors = $this->joinResults(
+            Course::class,
+            'directors',
+            "CONCAT(r.firstName, ' ', r.lastName, ' ', r.displayName) AS name",
+            $courseIds
+        );
+        foreach ($directors as $courseId => $arr) {
+            $indexableCourses[$courseId]->courseDirectors[] = $arr[0]['name'];
+        }
+
+        $administrators = $this->joinResults(
+            Course::class,
+            'administrators',
+            "CONCAT(r.firstName, ' ', r.lastName, ' ', r.displayName) AS name",
+            $courseIds
+        );
+        foreach ($administrators as $courseId => $arr) {
+            $indexableCourses[$courseId]->courseAdministrators[] = $arr[0]['name'];
+        }
+
+        $terms = $this->joinResults(
+            Course::class,
+            'terms',
+            "r.title",
+            $courseIds
+        );
+        foreach ($terms as $courseId => $arr) {
+            $indexableCourses[$courseId]->courseTerms[] = $arr[0]['title'];
+        }
+
+        $objectives = $this->joinResults(
+            Course::class,
+            'objectives',
+            "r.title",
+            $courseIds
+        );
+        foreach ($objectives as $courseId => $arr) {
+            $indexableCourses[$courseId]->courseObjectives[] = $arr[0]['title'];
+        }
+
+        $meshDescriptors = $this->joinResults(
+            Course::class,
+            'meshDescriptors',
+            "r.id, r.name, r.annotation",
+            $courseIds
+        );
+        foreach ($meshDescriptors as $courseId => $arr) {
+            $indexableCourses[$courseId]->courseMeshDescriptors[] = $arr[0]['id'];
+        }
+
+        $qb = $this->_em->createQueryBuilder()
+            ->select("c.id AS courseId, CONCAT(l.title, ' ', l.description) AS txt")
+            ->from(Course::class, 'c')
+            ->join("c.learningMaterials", 'clm')
+            ->join("clm.learningMaterial", 'l')
+            ->where($qb->expr()->in('c.id', ':courseIds'))
+            ->setParameter('courseIds', $courseIds);
+
+        foreach ($qb->getQuery()->getResult() as $arr) {
+            $indexableCourses[$arr['courseId']]->courseLearningMaterials[] = $arr['txt'];
+        }
+
+        $arr = $this->joinResults(
+            Course::class,
+            'sessions',
+            "r.id AS sessionId",
+            $courseIds
+        );
+
+        $sessionIds = array_reduce($arr, function (array $carry, array $item) {
+            return array_merge($carry, array_column($item, 'sessionId'));
+        }, []);
+
+        $chunks = array_chunk(array_unique($sessionIds), 500);
+        foreach ($chunks as $ids) {
+            $sessionBlocks = $this->sessionDataForIndex($ids);
+            foreach ($sessionBlocks as $arr) {
+                $indexableCourses[$arr['courseId']]->sessions[] = $arr;
+            }
+        }
+
+        return array_values($indexableCourses);
+    }
+
+    /**
+     * @param string $from
+     * @param string $rel
+     * @param string $select
+     * @param array $ids
+     *
+     * @return array
+     */
+    protected function joinResults(string $from, string $rel, string $select, array $ids)
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select("f.id AS fromId, ${select}")->from($from, 'f')
+            ->join("f.{$rel}", 'r')
+            ->where($qb->expr()->in('f.id', ':ids'))
+            ->setParameter('ids', $ids);
+
+        $rhett = [];
+        foreach ($qb->getQuery()->getResult() as $arr) {
+            $rhett[$arr['fromId']][] = $arr;
+        }
+
+        return $rhett;
+    }
+
+    /**
+     * @param array $sessionIds
+     *
+     * @return array
+     */
+    protected function sessionDataForIndex(array $sessionIds)
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select(
+            's.id AS sessionId, s.title AS title, sd.description AS description, c.id as courseId, ' .
+            'st.title AS sessionType'
+        )
+            ->from(Session::class, 's')
+            ->join('s.course', 'c')
+            ->leftJoin('s.sessionType', 'st')
+            ->leftJoin('s.sessionDescription', 'sd')
+            ->where($qb->expr()->in('s.id', ':ids'))
+            ->setParameter('ids', $sessionIds);
+
+        $sessions = [];
+        foreach ($qb->getQuery()->getResult(AbstractQuery::HYDRATE_ARRAY) as $arr) {
+            $sessions[$arr['sessionId']] = $arr;
+            $sessions[$arr['sessionId']]['administrators'] = [];
+            $sessions[$arr['sessionId']]['terms'] = [];
+            $sessions[$arr['sessionId']]['objectives'] = [];
+            $sessions[$arr['sessionId']]['meshDescriptors'] = [];
+            $sessions[$arr['sessionId']]['learningMaterials'] = [];
+        }
+
+        $administrators = $this->joinResults(
+            Session::class,
+            'administrators',
+            "CONCAT(r.firstName, ' ', r.lastName, ' ', r.displayName) AS name",
+            $sessionIds
+        );
+        foreach ($administrators as $sessionId => $arr) {
+            $sessions[$sessionId]['administrators'][] = $arr[0]['name'];
+        }
+
+        $terms = $this->joinResults(
+            Session::class,
+            'terms',
+            "r.title",
+            $sessionIds
+        );
+        foreach ($terms as $sessionId => $arr) {
+            $sessions[$sessionId]['terms'][] = $arr[0]['title'];
+        }
+
+        $objectives = $this->joinResults(
+            Session::class,
+            'objectives',
+            "r.title",
+            $sessionIds
+        );
+        foreach ($objectives as $sessionId => $arr) {
+            $sessions[$sessionId]['objectives'][] = $arr[0]['title'];
+        }
+
+        $meshDescriptors = $this->joinResults(
+            Session::class,
+            'meshDescriptors',
+            "r.id, r.name, r.annotation",
+            $sessionIds
+        );
+        foreach ($meshDescriptors as $sessionId => $arr) {
+            $sessions[$sessionId]['meshDescriptors'][] = $arr[0]['id'];
+        }
+
+        $qb = $this->_em->createQueryBuilder()
+            ->select("s.id AS sessionId, CONCAT(l.title, ' ', l.description) AS txt")
+            ->from(Session::class, 's')
+            ->join("s.learningMaterials", 'slm')
+            ->join("slm.learningMaterial", 'l')
+            ->where($qb->expr()->in('s.id', ':ids'))
+            ->setParameter('ids', $sessionIds);
+
+        foreach ($qb->getQuery()->getResult() as $arr) {
+            $sessions[$arr['sessionId']]['learningMaterials'][] = $arr['txt'];
+        }
+
+        return array_values($sessions);
     }
 }

--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -1,9 +1,15 @@
 <?php
 namespace App\EventListener;
 
+use App\Classes\IndexableCourse;
 use App\Entity\CourseInterface;
+use App\Entity\CourseLearningMaterialInterface;
 use App\Entity\DTO\CourseDTO;
 use App\Entity\DTO\UserDTO;
+use App\Entity\MeshDescriptorInterface;
+use App\Entity\ObjectiveInterface;
+use App\Entity\SessionLearningMaterialInterface;
+use App\Entity\TermInterface;
 use App\Entity\UserInterface;
 use App\Service\Index;
 use Doctrine\ORM\Event\LifecycleEventArgs;
@@ -76,8 +82,77 @@ class IndexEntityChanges
     protected function indexCourse(CourseInterface $course)
     {
         if ($this->index->isEnabled()) {
-            $dto = CourseDTO::createSearchIndexDTOFromEntity($course);
-             $this->index->indexCourses([$dto]);
+            $index = new IndexableCourse();
+            $dto = new CourseDTO(
+                $course->getId(),
+                $course->getTitle(),
+                $course->getLevel(),
+                $course->getYear(),
+                $course->getStartDate(),
+                $course->getEndDate(),
+                $course->getExternalId(),
+                $course->isLocked(),
+                $course->isArchived(),
+                $course->isPublishedAsTbd(),
+                $course->isPublished()
+            );
+
+            $index->courseDTO = $dto;
+            $index->school = $course->getSchool()->getTitle();
+            if ($clerkshipType = $course->getClerkshipType()) {
+                $index->clerkshipType = $clerkshipType->getTitle();
+            }
+            $index->courseDirectors = array_map(function (UserInterface $user) {
+                return $user->getFirstAndLastName() . ' ' . $user->getDisplayName();
+            }, $course->getDirectors()->toArray());
+            $index->courseAdministrators = array_map(function (UserInterface $user) {
+                return $user->getFirstAndLastName() . ' ' . $user->getDisplayName();
+            }, $course->getAdministrators()->toArray());
+            $index->courseTerms = array_map(function (TermInterface $term) {
+                return $term->getTitle();
+            }, $course->getTerms()->toArray());
+            $index->courseObjectives = array_map(function (ObjectiveInterface $objective) {
+                return $objective->getTitle();
+            }, $course->getObjectives()->toArray());
+            $index->courseMeshDescriptors = array_map(function (MeshDescriptorInterface $descriptor) {
+                return $descriptor->getId();
+            }, $course->getMeshDescriptors()->toArray());
+            $index->courseLearningMaterials = array_map(function (CourseLearningMaterialInterface $clm) {
+                $lm = $clm->getLearningMaterial();
+                return $lm->getTitle() . ' ' . $lm->getDescription();
+            }, $course->getLearningMaterials()->toArray());
+            foreach ($course->getSessions() as $session) {
+                $sessionArr = [
+                    'sessionId' => $session->getId(),
+                    'title' => $session->getTitle(),
+                    'description' => ''
+                ];
+                if ($sessionDescription = $session->getSessionDescription()) {
+                    $sessionArr['description'] = $sessionDescription->getDescription();
+                }
+                $sessionArr['sessionType'] = $session->getSessionType()->getTitle();
+
+                $sessionArr['administrators'] = array_map(function (UserInterface $user) {
+                    return $user->getFirstAndLastName() . ' ' . $user->getDisplayName();
+                }, $session->getAdministrators()->toArray());
+                $sessionArr['terms'] = array_map(function (TermInterface $term) {
+                    return $term->getTitle();
+                }, $session->getTerms()->toArray());
+                $sessionArr['objectives'] = array_map(function (ObjectiveInterface $objective) {
+                    return $objective->getTitle();
+                }, $session->getObjectives()->toArray());
+                $sessionArr['meshDescriptors'] = array_map(function (MeshDescriptorInterface $descriptor) {
+                    return $descriptor->getId();
+                }, $session->getMeshDescriptors()->toArray());
+                $sessionArr['learningMaterials'] = array_map(function (SessionLearningMaterialInterface $slm) {
+                    $lm = $slm->getLearningMaterial();
+                    return $lm->getTitle() . ' ' . $lm->getDescription();
+                }, $session->getLearningMaterials()->toArray());
+
+                $index->sessions[] = $sessionArr;
+            }
+            $this->index->deleteCourse($course->getId());
+            $this->index->indexCourses([$index]);
         }
     }
 }

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -33,13 +33,32 @@ class Search extends ElasticSearchBase
             throw new \Exception("Search is not configured, isEnabled() should be called before calling this method");
         }
         $params = [
-            'type' => UserDTO::class,
-            'index' => self::USER_INDEX,
+            'type' => '_doc',
+            'index' => self::PRIVATE_USER_INDEX,
             "size" => $size,
             'body' => [
                 'query' => [
-                    'query_string' => [
-                        'query' => "*${query}*",
+                    'bool' => [
+                        'must' => [
+                            'multi_match' => [
+                                'query' => $query,
+                                'type' => "cross_fields",
+                                'fields' => [
+                                    'user.fullName^2',
+                                    'user.email',
+                                    'user.campusId',
+                                    'user.username'
+                                ]
+                            ]
+                        ],
+                        'should' => [
+                            'match_phrase' => [
+                                'fullName' => [
+                                    'query' => $query,
+                                    'slop'  => 100
+                                ],
+                            ]
+                        ]
                     ]
                 ],
                 "_source" => [
@@ -66,7 +85,7 @@ class Search extends ElasticSearchBase
         }
         $params = [
             'type' => Descriptor::class,
-            'index' => self::MESH_INDEX,
+            'index' => self::PUBLIC_MESH_INDEX,
             'body' => [
                 'query' => [
                     'query_string' => [

--- a/tests/Command/PopulateIndexCommandTest.php
+++ b/tests/Command/PopulateIndexCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Tests\Command;
 
+use App\Classes\IndexableCourse;
 use App\Command\PopulateIndexCommand;
 use App\Entity\Course;
 use App\Entity\DTO\CourseDTO;
@@ -87,13 +88,11 @@ class PopulateIndexCommandTest extends KernelTestCase
 
 
         $this->courseManager->shouldReceive('getIds')->andReturn([89]);
-        $mockCourseDTO = m::mock(CourseDTO::class);
-        $mockCourseDTO->id = 11;
-        $mockCourseDTO->title = 'course title';
+        $mockIndexableCourse = m::mock(IndexableCourse::class);
 
-        $this->courseManager->shouldReceive('findDTOsBy')
-            ->with(['id' => [89]])->andReturn([$mockCourseDTO]);
-        $this->index->shouldReceive('indexCourses')->with([$mockCourseDTO]);
+        $this->courseManager->shouldReceive('getCourseIndexesFor')
+            ->with([89])->andReturn([$mockIndexableCourse]);
+        $this->index->shouldReceive('indexCourses')->with([$mockIndexableCourse]);
 
 
         $this->meshDescriptorManager->shouldReceive('getIds')->andReturn([99]);

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Tests\Service;
 
+use App\Classes\IndexableCourse;
 use App\Entity\Course;
 use App\Entity\DTO\CourseDTO;
 use App\Entity\DTO\UserDTO;
@@ -48,14 +49,14 @@ class IndexTest extends TestCase
         $this->assertTrue($obj->indexUsers($users));
     }
 
-    public function testIndexCoursesThrowsWhenNotDTO()
+    public function testIndexCoursesThrowsWhenNotIndexableCorurse()
     {
         $obj = $this->createWithoutHost();
         $this->expectException(\InvalidArgumentException::class);
         $courses = [
+            m::mock(IndexableCourse::class),
             m::mock(CourseDTO::class),
-            m::mock(Course::class),
-            m::mock(CourseDTO::class)
+            m::mock(IndexableCourse::class)
         ];
         $obj->indexCourses($courses);
     }
@@ -63,11 +64,10 @@ class IndexTest extends TestCase
     public function testIndexCoursesWorksWithoutSearch()
     {
         $obj = $this->createWithoutHost();
-        $courses = [
-            m::mock(CourseDTO::class),
-            m::mock(CourseDTO::class)
-        ];
-        $this->assertTrue($obj->indexCourses($courses));
+        $mockCourse = m::mock(IndexableCourse::class);
+        $mockDto = m::mock(CourseDTO::class);
+        $mockCourse->courseDTO = $mockDto;
+        $this->assertTrue($obj->indexCourses([$mockCourse]));
     }
 
     public function testIndexMeshDescriptorsThrowsWhenNotDescriptor()


### PR DESCRIPTION
Elastic search has abandoned the concept of types and an index can only
contain one type now (as far as I can tell). Since we can no longer put
sessions and courses together in the same index and the other ways are
too complicated I've denormalized session data into single documents for
each session.