### PR TITLE
Drop support for PHP 7.2

### DIFF
--- a/.azure/phpunit-job-template.yaml
+++ b/.azure/phpunit-job-template.yaml
@@ -16,8 +16,6 @@ jobs:
     vmImage: ${{ parameters.image }}
   strategy:
     matrix:
-      PHP72:
-        PHP_VERSION: '7.2'
       PHP73:
         PHP_VERSION: '7.3'
   steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM composer AS composer
 
 # get the proper 'PHP' image from the official PHP repo at
-FROM php:7.2-apache-stretch
+FROM php:7.3-apache-stretch
 
 # copy the Composer PHAR from the Composer image into the apache-php image
 COPY --from=composer /usr/bin/composer /usr/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,7 @@ ILIOS_TRACKING_CODE=UA-XXXXXXXX-1
 # configure Apache and the PHP extensions required for Ilios and delete the source files after install
 RUN \
     apt-get update \
-    && apt-get install sudo libldap2-dev zlib1g-dev libicu-dev -y \
-    # remove the apt source files to save space
+    && apt-get install sudo libldap2-dev zlib1g-dev libicu-dev libzip-dev libzip4 -y \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install zip \
@@ -65,6 +64,7 @@ RUN \
     # enable modules
     && a2enmod rewrite socache_shmcb mpm_prefork http2 \
     && rm -rf /var/lib/apt/lists/* \
+    # remove the apt source files to save space
     && apt-get purge libldap2-dev zlib1g-dev libicu-dev -y \
     && apt-get autoremove -y
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,6 @@ variables:
   ILIOS_FILE_SYSTEM_STORAGE_PATH: /tmp
   SYMFONY_DEPRECATIONS_HELPER: disabled
   IMAGE: 'Ubuntu-16.04'
-  PHP_VERSION: '7.3'
 
 jobs:
 - job: code_style_and_security

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "project",
   "description": "The \"Ilios Standard Edition\" distribution",
   "require": {
-    "php": ">= 7.2",
+    "php": ">= 7.3",
     "ext-apcu": "*",
     "ext-ctype": "*",
     "ext-dom": "*",
@@ -64,7 +64,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.2.0"
+      "php": "7.3.0"
     },
     "preferred-install": {
       "*": "dist"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61152d6a2da5a8483bf3fae5bd2e8d10",
+    "content-hash": "6253b14b057f2f72190aca7afa95bd1a",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.99.3",
+            "version": "3.100.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "6857f5a612f2f32363d33b770d36501ed8d57116"
+                "reference": "803f3cdc37f42112c4df1af0a77e25130b9448d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6857f5a612f2f32363d33b770d36501ed8d57116",
-                "reference": "6857f5a612f2f32363d33b770d36501ed8d57116",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/803f3cdc37f42112c4df1af0a77e25130b9448d3",
+                "reference": "803f3cdc37f42112c4df1af0a77e25130b9448d3",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-06-06T18:46:45+00:00"
+            "time": "2019-06-14T18:12:13+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -8258,16 +8258,16 @@
     "packages-dev": [
         {
             "name": "facebook/webdriver",
-            "version": "1.6.0",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-webdriver.git",
-                "reference": "bd8c740097eb9f2fc3735250fc1912bc811a954e"
+                "reference": "e43de70f3c7166169d0f14a374505392734160e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/bd8c740097eb9f2fc3735250fc1912bc811a954e",
-                "reference": "bd8c740097eb9f2fc3735250fc1912bc811a954e",
+                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/e43de70f3c7166169d0f14a374505392734160e5",
+                "reference": "e43de70f3c7166169d0f14a374505392734160e5",
                 "shasum": ""
             },
             "require": {
@@ -8314,7 +8314,7 @@
                 "selenium",
                 "webdriver"
             ],
-            "time": "2018-05-16T17:37:13+00:00"
+            "time": "2019-06-13T08:02:18+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -8662,77 +8662,6 @@
             "time": "2019-05-30T16:10:05+00:00"
         },
         {
-            "name": "symfony/contracts",
-            "version": "v1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/contracts.git",
-                "reference": "d3636025e8253c6144358ec0a62773cae588395b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/contracts/zipball/d3636025e8253c6144358ec0a62773cae588395b",
-                "reference": "d3636025e8253c6144358ec0a62773cae588395b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "require-dev": {
-                "psr/cache": "^1.0",
-                "psr/container": "^1.0",
-                "symfony/polyfill-intl-idn": "^1.10"
-            },
-            "suggest": {
-                "psr/cache": "When using the Cache contracts",
-                "psr/container": "When using the Service contracts",
-                "symfony/cache-contracts-implementation": "",
-                "symfony/event-dispatcher-implementation": "",
-                "symfony/http-client-contracts-implementation": "",
-                "symfony/service-contracts-implementation": "",
-                "symfony/translation-contracts-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\": ""
-                },
-                "exclude-from-classmap": [
-                    "**/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A set of abstractions extracted out of the Symfony components",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2019-04-27T14:29:50+00:00"
-        },
-        {
             "name": "symfony/css-selector",
             "version": "v4.3.1",
             "source": {
@@ -8944,23 +8873,22 @@
         },
         {
             "name": "symfony/panther",
-            "version": "v0.4.0",
+            "version": "v0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/panther.git",
-                "reference": "7a041cb4fc56e16f11808943633068a8fa3d6a51"
+                "reference": "6581f7bc0498f0328fe955a2894ffc40070d2bcb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/panther/zipball/7a041cb4fc56e16f11808943633068a8fa3d6a51",
-                "reference": "7a041cb4fc56e16f11808943633068a8fa3d6a51",
+                "url": "https://api.github.com/repos/symfony/panther/zipball/6581f7bc0498f0328fe955a2894ffc40070d2bcb",
+                "reference": "6581f7bc0498f0328fe955a2894ffc40070d2bcb",
                 "shasum": ""
             },
             "require": {
                 "facebook/webdriver": "^1.5",
                 "php": ">=7.1",
                 "symfony/browser-kit": "^4.0",
-                "symfony/contracts": "^1.1",
                 "symfony/http-client": "^4.3",
                 "symfony/polyfill-php72": "^1.9",
                 "symfony/process": "^3.4 || ^4.0"
@@ -9011,7 +8939,7 @@
                 "testing",
                 "webdriver"
             ],
-            "time": "2019-06-04T09:44:04+00:00"
+            "time": "2019-06-11T14:14:33+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
@@ -9397,7 +9325,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 7.2",
+        "php": ">= 7.3",
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-dom": "*",
@@ -9407,6 +9335,6 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.0"
+        "php": "7.3.0"
     }
 }

