### PR TITLE
Ignore Prerequisites in ICS feed

### DIFF
--- a/tests/Controller/IcsControllerTest.php
+++ b/tests/Controller/IcsControllerTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace App\Tests\Controller;
 
+use App\Tests\DataLoader\IlmSessionData;
 use App\Tests\GetUrlTrait;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\DataLoader\SessionData;
@@ -28,6 +30,7 @@ class IcsControllerTest extends WebTestCase
         parent::setUp();
         $this->fixtures = $this->loadFixtures([
             'App\Tests\Fixture\LoadAuthenticationData',
+            'App\Tests\Fixture\LoadSessionData',
             'App\Tests\Fixture\LoadOfferingData',
             'App\Tests\Fixture\LoadCourseLearningMaterialData',
             'App\Tests\Fixture\LoadSessionLearningMaterialData',
@@ -85,7 +88,7 @@ class IcsControllerTest extends WebTestCase
         );
         $matches = [];
         preg_match('/DESCRIPTION:(.+?)DTSTAMP/s', $content, $matches);
-        $this->assertEquals(count($matches), 2, 'Found description in response');
+        $this->assertEquals(2, count($matches), 'Found description in response');
         $firstDescription = preg_replace('/\s+/', '', $matches[1]);
 
         $this->assertRegExp(
@@ -151,7 +154,7 @@ class IcsControllerTest extends WebTestCase
         );
         $matches = [];
         preg_match('/DESCRIPTION:(.+?)DTSTAMP/s', $content, $matches);
-        $this->assertEquals(count($matches), 2, 'Found description in response');
+        $this->assertEquals(2, count($matches), 'Found description in response');
         $firstDescription = preg_replace('/\s+/', '', $matches[1]);
 
         $this->assertNotRegExp(
@@ -201,7 +204,7 @@ class IcsControllerTest extends WebTestCase
         );
         $matches = [];
         preg_match('/DESCRIPTION:(.+?)DTSTAMP/s', $content, $matches);
-        $this->assertEquals(count($matches), 2, 'Found description in response');
+        $this->assertEquals(2, count($matches), 'Found description in response');
         $firstDescription = preg_replace('/\s+/', '', $matches[1]);
 
         $today = new \DateTime();
@@ -212,5 +215,67 @@ class IcsControllerTest extends WebTestCase
             $firstDescription,
             'Event Links are absolute paths'
         );
+    }
+
+    protected function postOne(
+        KernelBrowser $client,
+        string $key,
+        array $postData
+    ) {
+        $this->makeJsonRequest(
+            $client,
+            'POST',
+            $this->getUrl($client, 'ilios_api_post', ['version' => 'v1', 'object' => strtolower($key)]),
+            json_encode([$key => [$postData]]),
+            $this->getTokenForUser($client, 2)
+        );
+
+        $response = $client->getResponse();
+        $this->assertJsonResponse($response, Response::HTTP_CREATED);
+
+        return json_decode($response->getContent(), true)[$key][0];
+    }
+
+    public function testLinkedSessionWithDueDatesNotShown2635()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+        $sessionData = $container->get(SessionData::class)->create();
+        $skipTitle = 'SKIP THIS SESSION';
+        $sessionData['title'] = $skipTitle;
+        $sessionData['postrequisite'] = '1';
+        $sessionData['publishedAsTbd'] = false;
+
+        $session = $this->postOne($client, 'sessions', $sessionData);
+        $ilmSessionData = $container->get(IlmSessionData::class)->create();
+        $ilmSessionData['session'] = $session['id'];
+        $dt = new \DateTime('tomorrow');
+        $dt->setTime(0, 0, 0);
+        $ilmSessionData['dueDate'] = $dt->format('c');
+        $this->postOne($client, 'ilmSessions', $ilmSessionData);
+        $url = '/ics/' . hash('sha256', '1');
+        $client->request('GET', $url);
+        $response = $client->getResponse();
+
+        $content = $response->getContent();
+
+        $this->assertEquals(
+            Response::HTTP_OK,
+            $response->getStatusCode(),
+            "Status Code: {$response->getStatusCode()} is not OK"
+        );
+        $this->assertTrue(
+            $response->headers->contains(
+                'Content-Type',
+                'text/calendar; charset=utf-8'
+            ),
+            var_export($response->headers, true)
+        );
+
+        $this->assertTrue(
+            (!empty($content)),
+            $content
+        );
+        $this->assertFalse(strpos($content, $skipTitle), 'Prerequisite Session Not Included');
     }
 }

