### PR TITLE
Add user search endpoint

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -41,9 +41,14 @@ _monitor:
   resource: "@LiipMonitorBundle/Resources/config/routing.xml"
   prefix: /ilios/health
 
-ilios_search:
-  path: /experimental_search
-  controller: App\Controller\Search:search
+ilios_curriculum_search:
+  path: /experimental_search/v1/curriculum
+  controller: App\Controller\Search:curriculumSearch
+  methods:  [GET]
+
+ilios_user_search:
+  path: /experimental_search/v1/users
+  controller: App\Controller\Search:userSearch
   methods:  [GET]
 
 ilios_swagger_redirect_docs:

--- a/src/Controller/Search.php
+++ b/src/Controller/Search.php
@@ -43,7 +43,7 @@ class Search extends AbstractController
         $this->permissionChecker = $permissionChecker;
     }
 
-    public function search(Request $request)
+    public function curriculumSearch(Request $request)
     {
         /** @var SessionUserInterface $sessionUser */
         $sessionUser = $this->tokenStorage->getToken()->getUser();
@@ -56,6 +56,28 @@ class Search extends AbstractController
         $onlySuggest = (bool) $request->get('onlySuggest');
 
         $result = $this->search->curriculumSearch($query, $onlySuggest);
+
+        return new JsonResponse(['results' => $result]);
+    }
+
+    public function userSearch(Request $request)
+    {
+        /** @var SessionUserInterface $sessionUser */
+        $sessionUser = $this->tokenStorage->getToken()->getUser();
+        if (! $this->permissionChecker->canSearchUsers($sessionUser)) {
+            throw new AccessDeniedException();
+        }
+
+        $query = $request->get('q');
+
+        $onlySuggest = (bool) $request->get('onlySuggest');
+        $size = $request->get('size');
+
+        if ($size === null) {
+            $size = 100;
+        }
+
+        $result = $this->search->userSearch($query, $size, $onlySuggest);
 
         return new JsonResponse(['results' => $result]);
     }

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -33,6 +33,8 @@ class Index extends ElasticSearchBase
                 'email' => $user->email,
                 'campusId' => $user->campusId,
                 'username' => $user->username,
+                'fullName' => $user->firstName . ' ' . $user->middleName . ' ' . $user->lastName,
+                'fullNameLastFirst' => $user->lastName . ', ' . $user->firstName . ' ' . $user->middleName,
             ];
         }, $users);
 
@@ -393,6 +395,9 @@ class Index extends ElasticSearchBase
                     'mappings' => [
                         '_doc' => [
                             'properties' => [
+                                'id' => [
+                                    'type' => 'keyword',
+                                ],
                                 'firstName' => [
                                     'type' => 'text',
                                     'analyzer' => 'ngram_analyzer',
@@ -430,17 +435,36 @@ class Index extends ElasticSearchBase
                                     'fields' => [
                                         'raw' => [
                                             'type' => 'keyword',
-                                        ]
+                                        ],
+                                        'cmp' => [
+                                            'type' => 'completion'
+                                        ],
                                     ],
+                                ],
+                                'fullName' => [
+                                    'type' => 'completion'
+                                ],
+                                'fullNameLastFirst' => [
+                                    'type' => 'completion'
                                 ],
                                 'username' => [
                                     'type' => 'keyword',
                                 ],
                                 'campusId' => [
                                     'type' => 'keyword',
+                                    'fields' => [
+                                        'cmp' => [
+                                            'type' => 'completion'
+                                        ]
+                                    ],
                                 ],
                                 'email' => [
                                     'type' => 'keyword',
+                                    'fields' => [
+                                        'cmp' => [
+                                            'type' => 'completion'
+                                        ]
+                                    ],
                                 ],
                             ]
                         ]

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -33,6 +33,7 @@ class Index extends ElasticSearchBase
                 'email' => $user->email,
                 'campusId' => $user->campusId,
                 'username' => $user->username,
+                'enabled' => $user->enabled,
                 'fullName' => $user->firstName . ' ' . $user->middleName . ' ' . $user->lastName,
                 'fullNameLastFirst' => $user->lastName . ', ' . $user->firstName . ' ' . $user->middleName,
             ];
@@ -465,6 +466,9 @@ class Index extends ElasticSearchBase
                                             'type' => 'completion'
                                         ]
                                     ],
