### PR TITLE
Re-enable automerge from dependabot

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -1,9 +1,14 @@
 version: 1
 
 update_configs:
-  - package_manager: "php:composer"
+  - package_manager: php:composer
     directory: "/"
-    update_schedule: "daily"
+    update_schedule: daily
     ignored_updates:
       - match:
           dependency_name: "symfony/*"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: all
+


### PR DESCRIPTION
Now that we've disabled symfony packages from getting updated on their
own we can re-enable automerging of everything else.