### PR TITLE
Index Courses Asynchronously

### DIFF
--- a/.env
+++ b/.env
@@ -30,3 +30,10 @@ ILIOS_DATABASE_MYSQL_VERSION=5.7
 # For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
 # Delivery is disabled by default via "null://localhost"
 ILIOS_MAILER_URL=null://localhost
+
+###> symfony/messenger ###
+# Choose one of the transports below
+# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
+# MESSENGER_TRANSPORT_DSN=doctrine://default
+# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
+###< symfony/messenger ###

--- a/.env
+++ b/.env
@@ -30,10 +30,3 @@ ILIOS_DATABASE_MYSQL_VERSION=5.7
 # For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
 # Delivery is disabled by default via "null://localhost"
 ILIOS_MAILER_URL=null://localhost
-
-###> symfony/messenger ###
-# Choose one of the transports below
-# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
-# MESSENGER_TRANSPORT_DSN=doctrine://default
-# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
-###< symfony/messenger ###

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "symfony/flex": "^1.1",
     "symfony/framework-bundle": "4.3.*",
     "symfony/lock": "4.3.*",
+    "symfony/messenger": "4.3.*",
     "symfony/monolog-bundle": "^3.1.0",
     "symfony/orm-pack": "^1.0.6",
     "symfony/requirements-checker": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7bdbb5ebcfc6356810185a28864c200f",
+    "content-hash": "aaa4bd1c1c95d36a954e96a9a581487c",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -6003,6 +6003,80 @@
                 "semaphore"
             ],
             "time": "2019-08-14T12:26:46+00:00"
+        },
+        {
+            "name": "symfony/messenger",
+            "version": "v4.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/messenger.git",
+                "reference": "ac9ab05acc8eba0ac311eb8511484f0c5155cde2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/ac9ab05acc8eba0ac311eb8511484f0c5155cde2",
+                "reference": "ac9ab05acc8eba0ac311eb8511484f0c5155cde2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/debug": "<4.1",
+                "symfony/event-dispatcher": "<4.3"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.5",
+                "psr/cache": "~1.0",
+                "symfony/console": "~3.4|~4.0",
+                "symfony/debug": "~4.1",
+                "symfony/dependency-injection": "~3.4.19|^4.1.8",
+                "symfony/doctrine-bridge": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~4.3",
+                "symfony/http-kernel": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/serializer": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1",
+                "symfony/stopwatch": "~3.4|~4.0",
+                "symfony/validator": "~3.4|~4.0",
+                "symfony/var-dumper": "~3.4|~4.0"
+            },
+            "suggest": {
+                "enqueue/messenger-adapter": "For using the php-enqueue library as a transport."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Samuel Roze",
+                    "email": "samuel.roze@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Messenger Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-08-23T06:45:45+00:00"
         },
         {
             "name": "symfony/mime",

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -14,6 +14,8 @@ doctrine:
         default_table_options:
             charset: utf8mb4
             collate: utf8mb4_unicode_ci
+        # ignore this messenger table in migrations
+        schema_filter: '~^(?!messenger_messages)~'
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.default

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,0 +1,14 @@
+framework:
+    messenger:
+        # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
+        # failure_transport: failed
+
+        transports:
+            # https://symfony.com/doc/current/messenger.html#transport-configuration
+            # async: '%env(MESSENGER_TRANSPORT_DSN)%'
+            # failed: 'doctrine://default?queue_name=failed'
+            # sync: 'sync://'
+
+        routing:
+            # Route your messages to the transports
+            # 'App\Message\YourMessage': async

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -5,10 +5,10 @@ framework:
 
         transports:
             # https://symfony.com/doc/current/messenger.html#transport-configuration
-            # async: '%env(MESSENGER_TRANSPORT_DSN)%'
+             async: '%env(MESSENGER_TRANSPORT_DSN)%'
             # failed: 'doctrine://default?queue_name=failed'
             # sync: 'sync://'
 
         routing:
             # Route your messages to the transports
-            # 'App\Message\YourMessage': async
+             'App\Message\CourseIndexRequest': async

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,12 +1,12 @@
 framework:
     messenger:
         # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
-        # failure_transport: failed
+        failure_transport: failed
 
         transports:
             # https://symfony.com/doc/current/messenger.html#transport-configuration
-             async: '%env(MESSENGER_TRANSPORT_DSN)%'
-            # failed: 'doctrine://default?queue_name=failed'
+             async: 'doctrine://default'
+             failed: 'doctrine://default?queue_name=failed'
             # sync: 'sync://'
 
         routing:

--- a/config/packages/test/messenger.yaml
+++ b/config/packages/test/messenger.yaml
@@ -1,0 +1,4 @@
+framework:
+  messenger:
+    transports:
+      async: 'in-memory:///'

--- a/src/Message/CourseIndexRequest.php
+++ b/src/Message/CourseIndexRequest.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Message;
+
+class CourseIndexRequest
+{
+    private $courseIds;
+
+    /**
+     * CourseIndexRequest constructor.
+     * @param int[] $courseIds
+     */
+    public function __construct(array $courseIds)
+    {
+        $this->courseIds = $courseIds;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getCourseIds(): array
+    {
+        return $this->courseIds;
+    }
+}

--- a/src/MessageHandler/CourseIndexHandler.php
+++ b/src/MessageHandler/CourseIndexHandler.php
@@ -1,0 +1,32 @@
+<?php
+namespace App\MessageHandler;
+
+use App\Entity\Manager\CourseManager;
+use App\Message\CourseIndexRequest;
+use App\Service\Index;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+class CourseIndexHandler implements MessageHandlerInterface
+{
+    /**
+     * @var Index
+     */
+    private $index;
+
+    /**
+     * @var CourseManager
+     */
+    private $courseManager;
+
+    public function __construct(Index $index, CourseManager $courseManager)
+    {
+        $this->index = $index;
+        $this->courseManager = $courseManager;
+    }
+
+    public function __invoke(CourseIndexRequest $message)
+    {
+        $indexes = $this->courseManager->getCourseIndexesFor($message->getCourseIds());
+        $this->index->indexCourses($indexes);
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -476,6 +476,18 @@
     "symfony/lock": {
         "version": "v4.3.0"
     },
+    "symfony/messenger": {
+        "version": "4.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.3",
+            "ref": "8a2675c061737658bed85102e9241c752620e575"
+        },
+        "files": [
+            "config/packages/messenger.yaml"
+        ]
+    },
     "symfony/mime": {
         "version": "v4.3.0"
     },


### PR DESCRIPTION
By using a message bus we can fix #2633 and handle indexing out of band from the save requests. In this way data can only be as stale as the last time the messages were processed. Courses that need to be re-indexed are stored in the database in a `messenger_messages` table and are read whenever `bin/console messenger:consume` is run. 

The consumer can be [configured in several different ways](https://symfony.com/doc/current/messenger.html#transport-configuration) and is designed to be a long running process, however I think for our case we'll probably want to put it in a cron job to run every minute to start and stop after 45 seconds like

`bin/console messenger:consume --time-limit=45 async`