### PR TITLE
Re-index when anything indexable is updated

### DIFF
--- a/src/Entity/Course.php
+++ b/src/Entity/Course.php
@@ -778,4 +778,12 @@ class Course implements CourseInterface
     {
         return $this->sequenceBlocks;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        return [$this];
+    }
 }

--- a/src/Entity/CourseInterface.php
+++ b/src/Entity/CourseInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
@@ -38,7 +39,8 @@ interface CourseInterface extends
     CohortsEntityInterface,
     MeshDescriptorsEntityInterface,
     DirectorsEntityInterface,
-    AdministratorsEntityInterface
+    AdministratorsEntityInterface,
+    IndexableCoursesEntityInterface
 {
     /**
      * @param int $level

--- a/src/Entity/LearningMaterial.php
+++ b/src/Entity/LearningMaterial.php
@@ -683,4 +683,25 @@ class LearningMaterial implements LearningMaterialInterface
 
         return ['Default', 'file'];
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        $directCourses = $this->courseLearningMaterials
+            ->map(function (CourseLearningMaterialInterface $clm) {
+                return $clm->getCourse();
+            });
+
+        $sessionCourses = $this->sessionLearningMaterials
+            ->map(function (SessionLearningMaterialInterface $slm) {
+                return $slm->getSession()->getCourse();
+            });
+
+        return array_merge(
+            $directCourses->toArray(),
+            $sessionCourses->toArray()
+        );
+    }
 }

--- a/src/Entity/LearningMaterialInterface.php
+++ b/src/Entity/LearningMaterialInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
@@ -17,7 +18,8 @@ interface LearningMaterialInterface extends
     TitledEntityInterface,
     DescribableEntityInterface,
     LoggableEntityInterface,
-    SessionStampableInterface
+    SessionStampableInterface,
+    IndexableCoursesEntityInterface
 {
 
     /**

--- a/src/Entity/MeshDescriptor.php
+++ b/src/Entity/MeshDescriptor.php
@@ -532,4 +532,39 @@ class MeshDescriptor implements MeshDescriptorInterface
     {
         $this->deleted = $deleted;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        $courseLmCourses = $this->courseLearningMaterials
+            ->map(function (CourseLearningMaterialInterface $clm) {
+                return $clm->getCourse();
+            });
+
+        $sessionLMCourses = $this->sessionLearningMaterials
+            ->map(function (SessionLearningMaterialInterface $slm) {
+                return $slm->getSession()->getCourse();
+            });
+
+        $sessionCourses = $this->sessions
+            ->map(function (SessionInterface $session) {
+                return $session->getCourse();
+            });
+
+        $objectiveCourses = $this->objectives
+            ->map(function (ObjectiveInterface $objective) {
+                return $objective->getIndexableCourses();
+            });
+        $flatObjectiveCourses = count($objectiveCourses) ? array_merge(...$objectiveCourses) : [];
+
+        return array_merge(
+            $this->courses->toArray(),
+            $courseLmCourses->toArray(),
+            $sessionLMCourses->toArray(),
+            $sessionCourses->toArray(),
+            $flatObjectiveCourses
+        );
+    }
 }

--- a/src/Entity/MeshDescriptorInterface.php
+++ b/src/Entity/MeshDescriptorInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 
@@ -24,7 +25,8 @@ interface MeshDescriptorInterface extends
     CoursesEntityInterface,
     SessionsEntityInterface,
     ObjectivesEntityInterface,
-    ConceptsEntityInterface
+    ConceptsEntityInterface,
+    IndexableCoursesEntityInterface
 {
     /**
      * @param string $annotation

--- a/src/Entity/Objective.php
+++ b/src/Entity/Objective.php
@@ -456,4 +456,19 @@ class Objective implements ObjectiveInterface
     {
         return $this->descendants;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        $sessionCourses = $this->sessions->map(function (SessionInterface $session) {
+            return $session->getCourse();
+        });
+
+        return array_merge(
+            $this->courses->toArray(),
+            $sessionCourses->toArray()
+        );
+    }
 }

--- a/src/Entity/ObjectiveInterface.php
+++ b/src/Entity/ObjectiveInterface.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Traits\ActivatableEntityInterface;
+use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
@@ -26,7 +27,8 @@ interface ObjectiveInterface extends
     LoggableEntityInterface,
     MeshDescriptorsEntityInterface,
     SortableEntityInterface,
-    ActivatableEntityInterface
+    ActivatableEntityInterface,
+    IndexableCoursesEntityInterface
 {
     /**
      * @param CompetencyInterface $competency

--- a/src/Entity/School.php
+++ b/src/Entity/School.php
@@ -545,4 +545,12 @@ class School implements SchoolInterface
     {
         return $this->configurations;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        return $this->courses->toArray();
+    }
 }

--- a/src/Entity/SchoolInterface.php
+++ b/src/Entity/SchoolInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
@@ -26,6 +27,7 @@ interface SchoolInterface extends
     TitledEntityInterface,
     StringableEntityInterface,
     CoursesEntityInterface,
+    IndexableCoursesEntityInterface,
     ProgramsEntityInterface,
     LoggableEntityInterface,
     StewardedEntityInterface,

--- a/src/Entity/Session.php
+++ b/src/Entity/Session.php
@@ -713,4 +713,12 @@ class Session implements SessionInterface
     {
         return $this->prerequisites;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        return [$this->course];
+    }
 }

--- a/src/Entity/SessionInterface.php
+++ b/src/Entity/SessionInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
@@ -32,7 +33,8 @@ interface SessionInterface extends
     CategorizableEntityInterface,
     MeshDescriptorsEntityInterface,
     SequenceBlocksEntityInterface,
-    AdministratorsEntityInterface
+    AdministratorsEntityInterface,
+    IndexableCoursesEntityInterface
 {
     /**
      * @param boolean $attireRequired

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -386,4 +386,19 @@ class Term implements TermInterface
     {
         return $this->aamcResourceTypes;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        $sessionCourses = $this->sessions->map(function (SessionInterface $session) {
+            return $session->getCourse();
+        });
+
+        return array_merge(
+            $this->courses->toArray(),
+            $sessionCourses->toArray()
+        );
+    }
 }

--- a/src/Entity/TermInterface.php
+++ b/src/Entity/TermInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use App\Traits\ActivatableEntityInterface;
@@ -25,7 +26,8 @@ interface TermInterface extends
     ProgramYearsEntityInterface,
     SessionsEntityInterface,
     CoursesEntityInterface,
-    ActivatableEntityInterface
+    ActivatableEntityInterface,
+    IndexableCoursesEntityInterface
 {
     /**
      * @param VocabularyInterface $vocabulary

--- a/src/Entity/Vocabulary.php
+++ b/src/Entity/Vocabulary.php
@@ -114,4 +114,16 @@ class Vocabulary implements VocabularyInterface
         $this->terms = new ArrayCollection();
         $this->active = true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        $termCourses = $this->terms->map(function (TermInterface $term) {
+            return $term->getIndexableCourses();
+        });
+
+        return count($termCourses) ? array_merge(...$termCourses) : [];
+    }
 }

--- a/src/Entity/VocabularyInterface.php
+++ b/src/Entity/VocabularyInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use App\Traits\ActivatableEntityInterface;
@@ -20,6 +21,7 @@ interface VocabularyInterface extends
     StringableEntityInterface,
     TitledEntityInterface,
     CategorizableEntityInterface,
-    ActivatableEntityInterface
+    ActivatableEntityInterface,
+    IndexableCoursesEntityInterface
 {
 }

--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -13,6 +13,7 @@ use App\Entity\SessionLearningMaterialInterface;
 use App\Entity\TermInterface;
 use App\Entity\UserInterface;
 use App\Service\Index;
+use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 
 /**
@@ -38,8 +39,11 @@ class IndexEntityChanges
         if ($entity instanceof UserInterface) {
             $this->indexUser($entity);
         }
-        if ($entity instanceof CourseInterface) {
-            $this->indexCourse($entity);
+
+        if ($entity instanceof IndexableCoursesEntityInterface) {
+            foreach ($entity->getIndexableCourses() as $course) {
+                $this->indexCourse($course);
+            }
         }
     }
     public function postUpdate(LifecycleEventArgs $args)
@@ -49,8 +53,11 @@ class IndexEntityChanges
         if ($entity instanceof UserInterface) {
             $this->indexUser($entity);
         }
-        if ($entity instanceof CourseInterface) {
-            $this->indexCourse($entity);
+
+        if ($entity instanceof IndexableCoursesEntityInterface) {
+            foreach ($entity->getIndexableCourses() as $course) {
+                $this->indexCourse($course);
+            }
         }
     }
 
@@ -69,6 +76,12 @@ class IndexEntityChanges
 
         if ($entity instanceof CourseInterface) {
             $this->index->deleteCourse($entity->getId());
+        }
+
+        if ($entity instanceof IndexableCoursesEntityInterface) {
+            foreach ($entity->getIndexableCourses() as $course) {
+                $this->indexCourse($course);
+            }
         }
     }
 

--- a/src/Traits/IndexableCoursesEntityInterface.php
+++ b/src/Traits/IndexableCoursesEntityInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Traits;
+
+use App\Entity\CourseInterface;
+
+/**
+ * Interface IndexableCoursesEntityInterface
+ */
+interface IndexableCoursesEntityInterface
+{
+    /**
+     * Returns any course with a relationship to this entity
+     * even deeply nested ones
+     * @return CourseInterface[]
+     */
+    public function getIndexableCourses() : array;
+}

--- a/tests/Endpoints/VocabularyTest.php
+++ b/tests/Endpoints/VocabularyTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Endpoints;
 
+use App\Entity\CourseInterface;
 use App\Tests\ReadWriteEndpointTest;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/tests/Entity/CourseTest.php
+++ b/tests/Entity/CourseTest.php
@@ -448,4 +448,12 @@ class CourseTest extends EntityBase
     {
         $this->entityCollectionSetTest('sequenceBlock', 'CurriculumInventorySequenceBlock');
     }
+
+    /**
+     * @covers \App\Entity\Course::getIndexableCourses
+     */
+    public function testGetIndexableCourses()
+    {
+        $this->assertEquals([$this->object], $this->object->getIndexableCourses());
+    }
 }

