### PR TITLE
better spacing in method names.

### DIFF
--- a/src/Service/CurriculumInventory/VerificationPreviewBuilder.php
+++ b/src/Service/CurriculumInventory/VerificationPreviewBuilder.php
@@ -56,8 +56,8 @@ class VerificationPreviewBuilder
         'Internal exams' => ['AM004', 'AM005'],
         'Lab or practical exams' => ['AM019'],
         'NBME subject exams' => ['AM008'],
-        'OSCE/SP exam' => ['AM003'],
-        'Faculty/resident rating' => ['AM001', 'AM002', 'AM009', 'AM010', 'AM012', 'AM018'],
+        'OSCE / SP exam' => ['AM003'],
+        'Faculty / resident rating' => ['AM001', 'AM002', 'AM009', 'AM010', 'AM012', 'AM018'],
         'Paper or oral pres.' => ['AM011', 'AM014', 'AM016'],
         'Other' => ['AM006', 'AM007', 'AM013', 'AM017'],
     ];
@@ -69,8 +69,8 @@ class VerificationPreviewBuilder
         'NBME subject exams' => ['AM008'],
         'Internal written exams' => ['AM004'],
         'Oral Exam or Pres.' => ['AM005', 'AM011'],
-        'Faculty/resident rating' => ['AM001', 'AM002', 'AM009', 'AM010', 'AM012', 'AM018'],
-        'OSCE/SP exam' => ['AM003'],
+        'Faculty / resident rating' => ['AM001', 'AM002', 'AM009', 'AM010', 'AM012', 'AM018'],
+        'OSCE / SP exam' => ['AM003'],
         'Other' => ['AM006', 'AM007', 'AM013', 'AM014', 'AM016', 'AM017', 'AM019'],
     ];
 

--- a/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
+++ b/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
@@ -524,10 +524,10 @@ class VerificationPreviewBuilderTest extends TestCase
         $rows = $rhett['rows'];
         $this->assertCount(6, $methods);
         $this->assertEquals([
-            'Faculty/resident rating',
+            'Faculty / resident rating',
             'Internal written exams',
             'NBME subject exams',
-            'OSCE/SP exam',
+            'OSCE / SP exam',
             'Oral Exam or Pres.',
             'Other',
         ], $methods);
@@ -535,10 +535,10 @@ class VerificationPreviewBuilderTest extends TestCase
             'title' => 'Zeppelin Clerkship Year 1',
             'level' => 1,
             'methods' => [
-                'Faculty/resident rating' => false,
+                'Faculty / resident rating' => false,
                 'Internal written exams' => true,
                 'NBME subject exams' => true,
-                'OSCE/SP exam' => false,
+                'OSCE / SP exam' => false,
                 'Oral Exam or Pres.' => false,
                 'Other' => false,
             ],
@@ -551,10 +551,10 @@ class VerificationPreviewBuilderTest extends TestCase
             'title' => 'Aardvark Clerkship Year 2',
             'level' => 2,
             'methods' => [
-                'Faculty/resident rating' => false,
+                'Faculty / resident rating' => false,
                 'Internal written exams' => false,
                 'NBME subject exams' => false,
-                'OSCE/SP exam' => true,
+                'OSCE / SP exam' => true,
                 'Oral Exam or Pres.' => false,
                 'Other' => true,
             ],
@@ -567,10 +567,10 @@ class VerificationPreviewBuilderTest extends TestCase
             'title' => 'Zeppelin Clerkship Year 2',
             'level' => 2,
             'methods' => [
-                'Faculty/resident rating' => true,
+                'Faculty / resident rating' => true,
                 'Internal written exams' => false,
                 'NBME subject exams' => false,
-                'OSCE/SP exam' => false,
+                'OSCE / SP exam' => false,
                 'Oral Exam or Pres.' => false,
                 'Other' => true,
             ],
@@ -821,11 +821,11 @@ class VerificationPreviewBuilderTest extends TestCase
         $rows = $rhett['rows'];
         $this->assertCount(7, $methods);
         $this->assertEquals([
-            'Faculty/resident rating',
+            'Faculty / resident rating',
             'Internal exams',
             'Lab or practical exams',
             'NBME subject exams',
-            'OSCE/SP exam',
+            'OSCE / SP exam',
             'Other',
             'Paper or oral pres.',
         ], $methods);
@@ -834,11 +834,11 @@ class VerificationPreviewBuilderTest extends TestCase
             'title' => 'Zeppelin Non-Clerkship Year 1',
             'level' => 1,
             'methods' => [
-                'Faculty/resident rating' => false,
+                'Faculty / resident rating' => false,
                 'Internal exams' => true,
                 'Lab or practical exams' => false,
                 'NBME subject exams' => true,
-                'OSCE/SP exam' => false,
+                'OSCE / SP exam' => false,
                 'Other' => false,
                 'Paper or oral pres.' => false,
             ],
@@ -851,11 +851,11 @@ class VerificationPreviewBuilderTest extends TestCase
             'title' => 'Aardvark Non-Clerkship Year 2',
             'level' => 2,
             'methods' => [
-                'Faculty/resident rating' => false,
+                'Faculty / resident rating' => false,
                 'Internal exams' => false,
                 'Lab or practical exams' => true,
                 'NBME subject exams' => false,
-                'OSCE/SP exam' => true,
+                'OSCE / SP exam' => true,
                 'Other' => false,
                 'Paper or oral pres.' => true,
             ],
@@ -868,11 +868,11 @@ class VerificationPreviewBuilderTest extends TestCase
             'title' => 'Zeppelin Non-Clerkship Year 2',
             'level' => 2,
             'methods' => [
-                'Faculty/resident rating' => true,
+                'Faculty / resident rating' => true,
                 'Internal exams' => false,
                 'Lab or practical exams' => false,
                 'NBME subject exams' => false,
-                'OSCE/SP exam' => false,
+                'OSCE / SP exam' => false,
                 'Other' => true,
                 'Paper or oral pres.' => false,
             ],


### PR DESCRIPTION
this came up while implementing the UI in the frontend.

without spacing:

![Selection_036](https://user-images.githubusercontent.com/1410427/65470545-931d4700-de20-11e9-9c09-22e351b3749c.png)

with proper spacing, cell content wraps better:

![Selection_037](https://user-images.githubusercontent.com/1410427/65470558-9a445500-de20-11e9-892a-83a0d4f0565c.png)

refs https://github.com/ilios/frontend/pull/4825