--- a/config/packages/monitor.yaml
+++ b/config/packages/monitor.yaml
@@ -6,7 +6,7 @@ liip_monitor:
       default:
         php_extensions: [apcu, mbstring, ldap, xml, dom, mysqlnd, pdo, zip, json, zlib, ctype, iconv]
         php_version:
-            "7.2": ">="
+            "7.3": ">="
         readable_directory: ["%kernel.cache_dir%"]
         writable_directory: ["%kernel.cache_dir%"]
         security_advisory:

--- a/docs/ilios_php_version_policy.md
+++ b/docs/ilios_php_version_policy.md
@@ -8,13 +8,13 @@ At any given time, the Ilios application will only be supported on the very late
  
 #### Policy Example
 
-For example, the current version of PHP is v7.2.  When PHP v7.3 is released, we will continue to ensure the Ilios code will work on PHP 7.2 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 7.3 going forward.
+For example, the current version of PHP is v7.3.  When PHP v7.4 is released, we will continue to ensure the Ilios code will work on PHP 7.3 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 7.4 going forward.
 
 ### Currently Supported Versions of PHP
 
 Based on the policy above, Ilios is currently compatible with the following versions of PHP:
 
-* PHP 7.2
+* PHP 7.3
  
 ### Up-To-Date PHP Repositories for CentOS and RHEL
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ Ilios 3 uses a Symfony (PHP/SQL) backend to serve its API, so these tools and th
 
 * CentOS 7 - Any modern Linux should work, but we recommend Redhat (RHEL, CentOS, or Fedora) or Ubuntu
 * MySQL using the InnoDB database engine (v5.5 or later required, 5.6+ recommended)
