### PR TITLE
Fix problem with search strings

### DIFF
--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -216,6 +216,9 @@ class Index extends ElasticSearchBase
                     'mappings' => [
                         '_doc' => [
                             'properties' => [
+                                'courseId' => [
+                                    'type' => 'keyword',
+                                ],
                                 'school' => [
                                     'type' => 'keyword',
                                     'fields' => [
@@ -225,7 +228,7 @@ class Index extends ElasticSearchBase
                                     ],
                                 ],
                                 'courseYear' => [
-                                    'type' => 'integer',
+                                    'type' => 'keyword',
                                 ],
                                 'courseTitle' => [
                                     'type' => 'text',
@@ -280,6 +283,9 @@ class Index extends ElasticSearchBase
                                             'type' => 'completion'
                                         ]
                                     ],
+                                ],
+                                'sessionId' => [
+                                    'type' => 'keyword',
                                 ],
                                 'sessionTitle' => [
                                     'type' => 'text',


### PR DESCRIPTION
Elastic search doesn't automatically convert search strings into numbers
when searching fields, since we're going to be sending a query as a
string I've indexed the numerics as keywords which ensures they count as
whole strings and not partial matches.