### PR TITLE
Stop relying on liip test bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,6 @@
   },
   "require-dev": {
     "fzaninotto/faker": "@stable",
-    "liip/functional-test-bundle": "~3.0@alpha",
     "liip/test-fixtures-bundle": "~1.0.0-RC1",
     "mockery/mockery": "1.2.0",
     "squizlabs/php_codesniffer": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c180083242efb32811c2be77517e37a",
+    "content-hash": "c24448c725bf7d274ef5e50a107d496a",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -8407,73 +8407,6 @@
             "time": "2016-01-20T08:20:44+00:00"
         },
         {
-            "name": "liip/functional-test-bundle",
-            "version": "3.0.0-RC1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liip/LiipFunctionalTestBundle.git",
-                "reference": "c9c9f473d82b6b428d6edfa86e6b26ce047c1e51"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/c9c9f473d82b6b428d6edfa86e6b26ce047c1e51",
-                "reference": "c9c9f473d82b6b428d6edfa86e6b26ce047c1e51",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/common": "^2.0",
-                "php": "^7.1",
-                "symfony/browser-kit": "^3.4 || ^4.1",
-                "symfony/framework-bundle": "^3.4 || ^4.1"
-            },
-            "require-dev": {
-                "doctrine/doctrine-bundle": "^1.8",
-                "doctrine/doctrine-fixtures-bundle": "^3.0.2",
-                "doctrine/orm": "^2.6",
-                "phpunit/phpunit": "^6.1 || ^7.0",
-                "symfony/monolog-bundle": "^3.1",
-                "symfony/phpunit-bridge": "^3.4 || ^4.1",
-                "symfony/symfony": "^3.4 || ^4.1",
-                "twig/twig": "^2.0"
-            },
-            "suggest": {
-                "brianium/paratest": "Required when using paratest to parallelize tests",
-                "doctrine/dbal": "Required when using the fixture loading functionality with an ORM and SQLite",
-                "doctrine/orm": "Required when using the fixture loading functionality with an ORM and SQLite"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Liip\\FunctionalTestBundle\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Liip AG",
-                    "homepage": "http://www.liip.ch/"
-                },
-                {
-                    "name": "Community contributions",
-                    "homepage": "https://github.com/liip/LiipFunctionalTestBundle/contributors"
-                }
-            ],
-            "description": "This bundles provides additional functional test-cases for Symfony applications",
-            "keywords": [
-                "symfony",
-                "testing"
-            ],
-            "time": "2019-06-02T20:48:55+00:00"
-        },
-        {
             "name": "liip/test-fixtures-bundle",
             "version": "1.0.0-RC1",
             "source": {
@@ -9450,7 +9383,6 @@
     "stability-flags": {
         "firebase/php-jwt": 0,
         "fzaninotto/faker": 0,
-        "liip/functional-test-bundle": 15,
         "liip/test-fixtures-bundle": 5,
         "squizlabs/php_codesniffer": 0
     },

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -11,7 +11,6 @@ return [
     Http\HttplugBundle\HttplugBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
-    Liip\FunctionalTestBundle\LiipFunctionalTestBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -10,6 +10,7 @@ services:
     public: true
 
   App\Tests\DataLoader\:
+    public: true
     resource: '%kernel.project_dir%/tests/DataLoader'
 
   App\Tests\Fixture\:

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace App\Tests\Controller;
 
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 
@@ -21,13 +21,13 @@ class ApiControllerTest extends WebTestCase
 
     public function testNoEndpoint()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
         $this->makeJsonRequest(
             $client,
             'GET',
             '/api/v1/nothing',
             null,
-            $this->getTokenForUser(1)
+            $this->getTokenForUser($client, 1)
         );
         $response = $client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
@@ -35,13 +35,13 @@ class ApiControllerTest extends WebTestCase
 
     public function testNoVersion()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
         $this->makeJsonRequest(
             $client,
             'GET',
             '/api/nothing',
             null,
-            $this->getTokenForUser(1)
+            $this->getTokenForUser($client, 1)
         );
         $response = $client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
@@ -49,13 +49,13 @@ class ApiControllerTest extends WebTestCase
 
     public function testBadVersion()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
         $this->makeJsonRequest(
             $client,
             'GET',
             '/api/1/courses',
             null,
-            $this->getTokenForUser(1)
+            $this->getTokenForUser($client, 1)
         );
         $response = $client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace App\Tests\Controller;
 
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Fixture\LoadApplicationConfigData;
 use App\Tests\Traits\JsonControllerTest;

--- a/tests/Controller/CurriculumInventoryDownloadControllerTest.php
+++ b/tests/Controller/CurriculumInventoryDownloadControllerTest.php
@@ -2,10 +2,11 @@
 
 namespace App\Tests\Controller;
 
+use App\Tests\GetUrlTrait;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 
 /**
  * Class CurriculumInventoryDownloadControllerTest
@@ -14,6 +15,7 @@ class CurriculumInventoryDownloadControllerTest extends WebTestCase
 {
     use JsonControllerTest;
     use FixturesTrait;
+    use GetUrlTrait;
 
     /**
      * @inheritdoc
@@ -37,7 +39,7 @@ class CurriculumInventoryDownloadControllerTest extends WebTestCase
      */
     public function testGetCurriculumInventoryDownload()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
         $curriculumInventoryExport = $client->getContainer()
             ->get('App\Tests\DataLoader\CurriculumInventoryExportData')
             ->getOne()
@@ -47,6 +49,7 @@ class CurriculumInventoryDownloadControllerTest extends WebTestCase
             $client,
             'GET',
             $this->getUrl(
+                $client,
                 'ilios_api_get',
                 [
                     'version' => 'v1',
@@ -55,7 +58,7 @@ class CurriculumInventoryDownloadControllerTest extends WebTestCase
                 ]
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($client)
         );
 
         $response = $client->getResponse();

--- a/tests/Controller/DownloadControllerTest.php
+++ b/tests/Controller/DownloadControllerTest.php
@@ -1,10 +1,11 @@
 <?php
 namespace App\Tests\Controller;
 
+use App\Tests\GetUrlTrait;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 
@@ -16,6 +17,7 @@ class DownloadControllerTest extends WebTestCase
 {
     use JsonControllerTest;
     use FixturesTrait;
+    use GetUrlTrait;
 
     /**
      * @var ProxyReferenceRepository
@@ -46,7 +48,7 @@ class DownloadControllerTest extends WebTestCase
 
     public function testDownloadLearningMaterial()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
         $learningMaterials = $client->getContainer()
             ->get('App\Tests\DataLoader\LearningMaterialData')
             ->getAll();
@@ -58,11 +60,12 @@ class DownloadControllerTest extends WebTestCase
             $client,
             'GET',
             $this->getUrl(
+                $client,
                 'ilios_api_learningmaterial_get',
                 ['version' => 'v1', 'object' => 'learningmaterials', 'id' => $learningMaterial['id']]
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($client)
         );
         $response = $client->getResponse();
 
@@ -87,18 +90,19 @@ class DownloadControllerTest extends WebTestCase
 
     public function testPdfInlineDownload()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
         $learningMaterial = $this->fixtures->getReference('learningMaterials4');
 
         $this->makeJsonRequest(
             $client,
             'GET',
             $this->getUrl(
+                $client,
                 'ilios_api_learningmaterial_get',
                 ['version' => 'v1', 'object' => 'learningmaterials', 'id' => $learningMaterial->getId()]
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($client)
         );
         $response = $client->getResponse();
 
@@ -120,7 +124,7 @@ class DownloadControllerTest extends WebTestCase
 
     public function testBadLearningMaterialToken()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
         //sending bad hash
         $client->request(
             'GET',

--- a/tests/Controller/ErrorControllerTest.php
+++ b/tests/Controller/ErrorControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace App\Tests\Controller;
 
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 use Faker\Factory as FakerFactory;
@@ -34,7 +34,7 @@ class ErrorControllerTest extends WebTestCase
             'POST',
             '/errors',
             json_encode(['data' => json_encode($data)]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($client)
         );
 
         $response = $client->getResponse();

--- a/tests/Controller/IcsControllerTest.php
+++ b/tests/Controller/IcsControllerTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace App\Tests\Controller;
 
+use App\Tests\GetUrlTrait;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\DataLoader\SessionData;
 use App\Tests\Traits\JsonControllerTest;
@@ -15,6 +16,7 @@ class IcsControllerTest extends WebTestCase
 {
     use JsonControllerTest;
     use FixturesTrait;
+    use GetUrlTrait;
 
     /**
      * @var ProxyReferenceRepository
@@ -36,7 +38,6 @@ class IcsControllerTest extends WebTestCase
     public function tearDown() : void
     {
         parent::tearDown();
-        $client = null;
         unset($this->fixtures);
     }
 
@@ -52,9 +53,9 @@ class IcsControllerTest extends WebTestCase
         $this->makeJsonRequest(
             $client,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'sessions', 'id' => $id]),
+            $this->getUrl($client, 'ilios_api_put', ['version' => 'v1', 'object' => 'sessions', 'id' => $id]),
             json_encode(['session' => $session]),
-            $this->getTokenForUser(2)
+            $this->getTokenForUser($client, 2)
         );
         $response = $client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_OK);
@@ -118,9 +119,9 @@ class IcsControllerTest extends WebTestCase
         $this->makeJsonRequest(
             $client,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'sessions', 'id' => $id]),
+            $this->getUrl($client, 'ilios_api_put', ['version' => 'v1', 'object' => 'sessions', 'id' => $id]),
             json_encode(['session' => $session]),
-            $this->getTokenForUser(2)
+            $this->getTokenForUser($client, 2)
         );
         $response = $client->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_OK);

--- a/tests/Controller/UploadControllerTest.php
+++ b/tests/Controller/UploadControllerTest.php
@@ -44,14 +44,14 @@ class UploadControllerTest extends WebTestCase
 
     public function testUploadFile()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
         
         $this->makeJsonRequest(
             $client,
             'POST',
             '/upload',
             null,
-            $this->getAuthenticatedUserToken(),
+            $this->getAuthenticatedUserToken($client),
             array('file' => $this->fakeTestFile)
         );
         
@@ -65,14 +65,14 @@ class UploadControllerTest extends WebTestCase
 
     public function testBadUpload()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
         
         $this->makeJsonRequest(
             $client,
             'POST',
             '/upload',
             null,
-            $this->getAuthenticatedUserToken(),
+            $this->getAuthenticatedUserToken($client),
             array('nofile' => $this->fakeTestFile)
         );
         

--- a/tests/DataFixtures/ORM/AbstractDataFixtureTest.php
+++ b/tests/DataFixtures/ORM/AbstractDataFixtureTest.php
@@ -5,8 +5,8 @@ namespace App\Tests\DataFixtures\ORM;
 use App\Entity\Manager\ManagerInterface;
 
 use App\Service\DataimportFileLocator;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
  * Base class for data loader tests.

--- a/tests/Endpoints/AbstractMeshTest.php
+++ b/tests/Endpoints/AbstractMeshTest.php
@@ -18,12 +18,12 @@ abstract class AbstractMeshTest extends ReadEndpointTest
 
         $this->createJsonRequest(
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => $endpoint]),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', ['version' => 'v1', 'object' => $endpoint]),
             json_encode([$responseKey => []]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -34,12 +34,12 @@ abstract class AbstractMeshTest extends ReadEndpointTest
 
         $this->createJsonRequest(
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_put', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
             json_encode([$responseKey => []]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -50,12 +50,16 @@ abstract class AbstractMeshTest extends ReadEndpointTest
 
         $this->createJsonRequest(
             'DELETE',
-            $this->getUrl('ilios_api_delete', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_delete',
+                ['version' => 'v1', 'object' => $endpoint, 'id' => 1]
+            ),
             json_encode([$responseKey => []]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 }

--- a/tests/Endpoints/AcademicYearTest.php
+++ b/tests/Endpoints/AcademicYearTest.php
@@ -54,13 +54,14 @@ class AcademicYearTest extends ReadEndpointTest
         $this->createJsonRequest(
             'GET',
             $this->getUrl(
+                $this->kernelBrowser,
                 'ilios_api_getall',
                 ['version' => 'v1', 'object' => $endpoint]
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_OK);
         $responses = json_decode($response->getContent(), true)[$responseKey];
@@ -101,6 +102,7 @@ class AcademicYearTest extends ReadEndpointTest
         );
 
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_academicyear_404',
             $parameters
         );
@@ -108,10 +110,10 @@ class AcademicYearTest extends ReadEndpointTest
             $type,
             $url,
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }

--- a/tests/Endpoints/AuthenticationTest.php
+++ b/tests/Endpoints/AuthenticationTest.php
@@ -308,6 +308,7 @@ class AuthenticationTest extends ReadWriteEndpointTest
     protected function getOne($endpoint, $responseKey, $userId)
     {
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_authentication_get',
             ['version' => 'v1', 'object' => $endpoint, 'userId' => $userId]
         );
@@ -315,10 +316,10 @@ class AuthenticationTest extends ReadWriteEndpointTest
             'GET',
             $url,
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/Endpoints/CohortTest.php
+++ b/tests/Endpoints/CohortTest.php
@@ -80,11 +80,11 @@ class CohortTest extends ReadEndpointTest implements PutEndpointTestInterface
         $data = $dataLoader->create();
         $this->createJsonRequest(
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'cohorts']),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', ['version' => 'v1', 'object' => 'cohorts']),
             json_encode(['cohort' => $data]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -94,15 +94,15 @@ class CohortTest extends ReadEndpointTest implements PutEndpointTestInterface
         $data = $dataLoader->create();
         $this->createJsonRequest(
             'PUT',
-            $this->getUrl('ilios_api_put', [
+            $this->getUrl($this->kernelBrowser, 'ilios_api_put', [
                 'version' => 'v1',
                 'object' => 'cohorts',
                 'id' => $data['id']
             ]),
             json_encode(['cohort' => $data]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -112,11 +112,15 @@ class CohortTest extends ReadEndpointTest implements PutEndpointTestInterface
         $data = $dataLoader->create();
         $this->createJsonRequest(
             'DELETE',
-            $this->getUrl('ilios_api_delete', ['version' => 'v1', 'object' => 'cohorts', 'id' => $data['id']]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_delete',
+                ['version' => 'v1', 'object' => 'cohorts', 'id' => $data['id']]
+            ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -379,14 +379,15 @@ class CourseTest extends ReadWriteEndpointTest
         $this->createJsonRequest(
             'POST',
             $this->getUrl(
+                $this->kernelBrowser,
                 'ilios_api_courserollover',
                 $parameters
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
         $data = json_decode($response->getContent(), true);
         $this->assertContains('Courses cannot be rolled over to a new year before', $data['message']);
@@ -466,14 +467,15 @@ class CourseTest extends ReadWriteEndpointTest
         $this->createJsonRequest(
             'POST',
             $this->getUrl(
+                $this->kernelBrowser,
                 'ilios_api_courserollover',
                 $parameters
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $data = json_decode($response->getContent(), true)['courses'];
 
@@ -489,9 +491,10 @@ class CourseTest extends ReadWriteEndpointTest
         $userId = 3;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'courses']),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', ['version' => 'v1', 'object' => 'courses']),
             json_encode(['courses' => [$course]])
         );
     }
@@ -504,9 +507,14 @@ class CourseTest extends ReadWriteEndpointTest
         $id = $course['id'];
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'courses', 'id' => $id]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_put',
+                ['version' => 'v1', 'object' => 'courses', 'id' => $id]
+            ),
             json_encode(['course' => $course])
         );
     }
@@ -520,9 +528,14 @@ class CourseTest extends ReadWriteEndpointTest
 
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'courses', 'id' => $id * 10000]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_put',
+                ['version' => 'v1', 'object' => 'courses', 'id' => $id * 10000]
+            ),
             json_encode(['course' => $course])
         );
     }
@@ -535,9 +548,14 @@ class CourseTest extends ReadWriteEndpointTest
         $id = $course['id'];
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'DELETE',
-            $this->getUrl('ilios_api_delete', ['version' => 'v1', 'object' => 'courses', 'id' => $id])
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_delete',
+                ['version' => 'v1', 'object' => 'courses', 'id' => $id]
+            )
         );
     }
 
@@ -556,7 +574,12 @@ class CourseTest extends ReadWriteEndpointTest
             'newStartDate' => 'false',
             'skipOfferings' => 'false',
         ];
-        $this->canNot($userId, 'POST', $this->getUrl('ilios_api_courserollover', $rolloverData));
+        $this->canNot(
+            $this->kernelBrowser,
+            $userId,
+            'POST',
+            $this->getUrl($this->kernelBrowser, 'ilios_api_courserollover', $rolloverData)
+        );
     }
 
     public function testCourseCanBeUnlocked()

--- a/tests/Endpoints/CurrentSessionTest.php
+++ b/tests/Endpoints/CurrentSessionTest.php
@@ -2,9 +2,11 @@
 
 namespace App\Tests\Endpoints;
 
+use App\Tests\GetUrlTrait;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
 
@@ -16,15 +18,22 @@ class CurrentSessionTest extends WebTestCase
 {
     use JsonControllerTest;
     use FixturesTrait;
+    use GetUrlTrait;
 
     /**
      * @var ProxyReferenceRepository
      */
     protected $fixtures;
 
+    /**
+     * @var KernelBrowser
+     */
+    protected $kernelBrowser;
+
 
     public function setUp()
     {
+        $this->kernelBrowser = self::createClient();
         $fixtures = [
             'App\Tests\Fixture\LoadAuthenticationData',
             'App\Tests\Fixture\LoadUserData',
@@ -39,14 +48,20 @@ class CurrentSessionTest extends WebTestCase
 
     public function testGetGetCurrentSession()
     {
-        $client = static::createClient();
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_currentsession',
             ['version' => 'v1']
         );
-        $this->makeJsonRequest($client, 'GET', $url, null, $this->getAuthenticatedUserToken());
+        $this->makeJsonRequest(
+            $this->kernelBrowser,
+            'GET',
+            $url,
+            null,
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
+        );
 
-        $response = $client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/Endpoints/CurriculumInventoryExportTest.php
+++ b/tests/Endpoints/CurriculumInventoryExportTest.php
@@ -97,6 +97,7 @@ class CurriculumInventoryExportTest extends AbstractEndpointTest
         );
 
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_curriculuminventoryexport_404',
             $parameters
         );
@@ -104,10 +105,10 @@ class CurriculumInventoryExportTest extends AbstractEndpointTest
             $type,
             $url,
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }

--- a/tests/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/Endpoints/CurriculumInventoryReportTest.php
@@ -110,13 +110,14 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
         $this->createJsonRequest(
             'GET',
             $this->getUrl(
+                $this->kernelBrowser,
                 'ilios_api_getall',
                 ['version' => 'v1', 'object' => $endpoint]
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_OK);
         $responses = json_decode($response->getContent(), true)[$responseKey];
@@ -248,6 +249,7 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
         $this->createJsonRequest(
             'POST',
             $this->getUrl(
+                $this->kernelBrowser,
                 'ilios_api_curriculuminventoryreport_rollover',
                 [
                     'version' => 'v1',
@@ -256,9 +258,9 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
                 ]
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $data = json_decode($response->getContent(), true)['curriculumInventoryReports'];
         $newReport = $data[0];
@@ -378,6 +380,7 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
         $this->createJsonRequest(
             'POST',
             $this->getUrl(
+                $this->kernelBrowser,
                 'ilios_api_curriculuminventoryreport_rollover',
                 [
                     'version' => 'v1',
@@ -386,9 +389,9 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
                 ]
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }
 
@@ -409,13 +412,14 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
         $this->createJsonRequest(
             'POST',
             $this->getUrl(
+                $this->kernelBrowser,
                 'ilios_api_curriculuminventoryreport_rollover',
                 $parameters
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $data = json_decode($response->getContent(), true)['curriculumInventoryReports'];
         $newReport = $data[0];
@@ -439,6 +443,7 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
         $this->createJsonRequest(
             'POST',
             $this->getUrl(
+                $this->kernelBrowser,
                 'ilios_api_curriculuminventoryreport_rollover',
                 [
                     'version' => 'v1',
@@ -447,9 +452,9 @@ class CurriculumInventoryReportTest extends ReadWriteEndpointTest
                 ]
             ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $data = json_decode($response->getContent(), true)['curriculumInventoryReports'];
         $newReport = $data[0];

--- a/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
@@ -230,11 +230,10 @@ class CurriculumInventorySequenceBlockTest extends ReadWriteEndpointTest
     public function testCreateTopLevelSequenceBlockSucceeds()
     {
         $dataLoader = $this->getDataLoader();
-        $parent = $dataLoader->getOne();
 
         $postData = $dataLoader->create();
         $postData['parent'] = null;
-        $newBlock = $this->postOne(
+        $this->postOne(
             'curriculuminventorysequenceblocks',
             'curriculumInventorySequenceBlock',
             'curriculumInventorySequenceBlocks',
@@ -553,22 +552,30 @@ class CurriculumInventorySequenceBlockTest extends ReadWriteEndpointTest
 
         $this->createJsonRequest(
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'curriculuminventorysequenceblocks']),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_post',
+                ['version' => 'v1', 'object' => 'curriculuminventorysequenceblocks']
+            ),
             json_encode(['curriculumInventorySequenceBlocks' => [$block]]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         //Fails on lower boundary
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
         $block['orderInSequence'] = count($parent['children']) + 2; // out of bounds on upper boundary
 
         $this->createJsonRequest(
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'curriculuminventorysequenceblocks']),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_post',
+                ['version' => 'v1', 'object' => 'curriculuminventorysequenceblocks']
+            ),
             json_encode(['curriculumInventorySequenceBlocks' => [$block]]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         //Fails on upper boundary
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
 
@@ -600,30 +607,30 @@ class CurriculumInventorySequenceBlockTest extends ReadWriteEndpointTest
 
         $this->createJsonRequest(
             'PUT',
-            $this->getUrl('ilios_api_put', [
+            $this->getUrl($this->kernelBrowser, 'ilios_api_put', [
                 'version' => 'v1',
                 'object' => 'curriculuminventorysequenceblocks',
                 'id' => $blockId
             ]),
             json_encode(['curriculumInventorySequenceBlock' => $block]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         //Fails on lower boundary
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
         $block['orderInSequence'] = count($parent['children']) + 2; // out of bounds on upper boundary
 
         $this->createJsonRequest(
             'PUT',
-            $this->getUrl('ilios_api_put', [
+            $this->getUrl($this->kernelBrowser, 'ilios_api_put', [
                 'version' => 'v1',
                 'object' => 'curriculuminventorysequenceblocks',
                 'id' => $blockId
             ]),
             json_encode(['curriculumInventorySequenceBlock' => $block]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         //Fails on upper boundary
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
 

--- a/tests/Endpoints/IngestionExceptionTest.php
+++ b/tests/Endpoints/IngestionExceptionTest.php
@@ -67,6 +67,7 @@ class IngestionExceptionTest extends ReadEndpointTest
         );
 
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_ingestionexception_404',
             $parameters
         );
@@ -74,10 +75,10 @@ class IngestionExceptionTest extends ReadEndpointTest
             $type,
             $url,
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -137,12 +137,12 @@ class LearningMaterialTest extends ReadWriteEndpointTest
         foreach ($responses as $response) {
             $uri = array_key_exists('absoluteFileUri', $response)?$response['absoluteFileUri']:null;
             if ($uri) {
-                self::$client->request(
+                $this->kernelBrowser->request(
                     'GET',
                     $uri
                 );
 
-                $response = self::$client->getResponse();
+                $response = $this->kernelBrowser->getResponse();
 
                 $this->assertJsonResponse($response, Response::HTTP_OK, false);
             }
@@ -199,14 +199,14 @@ class LearningMaterialTest extends ReadWriteEndpointTest
             $filesize
         );
         $this->makeJsonRequest(
-            self::$client,
+            $this->kernelBrowser,
             'POST',
             '/upload',
             null,
-            $this->getAuthenticatedUserToken(),
+            $this->getAuthenticatedUserToken($this->kernelBrowser),
             ['file' => $fakeTestFile]
         );
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_OK);
         $responseData = json_decode($response->getContent(), true);
 
@@ -223,12 +223,12 @@ class LearningMaterialTest extends ReadWriteEndpointTest
         $response = $this->postTest($data, $postData);
 
         $uri = array_key_exists('absoluteFileUri', $response)?$response['absoluteFileUri']:null;
-        self::$client->request(
+        $this->kernelBrowser->request(
             'GET',
             $uri
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
 
         $this->assertJsonResponse($response, Response::HTTP_OK, false);

--- a/tests/Endpoints/ObjectiveTest.php
+++ b/tests/Endpoints/ObjectiveTest.php
@@ -134,15 +134,15 @@ class ObjectiveTest extends ReadWriteEndpointTest
 
         $this->createJsonRequest(
             'POST',
-            $this->getUrl('ilios_api_post', [
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', [
                 'version' => 'v1',
                 'object' => 'objectives'
             ]),
             json_encode(['objectives' => [$postData]]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
         $this->assertEquals(
@@ -184,15 +184,15 @@ class ObjectiveTest extends ReadWriteEndpointTest
 
         $this->createJsonRequest(
             'POST',
-            $this->getUrl('ilios_api_post', [
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', [
                 'version' => 'v1',
                 'object' => 'objectives'
             ]),
             json_encode(['objectives' => [$postData]]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
     }
 }

--- a/tests/Endpoints/PermissionsTest.php
+++ b/tests/Endpoints/PermissionsTest.php
@@ -20,12 +20,12 @@ class PermissionsTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => $endpoint]),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', ['version' => 'v1', 'object' => $endpoint]),
             json_encode([$responseKey => []]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -36,12 +36,12 @@ class PermissionsTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_put', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
             json_encode([$responseKey => []]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -52,12 +52,16 @@ class PermissionsTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'DELETE',
-            $this->getUrl('ilios_api_delete', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_delete',
+                ['version' => 'v1', 'object' => $endpoint, 'id' => 1]
+            ),
             json_encode([$responseKey => []]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -67,12 +71,16 @@ class PermissionsTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'GET',
-            $this->getUrl('ilios_api_delete', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_delete',
+                ['version' => 'v1', 'object' => $endpoint, 'id' => 1]
+            ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -82,12 +90,12 @@ class PermissionsTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'GET',
-            $this->getUrl('ilios_api_getall', ['version' => 'v1', 'object' => $endpoint]),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_getall', ['version' => 'v1', 'object' => $endpoint]),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 }

--- a/tests/Endpoints/ProgramTest.php
+++ b/tests/Endpoints/ProgramTest.php
@@ -101,9 +101,10 @@ class ProgramTest extends ReadWriteEndpointTest
         $userId = 3;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'programs']),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', ['version' => 'v1', 'object' => 'programs']),
             json_encode(['programs' => [$program]])
         );
     }
@@ -115,9 +116,14 @@ class ProgramTest extends ReadWriteEndpointTest
         $userId = 3;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'programs', 'id' => $program['id']]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_put',
+                ['version' => 'v1', 'object' => 'programs', 'id' => $program['id']]
+            ),
             json_encode(['program' => $program])
         );
     }
@@ -129,9 +135,14 @@ class ProgramTest extends ReadWriteEndpointTest
         $userId = 3;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'programs', 'id' => $program['id'] * 10000]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_put',
+                ['version' => 'v1', 'object' => 'programs', 'id' => $program['id'] * 10000]
+            ),
             json_encode(['program' => $program])
         );
     }
@@ -143,9 +154,14 @@ class ProgramTest extends ReadWriteEndpointTest
         $userId = 3;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'DELETE',
-            $this->getUrl('ilios_api_delete', ['version' => 'v1', 'object' => 'programs', 'id' => $program['id']])
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_delete',
+                ['version' => 'v1', 'object' => 'programs', 'id' => $program['id']]
+            )
         );
     }
 }

--- a/tests/Endpoints/ProgramYearTest.php
+++ b/tests/Endpoints/ProgramYearTest.php
@@ -178,9 +178,10 @@ class ProgramYearTest extends ReadWriteEndpointTest
         $userId = 3;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'programyears']),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', ['version' => 'v1', 'object' => 'programyears']),
             json_encode(['programYears' => [$data]])
         );
     }
@@ -201,9 +202,14 @@ class ProgramYearTest extends ReadWriteEndpointTest
         $userId = 3;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'programyears', 'id' => $data['id']]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_put',
+                ['version' => 'v1', 'object' => 'programyears', 'id' => $data['id']]
+            ),
             json_encode(['programYear' => $data])
         );
     }
@@ -215,9 +221,14 @@ class ProgramYearTest extends ReadWriteEndpointTest
         $userId = 3;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'DELETE',
-            $this->getUrl('ilios_api_delete', ['version' => 'v1', 'object' => 'programyears', 'id' => $data['id']])
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_delete',
+                ['version' => 'v1', 'object' => 'programyears', 'id' => $data['id']]
+            )
         );
     }
 
