### PR TITLE
Re-index search to match long words

### DIFF
--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -299,12 +299,12 @@ class Index extends ElasticSearchBase
     {
         $txtTypeField = [
             'type' => 'text',
-            'analyzer' => 'ngram_analyzer',
-            'search_analyzer' => 'string_search_analyzer',
+            'analyzer' => 'standard',
             'fields' => [
-                'std' => [
+                'ngram' => [
                     'type' => 'text',
-                    'analyzer' => 'standard',
+                    'analyzer' => 'ngram_analyzer',
+                    'search_analyzer' => 'string_search_analyzer',
                 ],
                 'english' => [
                     'type' => 'text',

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -243,17 +243,26 @@ class Search extends ElasticSearchBase
             'courseId',
             'courseYear',
             'courseTitle',
+            'courseTitle.ngram',
             'courseTerms',
+            'courseTerms.ngram',
             'courseObjectives',
+            'courseObjectives.ngram',
             'courseLearningMaterials',
+            'courseLearningMaterials.ngram',
             'courseMeshDescriptors',
             'sessionId',
             'sessionTitle',
+            'sessionTitle.ngram',
             'sessionDescription',
+            'sessionDescription.ngram',
             'sessionType',
             'sessionTerms',
+            'sessionTerms.ngram',
             'sessionObjectives',
+            'sessionObjectives.ngram',
             'sessionLearningMaterials',
+            'sessionLearningMaterials.ngram',
             'sessionMeshDescriptors',
         ];
 
@@ -297,7 +306,7 @@ class Search extends ElasticSearchBase
                 $matches = array_map(function (string $type) use ($field, $query) {
                     $fullField = "${field}.${type}";
                     return [ 'match' => [ $fullField => ['query' => $query, '_name' => $fullField] ] ];
-                }, ['standard', 'english', 'raw']);
+                }, ['english', 'raw']);
 
                 return array_merge($carry, $matches);
             },


### PR DESCRIPTION
Words like interprofessional were not getting returned in the search
because we have a maximum ngram size of 15. This change ensures that
exact word long matches will still work along with partial string
shorter ones.

Fixes #2591