--- a/tests/DataLoader/SessionData.php
+++ b/tests/DataLoader/SessionData.php
@@ -26,8 +26,6 @@ class SessionData extends AbstractDataLoader
             'offerings' => ['1', '2'],
             'administrators' => ['1'],
             'prerequisites' => [],
-            'postrequisite' => '3',
-
         );
 
         $arr[] = array(
@@ -71,7 +69,7 @@ class SessionData extends AbstractDataLoader
             'learningMaterials' => ['2', '3', '4', '5', '6', '7', '8'],
             'offerings' => ['6', '7', '8'],
             'administrators' => [],
-            'prerequisites' => ['1', '2'],
+            'prerequisites' => ['2', '4'],
         );
 
         $arr[] = array(
@@ -92,6 +90,7 @@ class SessionData extends AbstractDataLoader
             'offerings' => [],
             'administrators' => [],
             'prerequisites' => [],
+            'postrequisite' => '3',
         );
 
         for ($i = 5; $i <= 8; $i++) {

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -166,10 +166,10 @@ class SchooleventsTest extends AbstractEndpointTest
             'instructional notes is correct for event 3'
         );
         $this->assertEmpty($events[3]['postrequisites']);
-        $this->assertEquals(5, count($events[3]['prerequisites']));
+        $this->assertEquals(3, count($events[3]['prerequisites']));
         $sessionIds = array_unique(array_column($events[3]['prerequisites'], 'session'));
         sort($sessionIds);
-        $this->assertEquals([1, 2], $sessionIds);
+        $this->assertEquals([2], $sessionIds);
 
         $this->assertEquals($events[4]['offering'], 7);
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate']);
@@ -191,10 +191,10 @@ class SchooleventsTest extends AbstractEndpointTest
             'instructional notes is correct for event 4'
         );
         $this->assertEmpty($events[4]['postrequisites']);
-        $this->assertEquals(5, count($events[4]['prerequisites']));
+        $this->assertEquals(3, count($events[4]['prerequisites']));
         $sessionIds = array_unique(array_column($events[4]['prerequisites'], 'session'));
         sort($sessionIds);
-        $this->assertEquals([1, 2], $sessionIds);
+        $this->assertEquals([2], $sessionIds);
 
         $this->assertEquals($events[5]['ilmSession'], 1);
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate']);
@@ -303,9 +303,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals(1, $events[9]['competencies'][1]['id']);
         $this->assertEquals('first competency', $events[9]['competencies'][1]['title']);
         $this->assertEquals(null, $events[9]['competencies'][1]['parent']);
-        $this->assertEquals(1, count($events[9]['postrequisites']));
-        $this->assertEquals(6, $events[9]['postrequisites'][0]['offering']);
-        $this->assertEquals(3, $events[9]['postrequisites'][0]['session']);
+        $this->assertEquals(0, count($events[9]['postrequisites']));
         $this->assertEmpty($events[9]['prerequisites']);
 
 
@@ -325,10 +323,10 @@ class SchooleventsTest extends AbstractEndpointTest
             'Event 10 has the correct number of learning materials'
         );
         $this->assertEmpty($events[10]['postrequisites']);
-        $this->assertEquals(5, count($events[10]['prerequisites']));
+        $this->assertEquals(3, count($events[10]['prerequisites']));
         $sessionIds = array_unique(array_column($events[10]['prerequisites'], 'session'));
         sort($sessionIds);