@@ -295,14 +306,15 @@ class ProgramYearTest extends ReadWriteEndpointTest
         $this->createJsonRequest(
             'GET',
             $this->getUrl(
+                $this->kernelBrowser,
                 'ilios_api_programyears_downloadobjectivesmapping',
                 $parameters
             ),
             null,
-            $this->getTokenForUser(2)
+            $this->getTokenForUser($this->kernelBrowser, 2)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         $expected = [
             [

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -455,11 +455,14 @@ class SchooleventsTest extends AbstractEndpointTest
             'to' => $to
         ];
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_schoolevents',
             $parameters
         );
 
-        $userToken = isset($userId) ? $this->getTokenForUser($userId) : $this->getAuthenticatedUserToken();
+        $userToken = isset($userId) ?
+            $this->getTokenForUser($this->kernelBrowser, $userId) :
+            $this->getAuthenticatedUserToken($this->kernelBrowser);
         $this->createJsonRequest(
             'GET',
             $url,
@@ -467,7 +470,7 @@ class SchooleventsTest extends AbstractEndpointTest
             $userToken
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");
@@ -485,11 +488,14 @@ class SchooleventsTest extends AbstractEndpointTest
             'session' => $sessionId
         ];
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_schoolevents',
             $parameters
         );
 
-        $userToken = isset($userId) ? $this->getTokenForUser($userId) : $this->getAuthenticatedUserToken();
+        $userToken = isset($userId) ?
+            $this->getTokenForUser($this->kernelBrowser, $userId) :
+            $this->getAuthenticatedUserToken($this->kernelBrowser);
         $this->createJsonRequest(
             'GET',
             $url,
@@ -497,7 +503,7 @@ class SchooleventsTest extends AbstractEndpointTest
             $userToken
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/Endpoints/UserMadeReminderTest.php
+++ b/tests/Endpoints/UserMadeReminderTest.php
@@ -20,12 +20,12 @@ class UserMadeReminderTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => $endpoint]),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', ['version' => 'v1', 'object' => $endpoint]),
             json_encode([$responseKey => []]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -36,12 +36,12 @@ class UserMadeReminderTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_put', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
             json_encode([$responseKey => []]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -52,12 +52,16 @@ class UserMadeReminderTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'DELETE',
-            $this->getUrl('ilios_api_delete', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_delete',
+                ['version' => 'v1', 'object' => $endpoint, 'id' => 1]
+            ),
             json_encode([$responseKey => []]),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -67,12 +71,16 @@ class UserMadeReminderTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'GET',
-            $this->getUrl('ilios_api_delete', ['version' => 'v1', 'object' => $endpoint, 'id' => 1]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_delete',
+                ['version' => 'v1', 'object' => $endpoint, 'id' => 1]
+            ),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 
@@ -82,12 +90,12 @@ class UserMadeReminderTest extends AbstractEndpointTest
 
         $this->createJsonRequest(
             'GET',
-            $this->getUrl('ilios_api_getall', ['version' => 'v1', 'object' => $endpoint]),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_getall', ['version' => 'v1', 'object' => $endpoint]),
             null,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_GONE);
     }
 }

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -220,9 +220,10 @@ class UserTest extends ReadWriteEndpointTest
         $postData['root'] = true;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'POST',
