### PR TITLE
only users who perform non-learner functions can view learning materials

### DIFF
--- a/src/RelationshipVoter/CourseLearningMaterial.php
+++ b/src/RelationshipVoter/CourseLearningMaterial.php
@@ -29,8 +29,7 @@ class CourseLearningMaterial extends AbstractVoter
 
         switch ($attribute) {
             case self::VIEW:
-                return true;
-                break;
+                return $user->performsNonLearnerFunction();
             case self::EDIT:
             case self::CREATE:
             case self::DELETE:

--- a/src/RelationshipVoter/ElevatedPermissionsViewDTOVoter.php
+++ b/src/RelationshipVoter/ElevatedPermissionsViewDTOVoter.php
@@ -30,7 +30,6 @@ class ElevatedPermissionsViewDTOVoter extends AbstractVoter
                 $subject instanceof AuthenticationDTO
                 || $subject instanceof CourseLearningMaterialDTO
                 || $subject instanceof IngestionExceptionDTO
-                || $subject instanceof LearningMaterialDTO
                 || $subject instanceof OfferingDTO
                 || $subject instanceof PendingUserUpdateDTO
                 || $subject instanceof SessionLearningMaterialDTO

--- a/src/RelationshipVoter/ElevatedPermissionsViewDTOVoter.php
+++ b/src/RelationshipVoter/ElevatedPermissionsViewDTOVoter.php
@@ -4,10 +4,13 @@ namespace App\RelationshipVoter;
 
 use App\Classes\SessionUserInterface;
 use App\Entity\DTO\AuthenticationDTO;
+use App\Entity\DTO\CourseLearningMaterialDTO;
 use App\Entity\DTO\IngestionExceptionDTO;
 use App\Entity\DTO\LearnerGroupDTO;
+use App\Entity\DTO\LearningMaterialDTO;
 use App\Entity\DTO\OfferingDTO;
 use App\Entity\DTO\PendingUserUpdateDTO;
+use App\Entity\DTO\SessionLearningMaterialDTO;
 use App\Entity\DTO\UserDTO;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -25,9 +28,12 @@ class ElevatedPermissionsViewDTOVoter extends AbstractVoter
         return (
             in_array($attribute, [self::VIEW]) && (
                 $subject instanceof AuthenticationDTO
+                || $subject instanceof CourseLearningMaterialDTO
                 || $subject instanceof IngestionExceptionDTO
+                || $subject instanceof LearningMaterialDTO
                 || $subject instanceof OfferingDTO
                 || $subject instanceof PendingUserUpdateDTO
+                || $subject instanceof SessionLearningMaterialDTO
             )
         );
     }

--- a/src/RelationshipVoter/GreenlightViewDTOVoter.php
+++ b/src/RelationshipVoter/GreenlightViewDTOVoter.php
@@ -11,7 +11,6 @@ use App\Entity\DTO\CohortDTO;
 use App\Entity\DTO\CompetencyDTO;
 use App\Entity\DTO\CourseClerkshipTypeDTO;
 use App\Entity\DTO\CourseDTO;
-use App\Entity\DTO\CourseLearningMaterialDTO;
 use App\Entity\DTO\CurriculumInventoryAcademicLevelDTO;
 use App\Entity\DTO\CurriculumInventoryInstitutionDTO;
 use App\Entity\DTO\CurriculumInventoryReportDTO;
@@ -20,7 +19,6 @@ use App\Entity\DTO\CurriculumInventorySequenceDTO;
 use App\Entity\DTO\DepartmentDTO;
 use App\Entity\DTO\IlmSessionDTO;
 use App\Entity\DTO\InstructorGroupDTO;
-use App\Entity\DTO\LearningMaterialDTO;
 use App\Entity\DTO\LearningMaterialStatusDTO;
 use App\Entity\DTO\LearningMaterialUserRoleDTO;
 use App\Entity\DTO\MeshConceptDTO;
@@ -37,7 +35,6 @@ use App\Entity\DTO\SchoolConfigDTO;
 use App\Entity\DTO\SchoolDTO;
 use App\Entity\DTO\SessionDescriptionDTO;
 use App\Entity\DTO\SessionDTO;
-use App\Entity\DTO\SessionLearningMaterialDTO;
 use App\Entity\DTO\SessionTypeDTO;
 use App\Entity\DTO\TermDTO;
 use App\Entity\DTO\UserRoleDTO;
@@ -63,7 +60,6 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof CompetencyDTO
                 || $subject instanceof CourseDTO
                 || $subject instanceof CourseClerkshipTypeDTO
-                || $subject instanceof CourseLearningMaterialDTO
                 || $subject instanceof CurriculumInventoryAcademicLevelDTO
                 || $subject instanceof CurriculumInventoryInstitutionDTO
                 || $subject instanceof CurriculumInventoryReportDTO
