### PR TITLE
Revert Update to Elastic Search 7

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -9,6 +9,9 @@ update_configs:
           dependency_name: "symfony/*"
     automerged_updates:
       - match:
+          dependency_name: "elasticsearch/elasticsearch"
+          update_type: "semver:minor"
+      - match:
           dependency_type: all
           update_type: all
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "doctrine/doctrine-fixtures-bundle": "^3.0",
     "dreamscapes/ldap-core": "^3.1",
     "easycorp/easy-log-handler": "^1.0",
-    "elasticsearch/elasticsearch": "^7.0",
+    "elasticsearch/elasticsearch": "^6.1",
     "eluceo/ical": "^0.15.0",
     "exercise/htmlpurifier-bundle": "^2.0",
     "firebase/php-jwt": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba210f924404438857f7f3df6e1ba66f",
+    "content-hash": "61152d6a2da5a8483bf3fae5bd2e8d10",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1667,33 +1667,33 @@
         },
         {
             "name": "elasticsearch/elasticsearch",
-            "version": "v7.0.0",
+            "version": "v6.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elastic/elasticsearch-php.git",
-                "reference": "e8d035bac967aeb6a47aca1f9b07a25e01cda93f"
+                "reference": "7be453dd36d1b141b779f2cb956715f8e04ac2f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/e8d035bac967aeb6a47aca1f9b07a25e01cda93f",
-                "reference": "e8d035bac967aeb6a47aca1f9b07a25e01cda93f",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/7be453dd36d1b141b779f2cb956715f8e04ac2f4",
+                "reference": "7be453dd36d1b141b779f2cb956715f8e04ac2f4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": ">=1.3.7",
                 "guzzlehttp/ringphp": "~1.0",
-                "php": "^7.1",
+                "php": "^7.0",
                 "psr/log": "~1.0"
             },
             "require-dev": {
-                "cpliakas/git-wrapper": "~2.0",
-                "doctrine/inflector": "^1.3",
+                "cpliakas/git-wrapper": "^1.7 || ^2.1",
+                "doctrine/inflector": "^1.1",
                 "mockery/mockery": "^1.2",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.5",
+                "phpstan/phpstan-shim": "^0.9 || ^0.11",
+                "phpunit/phpunit": "^5.7 || ^6.5",
                 "squizlabs/php_codesniffer": "^3.4",
-                "symfony/finder": "~4.0",
-                "symfony/yaml": "~4.0"
+                "symfony/finder": "^2.8",
+                "symfony/yaml": "^2.8"
             },
             "suggest": {
                 "ext-curl": "*",
@@ -1723,7 +1723,7 @@
                 "elasticsearch",
                 "search"
             ],
-            "time": "2019-06-13T15:21:54+00:00"
+            "time": "2019-05-20T14:15:55+00:00"
         },
         {
             "name": "eluceo/ical",


### PR DESCRIPTION
We're not quite ready to make this jump to v7 and it's API changes.
Would like to wait until the AWS service is updated as well to ensure
we're compatible with our most likely runtime.