### PR TITLE
List config values when database is not configured

### DIFF
--- a/src/Command/ListConfigValuesCommand.php
+++ b/src/Command/ListConfigValuesCommand.php
@@ -4,11 +4,11 @@ namespace App\Command;
 
 use App\Entity\ApplicationConfig;
 use App\Entity\Manager\ApplicationConfigManager;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
 
 /**
  * Get an application configuration value from the DB
@@ -63,8 +63,13 @@ class ListConfigValuesCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var ApplicationConfig[] $configs */
-        $configs = $this->applicationConfigManager->findBy([], ['name' => 'asc']);
+        try {
+            /** @var ApplicationConfig[] $configs */
+            $configs = $this->applicationConfigManager->findBy([], ['name' => 'asc']);
+        } catch (ConnectionException $e) {
+            $output->writeln('<error>Unable to connect to database.</error>');
+            $output->writeln($e->getMessage());
+        }
         if (empty($configs)) {
             $output->writeln('<error>There are no configuration values in the database.</error>');
         } else {

--- a/tests/Command/ListConfigValuesCommandTest.php
+++ b/tests/Command/ListConfigValuesCommandTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Command;
 use App\Command\ListConfigValuesCommand;
 use App\Entity\ApplicationConfig;
 use App\Entity\Manager\ApplicationConfigManager;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -58,6 +59,36 @@ class ListConfigValuesCommandTest extends KernelTestCase
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/\sthe-name\s|\sthe-value\s/',
+            $output
+        );
+        $this->assertRegExp(
+            '/\sEnvironment\s|\sTESTING123\s/',
+            $output
+        );
+        $this->assertRegExp(
+            '/\sKernel Secret\s|\sSECRET\s/',
+            $output
+        );
+        $this->assertRegExp(
+            '/\sDatabase URL\s|\smysql\s/',
+            $output
+        );
+    }
+
+    public function testExecuteWithConnectionException()
+    {
+        $connectionException = m::mock(ConnectionException::class);
+        $this->applicationConfigManager->shouldReceive('findBy')
+            ->with([], ['name' => 'asc'])
+            ->once()
+            ->andThrow($connectionException);
+
+        $this->commandTester->execute(array(
+            'command'      => self::COMMAND_NAME
+        ));
+        $output = $this->commandTester->getDisplay();
+        $this->assertRegExp(
+            '/^Unable to connect to database./',
             $output
         );
         $this->assertRegExp(


### PR DESCRIPTION
Without this change it's impossible to see exactly why the DB isn't
working. The exception prevents the other values from being written.
This way a missing DB configuration param is visible.