--- a/tests/Entity/LearningMaterialTest.php
+++ b/tests/Entity/LearningMaterialTest.php
@@ -1,8 +1,12 @@
 <?php
 namespace App\Tests\Entity;
 
+use App\Entity\CourseInterface;
+use App\Entity\CourseLearningMaterialInterface;
 use App\Entity\LearningMaterial;
 use App\Entity\School;
+use App\Entity\SessionInterface;
+use App\Entity\SessionLearningMaterialInterface;
 use App\Entity\User;
 use Mockery as m;
 
@@ -164,5 +168,29 @@ class LearningMaterialTest extends EntityBase
     public function getGetSessionLearningMaterials()
     {
         $this->entityCollectionSetTest('sessionLearningMaterial', 'SessionLearningMaterial');
+    }
+
+    /**
+     * @covers \App\Entity\LearningMaterial::getIndexableCourses
+     */
+    public function testGetIndexableCourses()
+    {
+        $course1 = m::mock(CourseInterface::class);
+        $courseLearningMaterial = m::mock(CourseLearningMaterialInterface::class)
+            ->shouldReceive('getCourse')->once()
+            ->andReturn($course1);
+        $this->object->addCourseLearningMaterial($courseLearningMaterial->getMock());
+
+        $course2 = m::mock(CourseInterface::class);
+        $session = m::mock(SessionInterface::class)
+            ->shouldReceive('getCourse')->once()
+            ->andReturn($course2);
+        $sessionLearningMaterial = m::mock(SessionLearningMaterialInterface::class)
+                    ->shouldReceive('getSession')->once()
+                    ->andReturn($session->getMock());
+        $this->object->addSessionLearningMaterial($sessionLearningMaterial->getMock());
+
+        $rhett = $this->object->getIndexableCourses();
+        $this->assertEquals([$course1, $course2], $rhett);
     }
 }