@@ -72,7 +68,6 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof DepartmentDTO
                 || $subject instanceof IlmSessionDTO
                 || $subject instanceof InstructorGroupDTO
-                || $subject instanceof LearningMaterialDTO
                 || $subject instanceof LearningMaterialStatusDTO
                 || $subject instanceof LearningMaterialUserRoleDTO
                 || $subject instanceof MeshConceptDTO
@@ -89,7 +84,6 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof SchoolConfigDTO
                 || $subject instanceof SessionDTO
                 || $subject instanceof SessionDescriptionDTO
-                || $subject instanceof SessionLearningMaterialDTO
                 || $subject instanceof SessionTypeDTO
                 || $subject instanceof TermDTO
                 || $subject instanceof UserRoleDTO

--- a/src/RelationshipVoter/GreenlightViewDTOVoter.php
+++ b/src/RelationshipVoter/GreenlightViewDTOVoter.php
@@ -19,6 +19,7 @@ use App\Entity\DTO\CurriculumInventorySequenceDTO;
 use App\Entity\DTO\DepartmentDTO;
 use App\Entity\DTO\IlmSessionDTO;
 use App\Entity\DTO\InstructorGroupDTO;
+use App\Entity\DTO\LearningMaterialDTO;
 use App\Entity\DTO\LearningMaterialStatusDTO;
 use App\Entity\DTO\LearningMaterialUserRoleDTO;
 use App\Entity\DTO\MeshConceptDTO;
@@ -68,6 +69,7 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof DepartmentDTO
                 || $subject instanceof IlmSessionDTO
                 || $subject instanceof InstructorGroupDTO
+                || $subject instanceof LearningMaterialDTO
                 || $subject instanceof LearningMaterialStatusDTO
                 || $subject instanceof LearningMaterialUserRoleDTO
                 || $subject instanceof MeshConceptDTO

