### PR TITLE
Improve re-indexing to avoid conflicts

### DIFF
--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -9,12 +9,14 @@ use App\Entity\DTO\CourseDTO;
 use App\Entity\DTO\UserDTO;
 use App\Entity\MeshDescriptorInterface;
 use App\Entity\ObjectiveInterface;
+use App\Entity\SessionInterface;
 use App\Entity\SessionLearningMaterialInterface;
 use App\Entity\TermInterface;
 use App\Entity\UserInterface;
 use App\Service\Index;
 use App\Traits\IndexableCoursesEntityInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Exception;
 
 /**
  * Doctrine event listener.
@@ -41,9 +43,7 @@ class IndexEntityChanges
         }
 
         if ($entity instanceof IndexableCoursesEntityInterface) {
-            foreach ($entity->getIndexableCourses() as $course) {
-                $this->indexCourse($course);
-            }
+            $this->indexCourses($entity->getIndexableCourses());
         }
     }
     public function postUpdate(LifecycleEventArgs $args)
@@ -55,9 +55,7 @@ class IndexEntityChanges
         }
 
         if ($entity instanceof IndexableCoursesEntityInterface) {
-            foreach ($entity->getIndexableCourses() as $course) {
-                $this->indexCourse($course);
-            }
+            $this->indexCourses($entity->getIndexableCourses());
         }
     }
 
@@ -78,10 +76,13 @@ class IndexEntityChanges
             $this->index->deleteCourse($entity->getId());
         }
 
+        if ($entity instanceof SessionInterface) {
+            $this->index->deleteSession($entity->getId());
+            return; //don't re-index our just removed session
+        }
+
         if ($entity instanceof IndexableCoursesEntityInterface) {
-            foreach ($entity->getIndexableCourses() as $course) {
-                $this->indexCourse($course);
-            }
+            $this->indexCourses($entity->getIndexableCourses());
         }
     }
 
@@ -93,78 +94,99 @@ class IndexEntityChanges
         }
     }
 
-    protected function indexCourse(CourseInterface $course)
+    /**
+     * @param CourseInterface[] $courses
+     * @throws Exception
+     */
+    protected function indexCourses(array $courses) : void
     {
         if ($this->index->isEnabled()) {
-            $index = new IndexableCourse();
-            $dto = new CourseDTO(
-                $course->getId(),
-                $course->getTitle(),
-                $course->getLevel(),
-                $course->getYear(),
-                $course->getStartDate(),
-                $course->getEndDate(),
-                $course->getExternalId(),
-                $course->isLocked(),
-                $course->isArchived(),
-                $course->isPublishedAsTbd(),
-                $course->isPublished()
-            );
-
-            $index->courseDTO = $dto;
-            $index->school = $course->getSchool()->getTitle();
-            if ($clerkshipType = $course->getClerkshipType()) {
-                $index->clerkshipType = $clerkshipType->getTitle();
-            }
-            $index->directors = array_map(function (UserInterface $user) {
-                return $user->getFirstAndLastName() . ' ' . $user->getDisplayName();
-            }, $course->getDirectors()->toArray());
-            $index->administrators = array_map(function (UserInterface $user) {
-                return $user->getFirstAndLastName() . ' ' . $user->getDisplayName();
-            }, $course->getAdministrators()->toArray());
-            $index->terms = array_map(function (TermInterface $term) {
-                return $term->getTitle();
-            }, $course->getTerms()->toArray());
-            $index->objectives = array_map(function (ObjectiveInterface $objective) {
-                return $objective->getTitle();
-            }, $course->getObjectives()->toArray());
-            $index->meshDescriptors = array_map(function (MeshDescriptorInterface $descriptor) {
-                return $descriptor->getId();
-            }, $course->getMeshDescriptors()->toArray());
-            $index->learningMaterials = array_map(function (CourseLearningMaterialInterface $clm) {
-                $lm = $clm->getLearningMaterial();
-                return $lm->getTitle() . ' ' . $lm->getDescription();
-            }, $course->getLearningMaterials()->toArray());
-            foreach ($course->getSessions() as $session) {
-                $sessionIndex = new IndexableSession();
-                $sessionIndex->sessionId = $session->getId();
-                $sessionIndex->title = $session->getTitle();
-                if ($sessionDescription = $session->getSessionDescription()) {
-                    $sessionIndex->description = $sessionDescription->getDescription();
-                }
-                $sessionIndex->sessionType = $session->getSessionType()->getTitle();
-
-                $sessionIndex->administrators = array_map(function (UserInterface $user) {
-                    return $user->getFirstAndLastName() . ' ' . $user->getDisplayName();
-                }, $session->getAdministrators()->toArray());
-                $sessionIndex->terms = array_map(function (TermInterface $term) {
-                    return $term->getTitle();
-                }, $session->getTerms()->toArray());
-                $sessionIndex->objectives = array_map(function (ObjectiveInterface $objective) {
-                    return $objective->getTitle();
-                }, $session->getObjectives()->toArray());
-                $sessionIndex->meshDescriptors = array_map(function (MeshDescriptorInterface $descriptor) {
-                    return $descriptor->getId();
-                }, $session->getMeshDescriptors()->toArray());
-                $sessionIndex->learningMaterials = array_map(function (SessionLearningMaterialInterface $slm) {
-                    $lm = $slm->getLearningMaterial();
-                    return $lm->getTitle() . ' ' . $lm->getDescription();
-                }, $session->getLearningMaterials()->toArray());
-
-                $index->sessions[] = $sessionIndex;
-            }
-            $this->index->deleteCourse($course->getId());
-            $this->index->indexCourses([$index]);
+            $indexes = array_map([$this, 'getIndexableCourse'], $courses);
+            $this->index->indexCourses($indexes);
         }
+    }
+
+    protected function getIndexableCourse(CourseInterface $course) : IndexableCourse
+    {
+        $index = new IndexableCourse();
+        $dto = new CourseDTO(
+            $course->getId(),
+            $course->getTitle(),
+            $course->getLevel(),
+            $course->getYear(),
+            $course->getStartDate(),
+            $course->getEndDate(),
+            $course->getExternalId(),
+            $course->isLocked(),
+            $course->isArchived(),
+            $course->isPublishedAsTbd(),
+            $course->isPublished()
+        );
+
+        $index->courseDTO = $dto;
+        $index->school = $course->getSchool()->getTitle();
+        if ($clerkshipType = $course->getClerkshipType()) {
+            $index->clerkshipType = $clerkshipType->getTitle();
+        }
+        $index->directors = array_map(function (UserInterface $user) {
+            return $user->getFirstAndLastName() . ' ' . $user->getDisplayName();
+        }, $course->getDirectors()->toArray());
+        $index->administrators = array_map(function (UserInterface $user) {
+            return $user->getFirstAndLastName() . ' ' . $user->getDisplayName();
+        }, $course->getAdministrators()->toArray());
+        $index->terms = array_map(function (TermInterface $term) {
+            return $term->getTitle();
+        }, $course->getTerms()->toArray());
+        $index->objectives = array_map(function (ObjectiveInterface $objective) {
+            return $objective->getTitle();
+        }, $course->getObjectives()->toArray());
+        $index->meshDescriptorIds = array_map(function (MeshDescriptorInterface $descriptor) {
+            return $descriptor->getId();
+        }, $course->getMeshDescriptors()->toArray());
+        $index->meshDescriptorNames = array_map(function (MeshDescriptorInterface $descriptor) {
+            return $descriptor->getName();
+        }, $course->getMeshDescriptors()->toArray());
+        $index->meshDescriptorAnnotations = array_map(function (MeshDescriptorInterface $descriptor) {
+            return $descriptor->getAnnotation();
+        }, $course->getMeshDescriptors()->toArray());
+        $index->learningMaterials = array_map(function (CourseLearningMaterialInterface $clm) {
+            $lm = $clm->getLearningMaterial();
+            return $lm->getTitle() . ' ' . $lm->getDescription();
+        }, $course->getLearningMaterials()->toArray());
+        foreach ($course->getSessions() as $session) {
+            $sessionIndex = new IndexableSession();
+            $sessionIndex->sessionId = $session->getId();
+            $sessionIndex->title = $session->getTitle();
+            if ($sessionDescription = $session->getSessionDescription()) {
+                $sessionIndex->description = $sessionDescription->getDescription();
+            }
+            $sessionIndex->sessionType = $session->getSessionType()->getTitle();
+
+            $sessionIndex->administrators = array_map(function (UserInterface $user) {
+                return $user->getFirstAndLastName() . ' ' . $user->getDisplayName();
+            }, $session->getAdministrators()->toArray());
+            $sessionIndex->terms = array_map(function (TermInterface $term) {
+                return $term->getTitle();
+            }, $session->getTerms()->toArray());
+            $sessionIndex->objectives = array_map(function (ObjectiveInterface $objective) {
+                return $objective->getTitle();
+            }, $session->getObjectives()->toArray());
+            $sessionIndex->meshDescriptorIds = array_map(function (MeshDescriptorInterface $descriptor) {
+                return $descriptor->getId();
+            }, $session->getMeshDescriptors()->toArray());
+            $sessionIndex->meshDescriptorNames = array_map(function (MeshDescriptorInterface $descriptor) {
+                return $descriptor->getName();
+            }, $session->getMeshDescriptors()->toArray());
+            $sessionIndex->meshDescriptorAnnotations = array_map(function (MeshDescriptorInterface $descriptor) {
+                return $descriptor->getAnnotation();
+            }, $session->getMeshDescriptors()->toArray());
+            $sessionIndex->learningMaterials = array_map(function (SessionLearningMaterialInterface $slm) {
+                $lm = $slm->getLearningMaterial();
+                return $lm->getTitle() . ' ' . $lm->getDescription();
+            }, $session->getLearningMaterials()->toArray());
+
+            $index->sessions[] = $sessionIndex;
+        }
+        return $index;
     }
 }

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -56,7 +56,7 @@ class Index extends ElasticSearchBase
             'id' => $id,
         ]);
 
-        return !$result['errors'];
+        return $result['result'] === 'deleted';
     }
 
     /**
@@ -113,6 +113,21 @@ class Index extends ElasticSearchBase
         ]);
 
         return !count($result['failures']);
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return bool
+     */
+    public function deleteSession(int $id) : bool
+    {
+        $result = $this->delete([
+            'index' => Search::PUBLIC_CURRICULUM_INDEX,
+            'id' => ElasticSearchBase::SESSION_ID_PREFIX . $id
+        ]);
+
+        return $result['result'] === 'deleted';
     }
 
     /**
@@ -173,7 +188,7 @@ class Index extends ElasticSearchBase
     protected function delete(array $params) : array
     {
         if (!$this->enabled) {
-            return ['errors' => false];
+            return ['result' => 'deleted'];
         }
         return $this->client->delete($params);
     }


### PR DESCRIPTION
When elasticsearch deletes by query it copies the data out and then
attempts to act on it. If another operation takes place on the same data
at the same time it causes a conflict and dies. So instead of deleting
everything in a course index every time I've switched this around to
only delete when a course or session is deleted. This keeps the index up
to date and avoids conflicts since courses are not deleted very often
and sessions can be deleted by ID and not by query which is more
reliable.

Fixes #2619