### PR TITLE
Ensure arrays are indexed in order

### DIFF
--- a/src/Classes/IndexableCourse.php
+++ b/src/Classes/IndexableCourse.php
@@ -55,8 +55,8 @@ class IndexableCourse
             'courseAdministrators' => implode(' ', $this->administrators),
             'courseObjectives' => implode(' ', $this->objectives),
             'courseTerms' => implode(' ', $this->terms),
-            'courseMeshDescriptorIds' => $this->meshDescriptorIds,
-            'courseMeshDescriptorNames' => $this->meshDescriptorNames,
+            'courseMeshDescriptorIds' => array_values($this->meshDescriptorIds),
+            'courseMeshDescriptorNames' => array_values($this->meshDescriptorNames),
             'courseMeshDescriptorAnnotations' => implode(' ', $this->meshDescriptorAnnotations),
             'courseLearningMaterials' => implode(' ', $this->learningMaterials),
         ];

--- a/src/Classes/IndexableSession.php
+++ b/src/Classes/IndexableSession.php
@@ -54,8 +54,8 @@ class IndexableSession
             'sessionAdministrators' => implode(' ', $this->administrators),
             'sessionObjectives' => implode(' ', $this->objectives),
             'sessionTerms' => implode(' ', $this->terms),
-            'sessionMeshDescriptorIds' => $this->meshDescriptorIds,
-            'sessionMeshDescriptorNames' => $this->meshDescriptorNames,
+            'sessionMeshDescriptorIds' => array_values($this->meshDescriptorIds),
+            'sessionMeshDescriptorNames' => array_values($this->meshDescriptorNames),
             'sessionMeshDescriptorAnnotations' => implode(' ', $this->meshDescriptorAnnotations),
             'sessionLearningMaterials' => implode(' ', $this->learningMaterials),
         ];


### PR DESCRIPTION
If these aren't consecutively zero indexed then JSON converts them into an
object which is not what search is expecting. Re-indexing the values
ensures we're getting at array.

Fixes #2655