### PR TITLE
Disable auto_setup for messenger

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,13 +1,19 @@
 framework:
     messenger:
-        # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
         failure_transport: failed
 
         transports:
             # https://symfony.com/doc/current/messenger.html#transport-configuration
-             async: 'doctrine://default'
-             failed: 'doctrine://default?queue_name=failed'
-            # sync: 'sync://'
+             async:
+               dsn: "doctrine://default"
+               options:
+                 queue_name: async
+                 auto_setup: false
+             failed:
+               dsn: "doctrine://default"
+               options:
+                 queue_name: failed
+                 auto_setup: false
 
         routing:
             # Route your messages to the transports

--- a/docs/install.md
+++ b/docs/install.md
@@ -85,6 +85,7 @@ If you are NOT upgrading from a previous version of Ilios, you can create a new,
 bin/console doctrine:database:create --env=prod
 bin/console doctrine:migrations:migrate --env=prod
 bin/console doctrine:fixtures:load --env=prod
+bin/console messenger:setup-transports
 ```
 
 This will create your database schema, with all tables and constraints, and will also load in all the default lookup table data, like competencies and topics --- which you can modify once you're done with setup --- but it won't have any course data or any other unique data about your specific school or curriculum until you log in and add some.

--- a/docs/update.md
+++ b/docs/update.md
@@ -50,6 +50,10 @@ sudo -u apache bin/console doctrine:migrations:migrate --env=prod --no-interacti
 
 ## Version-specific steps
 
+### Upgrading to Ilios 3.69.1
+
+1. A new asynchronous queue service has been added. You must run `bin/console messenger:setup-transports` to set it up.
+
 ### Upgrading to Ilios 3.56.0
 
 1. `parameters.yml` has been replaced with ENV configuration. See [env_vars_and_config](env_vars_and_config) for details.


### PR DESCRIPTION
Having this enabled causes conflicts when we run multiple workers to
consume the messages. Instead I've added the setup instructions to the
installation guide.