--- a/tests/Entity/ObjectiveTest.php
+++ b/tests/Entity/ObjectiveTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace App\Tests\Entity;
 
+use App\Entity\CourseInterface;
 use App\Entity\Objective;
+use App\Entity\SessionInterface;
 use Mockery as m;
 
 /**
@@ -287,5 +289,25 @@ class ObjectiveTest extends EntityBase
     public function testSetActive()
     {
         $this->booleanSetTest('active');
+    }
+
+    /**
+     * @covers \App\Entity\Objective::getIndexableCourses
+     */
+    public function testGetIndexableCourses()
+    {
+        $course1 = m::mock(CourseInterface::class)
+            ->shouldReceive('addObjective')->once()->with($this->object)->getMock();
+        $this->object->addCourse($course1);
+
+        $course2 = m::mock(CourseInterface::class);
+        $session = m::mock(SessionInterface::class)
+            ->shouldReceive('addObjective')->once()->with($this->object)
+            ->shouldReceive('getCourse')->once()
+            ->andReturn($course2);
+        $this->object->addSession($session->getMock());
+
+        $rhett = $this->object->getIndexableCourses();
+        $this->assertEquals($rhett, [$course1, $course2]);
     }
 }

--- a/tests/Entity/SchoolTest.php
+++ b/tests/Entity/SchoolTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Tests\Entity;
 
