### PR TITLE
Add autocomplete suggestions to search

### DIFF
--- a/src/Controller/Search.php
+++ b/src/Controller/Search.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Classes\SessionUserInterface;
 use App\Service\PermissionChecker;
 use App\Service\Search as SearchService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -44,6 +45,7 @@ class Search extends AbstractController
 
     public function search(Request $request)
     {
+        /** @var SessionUserInterface $sessionUser */
         $sessionUser = $this->tokenStorage->getToken()->getUser();
         if (! $this->permissionChecker->canSearchCurriculum($sessionUser)) {
             throw new AccessDeniedException();
@@ -51,7 +53,9 @@ class Search extends AbstractController
 
         $query = $request->get('q');
 
-        $result = $this->search->curriculumSearch($query);
+        $onlySuggest = (bool) $request->get('onlySuggest');
+
+        $result = $this->search->curriculumSearch($query, $onlySuggest);
 
         return new JsonResponse(['results' => $result]);
     }

--- a/src/Entity/Repository/CourseRepository.php
+++ b/src/Entity/Repository/CourseRepository.php
@@ -750,6 +750,7 @@ EOL;
             $session = new IndexableSession();
             $session->courseId = $arr['courseId'];
             $session->sessionId = $arr['sessionId'];
+            $session->title = $arr['title'];
             $session->sessionType = $arr['sessionType'];
             $session->description = $arr['description'];
 

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -216,9 +216,15 @@ class Index extends ElasticSearchBase
                             'properties' => [
                                 'school' => [
                                     'type' => 'keyword',
+                                    'fields' => [
+                                        'cmp' => [
+                                            'type' => 'completion'
+                                        ]
+                                    ],
                                 ],
                                 'courseYear' => [
                                     'type' => 'integer',
+
                                 ],
                                 'courseTitle' => [
                                     'type' => 'text',
@@ -227,6 +233,9 @@ class Index extends ElasticSearchBase
                                         'std' => [
                                             'type' => 'text',
                                             'analyzer' => 'standard',
+                                        ],
+                                        'cmp' => [
+                                            'type' => 'completion'
                                         ]
                                     ],
                                 ],
@@ -237,6 +246,9 @@ class Index extends ElasticSearchBase
                                         'std' => [
                                             'type' => 'text',
                                             'analyzer' => 'standard',
+                                        ],
+                                        'cmp' => [
+                                            'type' => 'completion'
                                         ]
                                     ],
                                 ],
@@ -262,6 +274,11 @@ class Index extends ElasticSearchBase
                                 ],
                                 'courseMeshDescriptors' => [
                                     'type' => 'keyword',
+                                    'fields' => [
+                                        'cmp' => [
+                                            'type' => 'completion'
+                                        ]
+                                    ],
                                 ],
                                 'sessionTitle' => [
                                     'type' => 'text',
@@ -270,6 +287,9 @@ class Index extends ElasticSearchBase
                                         'std' => [
                                             'type' => 'text',
                                             'analyzer' => 'standard',
+                                        ],
+                                        'cmp' => [
+                                            'type' => 'completion'
                                         ]
                                     ],
                                 ],
@@ -285,6 +305,11 @@ class Index extends ElasticSearchBase
                                 ],
                                 'sessionType' => [
                                     'type' => 'keyword',
+                                    'fields' => [
+                                        'cmp' => [
+                                            'type' => 'completion'
+                                        ]
+                                    ],
                                 ],
                                 'sessionTerms' => [
                                     'type' => 'text',
@@ -293,6 +318,9 @@ class Index extends ElasticSearchBase
                                         'std' => [
                                             'type' => 'text',
                                             'analyzer' => 'standard',
+                                        ],
+                                        'cmp' => [
+                                            'type' => 'completion'
                                         ]
                                     ],
                                 ],
@@ -318,6 +346,11 @@ class Index extends ElasticSearchBase
                                 ],
                                 'sessionMeshDescriptors' => [
                                     'type' => 'keyword',
+                                    'fields' => [
+                                        'cmp' => [
+                                            'type' => 'completion'
+                                        ]
+                                    ],
                                 ],
                             ]
                         ]


### PR DESCRIPTION
Using the built in Completions suggester from Elasticsearch as it is the
simplest to implement. It will return matches when the prefix is the
same, but not mid-word matches. This is probably sufficient for our
autocomplete use case.

Incidentally fixed a bug where session title was not being set properly.