### PR TITLE
Remove search passthroughs

### DIFF
--- a/src/Entity/Manager/MeshDescriptorManager.php
+++ b/src/Entity/Manager/MeshDescriptorManager.php
@@ -21,11 +21,6 @@ class MeshDescriptorManager extends BaseManager
     protected $transmogrifier;
 
     /**
-     * @var Search
-     */
-    protected $search;
-
-    /**
      * @param RegistryInterface $registry
      * @param string $class
      * @param MeshDescriptorSetTransmogrifier $transmogrifier
@@ -34,12 +29,10 @@ class MeshDescriptorManager extends BaseManager
     public function __construct(
         RegistryInterface $registry,
         $class,
-        MeshDescriptorSetTransmogrifier $transmogrifier,
-        Search $search
+        MeshDescriptorSetTransmogrifier $transmogrifier
     ) {
         parent::__construct($registry, $class);
         $this->transmogrifier = $transmogrifier;
-        $this->search = $search;
     }
 
     /**
@@ -58,13 +51,7 @@ class MeshDescriptorManager extends BaseManager
     ) {
         /** @var MeshDescriptorRepository $repository */
         $repository = $this->getRepository();
-        if ($this->search->isEnabled()) {
-            $ids = $this->search->meshDescriptorIdsQuery($q);
-            $criteria['id'] = $ids;
-            return $repository->findDTOsBy($criteria, $orderBy, $limit, $offset);
-        } else {
-            return $repository->findByQ($q, $orderBy, $limit, $offset);
-        }
+        return $repository->findByQ($q, $orderBy, $limit, $offset);
     }
 
     /**

--- a/src/Entity/Manager/UserManager.php
+++ b/src/Entity/Manager/UserManager.php
@@ -24,20 +24,14 @@ class UserManager extends BaseManager
     protected $factory;
 
     /**
-     * @var Search
-     */
-    protected $search;
-
-    /**
      * @param RegistryInterface $registry
      * @param string $class
      * @param UserMaterialFactory $factory
      */
-    public function __construct(RegistryInterface $registry, $class, UserMaterialFactory $factory, Search $search)
+    public function __construct(RegistryInterface $registry, $class, UserMaterialFactory $factory)
     {
         parent::__construct($registry, $class);
         $this->factory = $factory;
-        $this->search = $search;
     }
 
     /**
@@ -73,23 +67,7 @@ class UserManager extends BaseManager
     ) {
         /** @var UserRepository $repository */
         $repository = $this->getRepository();
-        if ($this->search->isEnabled()) {
-            $ids = $this->search->userIdsQuery($q, $limit);
-            $criteria['id'] = $ids;
-            $dtos = $repository->findDTOsBy($criteria, $orderBy, $limit, $offset);
-
-            if (empty($orderBy)) {
-                // resort results by their original search score
-                $keys = array_flip($ids);
-                usort($dtos, function (UserDTO $a, UserDTO $b) use ($keys) {
-                    return $keys[$a->id] - $keys[$b->id];
-                });
-            }
-
-            return $dtos;
-        } else {
-            return $repository->findDTOsByQ($q, $orderBy, $limit, $offset, $criteria);
-        }
+        return $repository->findDTOsByQ($q, $orderBy, $limit, $offset, $criteria);
     }
 
     /**


### PR DESCRIPTION
These were a way to get at elastic search without using the API, but the
sorting on top of elastic doesn't work for users so we need to force all
elastic queries to go through the right endpoint so the UI can handle
them.

Fixes ilios/frontend#4788