### PR TITLE
Index more of the mesh descriptor

### DIFF
--- a/src/Classes/IndexableCourse.php
+++ b/src/Classes/IndexableCourse.php
@@ -28,7 +28,13 @@ class IndexableCourse
     public $objectives = [];
 
     /** @var array  */
-    public $meshDescriptors = [];
+    public $meshDescriptorIds = [];
+
+    /** @var array  */
+    public $meshDescriptorNames = [];
+
+    /** @var array  */
+    public $meshDescriptorAnnotations = [];
 
     /** @var array  */
     public $learningMaterials = [];
@@ -49,7 +55,9 @@ class IndexableCourse
             'courseAdministrators' => implode(' ', $this->administrators),
             'courseObjectives' => implode(' ', $this->objectives),
             'courseTerms' => implode(' ', $this->terms),
-            'courseMeshDescriptors' => implode(' ', $this->meshDescriptors),
+            'courseMeshDescriptorIds' => $this->meshDescriptorIds,
+            'courseMeshDescriptorNames' => $this->meshDescriptorNames,
+            'courseMeshDescriptorAnnotations' => implode(' ', $this->meshDescriptorAnnotations),
             'courseLearningMaterials' => implode(' ', $this->learningMaterials),
         ];
 

--- a/src/Classes/IndexableSession.php
+++ b/src/Classes/IndexableSession.php
@@ -32,7 +32,13 @@ class IndexableSession
     public $objectives = [];
 
     /** @var array  */
-    public $meshDescriptors = [];
+    public $meshDescriptorIds = [];
+
+    /** @var array  */
+    public $meshDescriptorNames = [];
+
+    /** @var array  */
+    public $meshDescriptorAnnotations = [];
 
     /** @var array  */
     public $learningMaterials = [];
@@ -48,7 +54,9 @@ class IndexableSession
             'sessionAdministrators' => implode(' ', $this->administrators),
             'sessionObjectives' => implode(' ', $this->objectives),
             'sessionTerms' => implode(' ', $this->terms),
-            'sessionMeshDescriptors' => implode(' ', $this->meshDescriptors),
+            'sessionMeshDescriptorIds' => $this->meshDescriptorIds,
+            'sessionMeshDescriptorNames' => $this->meshDescriptorNames,
+            'sessionMeshDescriptorAnnotations' => implode(' ', $this->meshDescriptorAnnotations),
             'sessionLearningMaterials' => implode(' ', $this->learningMaterials),
         ];
     }

--- a/src/Entity/Repository/CourseRepository.php
+++ b/src/Entity/Repository/CourseRepository.php
@@ -663,8 +663,12 @@ EOL;
             "r.id, r.name, r.annotation",
             $courseIds
         );
-        foreach ($meshDescriptors as $courseId => $arr) {
-            $indexableCourses[$courseId]->meshDescriptors[] = $arr[0]['id'];
+        foreach ($meshDescriptors as $courseId => $courseDescriptors) {
+            foreach ($courseDescriptors as $arr) {
+                $indexableCourses[$courseId]->meshDescriptorIds[] = $arr['id'];
+                $indexableCourses[$courseId]->meshDescriptorNames[] = $arr['name'];
+                $indexableCourses[$courseId]->meshDescriptorAnnotations[] = $arr['annotation'];
+            }
         }
 
         $qb = $this->_em->createQueryBuilder()
@@ -793,8 +797,12 @@ EOL;
             "r.id, r.name, r.annotation",
             $sessionIds
         );