-            $this->getUrl('ilios_api_post', ['version' => 'v1', 'object' => 'users']),
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', ['version' => 'v1', 'object' => 'users']),
             json_encode(['users' => [$postData]])
         );
     }
@@ -240,7 +241,7 @@ class UserTest extends ReadWriteEndpointTest
         $data['root'] = true;
         $rootUser = $this->postOne('users', 'user', 'users', $data);
         $this->assertTrue($rootUser['root']);
-        $rootUserToken = $this->getTokenForUser($rootUser['id']);
+        $rootUserToken = $this->getTokenForUser($this->kernelBrowser, $rootUser['id']);
 
         // 2.
         $data = $dataLoader->create();
@@ -249,7 +250,7 @@ class UserTest extends ReadWriteEndpointTest
 
         $this->createJsonRequest(
             'POST',
-            $this->getUrl('ilios_api_post', [
+            $this->getUrl($this->kernelBrowser, 'ilios_api_post', [
                 'version' => 'v1',
                 'object' => 'users'
             ]),
@@ -258,7 +259,7 @@ class UserTest extends ReadWriteEndpointTest
         );
 
         // 3.
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_CREATED);
     }
 
@@ -274,9 +275,14 @@ class UserTest extends ReadWriteEndpointTest
         $postData['root'] = true;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'users', 'id' => $postData['id']]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_put',
