### PR TITLE
Silence symfony deprecations in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,7 @@ variables:
   ILIOS_LOCALE: en
   ILIOS_SECRET: ThisTokenIsNotSoSecretChangeIt
   ILIOS_FILE_SYSTEM_STORAGE_PATH: /tmp
+  SYMFONY_DEPRECATIONS_HELPER: disabled
   IMAGE: 'Ubuntu-16.04'
   PHP_VERSION: '7.3'
 


### PR DESCRIPTION
These clutter up test output and often cause failures that we cannot
control.