### PR TITLE
 Update to Symfony 4.3

### DIFF
--- a/.env
+++ b/.env
@@ -30,5 +30,3 @@ ILIOS_DATABASE_MYSQL_VERSION=5.7
 # For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
 # Delivery is disabled by default via "null://localhost"
 ILIOS_MAILER_URL=null://localhost
-
-

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,6 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
-APP_SECRET='s$cretf0rt3st'
+ILIOS_SECRET='s$cretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 
 ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp/ilios
@@ -13,4 +13,3 @@ ILIOS_ELASTICSEARCH_HOSTS=null
 ILIOS_STORAGE_S3_URL=null
 
 ILIOS_MAILER_URL=null://localhost
-

--- a/bin/console
+++ b/bin/console
@@ -6,6 +6,10 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
 
+if (false === in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.\PHP_SAPI.' SAPI'.\PHP_EOL;
+}
+
 set_time_limit(0);
 
 require dirname(__DIR__).'/vendor/autoload.php';

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,8 +1,8 @@
 #!/usr/bin/env php
 <?php
 
-if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
-    echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
+if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php')) {
+    echo "Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
     exit(1);
 }
 
@@ -16,4 +16,4 @@ if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
     putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
 }
 
-require dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit';
+require dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php';

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
   },
   "require-dev": {
     "fzaninotto/faker": "@stable",
-    "liip/functional-test-bundle": "~2.0@alpha",
+    "liip/functional-test-bundle": "~3.0@alpha",
+    "liip/test-fixtures-bundle": "~1.0.0-RC1",
     "mockery/mockery": "1.2.0",
     "squizlabs/php_codesniffer": "@stable",
     "symfony/debug-pack": "*",

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
   "extra": {
     "symfony": {
       "allow-contrib": true,
-      "require": "4.2.*"
+      "require": "4.3.*"
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d0314f0e0fc979d60eae8188bcfdaf2",
+    "content-hash": "03f7f7f554317881c9807e08da3ab119",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.99.0",
+            "version": "3.99.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "0a212802416698b1a452ca317c16cb909a2dd1ca"
+                "reference": "455e93cc4feb99847f88f4229659da2c79aa6371"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0a212802416698b1a452ca317c16cb909a2dd1ca",
-                "reference": "0a212802416698b1a452ca317c16cb909a2dd1ca",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/455e93cc4feb99847f88f4229659da2c79aa6371",
+                "reference": "455e93cc4feb99847f88f4229659da2c79aa6371",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-06-03T18:16:19+00:00"
+            "time": "2019-06-04T18:08:27+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -140,62 +140,6 @@
                 "stream_filter_register"
             ],
             "time": "2019-04-09T12:31:48+00:00"
-        },
-        {
-            "name": "composer/ca-bundle",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
-                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
-                "psr/log": "^1.0",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\CaBundle\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-            "keywords": [
-                "cabundle",
-                "cacert",
-                "certificate",
-                "ssl",
-                "tls"
-            ],
-            "time": "2019-01-28T09:30:10+00:00"
         },
         {
             "name": "danielstjules/stringy",
@@ -691,16 +635,16 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "1.11.1",
+            "version": "1.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "09a38417339dc93849d051b914aae3947eb231a7"
+                "reference": "28101e20776d8fa20a00b54947fbae2db0d09103"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/09a38417339dc93849d051b914aae3947eb231a7",
-                "reference": "09a38417339dc93849d051b914aae3947eb231a7",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/28101e20776d8fa20a00b54947fbae2db0d09103",
+                "reference": "28101e20776d8fa20a00b54947fbae2db0d09103",
                 "shasum": ""
             },
             "require": {
@@ -776,7 +720,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2019-05-13T14:30:38+00:00"
+            "time": "2019-06-04T07:35:05+00:00"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
@@ -4324,22 +4268,23 @@
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v5.0.3",
+            "version": "v6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1"
+                "reference": "eb5141732b39ea852d2702fbdbc856344b99a12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/46be3f58adac13084497961e10eed9a7fb4d44d1",
-                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1",
+                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/eb5141732b39ea852d2702fbdbc856344b99a12d",
+                "reference": "eb5141732b39ea852d2702fbdbc856344b99a12d",
                 "shasum": ""
             },
             "require": {
-                "composer/ca-bundle": "^1.0",
-                "php": ">=5.5.9",
-                "symfony/console": "~2.7|~3.0|~4.0"
+                "php": ">=7.1.3",
+                "symfony/console": "^2.8|^3.4|^4.2",
+                "symfony/http-client": "^4.3",
+                "symfony/mime": "^4.3"
             },
             "bin": [
                 "security-checker"
@@ -4347,7 +4292,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4366,7 +4311,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2018-12-19T17:14:59+00:00"
+            "time": "2019-06-04T09:18:15+00:00"
         },
         {
             "name": "sentry/sentry",
@@ -4723,6 +4668,64 @@
             "time": "2019-05-27T08:16:38+00:00"
         },
         {
+            "name": "symfony/cache-contracts",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "7ff3902cc747dd5e2c6f26dc42603ed07b530293"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/7ff3902cc747dd5e2c6f26dc42603ed07b530293",
+                "reference": "7ff3902cc747dd5e2c6f26dc42603ed07b530293",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/cache": "",
+                "symfony/cache-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-05-22T12:23:29+00:00"
+        },
+        {
             "name": "symfony/config",
             "version": "v4.3.0",
             "source": {
@@ -4860,85 +4863,6 @@
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
             "time": "2019-05-27T08:16:38+00:00"
-        },
-        {
-            "name": "symfony/contracts",
-            "version": "v1.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/contracts.git",
-                "reference": "b6e291a08e6b002fb56aa6f3e2a2beb6674d2b2f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/contracts/zipball/b6e291a08e6b002fb56aa6f3e2a2beb6674d2b2f",
-                "reference": "b6e291a08e6b002fb56aa6f3e2a2beb6674d2b2f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "replace": {
-                "symfony/cache-contracts": "self.version",
-                "symfony/event-dispatcher-contracts": "self.version",
-                "symfony/http-client-contracts": "self.version",
-                "symfony/service-contracts": "self.version",
-                "symfony/translation-contracts": "self.version"
-            },
-            "require-dev": {
-                "psr/cache": "^1.0",
-                "psr/container": "^1.0",
-                "symfony/polyfill-intl-idn": "^1.10"
-            },
-            "suggest": {
-                "psr/cache": "When using the Cache contracts",
-                "psr/container": "When using the Service contracts",
-                "psr/event-dispatcher": "When using the EventDispatcher contracts",
-                "symfony/cache-implementation": "",
-                "symfony/event-dispatcher-implementation": "",
-                "symfony/http-client-implementation": "",
-                "symfony/service-implementation": "",
-                "symfony/translation-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\": ""
-                },
-                "exclude-from-classmap": [
-                    "**/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A set of abstractions extracted out of the Symfony components",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2019-05-28T07:50:59+00:00"
         },
         {
             "name": "symfony/debug",
@@ -5287,6 +5211,64 @@
             "time": "2019-05-28T07:50:59+00:00"
         },
         {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "8fa2cf2177083dd59cf8e44ea4b6541764fbda69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/8fa2cf2177083dd59cf8e44ea4b6541764fbda69",
+                "reference": "8fa2cf2177083dd59cf8e44ea4b6541764fbda69",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-05-22T12:23:29+00:00"
+        },
+        {
             "name": "symfony/filesystem",
             "version": "v4.3.0",
             "source": {
@@ -5436,49 +5418,49 @@
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "6b51be8f4a8f7966efd54c212662db1bb6cb656a"
+                "reference": "19714b45c7b5af238e66720017bae6fcf2d5fa01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/6b51be8f4a8f7966efd54c212662db1bb6cb656a",
-                "reference": "6b51be8f4a8f7966efd54c212662db1bb6cb656a",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/19714b45c7b5af238e66720017bae6fcf2d5fa01",
+                "reference": "19714b45c7b5af238e66720017bae6fcf2d5fa01",
                 "shasum": ""
             },
             "require": {
                 "ext-xml": "*",
                 "php": "^7.1.3",
-                "symfony/cache": "~4.2",
+                "symfony/cache": "~4.3",
                 "symfony/config": "~4.2",
-                "symfony/contracts": "^1.0.2",
-                "symfony/dependency-injection": "^4.2.5",
-                "symfony/event-dispatcher": "^4.1",
+                "symfony/dependency-injection": "^4.3",
                 "symfony/filesystem": "~3.4|~4.0",
                 "symfony/finder": "~3.4|~4.0",
-                "symfony/http-foundation": "^4.2.5",
-                "symfony/http-kernel": "^4.2",
+                "symfony/http-foundation": "^4.3",
+                "symfony/http-kernel": "^4.3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/routing": "^4.2.8"
+                "symfony/routing": "^4.3"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.0",
                 "phpdocumentor/type-resolver": "<0.2.1",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
                 "symfony/asset": "<3.4",
-                "symfony/console": "<3.4",
+                "symfony/browser-kit": "<4.3",
+                "symfony/console": "<4.3",
+                "symfony/dom-crawler": "<4.3",
                 "symfony/dotenv": "<4.2",
-                "symfony/form": "<4.2",
-                "symfony/messenger": "<4.2",
+                "symfony/form": "<4.3",
+                "symfony/messenger": "<4.3",
                 "symfony/property-info": "<3.4",
                 "symfony/serializer": "<4.2",
                 "symfony/stopwatch": "<3.4",
-                "symfony/translation": "<4.2",
+                "symfony/translation": "<4.3",
                 "symfony/twig-bridge": "<4.1.1",
                 "symfony/validator": "<4.1",
-                "symfony/workflow": "<4.1"
+                "symfony/workflow": "<4.3"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
@@ -5486,28 +5468,31 @@
                 "fig/link-util": "^1.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0",
                 "symfony/asset": "~3.4|~4.0",
-                "symfony/browser-kit": "~3.4|~4.0",
-                "symfony/console": "~3.4|~4.0",
+                "symfony/browser-kit": "^4.3",
+                "symfony/console": "^4.3",
                 "symfony/css-selector": "~3.4|~4.0",
-                "symfony/dom-crawler": "~3.4|~4.0",
+                "symfony/dom-crawler": "^4.3",
                 "symfony/expression-language": "~3.4|~4.0",
-                "symfony/form": "^4.2.3",
+                "symfony/form": "^4.3",
+                "symfony/http-client": "^4.3",
                 "symfony/lock": "~3.4|~4.0",
-                "symfony/messenger": "^4.2",
+                "symfony/mailer": "^4.3",
+                "symfony/messenger": "^4.3",
+                "symfony/mime": "^4.3",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/process": "~3.4|~4.0",
                 "symfony/property-info": "~3.4|~4.0",
-                "symfony/security": "~3.4|~4.0",
-                "symfony/security-core": "~3.4|~4.0",
                 "symfony/security-csrf": "~3.4|~4.0",
-                "symfony/serializer": "^4.2",
+                "symfony/security-http": "~3.4|~4.0",
+                "symfony/serializer": "^4.3",
                 "symfony/stopwatch": "~3.4|~4.0",
                 "symfony/templating": "~3.4|~4.0",
                 "symfony/translation": "~4.2",
+                "symfony/twig-bundle": "~2.8|~3.2|~4.0",
                 "symfony/validator": "^4.1",
-                "symfony/var-dumper": "~3.4|~4.0",
+                "symfony/var-dumper": "^4.3",
                 "symfony/web-link": "~3.4|~4.0",
-                "symfony/workflow": "^4.1",
+                "symfony/workflow": "^4.3",
                 "symfony/yaml": "~3.4|~4.0",
                 "twig/twig": "~1.34|~2.4"
             },
@@ -5524,7 +5509,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5551,7 +5536,126 @@
             ],
             "description": "Symfony FrameworkBundle",
             "homepage": "https://symfony.com",
-            "time": "2019-05-22T18:38:35+00:00"
+            "time": "2019-05-30T03:17:01+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "fec81f1da93f50334085b00113d2fb6f34efc801"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/fec81f1da93f50334085b00113d2fb6f34efc801",
+                "reference": "fec81f1da93f50334085b00113d2fb6f34efc801",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "^1.0",
+                "symfony/http-client-contracts": "^1.1",
+                "symfony/polyfill-php73": "^1.11"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "1.1"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.0",
+                "psr/http-client": "^1.0",
+                "symfony/http-kernel": "^4.3",
+                "symfony/process": "^4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpClient component",
+            "homepage": "https://symfony.com",
+            "time": "2019-05-28T08:25:44+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "c87486c0fa65ae04736140389037fcbdd149ddd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/c87486c0fa65ae04736140389037fcbdd149ddd6",
+                "reference": "c87486c0fa65ae04736140389037fcbdd149ddd6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "symfony/http-client-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-05-22T12:23:29+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -5610,30 +5714,31 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "ca9c1fe747f9704afd5e3c9097b80db0e31d158f"
+                "reference": "b4ce396bdce518978a17324d3d39d61058d039e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/ca9c1fe747f9704afd5e3c9097b80db0e31d158f",
-                "reference": "ca9c1fe747f9704afd5e3c9097b80db0e31d158f",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/b4ce396bdce518978a17324d3d39d61058d039e6",
+                "reference": "b4ce396bdce518978a17324d3d39d61058d039e6",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "psr/log": "~1.0",
-                "symfony/contracts": "^1.0.2",
                 "symfony/debug": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~4.1",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/http-foundation": "^4.1.1",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php73": "^1.9"
             },
             "conflict": {
+                "symfony/browser-kit": "<4.3",
                 "symfony/config": "<3.4",
-                "symfony/dependency-injection": "<4.2",
+                "symfony/dependency-injection": "<4.3",
                 "symfony/translation": "<4.2",
                 "symfony/var-dumper": "<4.1.1",
                 "twig/twig": "<1.34|<2.4,>=2"
@@ -5643,11 +5748,11 @@
             },
             "require-dev": {
                 "psr/cache": "~1.0",
-                "symfony/browser-kit": "~3.4|~4.0",
+                "symfony/browser-kit": "^4.3",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/console": "~3.4|~4.0",
                 "symfony/css-selector": "~3.4|~4.0",
-                "symfony/dependency-injection": "^4.2",
+                "symfony/dependency-injection": "^4.3",
                 "symfony/dom-crawler": "~3.4|~4.0",
                 "symfony/expression-language": "~3.4|~4.0",
                 "symfony/finder": "~3.4|~4.0",
@@ -5656,7 +5761,9 @@
                 "symfony/stopwatch": "~3.4|~4.0",
                 "symfony/templating": "~3.4|~4.0",
                 "symfony/translation": "~4.2",
-                "symfony/var-dumper": "^4.1.1"
+                "symfony/translation-contracts": "^1.1",
+                "symfony/var-dumper": "^4.1.1",
+                "twig/twig": "^1.34|^2.4"
             },
             "suggest": {
                 "symfony/browser-kit": "",
@@ -5668,7 +5775,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5695,7 +5802,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-28T12:07:12+00:00"
+            "time": "2019-05-30T06:21:08+00:00"
         },
         {
             "name": "symfony/inflector",
@@ -5757,16 +5864,16 @@
         },
         {
             "name": "symfony/lock",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/lock.git",
-                "reference": "e1067037abe6aeb3706e492db4b93bf6ad14c5d8"
+                "reference": "4c337c9c7b0927e7a07d5253a051366f77d38f40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/lock/zipball/e1067037abe6aeb3706e492db4b93bf6ad14c5d8",
-                "reference": "e1067037abe6aeb3706e492db4b93bf6ad14c5d8",
+                "url": "https://api.github.com/repos/symfony/lock/zipball/4c337c9c7b0927e7a07d5253a051366f77d38f40",
+                "reference": "4c337c9c7b0927e7a07d5253a051366f77d38f40",
                 "shasum": ""
             },
             "require": {
@@ -5775,12 +5882,13 @@
             },
             "require-dev": {
                 "doctrine/dbal": "~2.4",
+                "mongodb/mongodb": "~1.1",
                 "predis/predis": "~1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5815,7 +5923,7 @@
                 "redlock",
                 "semaphore"
             ],
-            "time": "2019-04-06T10:12:12+00:00"
+            "time": "2019-04-07T08:54:19+00:00"
         },
         {
             "name": "symfony/mime",
@@ -5878,23 +5986,23 @@
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "06cd3ca9f3fb68e21b227636671d7638dbe90cb3"
+                "reference": "8365f0e5fed85841f977cf9d665bfb61b392dcdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/06cd3ca9f3fb68e21b227636671d7638dbe90cb3",
-                "reference": "06cd3ca9f3fb68e21b227636671d7638dbe90cb3",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/8365f0e5fed85841f977cf9d665bfb61b392dcdf",
+                "reference": "8365f0e5fed85841f977cf9d665bfb61b392dcdf",
                 "shasum": ""
             },
             "require": {
                 "monolog/monolog": "~1.19",
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0",
-                "symfony/http-kernel": "~3.4|~4.0"
+                "symfony/http-kernel": "^4.3",
+                "symfony/service-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/console": "<3.4",
@@ -5902,20 +6010,18 @@
             },
             "require-dev": {
                 "symfony/console": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~3.4|~4.0",
                 "symfony/security-core": "~3.4|~4.0",
                 "symfony/var-dumper": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings.",
-                "symfony/event-dispatcher": "Needed when using log messages in console commands.",
                 "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",
                 "symfony/var-dumper": "For using the debugging handlers like the console handler or the log server handler."
             },
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5942,7 +6048,7 @@
             ],
             "description": "Symfony Monolog Bridge",
             "homepage": "https://symfony.com",