-        foreach ($meshDescriptors as $sessionId => $arr) {
-            $sessions[$sessionId]->meshDescriptors[] = $arr[0]['id'];
+        foreach ($meshDescriptors as $sessionId => $sessionDescriptors) {
+            foreach ($sessionDescriptors as $arr) {
+                $sessions[$sessionId]->meshDescriptorIds[] = $arr['id'];
+                $sessions[$sessionId]->meshDescriptorNames[] = $arr['name'];
+                $sessions[$sessionId]->meshDescriptorAnnotations[] = $arr['annotation'];
+            }
         }
 
         $qb = $this->_em->createQueryBuilder()

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -350,14 +350,19 @@ class Index extends ElasticSearchBase
                             'courseTerms' => $txtTypeFieldWithCompletion,
                             'courseObjectives'  => $txtTypeField,
                             'courseLearningMaterials'  => $txtTypeField,
-                            'courseMeshDescriptors' => [
+                            'courseMeshDescriptorIds' => [
                                 'type' => 'keyword',
                                 'fields' => [
                                     'cmp' => [
-                                        'type' => 'completion'
+                                        'type' => 'completion',
+                                        // we have to override the analyzer here because the default strips
+                                        // out numbers and mesh ids are mostly numbers
+                                        'analyzer' => 'standard',
                                     ]
                                 ],
                             ],
+                            'courseMeshDescriptorNames' => $txtTypeFieldWithCompletion,
+                            'courseMeshDescriptorAnnotations' => $txtTypeField,
                             'sessionId' => [
                                 'type' => 'keyword',
                             ],
@@ -374,14 +379,19 @@ class Index extends ElasticSearchBase
                             'sessionTerms' => $txtTypeFieldWithCompletion,
                             'sessionObjectives'  => $txtTypeField,
                             'sessionLearningMaterials'  => $txtTypeField,
-                            'sessionMeshDescriptors' => [
+                            'sessionMeshDescriptorIds' => [
                                 'type' => 'keyword',
                                 'fields' => [
                                     'cmp' => [
-                                        'type' => 'completion'
+                                        'type' => 'completion',
+                                        // we have to override the analyzer here because the default strips
+                                        // out numbers and mesh ids are mostly numbers
+                                        'analyzer' => 'standard',
                                     ]
                                 ],
                             ],
+                            'sessionMeshDescriptorNames' => $txtTypeFieldWithCompletion,
+                            'sessionMeshDescriptorAnnotations' => $txtTypeField,
                         ]
                     ]
                 ]

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -51,11 +51,13 @@ class Search extends ElasticSearchBase
         $suggestFields = [
             'courseTitle',
             'courseTerms',
-            'courseMeshDescriptors',
+            'courseMeshDescriptorIds',
+            'courseMeshDescriptorNames',
             'sessionTitle',
             'sessionType',
             'sessionTerms',
-            'sessionMeshDescriptors',
+            'sessionMeshDescriptorIds',
+            'sessionMeshDescriptorNames',
         ];
         $suggest = array_reduce($suggestFields, function ($carry, $field) use ($query) {
             $carry[$field] = [
@@ -251,7 +253,11 @@ class Search extends ElasticSearchBase
             'courseObjectives.ngram',
             'courseLearningMaterials',
             'courseLearningMaterials.ngram',
-            'courseMeshDescriptors',
+            'courseMeshDescriptorIds',
+            'courseMeshDescriptorNames',
+            'courseMeshDescriptorNames.ngram',
+            'courseMeshDescriptorAnnotations',
+            'courseMeshDescriptorAnnotations.ngram',
             'sessionId',
             'sessionTitle',
             'sessionTitle.ngram',
@@ -264,7 +270,11 @@ class Search extends ElasticSearchBase
             'sessionObjectives.ngram',
             'sessionLearningMaterials',
             'sessionLearningMaterials.ngram',
-            'sessionMeshDescriptors',
+            'sessionMeshDescriptorIds',
+            'sessionMeshDescriptorNames',
+            'sessionMeshDescriptorNames.ngram',
+            'sessionMeshDescriptorAnnotations',
+            'sessionMeshDescriptorAnnotations.ngram',
         ];
 
         $shouldFields = [
@@ -366,11 +376,21 @@ class Search extends ElasticSearchBase
             }
             $courseMatches = array_map(function (string $match) {
                 $split = explode('.', $match);
-                return strtolower(substr($split[0], strlen('course')));
+                $field = strtolower(substr($split[0], strlen('course')));
+                if (strpos($field, 'meshdescriptor') !== false) {
+                    $field = 'meshdescriptors';
+                }
+
+                return $field;
             }, $item['courseMatches']);
             $sessionMatches = array_map(function (string $match) {
                 $split = explode('.', $match);
-                return strtolower(substr($split[0], strlen('session')));
+                $field = strtolower(substr($split[0], strlen('session')));
+                if (strpos($field, 'meshdescriptor') !== false) {
+                    $field = 'meshdescriptors';
+                }
+
+                return $field;
             }, $item['sessionMatches']);
             $carry[$id]['matchedIn'] = array_unique(
                 array_merge($courseMatches, $carry[$id]['matchedIn'])


### PR DESCRIPTION
Instead of just the first ID this indexes all IDs, names, and
annotations attached to each course and session.

Fixes #2610