+                                ],
+                                'enabled' => [
+                                    'type' => 'boolean',
                                 ],
                             ]
                         ]

--- a/src/Service/PermissionChecker.php
+++ b/src/Service/PermissionChecker.php
@@ -1349,4 +1349,14 @@ class PermissionChecker
     {
         return $sessionUser->performsNonLearnerFunction();
     }
+
+    /**
+     * Checks if the given user can search for users
+     * @param SessionUserInterface $sessionUser
+     * @return bool
+     */
+    public function canSearchUsers(SessionUserInterface $sessionUser): bool
+    {
+        return $sessionUser->performsNonLearnerFunction();
+    }
 }

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -221,7 +221,14 @@ class Search extends ElasticSearchBase
             'body' => [
                 'suggest' => $suggest,
                 "_source" => [
-                    'id', 'firstName', 'middleName', 'lastName', 'displayName', 'campusId', 'email'
+                    'id',
+                    'firstName',
+                    'middleName',
+                    'lastName',
+                    'displayName',
+                    'campusId',
+                    'email',
+                    'enabled',
                 ],
                 'sort' => '_score'
             ]

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -175,51 +175,100 @@ class Search extends ElasticSearchBase
      * @param string $query
      * @param int $size
      * @return array
-     * @throws \Exception when search is not configured
      */
     public function userIdsQuery(string $query, int $size = 1000)
