### PR TITLE
treat trailing S in school name correctly.

### DIFF
--- a/templates/email/teachingreminder.text.twig
+++ b/templates/email/teachingreminder.text.twig
@@ -10,6 +10,8 @@
  * - $timezone:           The institution timezone.
  */
 #}
+{%- set schoolTitle = offering.session.course.school.title -%}
+{%- set adminEmail = offering.session.course.school.iliosAdministratorEmail -%}
 Dear {{ instructor.firstName|raw }} {{ instructor.lastName|raw }}:
 
 This message is a reminder for your upcoming {{ offering.session.sessionType.title }} in this School of {{ offering.session.course.school.title }} course.
@@ -42,4 +44,4 @@ The learning objectives listed for this course are:
 
 For a complete review of the session details and its associated learning materials, visit the session details on your Ilios Calendar at {{ base_url }}/courses/{{ offering.session.course.id }}.
 
-If you would like to edit the details of this session and do not have editing rights in Ilios for this course please contact the School of {{ offering.session.course.school.title }}'s Curriculum Coordinator at {{ offering.session.course.school.iliosAdministratorEmail }}.
+If you would like to edit the details of this session and do not have editing rights in Ilios for this course please contact the School of {{ schoolTitle }}'{% if 's' != schoolTitle|lower|last %}s{% endif %} Curriculum Coordinator at {{ adminEmail }}.


### PR DESCRIPTION
fixes #1975 