### PR TITLE
Configure Dependabot to ignore all symfony packages

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -1,0 +1,9 @@
+version: 1
+
+update_configs:
+  - package_manager: "php:composer"
+    directory: "/"
+    update_schedule: "daily"
+    ignored_updates:
+      - match:
+          dependency_name: "symfony/*"


### PR DESCRIPTION
Symfony always updates everything at the same time, but dependabot
doesn't understand that and opens a dozen individual pull requests.
Instead I'm skipping all symfony package and we'll catch them manually
when a new version is released.