-        $this->assertEquals([1, 2], $sessionIds);
+        $this->assertEquals([2], $sessionIds);
         foreach ($events as $event) {
             $this->assertEquals($school['id'], $event['school']);
         }

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -357,10 +357,10 @@ class UsereventTest extends AbstractEndpointTest
             'attendanceRequired is correct for event 3'
         );
         $this->assertEmpty($events[3]['postrequisites']);
-        $this->assertEquals(5, count($events[3]['prerequisites']));
+        $this->assertEquals(3, count($events[3]['prerequisites']));
         $sessionIds = array_unique(array_column($events[3]['prerequisites'], 'session'));
         sort($sessionIds);
-        $this->assertEquals([1, 2], $sessionIds);
+        $this->assertEquals([2], $sessionIds);
 
         $this->assertEquals($events[4]['offering'], 7, 'offering is correct for event 4');
         $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate'], 'startDate is correct for event 4');
@@ -406,10 +406,10 @@ class UsereventTest extends AbstractEndpointTest
             'attendanceRequired is correct for event 4'
         );
         $this->assertEmpty($events[4]['postrequisites']);
-        $this->assertEquals(5, count($events[4]['prerequisites']));
+        $this->assertEquals(3, count($events[4]['prerequisites']));
         $sessionIds = array_unique(array_column($events[4]['prerequisites'], 'session'));
         sort($sessionIds);
-        $this->assertEquals([1, 2], $sessionIds);
+        $this->assertEquals([2], $sessionIds);
 
         $this->assertEquals($events[5]['ilmSession'], 1, 'ilmSession is correct for 5');
         $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate'], 'dueDate is correct for 5');
@@ -622,9 +622,7 @@ class UsereventTest extends AbstractEndpointTest
             $events[9],
             'attendanceRequired is correct for event 9'
         );
-        $this->assertEquals(1, count($events[9]['postrequisites']));
-        $this->assertEquals(6, $events[9]['postrequisites'][0]['offering']);
-        $this->assertEquals(3, $events[9]['postrequisites'][0]['session']);
+        $this->assertEquals(0, count($events[9]['postrequisites']));
         $this->assertEmpty($events[9]['prerequisites']);
 
         /** @var OfferingInterface $offering */
@@ -678,10 +676,10 @@ class UsereventTest extends AbstractEndpointTest
             'attendanceRequired is correct for event 10'
         );
         $this->assertEmpty($events[10]['postrequisites']);
-        $this->assertEquals(5, count($events[10]['prerequisites']));
+        $this->assertEquals(3, count($events[10]['prerequisites']));
         $sessionIds = array_unique(array_column($events[10]['prerequisites'], 'session'));
         sort($sessionIds);
-        $this->assertEquals([1, 2], $sessionIds);
+        $this->assertEquals([2], $sessionIds);
         foreach ($events as $event) {
             $this->assertEquals($userId, $event['user']);
         }

--- a/tests/Fixture/LoadSessionData.php
+++ b/tests/Fixture/LoadSessionData.php
@@ -66,8 +66,17 @@ class LoadSessionData extends AbstractFixture implements
             foreach ($arr['administrators'] as $id) {
                 $entity->addAdministrator($this->getReference('users' . $id));
             }
+            if (!empty($arr['postrequisite'])) {
+                $ref = 'sessions' . $arr['postrequisite'];
+                if ($this->hasReference($ref)) {
+                    $entity->setPostrequisite($this->getReference($ref));
+                }
+            }
             foreach ($arr['prerequisites'] as $id) {
-                $entity->addPrerequisite($this->getReference('sessions' . $id));
+                $ref = 'sessions' . $id;
+                if ($this->hasReference($ref)) {
+                    $entity->addPrerequisite($this->getReference($ref));
+                }
             }
             $manager->persist($entity);
 


### PR DESCRIPTION
Prerequisites don't need to be part of the feed as they are available
from the event details for the event.

Fixes #2635