### PR TITLE
Create a config option to disable learning materials

### DIFF
--- a/src/Controller/DownloadController.php
+++ b/src/Controller/DownloadController.php
@@ -2,6 +2,7 @@
 namespace App\Controller;
 
 use App\Entity\Manager\LearningMaterialManager;
+use App\Service\Config;
 use App\Service\IliosFileSystem;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,8 +20,15 @@ class DownloadController extends AbstractController
         $token,
         LearningMaterialManager $learningMaterialManager,
         IliosFileSystem $iliosFileSystem,
-        Request $request
+        Request $request,
+        Config $config
     ) {
+        if ($config->get('learningMaterialsDisabled') === true) {
+            return new Response(
+                'Learning Materials are disabled on this instance.',
+                200,
+            );
+        }
         $learningMaterial = $learningMaterialManager->findOneBy(['token' => $token]);
 
         if (!$learningMaterial) {

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -14,6 +14,7 @@ class Config
         'enable_tracking',
         'requireSecureConnection',
         'errorCaptureEnabled',
+        'learningMaterialsDisabled',
     ];
 
     /**

--- a/tests/Controller/DownloadControllerTest.php
+++ b/tests/Controller/DownloadControllerTest.php
@@ -1,10 +1,18 @@
 <?php
 namespace App\Tests\Controller;
 
+use App\Tests\DataLoader\ApplicationConfigData;
+use App\Tests\Fixture\LoadApplicationConfigData;
+use App\Tests\Fixture\LoadAuthenticationData;
+use App\Tests\Fixture\LoadCourseLearningMaterialData;
+use App\Tests\Fixture\LoadOfferingData;
+use App\Tests\Fixture\LoadSessionDescriptionData;
+use App\Tests\Fixture\LoadSessionLearningMaterialData;
 use App\Tests\GetUrlTrait;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 
 use Liip\TestFixturesBundle\Test\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\JsonControllerTest;
@@ -30,11 +38,12 @@ class DownloadControllerTest extends WebTestCase
     public function setUp()
     {
         $this->fixtures = $this->loadFixtures([
-            'App\Tests\Fixture\LoadAuthenticationData',
-            'App\Tests\Fixture\LoadOfferingData',
-            'App\Tests\Fixture\LoadCourseLearningMaterialData',
-            'App\Tests\Fixture\LoadSessionLearningMaterialData',
-            'App\Tests\Fixture\LoadSessionDescriptionData',
+            LoadAuthenticationData::class,
+            LoadOfferingData::class,
+            LoadCourseLearningMaterialData::class,
+            LoadSessionLearningMaterialData::class,
+            LoadSessionDescriptionData::class,
+            LoadApplicationConfigData::class,
         ])->getReferenceRepository();
     }
 
@@ -125,6 +134,92 @@ class DownloadControllerTest extends WebTestCase
     public function testBadLearningMaterialToken()
     {
         $client = static::createClient();
+        //sending bad hash
+        $client->request(
+            'GET',
+            '/lm/a7a8e202e9655ab81155c4c3e52b95098fcaa1c975f63f0327b467a981f6428f'
+        );
+
+        $response = $client->getResponse();
+        $this->assertEquals(
+            RESPONSE::HTTP_NOT_FOUND,
+            $response->getStatusCode()
+        );
+    }
+
+    protected function setLearningMaterialsDisabled(KernelBrowser $client, string $setTo)
+    {
+        $container = $client->getContainer();
+        $config = $container->get(ApplicationConfigData::class)->getOne();
+        $config['name'] = 'learningMaterialsDisabled';
+        $config['value'] = $setTo;
+        $this->makeJsonRequest(
+            $client,
+            'POST',
+            $this->getUrl($client, 'ilios_api_post', ['version' => 'v1', 'object' => 'applicationconfigs']),
+            json_encode(['applicationConfig' => $config]),
+            $this->getTokenForUser($client, 2)
+        );
+        $this->assertJsonResponse($client->getResponse(), Response::HTTP_CREATED);
+    }
+
+    public function testDisabledMaterialsWithLM()
+    {
+        $client = static::createClient();
+        $this->setLearningMaterialsDisabled($client, 'true');
+
+        $learningMaterial = $this->fixtures->getReference('learningMaterials4');
+        $this->makeJsonRequest(
+            $client,
+            'GET',
+            $this->getUrl(
+                $client,
+                'ilios_api_learningmaterial_get',
+                ['version' => 'v1', 'object' => 'learningmaterials', 'id' => $learningMaterial->getId()]
+            ),
+            null,
+            $this->getAuthenticatedUserToken($client)
+        );
+        $response = $client->getResponse();
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+        $data = json_decode($response->getContent(), true)['learningMaterials'][0];
+
+        $client->request(
+            'GET',
+            $data['absoluteFileUri'] . '?inline=true'
+        );
+
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        $this->assertEquals(
+            'Learning Materials are disabled on this instance.',
+            $response->getContent()
+        );
+    }
+
+    public function testDisabledMaterialsWithMissingLm()
+    {
+        $client = static::createClient();
+        $this->setLearningMaterialsDisabled($client, 'true');
+        $client->request(
+            'GET',
+            '/lm/a7a8e202e9655ab81155c4c3e52b95098fcaa1c975f63f0327b467a981f6428f'
+        );
+
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        $this->assertEquals(
+            'Learning Materials are disabled on this instance.',
+            $response->getContent()
+        );
+    }
+
+    public function testBadLearningMaterialTokenWithLmEnabled()
+    {
+        $client = static::createClient();
+        $this->setLearningMaterialsDisabled($client, 'false');
         //sending bad hash
         $client->request(
             'GET',

--- a/tests/Fixture/LoadApplicationConfigData.php
+++ b/tests/Fixture/LoadApplicationConfigData.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Fixture;
 
+use App\Tests\DataLoader\ApplicationConfigData;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
@@ -24,7 +25,7 @@ class LoadApplicationConfigData extends AbstractFixture implements
     public function load(ObjectManager $manager)
     {
         $data = $this->container
-            ->get('App\Tests\DataLoader\ApplicationConfigData')
+            ->get(ApplicationConfigData::class)
             ->getAll();
         foreach ($data as $arr) {
             $entity = new ApplicationConfig();


### PR DESCRIPTION
When the demo site (or a staging server) is scanned all of the learning
materials links throw missing 404 errors because the files are not
synced up. Instead they can be disabled by this configuration option to
return a simple string instead.