-            "time": "2019-05-01T08:36:31+00:00"
+            "time": "2019-05-27T08:16:38+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -6592,16 +6698,16 @@
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-bundle.git",
-                "reference": "5d3f378675a244a515dc8fdb96e96b9780639672"
+                "reference": "cb5ea7c36f0ee17ddd003dc3477d626281731115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/5d3f378675a244a515dc8fdb96e96b9780639672",
-                "reference": "5d3f378675a244a515dc8fdb96e96b9780639672",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/cb5ea7c36f0ee17ddd003dc3477d626281731115",
+                "reference": "cb5ea7c36f0ee17ddd003dc3477d626281731115",
                 "shasum": ""
             },
             "require": {
@@ -6609,16 +6715,15 @@
                 "php": "^7.1.3",
                 "symfony/config": "^4.2",
                 "symfony/dependency-injection": "^4.2",
-                "symfony/http-kernel": "^4.1",
-                "symfony/security-core": "~4.2",
+                "symfony/http-kernel": "^4.3",
+                "symfony/security-core": "~4.3",
                 "symfony/security-csrf": "~4.2",
                 "symfony/security-guard": "~4.2",
-                "symfony/security-http": "~4.2"
+                "symfony/security-http": "^4.3"
             },
             "conflict": {
                 "symfony/browser-kit": "<4.2",
                 "symfony/console": "<3.4",
-                "symfony/event-dispatcher": "<3.4",
                 "symfony/framework-bundle": "<4.2",
                 "symfony/twig-bundle": "<4.2",
                 "symfony/var-dumper": "<3.4"
@@ -6630,7 +6735,6 @@
                 "symfony/console": "~3.4|~4.0",
                 "symfony/css-selector": "~3.4|~4.0",
                 "symfony/dom-crawler": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~3.4|~4.0",
                 "symfony/expression-language": "~3.4|~4.0",
                 "symfony/form": "~3.4|~4.0",
                 "symfony/framework-bundle": "~4.2",
@@ -6647,7 +6751,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -6674,30 +6778,35 @@
             ],
             "description": "Symfony SecurityBundle",
             "homepage": "https://symfony.com",
