### PR TITLE
Index all sessions

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -313,3 +313,7 @@ services:
 
     League\Flysystem\FilesystemInterface:
       factory: ['@App\Service\FilesystemFactory', getFilesystem]
+
+    Elasticsearch\Client:
+      factory: ['App\Service\ElasticSearchFactory', 'getClient']
+      arguments: ['@App\Service\Config']

--- a/src/Classes/ElasticSearchBase.php
+++ b/src/Classes/ElasticSearchBase.php
@@ -2,9 +2,7 @@
 
 namespace App\Classes;
 
-use App\Service\Config;
 use Elasticsearch\Client;
-use Elasticsearch\ClientBuilder;
 
 class ElasticSearchBase
 {
@@ -25,15 +23,13 @@ class ElasticSearchBase
 
     /**
      * Search constructor.
-     * @param Config $config
+     * @param Client $client
      */
-    public function __construct(Config $config)
+    public function __construct(Client $client = null)
     {
-        $elasticSearchHosts = $config->get('elasticsearch_hosts');
-        if ($elasticSearchHosts) {
+        if ($client) {
             $this->enabled = true;
-            $hosts = explode(';', $elasticSearchHosts);
-            $this->client = ClientBuilder::create()->setHosts($hosts)->build();
+            $this->client = $client;
         }
     }
 

--- a/src/Service/ElasticSearchFactory.php
+++ b/src/Service/ElasticSearchFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Service;
+
+use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
+
+class ElasticSearchFactory
+{
+    public static function getClient(Config $config) : ?Client
+    {
+        $elasticSearchHosts = $config->get('elasticsearch_hosts');
+        if ($elasticSearchHosts) {
+            $hosts = explode(';', $elasticSearchHosts);
+            return ClientBuilder::create()->setHosts($hosts)->build();
+        }
+
+        return null;
+    }
+}

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -70,7 +70,7 @@ class Index extends ElasticSearchBase
         }
         $input = array_reduce($courses, function (array $carry, IndexableCourse $item) {
             $sessions = $item->createIndexObjects();
-            return $carry + $sessions;
+            return array_merge($carry, $sessions);
         }, []);
 
         $result = $this->bulkIndex(Search::PUBLIC_CURRICULUM_INDEX, $input);

--- a/tests/Service/SearchTest.php
+++ b/tests/Service/SearchTest.php
@@ -3,6 +3,7 @@ namespace App\Tests\Service;
 
 use App\Service\Config;
 use App\Service\Search;
+use Elasticsearch\Client;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Mockery as m;
 
@@ -43,15 +44,12 @@ class SearchTest extends TestCase
 
     protected function createWithHost()
     {
-        $config = m::mock(Config::class);
-        $config->shouldReceive('get')->with('elasticsearch_hosts')->once()->andReturn('host');
-        return new Search($config);
+        $client = m::mock(Client::class);
+        return new Search($client);
     }
 
     protected function createWithoutHost()
     {
-        $config = m::mock(Config::class);
-        $config->shouldReceive('get')->with('elasticsearch_hosts')->once()->andReturn(false);
-        return new Search($config);
+        return new Search(null);
     }
 }


### PR DESCRIPTION
The new + sign for arrays apparently doesn't do what I thought it did.
Use array_merge instead, it actually works.  Refactored the way
elasticsearch gets passed in so we can actually test the Index service.