### PR TITLE
Fix indexing course with no sessions

### DIFF
--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -68,10 +68,12 @@ class Index extends ElasticSearchBase
                 );
             }
         }
+
         $input = array_reduce($courses, function (array $carry, IndexableCourse $item) {
             $sessions = $item->createIndexObjects();
             return array_merge($carry, $sessions);
         }, []);
+
 
         $result = $this->bulkIndex(Search::PUBLIC_CURRICULUM_INDEX, $input);
 
@@ -186,7 +188,7 @@ class Index extends ElasticSearchBase
      */
     protected function bulkIndex(string $index, array $items) : array
     {
-        if (!$this->enabled) {
+        if (!$this->enabled || empty($items)) {
             return ['errors' => false];
         }
         $body = [];

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -119,6 +119,17 @@ class IndexTest extends TestCase
         $obj->indexCourses([$course1, $course2]);
     }
 
+    public function testIndexCourseWithNoSessions()
+    {
+        $client = m::mock(Client::class);
+        $obj = new Index($client);
+        $course1 = m::mock(IndexableCourse::class);
+        $course1->shouldReceive('createIndexObjects')->once()->andReturn([]);
+
+        $client->shouldNotReceive('bulk');
+        $obj->indexCourses([$course1]);
+    }
+
     public function testIndexMeshDescriptorsThrowsWhenNotDescriptor()
     {
         $obj = $this->createWithoutHost();


### PR DESCRIPTION
Since we index on course and not on session we need to skip attempting
to index empty courses.

Fixes #2516