+                ['version' => 'v1', 'object' => 'users', 'id' => $postData['id']]
+            ),
             json_encode(['user' => $postData])
         );
     }
@@ -293,9 +299,14 @@ class UserTest extends ReadWriteEndpointTest
         $postData['roles'] = ['1', '2'];
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'users', 'id' => $userId]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_put',
+                ['version' => 'v1', 'object' => 'users', 'id' => $userId]
+            ),
             json_encode(['user' => $postData])
         );
     }
@@ -314,9 +325,14 @@ class UserTest extends ReadWriteEndpointTest
         $postData['root'] = false;
 
         $this->canNot(
+            $this->kernelBrowser,
             $userId,
             'PUT',
-            $this->getUrl('ilios_api_put', ['version' => 'v1', 'object' => 'users', 'id' => $postData['id']]),
+            $this->getUrl(
+                $this->kernelBrowser,
+                'ilios_api_put',
+                ['version' => 'v1', 'object' => 'users', 'id' => $postData['id']]
+            ),
             json_encode(['user' => $postData])
         );
     }

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -43,7 +43,7 @@ class UsereventTest extends AbstractEndpointTest
             $userId,
             0,
             100000000000,
-            $this->getTokenForUser(5)
+            $this->getTokenForUser($this->kernelBrowser, 5)
         );
         $lms = $events[0]['learningMaterials'];
 