-            "time": "2019-04-11T11:58:13+00:00"
+            "time": "2019-04-18T16:59:05+00:00"
         },
         {
             "name": "symfony/security-core",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "3a72ce263c3c1a9868bd9743e2eb6e7e51995503"
+                "reference": "b69e4898a4a2f950e24672836c9ecd40ca4883bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/3a72ce263c3c1a9868bd9743e2eb6e7e51995503",
-                "reference": "3a72ce263c3c1a9868bd9743e2eb6e7e51995503",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/b69e4898a4a2f950e24672836c9ecd40ca4883bb",
+                "reference": "b69e4898a4a2f950e24672836c9ecd40ca4883bb",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0"
+                "symfony/event-dispatcher-contracts": "^1.1",
+                "symfony/service-contracts": "^1.1"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<4.3",
+                "symfony/security-guard": "<4.3"
             },
             "require-dev": {
                 "psr/container": "^1.0",
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/expression-language": "~3.4|~4.0",
                 "symfony/http-foundation": "~3.4|~4.0",
                 "symfony/ldap": "~3.4|~4.0",
@@ -6714,7 +6823,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -6741,7 +6850,7 @@
             ],
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
-            "time": "2019-05-06T11:28:52+00:00"
+            "time": "2019-05-27T08:16:38+00:00"
         },
         {
             "name": "symfony/security-csrf",
@@ -6804,22 +6913,22 @@
         },
         {
             "name": "symfony/security-guard",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-guard.git",
-                "reference": "1313f51e126e03e13aaf83d471f087647701e0ac"
+                "reference": "33621882e935a2b7fa558311ffe9a4f6b1b7ee9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-guard/zipball/1313f51e126e03e13aaf83d471f087647701e0ac",
-                "reference": "1313f51e126e03e13aaf83d471f087647701e0ac",
+                "url": "https://api.github.com/repos/symfony/security-guard/zipball/33621882e935a2b7fa558311ffe9a4f6b1b7ee9f",
+                "reference": "33621882e935a2b7fa558311ffe9a4f6b1b7ee9f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "symfony/security-core": "~3.4.22|^4.2.3",
-                "symfony/security-http": "~3.4|~4.0"
+                "symfony/security-http": "^4.3"
             },
             "require-dev": {
                 "psr/log": "~1.0"
@@ -6827,7 +6936,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -6854,29 +6963,28 @@
             ],
             "description": "Symfony Security Component - Guard",
             "homepage": "https://symfony.com",
-            "time": "2019-04-01T07:32:59+00:00"
+            "time": "2019-04-07T18:20:37+00:00"
         },
         {
             "name": "symfony/security-http",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-http.git",
-                "reference": "9d63e1be2bac44d838f6a30edf4719c59ffe5965"
+                "reference": "13594beb3faaeea891aaae9eeea8ffde16a99faf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/9d63e1be2bac44d838f6a30edf4719c59ffe5965",
-                "reference": "9d63e1be2bac44d838f6a30edf4719c59ffe5965",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/13594beb3faaeea891aaae9eeea8ffde16a99faf",
+                "reference": "13594beb3faaeea891aaae9eeea8ffde16a99faf",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/event-dispatcher": "~3.4|~4.0",
                 "symfony/http-foundation": "~3.4|~4.0",
-                "symfony/http-kernel": "~3.4|~4.0",
+                "symfony/http-kernel": "^4.3",
                 "symfony/property-access": "~3.4|~4.0",
-                "symfony/security-core": "~3.4|~4.0"
+                "symfony/security-core": "^4.3"
             },
             "conflict": {
                 "symfony/security-csrf": "<3.4.11|~4.0,<4.0.11"
@@ -6893,7 +7001,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -6920,7 +7028,7 @@
             ],
             "description": "Symfony Security Component - HTTP Integration",
             "homepage": "https://symfony.com",
-            "time": "2019-05-26T20:47:34+00:00"
+            "time": "2019-05-26T20:47:49+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -7031,6 +7139,64 @@
             ],
             "description": "A pack for the Symfony serializer",
             "time": "2018-12-10T12:14:14+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/container": "",
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-05-28T07:50:59+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -7204,6 +7370,63 @@
             "time": "2019-02-23T15:22:31+00:00"
         },
         {
+            "name": "symfony/translation-contracts",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "93597ce975d91c52ebfaca1253343cd9ccb7916d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/93597ce975d91c52ebfaca1253343cd9ccb7916d",
+                "reference": "93597ce975d91c52ebfaca1253343cd9ccb7916d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-05-27T08:16:38+00:00"
+        },
+        {
             "name": "symfony/twig-bridge",
             "version": "v4.3.0",
             "source": {
@@ -7303,30 +7526,30 @@
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bundle.git",
-                "reference": "3bb863ffabad2be25b9d5a5d8f7dd4458b8e2fa8"
+                "reference": "2792936cbcd92267596363b67b5cebb5e347af59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/3bb863ffabad2be25b9d5a5d8f7dd4458b8e2fa8",
-                "reference": "3bb863ffabad2be25b9d5a5d8f7dd4458b8e2fa8",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/2792936cbcd92267596363b67b5cebb5e347af59",
+                "reference": "2792936cbcd92267596363b67b5cebb5e347af59",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "symfony/config": "~4.2",
-                "symfony/http-foundation": "~4.1",
+                "symfony/http-foundation": "~4.3",
                 "symfony/http-kernel": "~4.1",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/twig-bridge": "^4.2",
+                "symfony/twig-bridge": "^4.3",
                 "twig/twig": "~1.41|~2.10"
             },
             "conflict": {
                 "symfony/dependency-injection": "<4.1",
-                "symfony/framework-bundle": "<4.1",
+                "symfony/framework-bundle": "<4.3",
                 "symfony/translation": "<4.2"
             },
             "require-dev": {
@@ -7337,7 +7560,7 @@
                 "symfony/expression-language": "~3.4|~4.0",
                 "symfony/finder": "~3.4|~4.0",
                 "symfony/form": "~3.4|~4.0",
-                "symfony/framework-bundle": "~4.1",
+                "symfony/framework-bundle": "~4.3",
                 "symfony/routing": "~3.4|~4.0",
                 "symfony/stopwatch": "~3.4|~4.0",
                 "symfony/templating": "~3.4|~4.0",
@@ -7348,7 +7571,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7375,7 +7598,7 @@
             ],
             "description": "Symfony TwigBundle",
             "homepage": "https://symfony.com",
-            "time": "2019-05-10T06:54:47+00:00"
+            "time": "2019-05-10T08:01:19+00:00"
         },
         {
             "name": "symfony/validator",
@@ -7531,16 +7754,16 @@
         },
         {
             "name": "symfony/web-link",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-link.git",
-                "reference": "47b8188b4bb8d24eef0bb287b0737d5b84a6cab8"
+                "reference": "af0e386322f192ed50bd9c812daedce05368733c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-link/zipball/47b8188b4bb8d24eef0bb287b0737d5b84a6cab8",
-                "reference": "47b8188b4bb8d24eef0bb287b0737d5b84a6cab8",
+                "url": "https://api.github.com/repos/symfony/web-link/zipball/af0e386322f192ed50bd9c812daedce05368733c",
+                "reference": "af0e386322f192ed50bd9c812daedce05368733c",
                 "shasum": ""
             },
             "require": {
@@ -7548,10 +7771,12 @@
                 "php": "^7.1.3",
                 "psr/link": "^1.0"
             },
