### PR TITLE
Fix return tags on search

### DIFF
--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -394,9 +394,9 @@ class Search extends ElasticSearchBase
 
                 return $field;
             }, $item['sessionMatches']);
-            $carry[$id]['matchedIn'] = array_unique(
+            $carry[$id]['matchedIn'] = array_values(array_unique(
                 array_merge($courseMatches, $carry[$id]['matchedIn'])
-            );
+            ));
             if ($item['score'] > $carry[$id]['bestScore']) {
                 $carry[$id]['bestScore'] = $item['score'];
             }
@@ -404,7 +404,7 @@ class Search extends ElasticSearchBase
                 'id' => $item['sessionId'],
                 'title' => $item['sessionTitle'],
                 'score' => $item['score'],
-                'matchedIn' => array_unique(array_values($sessionMatches)),
+                'matchedIn' => array_values(array_unique($sessionMatches)),
             ];
 
             return $carry;


### PR DESCRIPTION
When courses and session tags have array keys that are not consecutive
then the final JSON ends up being an object instead of an array which
can't be parsed by the frontend.

Fixes #2649