### PR TITLE
Split up large indexing operations

### DIFF
--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -118,7 +118,7 @@ class IndexTest extends TestCase
                     'fullNameLastFirst' => 'last2, first2 middle2',
                 ],
             ]
-        ])->andReturn(['errors' => false]);
+        ])->andReturn(['errors' => false, 'took' => 1, 'items' => []]);
         $obj->indexUsers([$user1, $user2]);
     }
 
@@ -188,7 +188,7 @@ class IndexTest extends TestCase
                     'id' => 3,
                 ],
             ]
-        ])->andReturn(['errors' => false]);
+        ])->andReturn(['errors' => false, 'took' => 1, 'items' => []]);
         $obj->indexCourses([$course1, $course2]);
     }
 


### PR DESCRIPTION
AWS has a hard upper limit of 10MB on bulk index operations. This splits
operations into smaller chunks when the request size is going to be too
big. Results in slightly more index calls, but ensures none of them
error out because they are too big.

Fixes #2624