+            "conflict": {
+                "symfony/http-kernel": "<4.3"
+            },
             "require-dev": {
-                "symfony/event-dispatcher": "~3.4|~4.0",
                 "symfony/http-foundation": "~3.4|~4.0",
-                "symfony/http-kernel": "~3.4|~4.0"
+                "symfony/http-kernel": "^4.3"
             },
             "suggest": {
                 "symfony/http-kernel": ""
@@ -7559,7 +7784,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7598,7 +7823,7 @@
                 "psr13",
                 "push"
             ],
-            "time": "2019-01-16T20:31:39+00:00"
+            "time": "2019-03-14T07:32:46+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -8373,16 +8598,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "c09c18cca96d7067152f78956faf55346c338283"
+                "reference": "3fa7d8cbd2e5006038a09b8ef93f3859a89b627e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/c09c18cca96d7067152f78956faf55346c338283",
-                "reference": "c09c18cca96d7067152f78956faf55346c338283",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/3fa7d8cbd2e5006038a09b8ef93f3859a89b627e",
+                "reference": "3fa7d8cbd2e5006038a09b8ef93f3859a89b627e",
                 "shasum": ""
             },
             "require": {
@@ -8391,6 +8616,8 @@
             },
             "require-dev": {
                 "symfony/css-selector": "~3.4|~4.0",
+                "symfony/http-client": "^4.3",
+                "symfony/mime": "^4.3",
                 "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
@@ -8399,7 +8626,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -8426,7 +8653,78 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-07T09:56:43+00:00"
+            "time": "2019-04-15T20:15:25+00:00"
+        },
+        {
+            "name": "symfony/contracts",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "d3636025e8253c6144358ec0a62773cae588395b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/d3636025e8253c6144358ec0a62773cae588395b",
+                "reference": "d3636025e8253c6144358ec0a62773cae588395b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0",
+                "symfony/polyfill-intl-idn": "^1.10"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/event-dispatcher-implementation": "",
+                "symfony/http-client-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-04-27T14:29:50+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -8640,22 +8938,24 @@
         },
         {
             "name": "symfony/panther",
-            "version": "v0.3.0",
+            "version": "v0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/panther.git",
-                "reference": "5e41bc856eded5f546c71173a1e8e260c5e3a07a"
+                "reference": "7a041cb4fc56e16f11808943633068a8fa3d6a51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/panther/zipball/5e41bc856eded5f546c71173a1e8e260c5e3a07a",
-                "reference": "5e41bc856eded5f546c71173a1e8e260c5e3a07a",
+                "url": "https://api.github.com/repos/symfony/panther/zipball/7a041cb4fc56e16f11808943633068a8fa3d6a51",
+                "reference": "7a041cb4fc56e16f11808943633068a8fa3d6a51",
                 "shasum": ""
             },
             "require": {
                 "facebook/webdriver": "^1.5",
                 "php": ">=7.1",
                 "symfony/browser-kit": "^4.0",
+                "symfony/contracts": "^1.1",
+                "symfony/http-client": "^4.3",
                 "symfony/polyfill-php72": "^1.9",
                 "symfony/process": "^3.4 || ^4.0"
             },
@@ -8705,7 +9005,7 @@
                 "testing",
                 "webdriver"
             ],
-            "time": "2019-02-27T12:48:28+00:00"
+            "time": "2019-06-04T09:44:04+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
@@ -8956,22 +9256,22 @@
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v4.2.9",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "1bd05666e23aff4306d7b236b6ccdf6d2e99fe00"
+                "reference": "b371e362dada3c1fcd9e7f7a31a91bd681860331"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/1bd05666e23aff4306d7b236b6ccdf6d2e99fe00",
-                "reference": "1bd05666e23aff4306d7b236b6ccdf6d2e99fe00",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/b371e362dada3c1fcd9e7f7a31a91bd681860331",
+                "reference": "b371e362dada3c1fcd9e7f7a31a91bd681860331",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "symfony/config": "^4.2",
-                "symfony/http-kernel": "^4.2.6",
+                "symfony/http-kernel": "^4.3",
                 "symfony/routing": "~3.4|~4.0",
                 "symfony/twig-bundle": "~4.2",
                 "symfony/var-dumper": "~3.4|~4.0",
@@ -8979,7 +9279,7 @@
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
-                "symfony/event-dispatcher": "<3.4",
+                "symfony/form": "<4.3",
                 "symfony/messenger": "<4.2",
                 "symfony/var-dumper": "<3.4"
             },
@@ -8991,7 +9291,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -9018,7 +9318,7 @@
             ],
             "description": "Symfony WebProfilerBundle",
             "homepage": "https://symfony.com",
-            "time": "2019-05-26T20:47:34+00:00"
+            "time": "2019-05-26T20:47:49+00:00"
         },
         {
             "name": "symfony/web-server-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03f7f7f554317881c9807e08da3ab119",
+    "content-hash": "3c180083242efb32811c2be77517e37a",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -8408,16 +8408,16 @@
         },
         {
             "name": "liip/functional-test-bundle",
-            "version": "2.0.0-alpha15",
+            "version": "3.0.0-RC1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/LiipFunctionalTestBundle.git",
-                "reference": "76c3fd3fef5bd149eaa4b00399194a41350223af"
+                "reference": "c9c9f473d82b6b428d6edfa86e6b26ce047c1e51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/76c3fd3fef5bd149eaa4b00399194a41350223af",
-                "reference": "76c3fd3fef5bd149eaa4b00399194a41350223af",
+                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/c9c9f473d82b6b428d6edfa86e6b26ce047c1e51",
+                "reference": "c9c9f473d82b6b428d6edfa86e6b26ce047c1e51",
                 "shasum": ""
             },
             "require": {
@@ -8427,25 +8427,19 @@
                 "symfony/framework-bundle": "^3.4 || ^4.1"
             },
             "require-dev": {
-                "doctrine/data-fixtures": "^1.3",
                 "doctrine/doctrine-bundle": "^1.8",
                 "doctrine/doctrine-fixtures-bundle": "^3.0.2",
                 "doctrine/orm": "^2.6",
-                "jackalope/jackalope-doctrine-dbal": "^1.3",
                 "phpunit/phpunit": "^6.1 || ^7.0",
                 "symfony/monolog-bundle": "^3.1",
                 "symfony/phpunit-bridge": "^3.4 || ^4.1",
                 "symfony/symfony": "^3.4 || ^4.1",
-                "theofidry/alice-data-fixtures": "^1.0.1",
                 "twig/twig": "^2.0"
             },
             "suggest": {
                 "brianium/paratest": "Required when using paratest to parallelize tests",
                 "doctrine/dbal": "Required when using the fixture loading functionality with an ORM and SQLite",
-                "doctrine/doctrine-fixtures-bundle": "Required when using the fixture loading functionality",
-                "doctrine/orm": "Required when using the fixture loading functionality with an ORM and SQLite",
-                "hautelook/alice-bundle": "Required when using loadFixtureFiles functionality with custom providers",
-                "theofidry/alice-data-fixtures": "Required when using loadFixtureFiles functionality"
+                "doctrine/orm": "Required when using the fixture loading functionality with an ORM and SQLite"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -8474,11 +8468,82 @@
             ],
             "description": "This bundles provides additional functional test-cases for Symfony applications",
             "keywords": [
+                "symfony",
+                "testing"
+            ],
+            "time": "2019-06-02T20:48:55+00:00"
+        },
+        {
+            "name": "liip/test-fixtures-bundle",
+            "version": "1.0.0-RC1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/liip/LiipTestFixturesBundle.git",
+                "reference": "e7ba73822e0b17f781707be437512588757b706e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/liip/LiipTestFixturesBundle/zipball/e7ba73822e0b17f781707be437512588757b706e",
+                "reference": "e7ba73822e0b17f781707be437512588757b706e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "^2.0",
+                "php": "^7.1",
+                "symfony/browser-kit": "^3.4 || ^4.1",
+                "symfony/framework-bundle": "^3.4 || ^4.1"
+            },
+            "require-dev": {
+                "doctrine/data-fixtures": "^1.3",
+                "doctrine/doctrine-bundle": "^1.8",
+                "doctrine/doctrine-fixtures-bundle": "^3.0.2",
+                "doctrine/orm": "^2.6",
+                "jackalope/jackalope-doctrine-dbal": "^1.3",
+                "phpunit/phpunit": "^6.1 || ^7.0",
+                "symfony/monolog-bundle": "^3.1",
+                "symfony/phpunit-bridge": "^3.4 || ^4.1",
+                "symfony/symfony": "^3.4 || ^4.1",
+                "theofidry/alice-data-fixtures": "^1.0.1"
+            },
+            "suggest": {
+                "doctrine/dbal": "Required when using the fixture loading functionality with an ORM and SQLite",
+                "doctrine/doctrine-fixtures-bundle": "Required when using the fixture loading functionality",
+                "doctrine/orm": "Required when using the fixture loading functionality with an ORM and SQLite",
+                "hautelook/alice-bundle": "Required when using loadFixtureFiles functionality with custom providers",
+                "theofidry/alice-data-fixtures": "Required when using loadFixtureFiles functionality"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liip\\TestFixturesBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Liip AG",
+                    "homepage": "http://www.liip.ch/"
+                },
+                {
+                    "name": "Community contributions",
+                    "homepage": "https://github.com/liip/LiipTestFixturesBundle/contributors"
+                }
+            ],
+            "description": "This bundles enables efficient loading of Doctrine fixtures in functional test-cases for Symfony applications",
+            "keywords": [
                 "fixtures",
                 "symfony",
                 "testing"
             ],