-* PHP v7.2+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
+* PHP v7.3+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
 
 NOTE: Several institutions have successfully deployed Ilios using Microsoft IIS on Windows as their webserver, but we do not recommend it as we do not have alot of experience with it ourselves and we've only ever support Ilios on Linux systems.  That being said, if you MUST use IIS for Windows and are having trouble getting Ilios running properly, please contact the [Ilios Project Support Team](https://iliosproject.org) at support@iliosproject.org if you have any problems and we might be able to help you out!
 
@@ -64,7 +64,7 @@ You should now be in the '/web/ilios3/ilios' directory
 # errors related to git files in your own user's `.config` directory:
 sudo -u apache git checkout tags/$(git fetch --tags; git describe --tags `git rev-list --tags --max-count=1`)
 ```
-5. Run the following command to build the packages and its dependencies.  This step assumes you have PHP 7.2+ and Composer installed on your system:
+5. Run the following command to build the packages and its dependencies.  This step assumes you have PHP 7.3+ and Composer installed on your system:
 ```bash
 sudo -u apache bin/setup
 ```

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,6 +1,6 @@
 {
     "aws/aws-sdk-php": {
-        "version": "3.97.0"
+        "version": "3.99.1"
     },
     "clue/stream-filter": {
         "version": "v1.4.1"
@@ -15,7 +15,10 @@
             "branch": "master",
             "version": "1.0",
             "ref": "cb4152ebcadbe620ea2261da1a1c5a9b8cea7672"
-        }
+        },
+        "files": [
+            "config/routes/annotations.yaml"
+        ]
     },
     "doctrine/cache": {
         "version": "v1.8.0"
@@ -69,7 +72,11 @@
             "branch": "master",
             "version": "1.2",
             "ref": "c1431086fec31f17fbcfe6d6d7e92059458facc1"
-        }
+        },
+        "files": [
+            "config/packages/doctrine_migrations.yaml",
+            "src/Migrations/.gitignore"
+        ]
     },
     "doctrine/event-manager": {
         "version": "v1.0.0"
@@ -105,7 +112,10 @@
             "branch": "master",
             "version": "1.0",
             "ref": "70062abc2cd58794d2a90274502f81b55cd9951b"
-        }
+        },
+        "files": [
+            "config/packages/dev/easy_log_handler.yaml"
+        ]
     },
     "egulias/email-validator": {
         "version": "2.1.8"
@@ -123,7 +133,10 @@
             "branch": "master",
             "version": "0.2",
             "ref": "0b76657841c2ba52647bb1b4a5595a0e3b9f485c"
-        }
+        },
+        "files": [
+            "config/packages/exercise_html_purifier.yaml"
+        ]
     },
     "ezyang/htmlpurifier": {
         "version": "v4.10.0"
@@ -177,7 +190,7 @@
         "version": "1.0.9"
     },
     "liip/functional-test-bundle": {
-        "version": "2.0.0-alpha15"
+        "version": "3.0.0-rc1"
     },
     "liip/monitor-bundle": {
         "version": "2.6",
@@ -186,10 +199,13 @@
             "branch": "master",
             "version": "2.6",
             "ref": "02ad65038eceb5231c73a530b67beedd955c40ed"
-        }
+        },
+        "files": [
+            "config/packages/monitor.yaml"
+        ]
     },
     "liip/test-fixtures-bundle": {
-        "version": "0.1.0-alpha1"
+        "version": "1.0.0-rc1"
     },
     "mockery/mockery": {
         "version": "1.2.0"
@@ -212,9 +228,6 @@
             "config/packages/nelmio_cors.yaml"
         ]
     },
-    "ocramius/package-versions": {
-        "version": "1.4.0"
-    },
     "ocramius/proxy-manager": {
         "version": "2.2.2"
     },
@@ -236,11 +249,14 @@
     "php-http/httplug-bundle": {
         "version": "1.6",
         "recipe": {
-            "repo": "github.com/symfony/recipes",
+            "repo": "github.com/symfony/recipes-contrib",
             "branch": "master",
             "version": "1.6",
             "ref": "4655962c64e2de96c418caf576c57215711c7877"
-        }
+        },
+        "files": [
+            "config/packages/httplug.yaml"
+        ]
     },
     "php-http/logger-plugin": {
         "version": "1.1.0"
@@ -315,7 +331,10 @@
             "branch": "master",
             "version": "3.0",
             "ref": "0dc9cceda799fd3a08b96987e176a261028a3709"
-        }
+        },
+        "files": [
+            "phpcs.xml.dist"
+        ]
     },
     "swagger-api/swagger-ui": {
         "version": "v3.22.2"
@@ -330,7 +349,10 @@
             "branch": "master",
             "version": "1.0",
             "ref": "c82bead70f9a4f656354a193df7bf0ca2114efa0"
-        }
+        },
+        "files": [
+            "public/.htaccess"
+        ]
     },
     "symfony/asset": {
         "version": "v4.3.0"
@@ -360,9 +382,6 @@
             "config/bootstrap.php"
         ]
     },
-    "symfony/contracts": {
-        "version": "v1.1.0"
-    },
     "symfony/css-selector": {
         "version": "v4.3.0"
     },
@@ -376,7 +395,10 @@
             "branch": "master",
             "version": "4.1",
             "ref": "f8863cbad2f2e58c4b65fa1eac892ab189971bea"
-        }
+        },
+        "files": [
+            "config/packages/dev/debug.yaml"
+        ]
     },
     "symfony/debug-pack": {
         "version": "v1.0.7"
@@ -461,13 +483,18 @@
         "version": "v4.3.0"
     },
     "symfony/monolog-bundle": {
-        "version": "3.1",
+        "version": "3.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "3.1",
-            "ref": "18ebf5a940573a20de06f9c4060101eeb438cf3d"
-        }
+            "version": "3.3",
+            "ref": "6240c6d43e8237a32452f057f81816820fd56ab6"
+        },
+        "files": [
+            "config/packages/dev/monolog.yaml",
+            "config/packages/prod/monolog.yaml",
+            "config/packages/test/monolog.yaml"
+        ]
     },
     "symfony/options-resolver": {
         "version": "v4.3.0"
@@ -476,7 +503,7 @@
         "version": "v1.0.5"
     },
     "symfony/panther": {
-        "version": "v0.3.0"
+        "version": "v0.4.0"
     },
     "symfony/phpunit-bridge": {
         "version": "4.3",
@@ -584,7 +611,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "2.5",
-            "ref": "62dbd4422d8ba6cbcb8964ca558c7f352eae955e"
+            "ref": "3db029c03e452b4a23f7fc45cec7c922c2247eb8"
         },
         "files": [
             "config/packages/dev/swiftmailer.yaml",
@@ -611,7 +638,12 @@
             "branch": "master",
             "version": "3.3",
             "ref": "369b5b29dc52b2c190002825ae7ec24ab6f962dd"
-        }
+        },
+        "files": [
+            "config/packages/twig.yaml",
+            "config/routes/dev/twig.yaml",
+            "templates/base.html.twig"
+        ]
     },
     "symfony/validator": {
         "version": "4.3",
@@ -619,7 +651,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.3",
-            "ref": "f8992cec2e7a33fb5453b1ba08acee62d01397e2"
+            "ref": "48a8e5ef925e82aa7d665c887cd1fa60f8b7921d"
         },
         "files": [
             "config/packages/test/validator.yaml",
@@ -642,7 +674,12 @@
             "branch": "master",
             "version": "3.3",
             "ref": "6bdfa1a95f6b2e677ab985cd1af2eae35d62e0f6"
-        }
+        },
+        "files": [
+            "config/packages/dev/web_profiler.yaml",
+            "config/packages/test/web_profiler.yaml",
+            "config/routes/dev/web_profiler.yaml"
+        ]
     },
     "symfony/web-server-bundle": {
         "version": "3.3",
@@ -657,7 +694,7 @@
         "version": "v4.3.0"
     },
     "twig/twig": {
-        "version": "v2.10.0"
+        "version": "v2.11.1"
     },
     "webmozart/assert": {
         "version": "1.4.0"


### PR DESCRIPTION
With 7.3 supported in major distros we can drop 7.2 now.

Wait to merge until we've made the announcement that the next version is the last to support 7.2