### PR TITLE
Add the ilios version to the package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "ilios/ilios",
+  "version": "3.68.1",
   "license": "MIT",
   "type": "project",
   "description": "The \"Ilios Standard Edition\" distribution",
@@ -22,6 +23,7 @@
     "guzzlehttp/psr7": "^1.5",
     "ilios/mesh-parser": "^2.0",
     "jaybizzle/crawler-detect": "^1.2",
+    "jean85/pretty-package-versions": "^1.2",
     "league/flysystem": "^1.0",
     "league/flysystem-aws-s3-v3": "^1.0",
     "league/flysystem-cached-adapter": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b692087b0899c242e8b984e0fb99693a",
+    "content-hash": "2585aec5028601ce685de6857987bfec",
     "packages": [
         {
             "name": "aws/aws-sdk-php",

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Service\AuthenticationInterface;
 use App\Service\Config;
 use App\Service\Search;
+use Jean85\PrettyVersions;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,6 +33,8 @@ class ConfigController extends AbstractController
         }
         $configuration['maxUploadSize'] = UploadedFile::getMaxFilesize();
         $configuration['apiVersion'] = $this->getParameter('ilios_api_version');
+        $iliosVersion = PrettyVersions::getVersion('ilios/ilios');
+        $configuration['iliosVersion'] = 'v' . $iliosVersion->getPrettyVersion();
 
         $configuration['trackingEnabled'] = $config->get('enable_tracking');
         if ($configuration['trackingEnabled']) {


### PR DESCRIPTION
Also outputs that version in the configuration path to be displayable to
users. This will make it easier to automate versioning ilios with a bot
as the tag and version will match just like they do with our node
packages.