### PR TITLE
Add a search API

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -23,6 +23,13 @@ security:
         authenticators:
           - App\Security\JsonWebTokenAuthenticator
       provider: session_user
+    authenticated_search:
+      pattern:    ^/experimental_search
+      stateless: true
+      guard:
+        authenticators:
+          - App\Security\JsonWebTokenAuthenticator
+      provider: session_user
     upload:
       pattern:    ^/upload
       stateless: true

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -41,6 +41,11 @@ _monitor:
   resource: "@LiipMonitorBundle/Resources/config/routing.xml"
   prefix: /ilios/health
 
+ilios_search:
+  path: /experimental_search
+  controller: App\Controller\Search:search
+  methods:  [GET]
+
 ilios_swagger_redirect_docs:
   path: /api/docs/
   controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction

--- a/src/Controller/Search.php
+++ b/src/Controller/Search.php
@@ -53,6 +53,6 @@ class Search extends AbstractController
 
         $result = $this->search->curriculumSearch($query);
 
-        return new JsonResponse(array('results' => $result));
+        return new JsonResponse(['results' => $result]);
     }
 }

--- a/src/Controller/Search.php
+++ b/src/Controller/Search.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\PermissionChecker;
+use App\Service\Search as SearchService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Class SearchController
+ *
+ * Search Ilios
+ */
+class Search extends AbstractController
+{
+    /**
+     * @var SearchService
+     */
+    protected $search;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    protected $tokenStorage;
+
+    /**
+     * @var PermissionChecker
+     */
+    protected $permissionChecker;
+
+    public function __construct(
+        SearchService $search,
+        TokenStorageInterface $tokenStorage,
+        PermissionChecker $permissionChecker
+    ) {
+        $this->search = $search;
+        $this->tokenStorage = $tokenStorage;
+        $this->permissionChecker = $permissionChecker;
+    }
+
+    public function search(Request $request)
+    {
+        $sessionUser = $this->tokenStorage->getToken()->getUser();
+        if (! $this->permissionChecker->canSearchCurriculum($sessionUser)) {
+            throw new AccessDeniedException();
+        }
+
+        $query = $request->get('q');
+
+        $result = $this->search->curriculumSearch($query);
+
+        return new JsonResponse(array('results' => $result));
+    }
+}

--- a/src/Service/PermissionChecker.php
+++ b/src/Service/PermissionChecker.php
@@ -1339,4 +1339,14 @@ class PermissionChecker
     {
         return $sessionUser->isInLearnerGroup($learnerGroupId) || $sessionUser->performsNonLearnerFunction();
     }
+
+    /**
+     * Checks if the given user can search the curriculum
+     * @param SessionUserInterface $sessionUser
+     * @return bool
+     */
+    public function canSearchCurriculum(SessionUserInterface $sessionUser): bool
+    {
+        return $sessionUser->performsNonLearnerFunction();
+    }
 }

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -3,7 +3,6 @@
 namespace App\Service;
 
 use App\Classes\ElasticSearchBase;
-use App\Entity\DTO\UserDTO;
 use Ilios\MeSH\Model\Descriptor;
 
 class Search extends ElasticSearchBase
@@ -19,6 +18,19 @@ class Search extends ElasticSearchBase
             throw new \Exception("Search is not configured, isEnabled() should be called before calling this method");
         }
         return $this->client->search($params);
