### PR TITLE
Expose mysql when running in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '2.1'
 services:
     db:
         image: ilios/mysql-demo
+        ports:
+            - "13306:3306"
     web:
         build: ./
         environment:


### PR DESCRIPTION
This makes it easier to file up a unified environment, but still run the
local webserver so that debugging is possible without complicated
configuration.