+use App\Entity\CourseInterface;
 use App\Entity\School;
 use Mockery as m;
 
@@ -398,5 +399,20 @@ class SchoolTest extends EntityBase
     public function testGetConfigurations()
     {
         $this->entityCollectionSetTest('configuration', 'SchoolConfig', 'getConfigurations', 'setConfigurations');
+    }
+
+    /**
+     * @covers \App\Entity\School::getIndexableCourses
+     */
+    public function testGetIndexableCourses()
+    {
+        $course1 = m::mock(CourseInterface::class);
+        $course2 = m::mock(CourseInterface::class);
+        $this->object->addCourse($course1);
+        $this->object->addCourse($course2);
+
+
+        $rhett = $this->object->getIndexableCourses();
+        $this->assertEquals([$course1, $course2], $rhett);
     }
 }

--- a/tests/Entity/SessionTest.php
+++ b/tests/Entity/SessionTest.php
@@ -2,6 +2,7 @@
 namespace App\Tests\Entity;
 
 use App\Entity\Course;
+use App\Entity\CourseInterface;
 use App\Entity\School;
 use App\Entity\Session;
 use Mockery as m;
@@ -433,5 +434,18 @@ class SessionTest extends EntityBase
     public function testGetPrerequisites()
     {
         $this->entityCollectionSetTest('prerequisite', 'Session', false, false, 'setPostrequisite');
+    }
+
+    /**
+     * @covers \App\Entity\Session::getIndexableCourses
+     */
+    public function testGetIndexableCourses()
+    {
+        $course = m::mock(CourseInterface::class);
+        $this->object->setCourse($course);
+
+
+        $rhett = $this->object->getIndexableCourses();
+        $this->assertEquals([$course], $rhett);
     }
 }

--- a/tests/Entity/TermTest.php
+++ b/tests/Entity/TermTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Tests\Entity;
 
+use App\Entity\CourseInterface;
+use App\Entity\SessionInterface;
 use App\Entity\Term;
 use Mockery as m;
 
@@ -198,5 +200,25 @@ class TermTest extends EntityBase
     public function testIsActive()
     {
         $this->booleanSetTest('active');
+    }
+
+    /**
+     * @covers \App\Entity\LearningMaterial::getIndexableCourses
+     */
+    public function testGetIndexableCourses()
+    {
+        $course1 = m::mock(CourseInterface::class)
+            ->shouldReceive('addTerm')->once()->with($this->object)->getMock();
+        $this->object->addCourse($course1);
+
+        $course2 = m::mock(CourseInterface::class);
+        $session = m::mock(SessionInterface::class)
+            ->shouldReceive('addTerm')->once()->with($this->object)
+            ->shouldReceive('getCourse')->once()
+            ->andReturn($course2);
+        $this->object->addSession($session->getMock());
+
+        $rhett = $this->object->getIndexableCourses();
+        $this->assertEquals($rhett, [$course1, $course2]);
     }
 }


### PR DESCRIPTION
We were only indexing changes to the course object directly, but there
are many other places where the index needs to be modified.

Fixes #2606