@@ -113,7 +113,7 @@ class UsereventTest extends AbstractEndpointTest
             $userId,
             0,
             100000000000,
-            $this->getTokenForUser(2)
+            $this->getTokenForUser($this->kernelBrowser, 2)
         );
         $lms = $events[0]['learningMaterials'];
 
@@ -135,7 +135,7 @@ class UsereventTest extends AbstractEndpointTest
             $userId,
             0,
             100000000000,
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
         $this->assertEquals(12, count($events), 'Expected events returned');
@@ -698,7 +698,7 @@ class UsereventTest extends AbstractEndpointTest
             $userId,
             $from->getTimestamp(),
             $to->getTimestamp(),
-            $this->getAuthenticatedUserToken()
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
         $this->assertEquals(1, count($events), 'Expected events returned');
 
@@ -714,7 +714,7 @@ class UsereventTest extends AbstractEndpointTest
             $userId,
             0,
             100000000000,
-            $this->getTokenForUser($userId)
+            $this->getTokenForUser($this->kernelBrowser, $userId)
         );
         $event = $events[3];
         $this->assertFalse($event['isPublished']);
@@ -739,7 +739,7 @@ class UsereventTest extends AbstractEndpointTest
         $events = $this->getEventsForSessionId(
             $userId,
             $sessionId,
-            $this->getTokenForUser($userId)
+            $this->getTokenForUser($this->kernelBrowser, $userId)
         );
 
         $this->assertEquals(3, count($events), 'Expected events returned');