--- a/src/RelationshipVoter/LearningMaterial.php
+++ b/src/RelationshipVoter/LearningMaterial.php
@@ -40,6 +40,7 @@ class LearningMaterial extends AbstractVoter
 
         switch ($attribute) {
             case self::VIEW:
+                return true;
             case self::CREATE:
             case self::EDIT:
             case self::DELETE:

--- a/src/RelationshipVoter/LearningMaterial.php
+++ b/src/RelationshipVoter/LearningMaterial.php
@@ -40,8 +40,6 @@ class LearningMaterial extends AbstractVoter
 
         switch ($attribute) {
             case self::VIEW:
-                return true;
-                break;
             case self::CREATE:
             case self::EDIT:
             case self::DELETE:

--- a/src/RelationshipVoter/SessionLearningMaterial.php
+++ b/src/RelationshipVoter/SessionLearningMaterial.php
@@ -29,8 +29,7 @@ class SessionLearningMaterial extends AbstractVoter
 
         switch ($attribute) {
             case self::VIEW:
-                return true;
-                break;
+                return $user->performsNonLearnerFunction();
             case self::EDIT:
             case self::CREATE:
             case self::DELETE:

--- a/tests/RelationshipVoter/AbstractBase.php
+++ b/tests/RelationshipVoter/AbstractBase.php
@@ -42,10 +42,36 @@ class AbstractBase extends TestCase
      *
      * @return TokenInterface
      */
-    protected function createMockTokenWithNonRootSessionUser($userId = null)
+    protected function createMockTokenWithNonRootSessionUser()
     {
         $sessionUser = m::mock(SessionUserInterface::class);
         $sessionUser->shouldReceive('isRoot')->andReturn(false);
+        return $this->createMockTokenWithSessionUser($sessionUser);
+    }
+
+    /**
+     * Creates a mock token with a user that's performs non-learner functions.
+     *
+     * @return TokenInterface
+     */
+    protected function createMockTokenWithSessionUserPerformingNonLearnerFunction()
+    {
+        $sessionUser = m::mock(SessionUserInterface::class);
+        $sessionUser->shouldReceive('isRoot')->andReturn(false);
+        $sessionUser->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        return $this->createMockTokenWithSessionUser($sessionUser);
+    }
+
+    /**
+     * Creates a mock token with a user that's doesn't perform non-learner functions.
+     *
+     * @return TokenInterface
+     */
+    protected function createMockTokenWithSessionUserPerformingOnlyLearnerFunction()
+    {
+        $sessionUser = m::mock(SessionUserInterface::class);
+        $sessionUser->shouldReceive('isRoot')->andReturn(false);
+        $sessionUser->shouldReceive('performsNonLearnerFunction')->andReturn(false);
         return $this->createMockTokenWithSessionUser($sessionUser);
     }
 

--- a/tests/RelationshipVoter/CourseLearningMaterialTest.php
+++ b/tests/RelationshipVoter/CourseLearningMaterialTest.php
@@ -7,7 +7,6 @@ use App\Service\PermissionChecker;
 use App\Entity\Course;
 use App\Entity\CourseLearningMaterial;
 use App\Entity\School;
-use App\Service\Config;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -24,12 +23,20 @@ class CourseLearningMaterialTest extends AbstractBase
         $this->checkRootEntityAccess(m::mock(CourseLearningMaterial::class));
     }
 
-    public function testCanView()
+    public function testCanViewUserPerformingNonLearnerFunction()
     {
-        $token = $this->createMockTokenWithNonRootSessionUser();
+        $token = $this->createMockTokenWithSessionUserPerformingNonLearnerFunction();
         $entity = m::mock(CourseLearningMaterial::class);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotViewAsLearnerOnly()
+    {
+        $token = $this->createMockTokenWithSessionUserPerformingOnlyLearnerFunction();
+        $entity = m::mock(CourseLearningMaterial::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View allowed");
     }
 
     public function testCanEdit()

--- a/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
+++ b/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
@@ -3,7 +3,6 @@
 namespace App\Tests\RelationshipVoter;
 
 use App\Entity\DTO\CourseLearningMaterialDTO;
-use App\Entity\DTO\LearningMaterialDTO;
 use App\Entity\DTO\SessionLearningMaterialDTO;
 use App\RelationshipVoter\AbstractVoter;
 use App\RelationshipVoter\ElevatedPermissionsViewDTOVoter as Voter;
@@ -36,7 +35,6 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
             [AuthenticationDTO::class],
             [CourseLearningMaterialDTO::class],
             [IngestionExceptionDTO::class],
-            [LearningMaterialDTO::class],
             [OfferingDTO::class],
             [PendingUserUpdateDTO::class],
             [SessionLearningMaterialDTO::class],

--- a/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -13,7 +13,6 @@ use App\Entity\DTO\CohortDTO;
 use App\Entity\DTO\CompetencyDTO;
 use App\Entity\DTO\CourseClerkshipTypeDTO;
 use App\Entity\DTO\CourseDTO;
-use App\Entity\DTO\CourseLearningMaterialDTO;
 use App\Entity\DTO\CurriculumInventoryAcademicLevelDTO;
 use App\Entity\DTO\CurriculumInventoryInstitutionDTO;
 use App\Entity\DTO\CurriculumInventoryReportDTO;
@@ -22,7 +21,6 @@ use App\Entity\DTO\CurriculumInventorySequenceDTO;
 use App\Entity\DTO\DepartmentDTO;
 use App\Entity\DTO\IlmSessionDTO;
 use App\Entity\DTO\InstructorGroupDTO;
-use App\Entity\DTO\LearningMaterialDTO;
 use App\Entity\DTO\LearningMaterialStatusDTO;
 use App\Entity\DTO\LearningMaterialUserRoleDTO;
 use App\Entity\DTO\MeshConceptDTO;
@@ -39,12 +37,10 @@ use App\Entity\DTO\SchoolConfigDTO;
 use App\Entity\DTO\SchoolDTO;
 use App\Entity\DTO\SessionDescriptionDTO;
 use App\Entity\DTO\SessionDTO;
-use App\Entity\DTO\SessionLearningMaterialDTO;
 use App\Entity\DTO\SessionTypeDTO;
 use App\Entity\DTO\TermDTO;
 use App\Entity\DTO\UserRoleDTO;
 use App\Entity\DTO\VocabularyDTO;
-use App\Service\Config;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -74,7 +70,6 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [CompetencyDTO::class],
             [CourseDTO::class],
             [CourseClerkshipTypeDTO::class],
-            [CourseLearningMaterialDTO::class],
             [CurriculumInventoryAcademicLevelDTO::class],
             [CurriculumInventoryInstitutionDTO::class],
             [CurriculumInventoryReportDTO::class],
@@ -83,7 +78,6 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [DepartmentDTO::class],
             [IlmSessionDTO::class],
             [InstructorGroupDTO::class],
-            [LearningMaterialDTO::class],
             [LearningMaterialStatusDTO::class],
             [LearningMaterialUserRoleDTO::class],
             [MeshConceptDTO::class],
@@ -100,7 +94,6 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [SchoolConfigDTO::class],
             [SessionDTO::class],
             [SessionDescriptionDTO::class],
-            [SessionLearningMaterialDTO::class],
             [SessionTypeDTO::class],
             [TermDTO::class],
             [UserRoleDTO::class],

--- a/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\RelationshipVoter;
 
+use App\Entity\DTO\LearningMaterialDTO;
 use App\RelationshipVoter\AbstractVoter;
 use App\RelationshipVoter\GreenlightViewDTOVoter as Voter;
 use App\Service\PermissionChecker;
@@ -78,6 +79,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
             [DepartmentDTO::class],
             [IlmSessionDTO::class],
             [InstructorGroupDTO::class],
+            [LearningMaterialDTO::class],
             [LearningMaterialStatusDTO::class],
             [LearningMaterialUserRoleDTO::class],
             [MeshConceptDTO::class],

--- a/tests/RelationshipVoter/LearningMaterialTest.php
+++ b/tests/RelationshipVoter/LearningMaterialTest.php
@@ -8,6 +8,7 @@ use App\Service\PermissionChecker;
 use App\Entity\LearningMaterial;
 use App\Entity\LearningMaterialInterface;
 
+use App\Service\Config;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -24,20 +25,12 @@ class LearningMaterialTest extends AbstractBase
         $this->checkRootEntityAccess(m::mock(LearningMaterialInterface::class));
     }
 
-    public function testCanViewUserPerformingNonLearnerFunction()
+    public function testCanView()
     {
-        $token = $this->createMockTokenWithSessionUserPerformingNonLearnerFunction();
+        $token = $this->createMockTokenWithNonRootSessionUser();
         $entity = m::mock(LearningMaterial::class);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
-    }
-
-    public function testCanNotViewAsLearnerOnly()
-    {
-        $token = $this->createMockTokenWithSessionUserPerformingOnlyLearnerFunction();
-        $entity = m::mock(LearningMaterial::class);
-        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
-        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View allowed");
     }
 
     public function testCanCreateLearningMaterial()

--- a/tests/RelationshipVoter/LearningMaterialTest.php
+++ b/tests/RelationshipVoter/LearningMaterialTest.php
@@ -8,7 +8,6 @@ use App\Service\PermissionChecker;
 use App\Entity\LearningMaterial;
 use App\Entity\LearningMaterialInterface;
 
-use App\Service\Config;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -25,12 +24,20 @@ class LearningMaterialTest extends AbstractBase
         $this->checkRootEntityAccess(m::mock(LearningMaterialInterface::class));
     }
 
-    public function testCanView()
+    public function testCanViewUserPerformingNonLearnerFunction()
     {
-        $token = $this->createMockTokenWithNonRootSessionUser();
+        $token = $this->createMockTokenWithSessionUserPerformingNonLearnerFunction();
         $entity = m::mock(LearningMaterial::class);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotViewAsLearnerOnly()
+    {
+        $token = $this->createMockTokenWithSessionUserPerformingOnlyLearnerFunction();
+        $entity = m::mock(LearningMaterial::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View allowed");
     }
 
     public function testCanCreateLearningMaterial()

--- a/tests/RelationshipVoter/SessionLearningMaterialTest.php
+++ b/tests/RelationshipVoter/SessionLearningMaterialTest.php
@@ -25,12 +25,20 @@ class SessionLearningMaterialTest extends AbstractBase
         $this->checkRootEntityAccess(m::mock(SessionLearningMaterial::class));
     }
 
-    public function testCanView()
+    public function testCanViewUserPerformingNonLearnerFunction()
     {
-        $token = $this->createMockTokenWithNonRootSessionUser();
+        $token = $this->createMockTokenWithSessionUserPerformingNonLearnerFunction();
         $entity = m::mock(SessionLearningMaterial::class);
         $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotViewAsLearnerOnly()
+    {
+        $token = $this->createMockTokenWithSessionUserPerformingOnlyLearnerFunction();
+        $entity = m::mock(SessionLearningMaterial::class);
+        $response = $this->voter->vote($token, $entity, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View allowed");
     }
 
     public function testCanEdit()


### PR DESCRIPTION
refs #2599 

this is the poor man's implementation - if you're only a learner then you cannot get to this data.
not a problem for students right now, since they don't hit up these endpoints on the dashboard, they get their LMs via user/school events which use a different filtering/blanking mechanism in order to restrict access.

... _however!_ this will come back to haunt us when we ever get around to implementing a "course overview" for learners (see lti convo with stanford). at that point, we'll have to check the current user's relationship with the given user. for example: 

> is this user in a learner group that is associated with a session that belongs to a course that this learning material is attached to? if so, they can see it.

rinse/repeat for similar relationships (learner-to-offering and up, learner-to-learnergroup-to-ilm and up etc)

we can kick that bucket down the road, i'd be fine with that. just want to get this poor man's solution in front of the team before i descend into implementing something much more elaborate, in case there's no immediate need for it.