### PR TITLE
Renamespace search API

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -26,13 +26,6 @@ security:
         authenticators:
           - App\Security\JsonWebTokenAuthenticator
       provider: session_user
-    authenticated_search:
-      pattern:    ^/search
-      stateless: true
-      guard:
-        authenticators:
-          - App\Security\JsonWebTokenAuthenticator
-      provider: session_user
     upload:
       pattern:    ^/upload
       stateless: true

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -42,12 +42,12 @@ _monitor:
   prefix: /ilios/health
 
 ilios_curriculum_search:
-  path: /search/v1/curriculum
+  path: /api/search/v1/curriculum
   controller: App\Controller\Search:curriculumSearch
   methods:  [GET]
 
 ilios_user_search:
-  path: /search/v1/users
+  path: /api/search/v1/users
   controller: App\Controller\Search:userSearch
   methods:  [GET]
 


### PR DESCRIPTION
In order to prevent conflicts with the UI and as it *is* part of the API
I've moved search into the /api path.

Fixes #2648