### PR TITLE
Stop allowing <u> in input

### DIFF
--- a/config/packages/exercise_html_purifier.yaml
+++ b/config/packages/exercise_html_purifier.yaml
@@ -2,7 +2,7 @@ exercise_html_purifier:
   # full configuration reference: http://htmlpurifier.org/live/configdoc/plain.html
   default:
     # the charset used by the original contents
-    HTML.Allowed: 'a[href|target],br,div,dd,dl,dt,em,li,ol,p,strong,sub,sup,ul,u'
+    HTML.Allowed: 'a[href|target],br,div,dd,dl,dt,em,li,ol,p,strong,sub,sup,ul'
     Core.Encoding: 'UTF-8'
     Attr.AllowedFrameTargets:
     - '_blank'

--- a/tests/Endpoints/ObjectiveTest.php
+++ b/tests/Endpoints/ObjectiveTest.php
@@ -166,7 +166,6 @@ class ObjectiveTest extends ReadWriteEndpointTest
                 '<a href="https://iliosproject.org" target="_blank">Ilios</a>',
                 '<a href="https://iliosproject.org" target="_blank" rel="noreferrer noopener">Ilios</a>'
             ],
-            ['<u>NOW I CRY</u>', '<u>NOW I CRY</u>'],
         ];
     }
 


### PR DESCRIPTION
This non-semantic presentation only HTML element is an a11y
violation. Let's prevent our users from making that mistake.

This reverts #1090 as the `<u>` tag is no longer included in our WYSIWYG editor we can safely remove it here as well. The only place it can still being used is in rolled over items and stripping these out is an improvement.