### PR TITLE
Split up course indexing into chunks

### DIFF
--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -125,7 +125,10 @@ class IndexEntityChanges
             $courseIds = array_map(function (CourseInterface $course) {
                 return $course->getId();
             }, $courses);
-            $this->bus->dispatch(new CourseIndexRequest($courseIds));
+            $chunks = array_chunk($courseIds, CourseIndexRequest::MAX_COURSES);
+            foreach ($chunks as $ids) {
+                $this->bus->dispatch(new CourseIndexRequest($ids));
+            }
         }
     }
 }


### PR DESCRIPTION
The message bus can only handle 50 messages at the same time so we need
to split this up here. We could also do this on the bus itself, but that
is more complicated.

Fixes #2666