-            "time": "2019-03-24T23:03:32+00:00"
+            "time": "2019-06-02T20:05:09+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -9386,6 +9451,7 @@
         "firebase/php-jwt": 0,
         "fzaninotto/faker": 0,
         "liip/functional-test-bundle": 15,
+        "liip/test-fixtures-bundle": 5,
         "squizlabs/php_codesniffer": 0
     },
     "prefer-stable": false,

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Annotations\AnnotationReader;
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
 if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
-    $_SERVER += $env;
     $_ENV += $env;
 } elseif (!class_exists(Dotenv::class)) {
     throw new RuntimeException(
@@ -17,14 +16,14 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
     );
 } else {
     // load all the .env files
-    (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+    (new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');
 }
 
+$_SERVER += $_ENV;
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] ||
     filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
-
 
 AnnotationReader::addGlobalIgnoredName('covers');
 AnnotationReader::addGlobalIgnoredName('group');

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -18,4 +18,5 @@ return [
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\WebServerBundle\WebServerBundle::class => ['dev' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
+    Liip\TestFixturesBundle\LiipTestFixturesBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -3,6 +3,9 @@ security:
     allow_if_all_abstain: false
     strategy: unanimous
   firewalls:
+    dev:
+      pattern: ^/(_(profiler|wdt)|css|images|js)/
+      security: false
     api_docs:
       pattern:   ^/api/doc
       anonymous: ~

--- a/config/packages/test/functional_test.yaml
+++ b/config/packages/test/functional_test.yaml
@@ -1,3 +1,0 @@
-liip_functional_test:
-  cache_db:
-    sqlite: liip_functional_test.services_database_backup.sqlite

--- a/config/packages/test/liip_test_fixtures.yaml
+++ b/config/packages/test/liip_test_fixtures.yaml
@@ -1,0 +1,3 @@
+liip_test_fixtures:
+  cache_db:
+    sqlite: liip_test_fixtures.services_database_backup.sqlite

--- a/config/packages/test/validator.yaml
+++ b/config/packages/test/validator.yaml
@@ -1,0 +1,3 @@
+framework:
+    validation:
+        not_compromised_password: true

--- a/config/packages/validator.yaml
+++ b/config/packages/validator.yaml
@@ -1,3 +1,8 @@
 framework:
     validation:
         email_validation_mode: html5
+
+        # Enables validator auto-mapping support.
+        # For instance, basic validation constraints will be inferred from Doctrine's metadata.
+        auto_mapping:
+            App\Entity\: []

--- a/config/packages/validator.yaml
+++ b/config/packages/validator.yaml
@@ -4,5 +4,5 @@ framework:
 
         # Enables validator auto-mapping support.
         # For instance, basic validation constraints will be inferred from Doctrine's metadata.
-        auto_mapping:
-            App\Entity\: []
+#        auto_mapping:
+#            App\Entity\: []

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,5 +17,6 @@
     <file>tests/</file>
     <exclude-pattern>src/Migrations/*</exclude-pattern>
     <exclude-pattern>public/index.php</exclude-pattern>
+    <exclude-pattern>bin/.phpunit</exclude-pattern>
 
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,15 +8,8 @@
          bootstrap="config/bootstrap.php"
 >
     <php>
-        <ini name="error_reporting" value="-1" />
-        <env name="APP_ENV" value="test" />
-        <!--
-            temporarily add SYMFONY_DEPRECATIONS_HELPER here
-            until Symfony 4.3 is released which should have have fixed
-            issues with ENV loading and this can be read from .env.test again
-        -->
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="99999" />
-        <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 
     <testsuites>

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -14,9 +14,9 @@ class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 
-    const CONFIG_EXTS = '.{php,xml,yaml,yml}';
+    private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         $contents = require $this->getProjectDir().'/config/bundles.php';
         foreach ($contents as $class => $envs) {
@@ -26,7 +26,12 @@ class Kernel extends BaseKernel
         }
     }
 
-    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+    public function getProjectDir(): string
+    {
+        return \dirname(__DIR__);
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $container->addResource(new FileResource($this->getProjectDir().'/config/bundles.php'));
         $container->setParameter('container.dumper.inline_class_loader', true);
@@ -38,12 +43,12 @@ class Kernel extends BaseKernel
         $loader->load($confDir.'/{services}_'.$this->environment.self::CONFIG_EXTS, 'glob');
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
         $confDir = $this->getProjectDir().'/config';
 
-        $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
     }
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -188,6 +188,9 @@
             "ref": "02ad65038eceb5231c73a530b67beedd955c40ed"
         }
     },
+    "liip/test-fixtures-bundle": {
+        "version": "0.1.0-alpha1"
+    },
     "mockery/mockery": {
         "version": "1.2.0"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -5,9 +5,6 @@
     "clue/stream-filter": {
         "version": "v1.4.0"
     },
-    "composer/ca-bundle": {
-        "version": "1.1.4"
-    },
     "danielstjules/stringy": {
         "version": "3.1.0"
     },
@@ -284,9 +281,6 @@
     "psr/log": {
         "version": "1.1.0"
     },
-    "psr/simple-cache": {
-        "version": "1.0.1"
-    },
     "ralouphie/getallheaders": {
         "version": "2.0.5"
     },
@@ -344,6 +338,9 @@
     "symfony/cache": {
         "version": "v4.2.3"
     },
+    "symfony/cache-contracts": {
+        "version": "v1.1.1"
+    },
     "symfony/config": {
         "version": "v4.2.3"
     },
@@ -361,7 +358,7 @@
         ]
     },
     "symfony/contracts": {
-        "version": "v1.0.2"
+        "version": "v1.1.0"
     },
     "symfony/css-selector": {
         "version": "v4.2.3"
@@ -395,6 +392,9 @@
     },
     "symfony/event-dispatcher": {
         "version": "v4.2.3"
+    },
+    "symfony/event-dispatcher-contracts": {
+        "version": "v1.1.1"
     },
     "symfony/filesystem": {
         "version": "v4.2.3"
@@ -433,6 +433,12 @@
             "src/Kernel.php"
         ]
     },
+    "symfony/http-client": {
+        "version": "v4.3.0"
+    },
+    "symfony/http-client-contracts": {
+        "version": "v1.1.1"
+    },
     "symfony/http-foundation": {
         "version": "v4.2.3"
     },
@@ -444,6 +450,9 @@
     },
     "symfony/lock": {
         "version": "v4.2.3"
+    },
+    "symfony/mime": {
+        "version": "v4.3.0"
     },
     "symfony/monolog-bridge": {
         "version": "v4.2.3"
@@ -490,6 +499,9 @@
     },
     "symfony/polyfill-php72": {
         "version": "v1.10.0"
+    },
+    "symfony/polyfill-php73": {
+        "version": "v1.11.0"
     },
     "symfony/process": {
         "version": "v4.2.3"
@@ -554,6 +566,9 @@
     "symfony/serializer-pack": {
         "version": "v1.0.2"
     },
+    "symfony/service-contracts": {
+        "version": "v1.1.2"
+    },
     "symfony/stopwatch": {
         "version": "v4.2.3"
     },
@@ -571,6 +586,9 @@
     },
     "symfony/test-pack": {
         "version": "v1.0.5"
+    },
+    "symfony/translation-contracts": {
+        "version": "v1.1.2"
     },
     "symfony/twig-bridge": {
         "version": "v4.2.3"

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,9 +1,9 @@
 {
     "aws/aws-sdk-php": {
-        "version": "3.87.16"
+        "version": "3.97.0"
     },
     "clue/stream-filter": {
-        "version": "v1.4.0"
+        "version": "v1.4.1"
     },
     "danielstjules/stringy": {
         "version": "3.1.0"
@@ -21,7 +21,7 @@
         "version": "v1.8.0"
     },
     "doctrine/collections": {
-        "version": "v1.5.0"
+        "version": "v1.6.1"
     },
     "doctrine/common": {
         "version": "v2.10.0"
@@ -38,7 +38,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "1.6",
-            "ref": "453e89b78ded666f351617baca5ae40d20622351"
+            "ref": "02bc9e7994b70f4fda004131a0c78b7b1bf09789"
         },
         "files": [
             "config/packages/doctrine.yaml",
@@ -78,7 +78,7 @@
         "version": "v1.3.0"
     },
     "doctrine/instantiator": {
-        "version": "1.1.0"
+        "version": "1.2.0"
     },
     "doctrine/lexer": {
         "version": "v1.0.1"
@@ -90,7 +90,7 @@
         "version": "v2.6.3"
     },
     "doctrine/persistence": {
-        "version": "v1.1.0"
+        "version": "1.1.1"
     },
     "doctrine/reflection": {
         "version": "v1.0.0"
@@ -108,10 +108,10 @@
         }
     },
     "egulias/email-validator": {
-        "version": "2.1.7"
+        "version": "2.1.8"
     },
     "elasticsearch/elasticsearch": {
-        "version": "v6.1.0"
+        "version": "v6.7.1"
     },
     "eluceo/ical": {
         "version": "0.15.0"
@@ -168,7 +168,7 @@
         "version": "1.2"
     },
     "league/flysystem": {
-        "version": "1.0.50"
+        "version": "1.0.52"
     },
     "league/flysystem-aws-s3-v3": {
         "version": "1.0.22"
@@ -177,7 +177,7 @@
         "version": "1.0.9"
     },
     "liip/functional-test-bundle": {
-        "version": "2.0.0-alpha12"
+        "version": "2.0.0-alpha15"
     },
     "liip/monitor-bundle": {
         "version": "2.6",
@@ -222,7 +222,7 @@
         "version": "v1.7.1"
     },
     "php-http/discovery": {
-        "version": "1.6.0"
+        "version": "1.6.1"
     },
     "php-http/guzzle6-adapter": {
         "version": "v1.1.1"
@@ -258,7 +258,7 @@
         "version": "1.0.1"
     },
     "phpdocumentor/reflection-docblock": {
-        "version": "4.3.0"
+        "version": "4.3.1"
     },
     "phpdocumentor/type-resolver": {
         "version": "0.4.0"
@@ -270,7 +270,7 @@
         "version": "1.0.0"
     },
     "psr/http-factory": {
-        "version": "1.0.0"
+        "version": "1.0.1"
     },
     "psr/http-message": {
         "version": "1.0.1"
@@ -303,7 +303,7 @@
         ]
     },
     "sentry/sentry": {
-        "version": "2.0.0-beta2"
+        "version": "2.1.0"
     },
     "squizlabs/php_codesniffer": {
         "version": "3.0",
@@ -315,10 +315,10 @@
         }
     },
     "swagger-api/swagger-ui": {
-        "version": "v3.20.8"
+        "version": "v3.22.2"
     },
     "swiftmailer/swiftmailer": {
-        "version": "v6.1.3"
+        "version": "v6.2.1"
     },
     "symfony/apache-pack": {
         "version": "1.0",
@@ -330,19 +330,19 @@
         }
     },
     "symfony/asset": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/browser-kit": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/cache": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/cache-contracts": {
         "version": "v1.1.1"
     },
     "symfony/config": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/console": {
         "version": "3.3",
@@ -350,7 +350,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "3.3",
-            "ref": "0fa049c19069a65f52c1c181d64be3de672c1504"
+            "ref": "482d233eb8de91ebd042992077bbd5838858890c"
         },
         "files": [
             "bin/console",
@@ -361,10 +361,10 @@
         "version": "v1.1.0"
     },
     "symfony/css-selector": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/debug": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/debug-bundle": {
         "version": "4.1",
@@ -379,28 +379,28 @@
         "version": "v1.0.7"
     },
     "symfony/dependency-injection": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/doctrine-bridge": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/dom-crawler": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/dotenv": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/event-dispatcher": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/event-dispatcher-contracts": {
         "version": "v1.1.1"
     },
     "symfony/filesystem": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/finder": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/flex": {
         "version": "1.0",
@@ -420,7 +420,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.2",
-            "ref": "5bb3a8c27df824d195fa68bb635d074854f8498f"
+            "ref": "f64037a414de7d861f68e9b5b5c0e4f7425e2002"
         },
         "files": [
             "config/bootstrap.php",
@@ -440,22 +440,22 @@
         "version": "v1.1.1"
     },
     "symfony/http-foundation": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/http-kernel": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/inflector": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/lock": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/mime": {
         "version": "v4.3.0"
     },
     "symfony/monolog-bridge": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/monolog-bundle": {
         "version": "3.1",
@@ -467,21 +467,21 @@
         }
     },
     "symfony/options-resolver": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/orm-pack": {
         "version": "v1.0.5"
     },
     "symfony/panther": {
-        "version": "v0.2.0"
+        "version": "v0.3.0"
     },
     "symfony/phpunit-bridge": {
-        "version": "4.1",
+        "version": "4.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "4.1",
-            "ref": "0e548dd90adba18fabd4ef419b14d361fe4d6c74"
+            "version": "4.3",
+            "ref": "04ecbfb3121b7418265aee7b1b2151959ba430b9"
         },
         "files": [
             ".env.test",
@@ -492,28 +492,28 @@
         ]
     },
     "symfony/polyfill-intl-idn": {
-        "version": "v1.10.0"
+        "version": "v1.11.0"
     },
     "symfony/polyfill-mbstring": {
-        "version": "v1.10.0"
+        "version": "v1.11.0"
     },
     "symfony/polyfill-php72": {
-        "version": "v1.10.0"
+        "version": "v1.11.0"
     },
     "symfony/polyfill-php73": {
         "version": "v1.11.0"
     },
     "symfony/process": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/profiler-pack": {
         "version": "v1.0.4"
     },
     "symfony/property-access": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/property-info": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/requirements-checker": {
         "version": "1.0",
@@ -545,23 +545,26 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "3.3",
-            "ref": "f8a63faa0d9521526499c0a8f403c9964ecb0527"
-        }
+            "ref": "9a2034eca6d83d9cda632014e06995b8d9d9fd09"
+        },
+        "files": [
+            "config/packages/security.yaml"
+        ]
     },
     "symfony/security-core": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/security-csrf": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/security-guard": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/security-http": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/serializer": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/serializer-pack": {
         "version": "v1.0.2"
@@ -570,7 +573,7 @@
         "version": "v1.1.2"
     },
     "symfony/stopwatch": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/swiftmailer-bundle": {
         "version": "2.5",
@@ -578,11 +581,16 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "2.5",
-            "ref": "3db029c03e452b4a23f7fc45cec7c922c2247eb8"
-        }
+            "ref": "62dbd4422d8ba6cbcb8964ca558c7f352eae955e"
+        },
+        "files": [
+            "config/packages/dev/swiftmailer.yaml",
+            "config/packages/swiftmailer.yaml",
+            "config/packages/test/swiftmailer.yaml"
+        ]
     },
     "symfony/templating": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/test-pack": {
         "version": "v1.0.5"
@@ -591,7 +599,7 @@
         "version": "v1.1.2"
     },
     "symfony/twig-bridge": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/twig-bundle": {
         "version": "3.3",
@@ -603,22 +611,26 @@
         }
     },
     "symfony/validator": {
-        "version": "4.1",
+        "version": "4.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "4.1",
-            "ref": "0cdc982334f45d554957a6167e030482795bf9d7"
-        }
+            "version": "4.3",
+            "ref": "f8992cec2e7a33fb5453b1ba08acee62d01397e2"
+        },
+        "files": [
+            "config/packages/test/validator.yaml",
+            "config/packages/validator.yaml"
+        ]
     },
     "symfony/var-dumper": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/var-exporter": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/web-link": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "symfony/web-profiler-bundle": {
         "version": "3.3",
@@ -639,10 +651,10 @@
         }
     },
     "symfony/yaml": {
-        "version": "v4.2.3"
+        "version": "v4.3.0"
     },
     "twig/twig": {
-        "version": "v2.6.2"
+        "version": "v2.10.0"
     },
     "webmozart/assert": {
         "version": "1.4.0"
@@ -651,12 +663,12 @@
         "version": "3.3.1"
     },
     "zendframework/zend-diactoros": {
-        "version": "2.1.1"
+        "version": "2.1.2"
     },
     "zendframework/zend-eventmanager": {
         "version": "3.2.1"
     },
     "zendframework/zenddiagnostics": {
-        "version": "v1.4.0"
+        "version": "v1.5.0"
     }
 }

--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use DateTime;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Bundle\FrameworkBundle\Client;
 use App\Tests\DataLoader\DataLoaderInterface;
@@ -22,6 +23,7 @@ use Faker\Generator as FakerGenerator;
 abstract class AbstractEndpointTest extends WebTestCase
 {
     use JsonControllerTest;
+    use FixturesTrait;
 
     /**
      * @var string|null the name of this endpoint (plural)

--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -29,15 +29,9 @@ abstract class AbstractEndpointTest extends WebTestCase
     protected $testName = null;
 
     /**
-     * @var Client
-     */
-    protected $client;
-
-    /**
      * @var ProxyReferenceRepository
      */
     protected $fixtures;
-
 
     /**
      * @var FakerGenerator
@@ -48,8 +42,7 @@ abstract class AbstractEndpointTest extends WebTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->client = $this->makeClient();
-        $this->client->followRedirects();
+        $this->makeClient();
 
         $authFixtures = [
             'App\Tests\Fixture\LoadAuthenticationData',
@@ -64,7 +57,7 @@ abstract class AbstractEndpointTest extends WebTestCase
     public function tearDown() : void
     {
         parent::tearDown();
-        unset($this->client);
+        self::$client = null;
         unset($this->fixtures);
         unset($this->faker);
     }
@@ -172,7 +165,7 @@ abstract class AbstractEndpointTest extends WebTestCase
      */
     protected function createJsonRequest($method, $url, $content = null, $token = null, $files = [])
     {
-        $this->makeJsonRequest($this->client, $method, $url, $content, $token, $files);
+        $this->makeJsonRequest(self::$client, $method, $url, $content, $token, $files);
     }
 
     /**
@@ -221,7 +214,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");
@@ -253,7 +246,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             null,
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_OK);
         $responses = json_decode($response->getContent(), true)[$responseKey];
@@ -359,7 +352,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             json_encode([$postKey => $postData]),
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
 
         return json_decode($response->getContent(), true)[$responseKey][0];
@@ -380,7 +373,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             json_encode([$responseKey => $postData]),
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
 
         return json_decode($response->getContent(), true)[$responseKey];
@@ -402,7 +395,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, $code);
     }
@@ -423,7 +416,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, $code);
     }
@@ -503,7 +496,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             json_encode([$responseKey => $data]),
             $this->getTokenForUser($userId)
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $expectedHeader = $new?Response::HTTP_CREATED:Response::HTTP_OK;
         $this->assertJsonResponse($response, $expectedHeader);
 
@@ -537,7 +530,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             null,
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
 
         $this->assertJsonResponse($response, Response::HTTP_NO_CONTENT, false);
@@ -563,7 +556,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }
@@ -622,7 +615,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             $this->getTokenForUser($userId)
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_OK);
 
@@ -651,7 +644,7 @@ abstract class AbstractEndpointTest extends WebTestCase
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
     }

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -3,12 +3,14 @@
 namespace App\Tests\Controller;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 
 class ApiControllerTest extends WebTestCase
 {
     use JsonControllerTest;
+    use FixturesTrait;
 
     public function setUp()
     {

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -7,6 +7,7 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Firebase\JWT\JWT;
 use DateTime;
 
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 use App\Service\JsonWebTokenManager;
@@ -14,6 +15,7 @@ use App\Service\JsonWebTokenManager;
 class AuthControllerTest extends WebTestCase
 {
     use JsonControllerTest;
+    use FixturesTrait;
 
     /**
      * @var string

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -2,6 +2,7 @@
 namespace App\Tests\Controller;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Fixture\LoadApplicationConfigData;
 use App\Tests\Traits\JsonControllerTest;
@@ -12,6 +13,7 @@ use App\Tests\Traits\JsonControllerTest;
 class ConfigControllerTest extends WebTestCase
 {
     use JsonControllerTest;
+    use FixturesTrait;
 
     public function setUp()
     {

--- a/tests/Controller/CurriculumInventoryDownloadControllerTest.php
+++ b/tests/Controller/CurriculumInventoryDownloadControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Controller;
 
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
@@ -12,6 +13,7 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
 class CurriculumInventoryDownloadControllerTest extends WebTestCase
 {
     use JsonControllerTest;
+    use FixturesTrait;
 
     /**
      * @inheritdoc

--- a/tests/Controller/DownloadControllerTest.php
+++ b/tests/Controller/DownloadControllerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Controller;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 
@@ -14,6 +15,7 @@ use App\Tests\Traits\JsonControllerTest;
 class DownloadControllerTest extends WebTestCase
 {
     use JsonControllerTest;
+    use FixturesTrait;
 
     /**
      * @var ProxyReferenceRepository

--- a/tests/Controller/ErrorControllerTest.php
+++ b/tests/Controller/ErrorControllerTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Controller;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 use Faker\Factory as FakerFactory;
@@ -10,6 +11,7 @@ use Faker\Factory as FakerFactory;
 class ErrorControllerTest extends WebTestCase
 {
     use JsonControllerTest;
+    use FixturesTrait;
 
     public function setUp()
     {

--- a/tests/Controller/IcsControllerTest.php
+++ b/tests/Controller/IcsControllerTest.php
@@ -3,6 +3,7 @@ namespace App\Tests\Controller;
 
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\DataLoader\SessionData;
 use App\Tests\Traits\JsonControllerTest;
@@ -13,6 +14,7 @@ use App\Tests\Traits\JsonControllerTest;
 class IcsControllerTest extends WebTestCase
 {
     use JsonControllerTest;
+    use FixturesTrait;
 
     /**
      * @var ProxyReferenceRepository

--- a/tests/Controller/IcsControllerTest.php
+++ b/tests/Controller/IcsControllerTest.php
@@ -3,7 +3,6 @@ namespace App\Tests\Controller;
 
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
-use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\DataLoader\SessionData;
 use App\Tests\Traits\JsonControllerTest;
@@ -20,15 +19,9 @@ class IcsControllerTest extends WebTestCase
      */
     protected $fixtures;
 
-    /**
-     * @var Client
-     */
-    protected $client;
-
     public function setUp()
     {
         parent::setUp();
-        $this->client = $this->makeClient();
         $this->fixtures = $this->loadFixtures([
             'App\Tests\Fixture\LoadAuthenticationData',
             'App\Tests\Fixture\LoadOfferingData',
@@ -41,31 +34,32 @@ class IcsControllerTest extends WebTestCase
     public function tearDown() : void
     {
         parent::tearDown();
-        unset($this->client);
+        $client = null;
         unset($this->fixtures);
     }
 
     public function testSessionAttributesShowUp()
     {
-        $container = $this->client->getContainer();
+        $client = static::createClient();
+        $container = $client->getContainer();
         $session = $container->get(SessionData::class)->getOne();
         $session['attireRequired'] = true;
         $session['equipmentRequired'] = true;
         $session['attendanceRequired'] = true;
         $id = $session['id'];
         $this->makeJsonRequest(
-            $this->client,
+            $client,
             'PUT',
             $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'sessions', 'id' => $id]),
             json_encode(['session' => $session]),
             $this->getTokenForUser(2)
         );
-        $response = $this->client->getResponse();
+        $response = $client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_OK);
 
         $url = '/ics/' . hash('sha256', '1');
-        $this->client->request('GET', $url);
-        $response = $this->client->getResponse();
+        $client->request('GET', $url);
+        $response = $client->getResponse();
 
         $content = $response->getContent();
 
@@ -112,25 +106,26 @@ class IcsControllerTest extends WebTestCase
 
     public function testSessionAttributesAreHidden()
     {
-        $container = $this->client->getContainer();
+        $client = static::createClient();
+        $container = $client->getContainer();
         $session = $container->get(SessionData::class)->getOne();
         $session['attireRequired'] = false;
         $session['equipmentRequired'] = false;
         $session['attendanceRequired'] = false;
         $id = $session['id'];
         $this->makeJsonRequest(
-            $this->client,
+            $client,
             'PUT',
             $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'sessions', 'id' => $id]),
             json_encode(['session' => $session]),
             $this->getTokenForUser(2)
         );
-        $response = $this->client->getResponse();
+        $response = $client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_OK);
 
         $url = '/ics/' . hash('sha256', '1');
-        $this->client->request('GET', $url);
-        $response = $this->client->getResponse();
+        $client->request('GET', $url);
+        $response = $client->getResponse();
 
         $content = $response->getContent();
 
@@ -177,9 +172,10 @@ class IcsControllerTest extends WebTestCase
 
     public function testAbsolutePathsToEvents()
     {
+        $client = static::createClient();
         $url = '/ics/' . hash('sha256', '1');
-        $this->client->request('GET', $url);
-        $response = $this->client->getResponse();
+        $client->request('GET', $url);
+        $response = $client->getResponse();
 
         $content = $response->getContent();
 

--- a/tests/DataFixtures/ORM/AbstractDataFixtureTest.php
+++ b/tests/DataFixtures/ORM/AbstractDataFixtureTest.php
@@ -6,6 +6,7 @@ use App\Entity\Manager\ManagerInterface;
 
 use App\Service\DataimportFileLocator;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 
 /**
  * Base class for data loader tests.
@@ -14,6 +15,8 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
  */
 abstract class AbstractDataFixtureTest extends WebTestCase
 {
+    use FixturesTrait;
+
     /**
      * @var ManagerInterface
      */

--- a/tests/Endpoints/AbstractMeshTest.php
+++ b/tests/Endpoints/AbstractMeshTest.php
@@ -23,7 +23,7 @@ abstract class AbstractMeshTest extends ReadEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -39,7 +39,7 @@ abstract class AbstractMeshTest extends ReadEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -55,7 +55,7 @@ abstract class AbstractMeshTest extends ReadEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 }

--- a/tests/Endpoints/AcademicYearTest.php
+++ b/tests/Endpoints/AcademicYearTest.php
@@ -60,7 +60,7 @@ class AcademicYearTest extends ReadEndpointTest
             null,
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_OK);
         $responses = json_decode($response->getContent(), true)[$responseKey];
@@ -111,7 +111,7 @@ class AcademicYearTest extends ReadEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }

--- a/tests/Endpoints/AuthenticationTest.php
+++ b/tests/Endpoints/AuthenticationTest.php
@@ -318,7 +318,7 @@ class AuthenticationTest extends ReadWriteEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/Endpoints/CohortTest.php
+++ b/tests/Endpoints/CohortTest.php
@@ -84,7 +84,7 @@ class CohortTest extends ReadEndpointTest implements PutEndpointTestInterface
             json_encode(['cohort' => $data]),
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -102,7 +102,7 @@ class CohortTest extends ReadEndpointTest implements PutEndpointTestInterface
             json_encode(['cohort' => $data]),
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -116,7 +116,7 @@ class CohortTest extends ReadEndpointTest implements PutEndpointTestInterface
             null,
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -386,7 +386,7 @@ class CourseTest extends ReadWriteEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
         $data = json_decode($response->getContent(), true);
         $this->assertContains('Courses cannot be rolled over to a new year before', $data['message']);
@@ -473,7 +473,7 @@ class CourseTest extends ReadWriteEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $data = json_decode($response->getContent(), true)['courses'];
 

--- a/tests/Endpoints/CurrentSessionTest.php
+++ b/tests/Endpoints/CurrentSessionTest.php
@@ -5,7 +5,6 @@ namespace App\Tests\Endpoints;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\FrameworkBundle\Client;
 use App\Tests\Traits\JsonControllerTest;
 
 /**
@@ -17,11 +16,6 @@ class CurrentSessionTest extends WebTestCase
     use JsonControllerTest;
 
     /**
-     * @var Client
-     */
-    protected $client;
-
-    /**
      * @var ProxyReferenceRepository
      */
     protected $fixtures;
@@ -29,8 +23,6 @@ class CurrentSessionTest extends WebTestCase
 
     public function setUp()
     {
-        $this->client = $this->makeClient();
-
         $fixtures = [
             'App\Tests\Fixture\LoadAuthenticationData',
             'App\Tests\Fixture\LoadUserData',
@@ -40,19 +32,19 @@ class CurrentSessionTest extends WebTestCase
 
     public function tearDown() : void
     {
-        unset($this->client);
         unset($this->fixtures);
     }
 
     public function testGetGetCurrentSession()
     {
+        $client = static::createClient();
         $url = $this->getUrl(
             'ilios_api_currentsession',
             ['version' => 'v1']
         );
-        $this->makeJsonRequest($this->client, 'GET', $url, null, $this->getAuthenticatedUserToken());
+        $this->makeJsonRequest($client, 'GET', $url, null, $this->getAuthenticatedUserToken());
 
-        $response = $this->client->getResponse();
+        $response = $client->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/Endpoints/CurrentSessionTest.php
+++ b/tests/Endpoints/CurrentSessionTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Endpoints;
 
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 
@@ -14,6 +15,7 @@ use App\Tests\Traits\JsonControllerTest;
 class CurrentSessionTest extends WebTestCase
 {
     use JsonControllerTest;
+    use FixturesTrait;
 
     /**
      * @var ProxyReferenceRepository

--- a/tests/Endpoints/CurriculumInventoryExportTest.php
+++ b/tests/Endpoints/CurriculumInventoryExportTest.php
@@ -107,7 +107,7 @@ class CurriculumInventoryExportTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }

--- a/tests/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/Endpoints/CurriculumInventoryReportTest.php
@@ -116,7 +116,7 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
             null,
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_OK);
         $responses = json_decode($response->getContent(), true)[$responseKey];
@@ -258,7 +258,7 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
             null,
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $data = json_decode($response->getContent(), true)['curriculumInventoryReports'];
         $newReport = $data[0];
@@ -388,7 +388,7 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
             null,
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }
 
@@ -415,7 +415,7 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
             null,
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $data = json_decode($response->getContent(), true)['curriculumInventoryReports'];
         $newReport = $data[0];
@@ -449,7 +449,7 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
             null,
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $data = json_decode($response->getContent(), true)['curriculumInventoryReports'];
         $newReport = $data[0];

--- a/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
@@ -557,7 +557,7 @@ class CurriculumInventorySequenceBlockTest extends ReadWriteEndpointTest
             json_encode(['curriculumInventorySequenceBlocks' => [$block]]),
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         //Fails on lower boundary
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
         $block['orderInSequence'] = count($parent['children']) + 2; // out of bounds on upper boundary
@@ -568,7 +568,7 @@ class CurriculumInventorySequenceBlockTest extends ReadWriteEndpointTest
             json_encode(['curriculumInventorySequenceBlocks' => [$block]]),
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         //Fails on upper boundary
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
 
@@ -608,7 +608,7 @@ class CurriculumInventorySequenceBlockTest extends ReadWriteEndpointTest
             json_encode(['curriculumInventorySequenceBlock' => $block]),
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         //Fails on lower boundary
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
         $block['orderInSequence'] = count($parent['children']) + 2; // out of bounds on upper boundary
@@ -623,7 +623,7 @@ class CurriculumInventorySequenceBlockTest extends ReadWriteEndpointTest
             json_encode(['curriculumInventorySequenceBlock' => $block]),
             $this->getAuthenticatedUserToken()
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         //Fails on upper boundary
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
 

--- a/tests/Endpoints/IngestionExceptionTest.php
+++ b/tests/Endpoints/IngestionExceptionTest.php
@@ -77,7 +77,7 @@ class IngestionExceptionTest extends ReadEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -137,12 +137,12 @@ class LearningMaterialTest extends ReadWriteEndpointTest
         foreach ($responses as $response) {
             $uri = array_key_exists('absoluteFileUri', $response)?$response['absoluteFileUri']:null;
             if ($uri) {
-                $this->client->request(
+                self::$client->request(
                     'GET',
                     $uri
                 );
 
-                $response = $this->client->getResponse();
+                $response = self::$client->getResponse();
 
                 $this->assertJsonResponse($response, Response::HTTP_OK, false);
             }
@@ -199,14 +199,14 @@ class LearningMaterialTest extends ReadWriteEndpointTest
             $filesize
         );
         $this->makeJsonRequest(
-            $this->client,
+            self::$client,
             'POST',
             '/upload',
             null,
             $this->getAuthenticatedUserToken(),
             ['file' => $fakeTestFile]
         );
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_OK);
         $responseData = json_decode($response->getContent(), true);
 
@@ -223,12 +223,12 @@ class LearningMaterialTest extends ReadWriteEndpointTest
         $response = $this->postTest($data, $postData);
 
         $uri = array_key_exists('absoluteFileUri', $response)?$response['absoluteFileUri']:null;
-        $this->client->request(
+        self::$client->request(
             'GET',
             $uri
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
 
         $this->assertJsonResponse($response, Response::HTTP_OK, false);

--- a/tests/Endpoints/ObjectiveTest.php
+++ b/tests/Endpoints/ObjectiveTest.php
@@ -142,7 +142,7 @@ class ObjectiveTest extends ReadWriteEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $this->assertEquals(
@@ -192,7 +192,7 @@ class ObjectiveTest extends ReadWriteEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
     }
 }

--- a/tests/Endpoints/PermissionsTest.php
+++ b/tests/Endpoints/PermissionsTest.php
@@ -25,7 +25,7 @@ class PermissionsTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -41,7 +41,7 @@ class PermissionsTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -57,7 +57,7 @@ class PermissionsTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -72,7 +72,7 @@ class PermissionsTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -87,7 +87,7 @@ class PermissionsTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 }

--- a/tests/Endpoints/ProgramYearTest.php
+++ b/tests/Endpoints/ProgramYearTest.php
@@ -302,7 +302,7 @@ class ProgramYearTest extends ReadWriteEndpointTest
             $this->getTokenForUser(2)
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $expected = [
             [

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -467,7 +467,7 @@ class SchooleventsTest extends AbstractEndpointTest
             $userToken
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");
@@ -497,7 +497,7 @@ class SchooleventsTest extends AbstractEndpointTest
             $userToken
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/Endpoints/UserMadeReminderTest.php
+++ b/tests/Endpoints/UserMadeReminderTest.php
@@ -25,7 +25,7 @@ class UserMadeReminderTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -41,7 +41,7 @@ class UserMadeReminderTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -57,7 +57,7 @@ class UserMadeReminderTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -72,7 +72,7 @@ class UserMadeReminderTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -87,7 +87,7 @@ class UserMadeReminderTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken()
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 }

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -258,7 +258,7 @@ class UserTest extends ReadWriteEndpointTest
         );
 
         // 3.
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
     }
 

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -803,7 +803,7 @@ class UsereventTest extends AbstractEndpointTest
             $userToken
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");
@@ -839,7 +839,7 @@ class UsereventTest extends AbstractEndpointTest
             $userToken
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/Endpoints/UsermaterialsTest.php
+++ b/tests/Endpoints/UsermaterialsTest.php
@@ -174,7 +174,7 @@ class UsermaterialsTest extends AbstractEndpointTest
             $token
         );
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/Traits/JsonControllerTest.php
+++ b/tests/Traits/JsonControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace App\Tests\Traits;
 
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use App\Service\JsonWebTokenManager;
 
@@ -91,14 +91,21 @@ trait JsonControllerTest
     /**
      * Create a JSON request
      *
-     * @param Client $client
+     * @param KernelBrowser $client
      * @param string $method
      * @param string $url
      * @param string $content
      * @param string $token
+     * @param array $files
      */
-    public function makeJsonRequest(Client $client, $method, $url, $content = null, $token = null, $files = array())
-    {
+    public function makeJsonRequest(
+        KernelBrowser $client,
+        $method,
+        $url,
+        $content = null,
+        $token = null,
+        $files = array()
+    ) {
         $headers = [
             'HTTP_ACCEPT' => 'application/json',
             'CONTENT_TYPE' => 'application/json'


### PR DESCRIPTION
Also updated flex recipes for symfony 4.3. This version had a breaking change in the test class that required a new version of liip testing stuff as well as a change to the way the client is built and used (it's now static).