@@ -763,7 +763,7 @@ class UsereventTest extends AbstractEndpointTest
         $events = $this->getEventsForSessionId(
             $userId,
             $sessionId,
-            $this->getTokenForUser($userId)
+            $this->getTokenForUser($this->kernelBrowser, $userId)
         );
 
         $this->assertEquals(2, count($events), 'Expected events returned');
@@ -793,6 +793,7 @@ class UsereventTest extends AbstractEndpointTest
             'to' => $to,
         ];
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_userevents',
             $parameters
         );
@@ -803,7 +804,7 @@ class UsereventTest extends AbstractEndpointTest
             $userToken
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");
@@ -816,8 +817,7 @@ class UsereventTest extends AbstractEndpointTest
 
     /**
      * @param int $userId
-     * @param int $from
-     * @param int $to
+     * @param int $sessionId
      * @param string|null $userToken
      * @return array
      */
@@ -829,6 +829,7 @@ class UsereventTest extends AbstractEndpointTest
             'session' => $sessionId,
         ];
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_userevents',
             $parameters
         );
@@ -839,7 +840,7 @@ class UsereventTest extends AbstractEndpointTest
             $userToken
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/Endpoints/UsermaterialsTest.php
+++ b/tests/Endpoints/UsermaterialsTest.php
@@ -162,11 +162,14 @@ class UsermaterialsTest extends AbstractEndpointTest
             $parameters['after'] = $after;
         }
         $url = $this->getUrl(
+            $this->kernelBrowser,
             'ilios_api_usermaterials',
             $parameters
         );
 
