### PR TITLE
Stop Redirecting Search Crawlers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "firebase/php-jwt": "@stable",
     "guzzlehttp/psr7": "^1.5",
     "ilios/mesh-parser": "^2.0",
+    "jaybizzle/crawler-detect": "^1.2",
     "league/flysystem": "^1.0",
     "league/flysystem-aws-s3-v3": "^1.0",
     "league/flysystem-cached-adapter": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "754d16aaa645322397b256b3ba39fd99",
+    "content-hash": "5486abd65706bd2054f67147ca3a38e4",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -2315,6 +2315,55 @@
                 "mesh"
             ],
             "time": "2019-02-05T19:18:47+00:00"
+        },
+        {
+            "name": "jaybizzle/crawler-detect",
+            "version": "v1.2.84",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JayBizzle/Crawler-Detect.git",
+                "reference": "b7f35477a56609dd0d753c07ada912b66af3df01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/b7f35477a56609dd0d753c07ada912b66af3df01",
+                "reference": "b7f35477a56609dd0d753c07ada912b66af3df01",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8|^5.5|^6.5",
+                "satooshi/php-coveralls": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jaybizzle\\CrawlerDetect\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Beech",
+                    "email": "m@rkbee.ch",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CrawlerDetect is a PHP class for detecting bots/crawlers/spiders via the user agent",
+            "homepage": "https://github.com/JayBizzle/Crawler-Detect/",
+            "keywords": [
+                "crawler",
+                "crawler detect",
+                "crawler detector",
+                "crawlerdetect",
+                "php crawler detect"
+            ],
+            "time": "2019-06-14T21:10:21+00:00"
         },
         {
             "name": "jdorn/sql-formatter",

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Service\Config;
 use App\Service\Filesystem;
 use App\Service\AuthenticationInterface;
+use Jaybizzle\CrawlerDetect\CrawlerDetect;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -98,7 +99,10 @@ class IndexController extends AbstractController
     {
         $response = $this->authentication->createAuthenticationResponse($request);
         if ($response instanceof RedirectResponse) {
-            return $response;
+            $crawlerDetect = new CrawlerDetect();
+            if (!$crawlerDetect->isCrawler($request->headers->get('User-Agent'))) {
+                return $response;
+            }
         }
 
         $path = $this->getFilePath('index.json');

--- a/symfony.lock
+++ b/symfony.lock
@@ -171,6 +171,9 @@
     "ilios/mesh-parser": {
         "version": "v2.0.1"
     },
+    "jaybizzle/crawler-detect": {
+        "version": "v1.2.84"
+    },
     "jdorn/sql-formatter": {
         "version": "v1.2.17"
     },


### PR DESCRIPTION
If we send this early redirect to search crawlers they will index the
SSO landing page instead of the site at that address.  Even though it is
a minimal set of information at this non-authenticated point it's still
worth showing to crawlers so they can read meta tags and improve SEO.