### PR TITLE
Set elasticsearch option to match AWS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
             - http.cors.allow-origin=http://localhost:1358
             - http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
             - http.cors.allow-credentials=true
+            - http.max_content_length=10mb #matches the AWS ElasticSearch limit
         ports:
             - "9200:9200"
     searchui:


### PR DESCRIPTION
We need to discover if we're going over this hard limit in development
instead of waiting for production.

Fixes #2604