-        $token = isset($authUser) ? $this->getTokenForUser($authUser) : $this->getAuthenticatedUserToken();
+        $token = isset($authUser) ?
+            $this->getTokenForUser($this->kernelBrowser, $authUser) :
+            $this->getAuthenticatedUserToken($this->kernelBrowser);
         $this->createJsonRequest(
             'GET',
             $url,
@@ -174,7 +177,7 @@ class UsermaterialsTest extends AbstractEndpointTest
             $token
         );
 
-        $response = self::$client->getResponse();
+        $response = $this->kernelBrowser->getResponse();
 
         if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
             $this->fail("Unable to load url: {$url}");

--- a/tests/GetUrlTrait.php
+++ b/tests/GetUrlTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Trait GetUrlTrait
+ * Extracted from https://git.io/fjzsa
+ */
+trait GetUrlTrait
+{
+    /**
+     * @param KernelBrowser $browser
+     * @param string $route
+     * @param array $params
+     * @param int $absolute
+     *
+     * @return string
+     */
+    public function getUrl(
+        KernelBrowser $browser,
+        $route,
+        $params = [],
+        $absolute = UrlGeneratorInterface::ABSOLUTE_PATH
+    ) {
+        return $browser->getContainer()->get('router')->generate($route, $params, $absolute);
+    }
+}