+    {
+        $results = $this->userSearch($query, $size, false);
+
+        return array_column($results['users'], 'id');
+    }
+
+    /**
+     * @param string $query
+     * @param int $size
+     * @return array
+     * @throws \Exception when search is not configured
+     */
+    public function userSearch(string $query, int $size, bool $onlySuggest)
     {
         if (!$this->enabled) {
             throw new \Exception("Search is not configured, isEnabled() should be called before calling this method");
         }
+
+        $suggestFields = [
+            'fullName',
+            'fullNameLastFirst',
+            'email.cmp',
+            'campusId.cmp',
+        ];
+        $suggest = array_reduce($suggestFields, function ($carry, $field) use ($query) {
+            $carry[$field] = [
+                'prefix' => $query,
+                'completion' => [
+                    'field' => "${field}",
+                    'skip_duplicates' => true,
+                ]
+            ];
+
+            return $carry;
+        }, []);
+
 
         $params = [
             'type' => '_doc',
             'index' => self::PRIVATE_USER_INDEX,
             'size' => $size,
             'body' => [
-                'explain' => true,
-                'query' => [
-                    'multi_match' => [
-                        'query' => $query,
-                        'type' => 'most_fields',
-                        'fields' => [
-                            'firstName',
-                            'firstName.raw^3',
-                            'middleName',
-                            'middleName.raw^3',
-                            'lastName',
-                            'lastName.raw^3',
-                            'displayName',
-                            'displayName.raw^3',
-                            'userName^5',
-                            'campusId^5',
-                            'email^5',
-                        ]
-                    ]
-                ],
+                'suggest' => $suggest,
                 "_source" => [
-                    '_id'
+                    'id', 'firstName', 'middleName', 'lastName', 'displayName', 'campusId', 'email'
                 ],
                 'sort' => '_score'
             ]
         ];
 
+        if (!$onlySuggest) {
+            $params['body']['query'] = [
+                'multi_match' => [
+                    'query' => $query,
+                    'type' => 'most_fields',
+                    'fields' => [
+                        'firstName',
+                        'firstName.raw^3',
+                        'middleName',
+                        'middleName.raw^3',
+                        'lastName',
+                        'lastName.raw^3',
+                        'displayName',
+                        'displayName.raw^3',
+                        'userName^5',
+                        'campusId^5',
+                        'email^5',
+                    ]
+                ]
+            ];
+        }
+
         $results = $this->search($params);
 
-        return array_map(function (array $arr) {
-            return $arr['_id'];
-        }, $results['hits']['hits']);
+        $autocompleteSuggestions = array_reduce(
+            $results['suggest'],
+            function (array $carry, array $item) {
+                $options = array_map(function (array $arr) {
+                    return $arr['text'];
+                }, $item[0]['options']);
+
+                return array_unique(array_merge($carry, $options));
+            },
+            []
+        );
+
+        $users = array_column($results['hits']['hits'], '_source');
+
+        return [
+            'autocomplete' => $autocompleteSuggestions,
+            'users' => $users
+        ];
     }
 
     /**

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -50,6 +50,77 @@ class IndexTest extends TestCase
         $this->assertTrue($obj->indexUsers($users));
     }
 
+
+    public function testIndexUsers()
+    {
+        $client = m::mock(Client::class);
+        $obj = new Index($client);
+        $user1 = m::mock(UserDTO::class);
+        $user1->id = 13;
+        $user1->firstName = 'first';
+        $user1->middleName = 'middle';
+        $user1->lastName = 'last';
+        $user1->displayName = 'display name';
+        $user1->email = 'jackson@awesome.com';
+        $user1->campusId = '99';
+        $user1->username = 'thebestone';
+
+        $user2 = m::mock(UserDTO::class);
+        $user2->id = 11;
+        $user2->firstName = 'first2';
+        $user2->middleName = 'middle2';
+        $user2->lastName = 'last2';
+        $user2->displayName = null;
+        $user2->email = 'jasper@awesome.com';
+        $user2->campusId = 'OG';
+        $user2->username = null;
+
+        $client->shouldReceive('bulk')->once()->with([
+            'body' => [
+                [
+                    'index' => [
+                        '_index' => ElasticSearchBase::PRIVATE_USER_INDEX,
+                        '_type' => '_doc',
+                        '_id' => $user1->id
+                    ]
+                ],
+                [
+                    'id' => $user1->id,
+                    'firstName' => $user1->firstName,
+                    'lastName' => $user1->lastName,
+                    'middleName' => $user1->middleName,
+                    'displayName' => $user1->displayName,
+                    'email' => $user1->email,
+                    'campusId' => $user1->campusId,
+                    'username' => $user1->username,
+                    'fullName' => 'first middle last',
+                    'fullNameLastFirst' => 'last, first middle',
+                ],
+                [
+                    'index' => [
+                        '_index' => ElasticSearchBase::PRIVATE_USER_INDEX,
+                        '_type' => '_doc',
+                        '_id' => $user2->id
+                    ]
+                ],
+                [
+                    'id' => $user2->id,
+                    'firstName' => $user2->firstName,
+                    'lastName' => $user2->lastName,
+                    'middleName' => $user2->middleName,
+                    'displayName' => $user2->displayName,
+                    'email' => $user2->email,
+                    'campusId' => $user2->campusId,
+                    'username' => $user2->username,
+                    'fullName' => 'first2 middle2 last2',
+                    'fullNameLastFirst' => 'last2, first2 middle2',
+                ],
+            ]
+        ])->andReturn(['errors' => false]);
+        $obj->indexUsers([$user1, $user2]);
+    }
+
+
     public function testIndexCoursesThrowsWhenNotIndexableCourse()
     {
         $obj = $this->createWithoutHost();

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -62,6 +62,7 @@ class IndexTest extends TestCase
         $user1->lastName = 'last';
         $user1->displayName = 'display name';
         $user1->email = 'jackson@awesome.com';
+        $user1->enabled = false;
         $user1->campusId = '99';
         $user1->username = 'thebestone';
 
@@ -72,6 +73,7 @@ class IndexTest extends TestCase
         $user2->lastName = 'last2';
         $user2->displayName = null;
         $user2->email = 'jasper@awesome.com';
+        $user1->enabled = true;
         $user2->campusId = 'OG';
         $user2->username = null;
 
@@ -93,6 +95,7 @@ class IndexTest extends TestCase
                     'email' => $user1->email,
                     'campusId' => $user1->campusId,
                     'username' => $user1->username,
+                    'enabled' => $user1->enabled,
                     'fullName' => 'first middle last',
                     'fullNameLastFirst' => 'last, first middle',
                 ],
@@ -112,6 +115,7 @@ class IndexTest extends TestCase
                     'email' => $user2->email,
                     'campusId' => $user2->campusId,
                     'username' => $user2->username,
+                    'enabled' => $user2->enabled,
                     'fullName' => 'first2 middle2 last2',
                     'fullNameLastFirst' => 'last2, first2 middle2',
                 ],


### PR DESCRIPTION
Just like curriculum users can be searched for. Moves everything under
a new `/experimental_search/v1` top level:

`/experimental_search/v1/curriculum`
`/experimental_search/v1/users`

Also adds autocomplete to user search to speed up that in our admin panel.