+    }
+
+    /**
+     * @param string $query
+     * @return array
+     * @throws \Exception when search is not configured
+     */
+    public function curriculumSearch(string $query)
+    {
+        if (!$this->enabled) {
+            throw new \Exception("Search is not configured, isEnabled() should be called before calling this method");
+        }
+        return [];
     }
 
     /**

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -73,7 +73,23 @@ class SearchControllerTest extends TestCase
     public function testSearch()
     {
         $searchTerm = 'jasper & jackson';
-        $result = [];
+        $result = [
+            'courses' => [
+                [
+                    'id' => 1,
+                    'title' => 'This Course',
+                    'year' => 2019,
+                    'matchedIn' => [],
+                    'sessions' => [
+                        [
+                            'id' => 11,
+                            'title' => 'This Session',
+                            'matchedIn' => []
+                        ]
+                    ]
+                ]
+            ]
+        ];
 
         $this->mockSearch
             ->shouldReceive('curriculumSearch')

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Classes\SessionUserInterface;
+use App\Controller\Search;
+use App\Service\PermissionChecker;
+use App\Service\Search as SearchService;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class SearchControllerTest extends TestCase
+{
+    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    /**
+     * @var Search
+     */
+    protected $controller;
+
+    /**
+     * @var m\MockInterface
+     */
+    protected $mockSearch;
+
+    /**
+     * @var m\MockInterface
+     */
+    protected $mockTokenStorage;
+
+    /**
+     * @var m\MockInterface
+     */
+    protected $mockPermissionChecker;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->mockSearch = m::mock(SearchService::class);
+        $this->mockTokenStorage = m::mock(TokenStorageInterface::class);
+        $this->mockPermissionChecker = m::mock(PermissionChecker::class);
+
+        $mockSessionUser = m::mock(SessionUserInterface::class);
+
+        $mockToken = m::mock(TokenInterface::class);
+        $mockToken->shouldReceive('getUser')->andReturn($mockSessionUser);
+
+        $this->mockTokenStorage->shouldReceive('getToken')->andReturn($mockToken);
+
+        $this->controller = new Search(
+            $this->mockSearch,
+            $this->mockTokenStorage,
+            $this->mockPermissionChecker
+        );
+    }
+
+    public function tearDown() : void
+    {
+        unset($this->controller);
+        unset($this->mockSearch);
+        unset($this->mockTokenStorage);
+        unset($this->mockPermissionChecker);
+
+
+        parent::tearDown();
+    }
+
+    public function testSearch()
+    {
+        $searchTerm = 'jasper & jackson';
+        $result = [];
+
+        $this->mockSearch
+            ->shouldReceive('curriculumSearch')
+            ->with($searchTerm)
+            ->once()
+            ->andReturn([$result]);
+
+        $this->mockPermissionChecker
+            ->shouldReceive('canSearchCurriculum')
+            ->andReturn(true);
+
+        $request = new Request();
+        $request->query->add(['q' => $searchTerm]);
+
+        $response = $this->controller->search($request);
+        $content = $response->getContent();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode(), var_export($content, true));
+
+        $this->assertEquals(
+            array('results' => array($result)),
+            json_decode($content, true),
+            var_export($content, true)
+        );
+    }
+
+    public function testSearchFailsIfUserDoesntHaveProperPermissions()
+    {
+        $this->mockPermissionChecker
+            ->shouldReceive('canSearchCurriculum')
+            ->andReturn(false);
+        $this->expectException(AccessDeniedException::class);
+        $this->controller->search(new Request());
+    }
+}


### PR DESCRIPTION
Created an api at `/experimental_search` that takes a single `q` parameter and searches the curriculum. This is a first pass, the results are poorly ranked as we're not applying as much individual weighting criteria as we should, but it does work and searches. 

The results are returned in a course object with each matching session under the respective course. The fields that were matched appear at the course and session level respectively for badging.

Search Results look like:

```
'courses' => [
  [
  'id' => 1,
  'title' => 'This Course',
  'year' => 2019,
  'matchedIn' => ['title', 'objectives'],
  'bestScore' => 56.777888,
  'sessions' => [
    [
	'id' => 11,
	'title' => 'This Session',
        'score' => 56.777888,
	'matchedIn' => ['description', 'learningMaterials']
    ],
    [															[
	'id' => 99,
	'title' => 'Another Session',
        'score' => 19.0005,
	'matchedIn' => ['title']
    ],
  ]
]
```