--- a/tests/Traits/JsonControllerTest.php
+++ b/tests/Traits/JsonControllerTest.php
@@ -45,25 +45,27 @@ trait JsonControllerTest
             );
         }
     }
-    
+
 
     /**
      * Logs the 'newuser' user in and returns the user's JSON Web Token (JWT).
+     * @param KernelBrowser $browser
      * @return string the JWT
      */
-    protected function getAuthenticatedUserToken()
+    protected function getAuthenticatedUserToken(KernelBrowser $browser)
     {
-        return $this->getTokenForUser(2);
+        return $this->getTokenForUser($browser, 2);
     }
 
 
     /**
      * Logs in a specific user and returns the token for them
      *
+     * @param KernelBrowser $browser
      * @param string $userId
      * @return string the JWT
      */
-    protected function getTokenForUser($userId)
+    protected function getTokenForUser(KernelBrowser $browser, $userId)
     {
         static $tokens;
 
@@ -73,10 +75,8 @@ trait JsonControllerTest
         $userId = (int) $userId;
 
         if (!array_key_exists($userId, $tokens)) {
-            $client = $this->createClient();
-
             /** @var ContainerInterface $container **/
-            $container = $client->getContainer();
+            $container = $browser->getContainer();
 
             /** @var JsonWebTokenManager $jwtManager **/
             $jwtManager = $container->get(JsonWebTokenManager::class);
@@ -128,23 +128,23 @@ trait JsonControllerTest
     /**
      * Tests to ensure that a user cannot access a certain function
      *
+     * @param KernelBrowser $browser
      * @param string $userId
      * @param string $method
      * @param string $url
      * @param string $data
      */
-    protected function canNot($userId, $method, $url, $data = null)
+    protected function canNot(KernelBrowser $browser, $userId, $method, $url, $data = null)
     {
-        $client = $this->createClient();
         $this->makeJsonRequest(
-            $client,
+            $browser,
             $method,
             $url,
             $data,
-            $this->getTokenForUser($userId)
+            $this->getTokenForUser($browser, $userId)
         );
 
-        $response = $client->getResponse();
+        $response = $browser->getResponse();
         $this->assertEquals(
             Response::HTTP_FORBIDDEN,
             $response->getStatusCode(),


### PR DESCRIPTION
Since fixture extraction has been extracted the only thing we needed
from this bundle was the getUrl method which I've extracted into a
fixture.

Changed the way we work with the test client. Instead of constantly
creating it the helper methods now take the existing client as an
argument. This prevents errors when the client is called twice and
removes the container from the first call.