### PR TITLE
Index the contents of learning materials

### DIFF
--- a/.env
+++ b/.env
@@ -26,6 +26,9 @@ ILIOS_LOCALE=en
 ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
 ILIOS_DATABASE_MYSQL_VERSION=5.7
 
+# Set a default upload limit to match AWS's non-huge ES service limits
+ILIOS_ELASTICSEARCH_UPLOAD_LIMIT=8000000
+
 # For Gmail as a transport, use: "gmail://username:password@localhost"
 # For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
 # Delivery is disabled by default via "null://localhost"

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,8 @@
     "psr/log": "^1.0.0",
     "sensiolabs/security-checker": "^6.0",
     "sentry/sdk": "^2.0",
+    "setasign/fpdi": "^2.2",
+    "setasign/fpdi-fpdf": "^2.2",
     "swagger-api/swagger-ui": "^3.0",
     "symfony/apache-pack": "^1.0",
     "symfony/asset": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4942d9910a0cfe82b372276c179b44ca",
+    "content-hash": "0529bf810c4cd8ebd903aef0690af62f",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.130.3",
+            "version": "3.132.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "916356edb5c30fa564d02de94bde51a9c0bb4469"
+                "reference": "f814995664d4ad616f674e664ae069b9f4e340bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/916356edb5c30fa564d02de94bde51a9c0bb4469",
-                "reference": "916356edb5c30fa564d02de94bde51a9c0bb4469",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/f814995664d4ad616f674e664ae069b9f4e340bf",
+                "reference": "f814995664d4ad616f674e664ae069b9f4e340bf",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
-                "guzzlehttp/guzzle": "^5.3.3|^6.2.1",
-                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
+                "guzzlehttp/promises": "^1.0",
                 "guzzlehttp/psr7": "^1.4.1",
-                "mtdowling/jmespath.php": "~2.2",
+                "mtdowling/jmespath.php": "^2.5",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -88,7 +88,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2020-01-02T19:13:50+00:00"
+            "time": "2020-01-10T19:14:49+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -420,16 +420,16 @@
         },
         {
             "name": "doctrine/common",
-            "version": "v2.11.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "b8ca1dcf6b0dc8a2af7a09baac8d0c48345df4ff"
+                "reference": "2053eafdf60c2172ee1373d1b9289ba1db7f1fc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/b8ca1dcf6b0dc8a2af7a09baac8d0c48345df4ff",
-                "reference": "b8ca1dcf6b0dc8a2af7a09baac8d0c48345df4ff",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/2053eafdf60c2172ee1373d1b9289ba1db7f1fc6",
+                "reference": "2053eafdf60c2172ee1373d1b9289ba1db7f1fc6",
                 "shasum": ""
             },
             "require": {
@@ -499,7 +499,7 @@
                 "doctrine",
                 "php"
             ],
-            "time": "2019-09-10T10:10:14+00:00"
+            "time": "2020-01-10T15:49:25+00:00"
         },
         {
             "name": "doctrine/data-fixtures",
@@ -1145,16 +1145,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "8e124252d2f6be1124017d746d5994dd4095d66f"
+                "reference": "a3987131febeb0e9acb3c47ab0df0af004588934"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/8e124252d2f6be1124017d746d5994dd4095d66f",
-                "reference": "8e124252d2f6be1124017d746d5994dd4095d66f",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/a3987131febeb0e9acb3c47ab0df0af004588934",
+                "reference": "a3987131febeb0e9acb3c47ab0df0af004588934",
                 "shasum": ""
             },
             "require": {
@@ -1223,7 +1223,7 @@
                 "migrations",
                 "php"
             ],
-            "time": "2019-11-13T11:06:31+00:00"
+            "time": "2019-12-04T06:09:14+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -1310,16 +1310,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "99b196bbd4715a94fa100fac664a351ffa46d6a5"
+                "reference": "ff7e08b0f814be2cd20c52dc3c8a262579376b94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/99b196bbd4715a94fa100fac664a351ffa46d6a5",
-                "reference": "99b196bbd4715a94fa100fac664a351ffa46d6a5",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/ff7e08b0f814be2cd20c52dc3c8a262579376b94",
+                "reference": "ff7e08b0f814be2cd20c52dc3c8a262579376b94",
                 "shasum": ""
             },
             "require": {
@@ -1389,20 +1389,20 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2019-12-13T10:43:02+00:00"
+            "time": "2020-01-09T19:49:17+00:00"
         },
         {
             "name": "doctrine/reflection",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/reflection.git",
-                "reference": "02538d3f95e88eb397a5f86274deb2c6175c2ab6"
+                "reference": "bc420ead87fdfe08c03ecc3549db603a45b06d4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/reflection/zipball/02538d3f95e88eb397a5f86274deb2c6175c2ab6",
-                "reference": "02538d3f95e88eb397a5f86274deb2c6175c2ab6",
+                "url": "https://api.github.com/repos/doctrine/reflection/zipball/bc420ead87fdfe08c03ecc3549db603a45b06d4c",
+                "reference": "bc420ead87fdfe08c03ecc3549db603a45b06d4c",
                 "shasum": ""
             },
             "require": {
@@ -1410,13 +1410,15 @@
                 "ext-tokenizer": "*",
                 "php": "^7.1"
             },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "^4.0",
-                "doctrine/common": "^2.8",
-                "phpstan/phpstan": "^0.9.2",
-                "phpstan/phpstan-phpunit": "^0.9.4",
-                "phpunit/phpunit": "^7.0",
-                "squizlabs/php_codesniffer": "^3.0"
+                "doctrine/coding-standard": "^5.0",
+                "doctrine/common": "^2.10",
+                "phpstan/phpstan": "^0.11.0",
+                "phpstan/phpstan-phpunit": "^0.11.0",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -1435,16 +1437,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -1459,12 +1461,13 @@
                     "email": "ocramius@gmail.com"
                 }
             ],
-            "description": "Doctrine Reflection component",
+            "description": "The Doctrine Reflection project is a simple library used by the various Doctrine projects which adds some additional functionality on top of the reflection functionality that comes with PHP. It allows you to get the reflection information about classes, methods and properties statically.",
             "homepage": "https://www.doctrine-project.org/projects/reflection.html",
             "keywords": [
-                "reflection"
+                "reflection",
+                "static"
             ],
-            "time": "2018-06-14T14:45:07+00:00"
+            "time": "2020-01-08T19:53:19+00:00"
         },
         {
             "name": "dreamscapes/ldap-core",
@@ -1568,16 +1571,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.13",
+            "version": "2.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "834593d5900615639208417760ba6a17299e2497"
+                "reference": "c4b8d12921999d8a561004371701dbc2e05b5ece"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/834593d5900615639208417760ba6a17299e2497",
-                "reference": "834593d5900615639208417760ba6a17299e2497",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/c4b8d12921999d8a561004371701dbc2e05b5ece",
+                "reference": "c4b8d12921999d8a561004371701dbc2e05b5ece",
                 "shasum": ""
             },
             "require": {
@@ -1621,7 +1624,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2019-12-30T08:14:25+00:00"
+            "time": "2020-01-05T14:11:20+00:00"
         },
         {
             "name": "elasticsearch/elasticsearch",
@@ -4165,6 +4168,145 @@
                 "sentry"
             ],
             "time": "2020-01-08T11:27:08+00:00"
+        },
+        {
+            "name": "setasign/fpdf",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDF.git",
+                "reference": "d77904018090c17dc9f3ab6e944679a7a47e710a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDF/zipball/d77904018090c17dc9f3ab6e944679a7a47e710a",
+                "reference": "d77904018090c17dc9f3ab6e944679a7a47e710a",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "fpdf.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Plathey",
+                    "email": "oliver@fpdf.org",
+                    "homepage": "http://fpdf.org/"
+                }
+            ],
+            "description": "FPDF is a PHP class which allows to generate PDF files with pure PHP. F from FPDF stands for Free: you may use it for any kind of usage and modify it to suit your needs.",
+            "homepage": "http://www.fpdf.org",
+            "keywords": [
+                "fpdf",
+                "pdf"
+            ],
+            "time": "2019-12-08T10:32:10+00:00"
+        },
+        {
+            "name": "setasign/fpdi",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDI.git",
+                "reference": "3c266002f8044f61b17329f7cd702d44d73f0f7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/3c266002f8044f61b17329f7cd702d44d73f0f7f",
+                "reference": "3c266002f8044f61b17329f7cd702d44d73f0f7f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zlib": "*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7",
+                "setasign/fpdf": "~1.8",
+                "setasign/tfpdf": "1.25",
+                "tecnickcom/tcpdf": "~6.2"
+            },
+            "suggest": {
+                "setasign/fpdf": "FPDI will extend this class but as it is also possible to use TCPDF or tFPDF as an alternative. There's no fixed dependency configured.",
+                "setasign/fpdi-fpdf": "Use this package to automatically evaluate dependencies to FPDF.",
+                "setasign/fpdi-tcpdf": "Use this package to automatically evaluate dependencies to TCPDF.",
+                "setasign/fpdi-tfpdf": "Use this package to automatically evaluate dependencies to tFPDF."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "setasign\\Fpdi\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Slabon",
+                    "email": "jan.slabon@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                },
+                {
+                    "name": "Maximilian Kresse",
+                    "email": "maximilian.kresse@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                }
+            ],
+            "description": "FPDI is a collection of PHP classes facilitating developers to read pages from existing PDF documents and use them as templates in FPDF. Because it is also possible to use FPDI with TCPDF, there are no fixed dependencies defined. Please see suggestions for packages which evaluates the dependencies automatically.",
+            "homepage": "https://www.setasign.com/fpdi",
+            "keywords": [
+                "fpdf",
+                "fpdi",
+                "pdf"
+            ],
+            "time": "2019-01-30T14:11:19+00:00"
+        },
+        {
+            "name": "setasign/fpdi-fpdf",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDI-FPDF.git",
+                "reference": "e4363ac09e1b766b38ebea1c3cbe82b3480a11e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDI-FPDF/zipball/e4363ac09e1b766b38ebea1c3cbe82b3480a11e9",
+                "reference": "e4363ac09e1b766b38ebea1c3cbe82b3480a11e9",
+                "shasum": ""
+            },
+            "require": {
+                "setasign/fpdf": "^1.8",
+                "setasign/fpdi": "^2.2"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Slabon",
+                    "email": "jan.slabon@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                }
+            ],
+            "description": "Kind of metadata package for dependencies of the latest versions of FPDI and FPDF.",
+            "homepage": "https://www.setasign.com/fpdi",
+            "keywords": [
+                "fpdf",
+                "fpdi",
+                "pdf"
+            ],
+            "time": "2019-01-30T14:38:19+00:00"
         },
         {
             "name": "swagger-api/swagger-ui",

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -20,6 +20,7 @@ framework:
        'App\Message\CourseIndexRequest': async
        'App\Message\UserIndexRequest': async
        'App\Message\MeshDescriptorIndexRequest': async
+       'App\Message\LearningMaterialIndexRequest': async
 
     default_bus: messenger.bus.default
     buses:
@@ -39,4 +40,3 @@ framework:
             - failed_message_processing_middleware
             - send_message
             - handle_message
-

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -1,16 +1,9 @@
 monolog:
     handlers:
         main:
-            type: fingers_crossed
-            action_level: error
-            handler: nested
-            excluded_404s:
-                # regex: exclude all 404 errors from the logs
-                - ^/
-        nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
-            level: debug
+            level: error
         console:
             type: console
             process_psr_3_messages: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         volumes:
             - ./:/var/www/ilios:delegated
     elasticsearch:
-        image: elasticsearch:6.7.1
+        build: ./docker/elasticsearch-dev
         environment:
             - http.cors.enabled=true
             - http.cors.allow-origin=http://localhost:1358

--- a/docker/elasticsearch-dev/Dockerfile
+++ b/docker/elasticsearch-dev/Dockerfile
@@ -1,0 +1,3 @@
+FROM elasticsearch:6.7.1
+MAINTAINER Ilios Project Team <support@iliosproject.org>
+RUN bin/elasticsearch-plugin install -b ingest-attachment

--- a/src/Classes/ElasticSearchBase.php
+++ b/src/Classes/ElasticSearchBase.php
@@ -16,7 +16,10 @@ class ElasticSearchBase
      */
     protected $enabled = false;
 
+    /** @deprecated */
     public const PUBLIC_CURRICULUM_INDEX = 'ilios-public-curriculum';
+
+    public const CURRICULUM_INDEX = 'ilios-curriculum';
     public const PRIVATE_USER_INDEX = 'ilios-private-users';
     public const PUBLIC_MESH_INDEX = 'ilios-public-mesh';
     public const PRIVATE_LEARNING_MATERIAL_INDEX = 'ilios-private-learning-materials';

--- a/src/Classes/ElasticSearchBase.php
+++ b/src/Classes/ElasticSearchBase.php
@@ -19,6 +19,7 @@ class ElasticSearchBase
     public const PUBLIC_CURRICULUM_INDEX = 'ilios-public-curriculum';
     public const PRIVATE_USER_INDEX = 'ilios-private-users';
     public const PUBLIC_MESH_INDEX = 'ilios-public-mesh';
+    public const PRIVATE_LEARNING_MATERIAL_INDEX = 'ilios-private-learning-materials';
     public const SESSION_ID_PREFIX = 'session_';
 
     /**

--- a/src/Classes/ElasticSearchBase.php
+++ b/src/Classes/ElasticSearchBase.php
@@ -16,13 +16,10 @@ class ElasticSearchBase
      */
     protected $enabled = false;
 
-    /** @deprecated */
-    public const PUBLIC_CURRICULUM_INDEX = 'ilios-public-curriculum';
-
     public const CURRICULUM_INDEX = 'ilios-curriculum';
-    public const PRIVATE_USER_INDEX = 'ilios-private-users';
-    public const PUBLIC_MESH_INDEX = 'ilios-public-mesh';
-    public const PRIVATE_LEARNING_MATERIAL_INDEX = 'ilios-private-learning-materials';
+    public const USER_INDEX = 'ilios-users';
+    public const MESH_INDEX = 'ilios-mesh';
+    public const LEARNING_MATERIAL_INDEX = 'ilios-learning-materials';
     public const SESSION_ID_PREFIX = 'session_';
 
     /**

--- a/src/Classes/IndexableCourse.php
+++ b/src/Classes/IndexableCourse.php
@@ -45,6 +45,9 @@ class IndexableCourse
     /** @var array  */
     public $learningMaterialCitations = [];
 
+    /** @var array  */
+    public $fileLearningMaterialIds = [];
+
     /** @var IndexableSession[]  */
     public $sessions = [];
 
@@ -68,6 +71,7 @@ class IndexableCourse
             'courseLearningMaterialDescriptions' => array_values($this->learningMaterialDescriptions),
             'courseLearningMaterialCitations' => array_values($this->learningMaterialCitations),
             'courseLearningMaterialAttachments' => [],
+            'courseFileLearningMaterialIds' => array_values($this->fileLearningMaterialIds),
         ];
 
         return array_map(function (IndexableSession $session) use ($courseData) {

--- a/src/Classes/IndexableCourse.php
+++ b/src/Classes/IndexableCourse.php
@@ -37,7 +37,13 @@ class IndexableCourse
     public $meshDescriptorAnnotations = [];
 
     /** @var array  */
-    public $learningMaterials = [];
+    public $learningMaterialTitles = [];
+
+    /** @var array  */
+    public $learningMaterialDescriptions = [];
+
+    /** @var array  */
+    public $learningMaterialCitations = [];
 
     /** @var IndexableSession[]  */
     public $sessions = [];
@@ -58,7 +64,9 @@ class IndexableCourse
             'courseMeshDescriptorIds' => array_values($this->meshDescriptorIds),
             'courseMeshDescriptorNames' => array_values($this->meshDescriptorNames),
             'courseMeshDescriptorAnnotations' => implode(' ', $this->meshDescriptorAnnotations),
-            'courseLearningMaterials' => implode(' ', $this->learningMaterials),
+            'courseLearningMaterialTitles' => array_values($this->learningMaterialTitles),
+            'courseLearningMaterialDescriptions' => array_values($this->learningMaterialDescriptions),
+            'courseLearningMaterialCitations' => array_values($this->learningMaterialCitations),
         ];
 
         return array_map(function (IndexableSession $session) use ($courseData) {

--- a/src/Classes/IndexableCourse.php
+++ b/src/Classes/IndexableCourse.php
@@ -67,6 +67,7 @@ class IndexableCourse
             'courseLearningMaterialTitles' => array_values($this->learningMaterialTitles),
             'courseLearningMaterialDescriptions' => array_values($this->learningMaterialDescriptions),
             'courseLearningMaterialCitations' => array_values($this->learningMaterialCitations),
+            'courseLearningMaterialAttachments' => [],
         ];
 
         return array_map(function (IndexableSession $session) use ($courseData) {

--- a/src/Classes/IndexableSession.php
+++ b/src/Classes/IndexableSession.php
@@ -66,7 +66,7 @@ class IndexableSession
             'sessionLearningMaterialTitles' => array_values($this->learningMaterialTitles),
             'sessionLearningMaterialDescriptions' => array_values($this->learningMaterialDescriptions),
             'sessionLearningMaterialCitations' => array_values($this->learningMaterialCitations),
-            'learningMaterialAttachments' => [],
+            'sessionLearningMaterialAttachments' => [],
         ];
     }
 }

--- a/src/Classes/IndexableSession.php
+++ b/src/Classes/IndexableSession.php
@@ -49,6 +49,9 @@ class IndexableSession
     /** @var array  */
     public $learningMaterialCitations = [];
 
+    /** @var array  */
+    public $fileLearningMaterialIds = [];
+
     public function createIndexObject()
     {
         return [
@@ -67,6 +70,7 @@ class IndexableSession
             'sessionLearningMaterialDescriptions' => array_values($this->learningMaterialDescriptions),
             'sessionLearningMaterialCitations' => array_values($this->learningMaterialCitations),
             'sessionLearningMaterialAttachments' => [],
+            'sessionFileLearningMaterialIds' => array_values($this->fileLearningMaterialIds),
         ];
     }
 }

--- a/src/Classes/IndexableSession.php
+++ b/src/Classes/IndexableSession.php
@@ -41,7 +41,13 @@ class IndexableSession
     public $meshDescriptorAnnotations = [];
 
     /** @var array  */
-    public $learningMaterials = [];
+    public $learningMaterialTitles = [];
+
+    /** @var array  */
+    public $learningMaterialDescriptions = [];
+
+    /** @var array  */
+    public $learningMaterialCitations = [];
 
     public function createIndexObject()
     {
@@ -57,7 +63,10 @@ class IndexableSession
             'sessionMeshDescriptorIds' => array_values($this->meshDescriptorIds),
             'sessionMeshDescriptorNames' => array_values($this->meshDescriptorNames),
             'sessionMeshDescriptorAnnotations' => implode(' ', $this->meshDescriptorAnnotations),
-            'sessionLearningMaterials' => implode(' ', $this->learningMaterials),
+            'sessionLearningMaterialTitles' => array_values($this->learningMaterialTitles),
+            'sessionLearningMaterialDescriptions' => array_values($this->learningMaterialDescriptions),
+            'sessionLearningMaterialCitations' => array_values($this->learningMaterialCitations),
+            'learningMaterialAttachments' => [],
         ];
     }
 }

--- a/src/Command/PopulateIndexCommand.php
+++ b/src/Command/PopulateIndexCommand.php
@@ -91,7 +91,8 @@ class PopulateIndexCommand extends Command
         $output->writeln("<info>Ok.</info>");
 
         $this->populateUsers($output);
-        $this->populateLearningMaterials($output);
+        //temporarily disable LM indexing for performance reasons.
+//        $this->populateLearningMaterials($output);
         $this->populateCourses($output);
         $this->populateMesh($output);
     }

--- a/src/Command/PopulateIndexCommand.php
+++ b/src/Command/PopulateIndexCommand.php
@@ -122,9 +122,8 @@ class PopulateIndexCommand extends Command
     {
         $allIds = $this->learningMaterialManager->getFileLearningMaterialIds();
         $count = count($allIds);
-        $chunks = array_chunk($allIds, LearningMaterialIndexRequest::MAX);
-        foreach ($chunks as $ids) {
-            $this->bus->dispatch(new LearningMaterialIndexRequest($ids));
+        foreach ($allIds as $id) {
+            $this->bus->dispatch(new LearningMaterialIndexRequest($id));
         }
         $output->writeln("<info>${count} learning materials have been queued for indexing.</info>");
     }

--- a/src/Command/PopulateIndexCommand.php
+++ b/src/Command/PopulateIndexCommand.php
@@ -89,9 +89,10 @@ class PopulateIndexCommand extends Command
         $output->writeln("<info>Clearing the index and preparing to insert data.</info>");
         $this->index->clear();
         $output->writeln("<info>Ok.</info>");
+
         $this->populateUsers($output);
-        $this->populateCourses($output);
         $this->populateLearningMaterials($output);
+        $this->populateCourses($output);
         $this->populateMesh($output);
     }
 

--- a/src/Entity/CourseLearningMaterial.php
+++ b/src/Entity/CourseLearningMaterial.php
@@ -197,4 +197,12 @@ class CourseLearningMaterial implements CourseLearningMaterialInterface
     {
         return $this->course;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        return [$this->course];
+    }
 }

--- a/src/Entity/CourseLearningMaterialInterface.php
+++ b/src/Entity/CourseLearningMaterialInterface.php
@@ -2,10 +2,14 @@
 
 namespace App\Entity;
 
+use App\Traits\IndexableCoursesEntityInterface;
+
 /**
  * Interface CourseLearningMaterialInterface
  */
-interface CourseLearningMaterialInterface extends LearningMaterialRelationshipInterface
+interface CourseLearningMaterialInterface extends
+    LearningMaterialRelationshipInterface,
+    IndexableCoursesEntityInterface
 {
     /**
      * @param CourseInterface $course

--- a/src/Entity/DTO/LearningMaterialDTO.php
+++ b/src/Entity/DTO/LearningMaterialDTO.php
@@ -223,5 +223,6 @@ class LearningMaterialDTO
         $this->mimetype = null;
         $this->originalAuthor = null;
         $this->token = null;
+        $this->relativePath = null;
     }
 }

--- a/src/Entity/DTO/LearningMaterialDTO.php
+++ b/src/Entity/DTO/LearningMaterialDTO.php
@@ -167,6 +167,21 @@ class LearningMaterialDTO
      */
     public $token;
 
+    /**
+     * List of all sessions a material is attached to, including the ones
+     * where the LM is attached to the course a session is in.
+     * Not exposed, used by indexing
+     *
+     * @var int[]
+     */
+    public $indexSessions;
+
+    /**
+     * Not exposed, used by indexing
+     * @var string
+     */
+    public $relativePath;
+
     public function __construct(
         $id,
         $title,
@@ -180,7 +195,8 @@ class LearningMaterialDTO
         $mimetype,
         $filesize,
         $link,
-        $token
+        $token,
+        $relativePath
     ) {
         $this->id = $id;
         $this->title = $title;
@@ -195,9 +211,11 @@ class LearningMaterialDTO
         $this->filesize = $filesize;
         $this->link = $link;
         $this->token = $token;
+        $this->relativePath = $relativePath;
 
         $this->sessionLearningMaterials = [];
         $this->courseLearningMaterials = [];
+        $this->indexSessions = [];
     }
 
     /**

--- a/src/Entity/DTO/LearningMaterialDTO.php
+++ b/src/Entity/DTO/LearningMaterialDTO.php
@@ -168,13 +168,20 @@ class LearningMaterialDTO
     public $token;
 
     /**
-     * List of all sessions a material is attached to, including the ones
-     * where the LM is attached to the course a session is in.
+     * List of all courses a material is attached to
      * Not exposed, used by indexing
      *
      * @var int[]
      */
-    public $indexSessions;
+    public $courses;
+
+    /**
+     * List of all sessions a material is attached to
+     * Not exposed, used by indexing
+     *
+     * @var int[]
+     */
+    public $sessions;
 
     /**
      * Not exposed, used by indexing
@@ -215,7 +222,8 @@ class LearningMaterialDTO
 
         $this->sessionLearningMaterials = [];
         $this->courseLearningMaterials = [];
-        $this->indexSessions = [];
+        $this->courses = [];
+        $this->sessions = [];
     }
 
     /**

--- a/src/Entity/DTO/LearningMaterialDTO.php
+++ b/src/Entity/DTO/LearningMaterialDTO.php
@@ -168,22 +168,6 @@ class LearningMaterialDTO
     public $token;
 
     /**
-     * List of all courses a material is attached to
-     * Not exposed, used by indexing
-     *
-     * @var int[]
-     */
-    public $courses;
-
-    /**
-     * List of all sessions a material is attached to
-     * Not exposed, used by indexing
-     *
-     * @var int[]
-     */
-    public $sessions;
-
-    /**
      * Not exposed, used by indexing
      * @var string
      */
@@ -222,8 +206,6 @@ class LearningMaterialDTO
 
         $this->sessionLearningMaterials = [];
         $this->courseLearningMaterials = [];
-        $this->courses = [];
-        $this->sessions = [];
     }
 
     /**

--- a/src/Entity/Manager/LearningMaterialManager.php
+++ b/src/Entity/Manager/LearningMaterialManager.php
@@ -66,10 +66,13 @@ class LearningMaterialManager extends BaseManager
 
     /**
      * Get all the IDs for learning materials that are files
+     * int[]
      */
     public function getFileLearningMaterialIds() : array
     {
         $dql = 'SELECT l.id FROM App\Entity\LearningMaterial l WHERE l.relativePath IS NOT NULL';
-        return $this->em->createQuery($dql)->getScalarResult();
+        $results = $this->em->createQuery($dql)->getScalarResult();
+        $ids = array_column($results, 'id');
+        return array_map('intval', $ids);
     }
 }

--- a/src/Entity/Manager/LearningMaterialManager.php
+++ b/src/Entity/Manager/LearningMaterialManager.php
@@ -68,7 +68,7 @@ class LearningMaterialManager extends BaseManager
      * Get all the IDs for learning materials that are files
      * int[]
      */
-    public function getFileLearningMaterialIds() : array
+    public function getFileLearningMaterialIds(): array
     {
         $dql = 'SELECT l.id FROM App\Entity\LearningMaterial l WHERE l.relativePath IS NOT NULL';
         $results = $this->em->createQuery($dql)->getScalarResult();

--- a/src/Entity/Manager/LearningMaterialManager.php
+++ b/src/Entity/Manager/LearningMaterialManager.php
@@ -63,4 +63,13 @@ class LearningMaterialManager extends BaseManager
         return $this->em
             ->createQuery('SELECT COUNT(l.id) FROM App\Entity\LearningMaterial l')->getSingleScalarResult();
     }
+
+    /**
+     * Get all the IDs for learning materials that are files
+     */
+    public function getFileLearningMaterialIds() : array
+    {
+        $dql = 'SELECT l.id FROM App\Entity\LearningMaterial l WHERE l.relativePath IS NOT NULL';
+        return $this->em->createQuery($dql)->getScalarResult();
+    }
 }

--- a/src/Entity/Repository/CourseRepository.php
+++ b/src/Entity/Repository/CourseRepository.php
@@ -806,7 +806,7 @@ EOL;
         }
 
         $qb = $this->_em->createQueryBuilder()
-            ->select("s.id AS sessionId, CONCAT(l.title, ' ', l.description) AS txt")
+            ->select("s.id AS sessionId, l.title, l.description, l.citation")
             ->from(Session::class, 's')
             ->join("s.learningMaterials", 'slm')
             ->join("slm.learningMaterial", 'l')
@@ -814,7 +814,9 @@ EOL;
             ->setParameter('ids', $sessionIds);
 
         foreach ($qb->getQuery()->getResult() as $arr) {
-            $sessions[$arr['sessionId']]->learningMaterials[] = $arr['txt'];
+            $sessions[$arr['sessionId']]->learningMaterialTitles[] = $arr['title'];
+            $sessions[$arr['sessionId']]->learningMaterialDescriptions[] = $arr['description'];
+            $sessions[$arr['sessionId']]->learningMaterialCitations[] = $arr['citation'];
         }
 
         return array_values($sessions);

--- a/src/Entity/Repository/CourseRepository.php
+++ b/src/Entity/Repository/CourseRepository.php
@@ -672,15 +672,21 @@ EOL;
         }
 
         $qb = $this->_em->createQueryBuilder()
-            ->select("c.id AS courseId, CONCAT(l.title, ' ', l.description) AS txt")
+            ->select("c.id AS courseId, l.id as learningMaterialId, l.relativePath, " .
+                "l.title, l.description, l.citation")
             ->from(Course::class, 'c')
             ->join("c.learningMaterials", 'clm')
             ->join("clm.learningMaterial", 'l')
-            ->where($qb->expr()->in('c.id', ':courseIds'))
-            ->setParameter('courseIds', $courseIds);
+            ->where($qb->expr()->in('c.id', ':ids'))
+            ->setParameter('ids', $courseIds);
 
         foreach ($qb->getQuery()->getResult() as $arr) {
-            $indexableCourses[$arr['courseId']]->learningMaterials[] = $arr['txt'];
+            $indexableCourses[$arr['courseId']]->learningMaterialTitles[] = $arr['title'];
+            $indexableCourses[$arr['courseId']]->learningMaterialDescriptions[] = $arr['description'];
+            $indexableCourses[$arr['courseId']]->learningMaterialCitations[] = $arr['citation'];
+            if ($arr['relativePath']) {
+                $indexableCourses[$arr['courseId']]->fileLearningMaterialIds[] = $arr['learningMaterialId'];
+            }
         }
 
         $arr = $this->joinResults(
@@ -806,7 +812,8 @@ EOL;
         }
 
         $qb = $this->_em->createQueryBuilder()
-            ->select("s.id AS sessionId, l.title, l.description, l.citation")
+            ->select("s.id AS sessionId, l.id as learningMaterialId, l.relativePath, " .
+                "l.title, l.description, l.citation")
             ->from(Session::class, 's')
             ->join("s.learningMaterials", 'slm')
             ->join("slm.learningMaterial", 'l')
@@ -817,6 +824,9 @@ EOL;
             $sessions[$arr['sessionId']]->learningMaterialTitles[] = $arr['title'];
             $sessions[$arr['sessionId']]->learningMaterialDescriptions[] = $arr['description'];
             $sessions[$arr['sessionId']]->learningMaterialCitations[] = $arr['citation'];
+            if ($arr['relativePath']) {
+                $sessions[$arr['sessionId']]->fileLearningMaterialIds[] = $arr['learningMaterialId'];
+            }
         }
 
         return array_values($sessions);

--- a/src/Entity/Repository/LearningMaterialRepository.php
+++ b/src/Entity/Repository/LearningMaterialRepository.php
@@ -79,23 +79,22 @@ class LearningMaterialRepository extends EntityRepository implements DTOReposito
             $learningMaterialDTOs[$arr['xId']]->status = (int) $arr['statusId'];
         }
         $qb = $this->_em->createQueryBuilder()
-            ->select('clm.id AS clmId, s.id as sessionId, x.id AS learningMaterialId')
+            ->select('clm.id AS clmId, c.id as courseId, x.id AS learningMaterialId')
             ->from(LearningMaterial::class, 'x')
             ->join("x.courseLearningMaterials", 'clm')
             ->leftJoin("clm.course", 'c')
-            ->leftJoin("c.sessions", 's')
             ->where($qb->expr()->in('x.id', ':ids'))
             ->orderBy('clmId')
             ->setParameter('ids', $learningMaterialIds);
         foreach ($qb->getQuery()->getResult() as $arr) {
             $lm = $learningMaterialDTOs[$arr['learningMaterialId']];
             $id = $arr['clmId'];
-            $sessionId = $arr['sessionId'];
+            $courseId = $arr['courseId'];
             if (!in_array($id, $lm->courseLearningMaterials)) {
                 $lm->courseLearningMaterials[] = $id;
             }
-            if (!in_array($sessionId, $lm->indexSessions)) {
-                $lm->indexSessions[] = $sessionId;
+            if (!in_array($courseId, $lm->courses)) {
+                $lm->courses[] = $courseId;
             }
         }
         $qb = $this->_em->createQueryBuilder()
@@ -113,8 +112,8 @@ class LearningMaterialRepository extends EntityRepository implements DTOReposito
             if (!in_array($id, $lm->sessionLearningMaterials)) {
                 $lm->sessionLearningMaterials[] = $id;
             }
-            if (!in_array($sessionId, $lm->indexSessions)) {
-                $lm->indexSessions[] = $sessionId;
+            if (!in_array($sessionId, $lm->sessions)) {
+                $lm->sessions[] = $sessionId;
             }
         }
 

--- a/src/Entity/SessionLearningMaterial.php
+++ b/src/Entity/SessionLearningMaterial.php
@@ -203,4 +203,12 @@ class SessionLearningMaterial implements SessionLearningMaterialInterface
     {
         return $this->session;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndexableCourses(): array
+    {
+        return [$this->session->getCourse()];
+    }
 }

--- a/src/Entity/SessionLearningMaterialInterface.php
+++ b/src/Entity/SessionLearningMaterialInterface.php
@@ -2,10 +2,15 @@
 
 namespace App\Entity;
 
+use App\Traits\IndexableCoursesEntityInterface;
+
 /**
  * Interface SessionLearningMaterialInterface
  */
-interface SessionLearningMaterialInterface extends LearningMaterialRelationshipInterface, SessionStampableInterface
+interface SessionLearningMaterialInterface extends
+    LearningMaterialRelationshipInterface,
+    SessionStampableInterface,
+    IndexableCoursesEntityInterface
 {
     /**
      * @param SessionInterface $session

--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -155,8 +155,9 @@ class IndexEntityChanges
 
     protected function indexLearningMaterial(LearningMaterialInterface $lm)
     {
-        if ($this->index->isEnabled()) {
-            $this->bus->dispatch(new LearningMaterialIndexRequest($lm->getId()));
-        }
+        //temporarily disable indexing learning materials while we figure out performance
+//        if ($this->index->isEnabled()) {
+//            $this->bus->dispatch(new LearningMaterialIndexRequest($lm->getId()));
+//        }
     }
 }

--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -156,7 +156,7 @@ class IndexEntityChanges
     protected function indexLearningMaterial(LearningMaterialInterface $lm)
     {
         if ($this->index->isEnabled()) {
-            $this->bus->dispatch(new LearningMaterialIndexRequest([$lm->getId()]));
+            $this->bus->dispatch(new LearningMaterialIndexRequest($lm->getId()));
         }
     }
 }

--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -9,6 +9,7 @@ use App\Entity\CourseInterface;
 use App\Entity\CourseLearningMaterialInterface;
 use App\Entity\DTO\CourseDTO;
 use App\Entity\DTO\UserDTO;
+use App\Entity\LearningMaterialInterface;
 use App\Entity\MeshDescriptorInterface;
 use App\Entity\ObjectiveInterface;
 use App\Entity\SessionInterface;
@@ -16,6 +17,7 @@ use App\Entity\SessionLearningMaterialInterface;
 use App\Entity\TermInterface;
 use App\Entity\UserInterface;
 use App\Message\CourseIndexRequest;
+use App\Message\LearningMaterialIndexRequest;
 use App\Message\UserIndexRequest;
 use App\Service\Index;
 use App\Traits\IndexableCoursesEntityInterface;
@@ -63,6 +65,10 @@ class IndexEntityChanges
             $this->indexUser($entity->getUser());
         }
 
+        if ($entity instanceof LearningMaterialInterface) {
+            $this->indexLearningMaterial($entity);
+        }
+
         if ($entity instanceof IndexableCoursesEntityInterface) {
             $this->indexCourses($entity->getIndexableCourses());
         }
@@ -77,6 +83,10 @@ class IndexEntityChanges
 
         if ($entity instanceof AuthenticationInterface) {
             $this->indexUser($entity->getUser());
+        }
+
+        if ($entity instanceof LearningMaterialInterface) {
+            $this->indexLearningMaterial($entity);
         }
 
         if ($entity instanceof IndexableCoursesEntityInterface) {
@@ -110,6 +120,10 @@ class IndexEntityChanges
             return; //don't re-index our just removed session
         }
 
+        if ($entity instanceof LearningMaterialInterface) {
+            $this->index->deleteLearningMaterial($entity->getId());
+        }
+
         if ($entity instanceof IndexableCoursesEntityInterface) {
             $this->indexCourses($entity->getIndexableCourses());
         }
@@ -136,6 +150,13 @@ class IndexEntityChanges
             foreach ($chunks as $ids) {
                 $this->bus->dispatch(new CourseIndexRequest($ids));
             }
+        }
+    }
+
+    protected function indexLearningMaterial(LearningMaterialInterface $lm)
+    {
+        if ($this->index->isEnabled()) {
+            $this->bus->dispatch(new LearningMaterialIndexRequest([$lm->getId()]));
         }
     }
 }

--- a/src/Message/LearningMaterialIndexRequest.php
+++ b/src/Message/LearningMaterialIndexRequest.php
@@ -1,37 +1,17 @@
 <?php
 namespace App\Message;
 
-use InvalidArgumentException;
-
 class LearningMaterialIndexRequest
 {
-    private $ids;
-    const MAX = 10;
+    private $id;
 
-    /**
-     * LearningMaterialIndexRequest constructor.
-     * @param int[] $ids
-     */
-    public function __construct(array $ids)
+    public function __construct(int $id)
     {
-        $count = count($ids);
-        if ($count > self::MAX) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'A maximum of %d learning material ids can be indexed at the same time, you sent %d',
-                    self::MAX,
-                    $count
-                )
-            );
-        }
-        $this->ids = $ids;
+        $this->id = $id;
     }
 
-    /**
-     * @return int[]
-     */
-    public function getIds(): array
+    public function getId(): int
     {
-        return $this->ids;
+        return $this->id;
     }
 }

--- a/src/Message/LearningMaterialIndexRequest.php
+++ b/src/Message/LearningMaterialIndexRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Message;
 
 class LearningMaterialIndexRequest

--- a/src/Message/LearningMaterialIndexRequest.php
+++ b/src/Message/LearningMaterialIndexRequest.php
@@ -1,0 +1,37 @@
+<?php
+namespace App\Message;
+
+use InvalidArgumentException;
+
+class LearningMaterialIndexRequest
+{
+    private $ids;
+    const MAX = 10;
+
+    /**
+     * LearningMaterialIndexRequest constructor.
+     * @param int[] $ids
+     */
+    public function __construct(array $ids)
+    {
+        $count = count($ids);
+        if ($count > self::MAX) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'A maximum of %d learning material ids can be indexed at the same time, you sent %d',
+                    self::MAX,
+                    $count
+                )
+            );
+        }
+        $this->ids = $ids;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getIds(): array
+    {
+        return $this->ids;
+    }
+}

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -6,6 +6,7 @@ use App\Entity\Manager\LearningMaterialManager;
 use App\Message\LearningMaterialIndexRequest;
 use App\Service\IliosFileSystem;
 use App\Service\Index;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 class LearningMaterialIndexHandler implements MessageHandlerInterface
@@ -25,14 +26,21 @@ class LearningMaterialIndexHandler implements MessageHandlerInterface
      */
     private $iliosFileSystem;
 
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     public function __construct(
         Index $index,
         LearningMaterialManager $manager,
-        IliosFileSystem $iliosFileSystem
+        IliosFileSystem $iliosFileSystem,
+        LoggerInterface $logger
     ) {
         $this->index = $index;
         $this->manager = $manager;
         $this->iliosFileSystem = $iliosFileSystem;
+        $this->logger = $logger;
     }
 
     public function __invoke(LearningMaterialIndexRequest $message)
@@ -42,7 +50,13 @@ class LearningMaterialIndexHandler implements MessageHandlerInterface
             return $this->iliosFileSystem->checkLearningMaterialRelativePath($dto->relativePath);
         });
         if (count($filteredDtos)) {
+            $this->logger->debug('Start Indexing Learning Materials', [
+                'material_ids' => array_column($filteredDtos, 'id'),
+            ]);
             $this->index->indexLearningMaterials($filteredDtos);
+            $this->logger->debug('Complete Indexing Learning Materials', [
+                'material_ids' => array_column($filteredDtos, 'id'),
+            ]);
         }
     }
 }

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -1,0 +1,52 @@
+<?php
+namespace App\MessageHandler;
+
+use App\Entity\DTO\LearningMaterialDTO;
+use App\Entity\Manager\CourseManager;
+use App\Entity\Manager\LearningMaterialManager;
+use App\Message\LearningMaterialIndexRequest;
+use App\Service\IliosFileSystem;
+use App\Service\Index;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+class LearningMaterialIndexHandler implements MessageHandlerInterface
+{
+    /**
+     * @var Index
+     */
+    private $index;
+
+    /**
+     * @var LearningMaterialManager
+     */
+    private $manager;
+
+    /**
+     * @var IliosFileSystem
+     */
+    private $iliosFileSystem;
+
+    public function __construct(
+        Index $index,
+        LearningMaterialManager $manager,
+        IliosFileSystem $iliosFileSystem
+    ) {
+        $this->index = $index;
+        $this->manager = $manager;
+        $this->iliosFileSystem = $iliosFileSystem;
+    }
+
+    public function __invoke(LearningMaterialIndexRequest $message)
+    {
+        $dtos = $this->manager->findDTOsBy(['id' => $message->getIds()]);
+        $filteredDtos = array_filter($dtos, function (LearningMaterialDTO $dto) {
+            if (empty($dto->indexSessions)) {
+                return false;
+            }
+            return $this->iliosFileSystem->checkLearningMaterialRelativePath($dto->relativePath);
+        });
+        if (count($filteredDtos)) {
+            $this->index->indexLearningMaterials($filteredDtos);
+        }
+    }
+}

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -2,7 +2,6 @@
 namespace App\MessageHandler;
 
 use App\Entity\DTO\LearningMaterialDTO;
-use App\Entity\Manager\CourseManager;
 use App\Entity\Manager\LearningMaterialManager;
 use App\Message\LearningMaterialIndexRequest;
 use App\Service\IliosFileSystem;
@@ -38,7 +37,7 @@ class LearningMaterialIndexHandler implements MessageHandlerInterface
 
     public function __invoke(LearningMaterialIndexRequest $message)
     {
-        $dtos = $this->manager->findDTOsBy(['id' => $message->getIds()]);
+        $dtos = $this->manager->findDTOsBy(['id' => $message->getId()]);
         $filteredDtos = array_filter($dtos, function (LearningMaterialDTO $dto) {
             return $this->iliosFileSystem->checkLearningMaterialRelativePath($dto->relativePath);
         });

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -40,7 +40,7 @@ class LearningMaterialIndexHandler implements MessageHandlerInterface
     {
         $dtos = $this->manager->findDTOsBy(['id' => $message->getIds()]);
         $filteredDtos = array_filter($dtos, function (LearningMaterialDTO $dto) {
-            if (empty($dto->indexSessions)) {
+            if (empty($dto->courses) && empty($dto->sessions)) {
                 return false;
             }
             return $this->iliosFileSystem->checkLearningMaterialRelativePath($dto->relativePath);

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\MessageHandler;
 
 use App\Entity\DTO\LearningMaterialDTO;

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -40,9 +40,6 @@ class LearningMaterialIndexHandler implements MessageHandlerInterface
     {
         $dtos = $this->manager->findDTOsBy(['id' => $message->getIds()]);
         $filteredDtos = array_filter($dtos, function (LearningMaterialDTO $dto) {
-            if (empty($dto->courses) && empty($dto->sessions)) {
-                return false;
-            }
             return $this->iliosFileSystem->checkLearningMaterialRelativePath($dto->relativePath);
         });
         if (count($filteredDtos)) {

--- a/src/Service/IliosFileSystem.php
+++ b/src/Service/IliosFileSystem.php
@@ -116,7 +116,7 @@ class IliosFileSystem
      * @param string $path
      * @return bool
      */
-    public function checkLearningMaterialRelativePath(string $path) : bool
+    public function checkLearningMaterialRelativePath(string $path): bool
     {
         return $this->fileSystem->has($path);
     }

--- a/src/Service/IliosFileSystem.php
+++ b/src/Service/IliosFileSystem.php
@@ -100,7 +100,7 @@ class IliosFileSystem
     }
 
     /**
-     * Get if a learning material file path is valid
+     * Get if a learning material has a valid file path
      * @param LearningMaterialInterface $lm
      *
      * @return bool
@@ -108,7 +108,17 @@ class IliosFileSystem
     public function checkLearningMaterialFilePath(LearningMaterialInterface $lm): bool
     {
         $relativePath = $lm->getRelativePath();
-        return $this->fileSystem->has($relativePath);
+        return $this->checkLearningMaterialRelativePath($relativePath);
+    }
+
+    /**
+     * Get if a learning material file path is valid
+     * @param string $path
+     * @return bool
+     */
+    public function checkLearningMaterialRelativePath(string $path) : bool
+    {
+        return $this->fileSystem->has($path);
     }
 
     /**

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -239,6 +239,21 @@ class Index extends ElasticSearchBase
         return empty($errors);
     }
 
+    /**
+     * @param int $id
+     *
+     * @return bool
+     */
+    public function deleteLearningMaterial(int $id): bool
+    {
+        $result = $this->delete([
+            'index' => Search::PRIVATE_LEARNING_MATERIAL_INDEX,
+            'id' => $id
+        ]);
+
+        return $result['result'] === 'deleted';
+    }
+
     protected function index(array $params): array
     {
         if (!$this->enabled) {
@@ -627,7 +642,7 @@ class Index extends ElasticSearchBase
             ]
         ];
     }
-
+    
     protected function buildLearningMaterialIndex(): array
     {
         return [

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -33,7 +33,11 @@ class Index extends ElasticSearchBase
         foreach ($users as $user) {
             if (!$user instanceof UserDTO) {
                 throw new \InvalidArgumentException(
-                    '$users must be an array of ' . UserDTO::class . ' ' . get_class($user) . ' found'
+                    sprintf(
+                        '$users must be an array of %s. %s found',
+                        UserDTO::class,
+                        get_class($user)
+                    )
                 );
             }
         }
@@ -81,7 +85,11 @@ class Index extends ElasticSearchBase
         foreach ($courses as $course) {
             if (!$course instanceof IndexableCourse) {
                 throw new \InvalidArgumentException(
-                    '$courses must be an array of ' . IndexableCourse::class . ' ' . get_class($course) . ' found'
+                    sprintf(
+                        '$courses must be an array of %s. %s found',
+                        IndexableCourse::class,
+                        get_class($course)
+                    )
                 );
             }
         }
@@ -152,7 +160,11 @@ class Index extends ElasticSearchBase
         foreach ($descriptors as $descriptor) {
             if (!$descriptor instanceof Descriptor) {
                 throw new \InvalidArgumentException(
-                    '$descriptors must be an array of ' . Descriptor::class . ' ' . get_class($descriptor) . ' found'
+                    sprintf(
+                        '$descriptors must be an array of %s. %s found',
+                        Descriptor::class,
+                        get_class($descriptor)
+                    )
                 );
             }
         }
@@ -199,8 +211,11 @@ class Index extends ElasticSearchBase
         foreach ($materials as $material) {
             if (!$material instanceof LearningMaterialDTO) {
                 throw new \InvalidArgumentException(
-                    '$materials must be an array of ' . LearningMaterialDTO::class .
-                    ' ' . get_class($material) . ' found'
+                    sprintf(
+                        '$materials must be an array of %s. %s found',
+                        LearningMaterialDTO::class,
+                        get_class($material)
+                    )
                 );
             }
         }

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -13,16 +13,15 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use setasign\Fpdi\Fpdi;
 use setasign\Fpdi\FpdiException;
-use setasign\Fpdi\PdfParser\PdfParserException;
 use setasign\Fpdi\PdfParser\StreamReader;
 use SplFileInfo;
 
 class Index extends ElasticSearchBase
 {
     /**
-     * @var IliosFileSystem
+     * @var NonCachingIliosFileSystem
      */
-    private $iliosFileSystem;
+    private $nonCachingIliosFileSystem;
 
     /**
      * @var LoggerInterface
@@ -33,13 +32,13 @@ class Index extends ElasticSearchBase
     private $uploadLimit;
 
     public function __construct(
-        IliosFileSystem $iliosFileSystem,
+        NonCachingIliosFileSystem $nonCachingIliosFileSystem,
         Config $config,
         LoggerInterface $logger,
         Client $client = null
     ) {
         parent::__construct($client);
-        $this->iliosFileSystem = $iliosFileSystem;
+        $this->nonCachingIliosFileSystem = $nonCachingIliosFileSystem;
         $this->logger = $logger;
         $limit = $config->get('elasticsearch_upload_limit');
         //10mb AWS hard limit on non-huge ES clusters and we need some overhead for control statements
@@ -848,7 +847,7 @@ class Index extends ElasticSearchBase
             return [];
         }
 
-        $data = $this->iliosFileSystem->getFileContents($dto->relativePath);
+        $data = $this->nonCachingIliosFileSystem->getFileContents($dto->relativePath);
         $encodedData = base64_encode($data);
         if (strlen($encodedData) < $this->uploadLimit) {
             return [

--- a/src/Service/Index.php
+++ b/src/Service/Index.php
@@ -835,7 +835,7 @@ class Index extends ElasticSearchBase
      * @param LearningMaterialDTO $dto
      * @return array
      */
-    protected function extractLearningMaterialData(LearningMaterialDTO $dto) : array
+    protected function extractLearningMaterialData(LearningMaterialDTO $dto): array
     {
         //skip files without useful text content
         if ($dto->mimetype && preg_match('/image|video|audio/', $dto->mimetype)) {
@@ -886,7 +886,7 @@ class Index extends ElasticSearchBase
      * @param string $pdfContents
      * @return array
      */
-    protected function splitPDFIntoSmallParts(string $pdfContents) : array
+    protected function splitPDFIntoSmallParts(string $pdfContents): array
     {
         // Base64 Encoding makes files about 30% bigger so we need some padding when comparing
         $fileSizeLimit = $this->uploadLimit * .66;
@@ -932,7 +932,7 @@ class Index extends ElasticSearchBase
         return $PDFs;
     }
 
-    protected function addPageToPdf(FPDI $pdf, int $pageNumber) : void
+    protected function addPageToPdf(FPDI $pdf, int $pageNumber): void
     {
         $templateId = $pdf->importPage($pageNumber);
         $size = $pdf->getTemplateSize($templateId);

--- a/src/Service/LearningMaterialDecoratorFactory.php
+++ b/src/Service/LearningMaterialDecoratorFactory.php
@@ -61,7 +61,8 @@ class LearningMaterialDecoratorFactory
             $learningMaterial->getMimetype(),
             $learningMaterial->getFilesize(),
             $learningMaterial->getLink(),
-            $learningMaterial->getToken()
+            $learningMaterial->getToken(),
+            $learningMaterial->getRelativePath()
         );
         $dto->userRole = $learningMaterial->getUserRole()->getId();
         $dto->owningUser = $learningMaterial->getOwningUser()->getId();

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -52,11 +52,13 @@ class Search extends ElasticSearchBase
             'courseTerms',
             'courseMeshDescriptorIds',
             'courseMeshDescriptorNames',
+            'courseLearningMaterialTitles',
             'sessionTitle',
             'sessionType',
             'sessionTerms',
             'sessionMeshDescriptorIds',
             'sessionMeshDescriptorNames',
+            'sessionLearningMaterialTitles',
         ];
         $suggest = array_reduce($suggestFields, function ($carry, $field) use ($query) {
             $carry[$field] = [
@@ -253,8 +255,12 @@ class Search extends ElasticSearchBase
             'courseTerms.ngram',
             'courseObjectives',
             'courseObjectives.ngram',
-            'courseLearningMaterials',
-            'courseLearningMaterials.ngram',
+            'courseLearningMaterialTitles',
+            'courseLearningMaterialTitles.ngram',
+            'courseLearningMaterialDescriptions',
+            'courseLearningMaterialDescriptions.ngram',
+            'courseLearningMaterialCitation',
+            'courseLearningMaterialCitation.ngram',
             'courseMeshDescriptorIds',
             'courseMeshDescriptorNames',
             'courseMeshDescriptorNames.ngram',
@@ -270,26 +276,35 @@ class Search extends ElasticSearchBase
             'sessionTerms.ngram',
             'sessionObjectives',
             'sessionObjectives.ngram',
-            'sessionLearningMaterials',
-            'sessionLearningMaterials.ngram',
+            'sessionLearningMaterialTitles',
+            'sessionLearningMaterialTitles.ngram',
+            'sessionLearningMaterialDescriptions',
+            'sessionLearningMaterialDescriptions.ngram',
+            'sessionLearningMaterialCitation',
+            'sessionLearningMaterialCitation.ngram',
             'sessionMeshDescriptorIds',
             'sessionMeshDescriptorNames',
             'sessionMeshDescriptorNames.ngram',
             'sessionMeshDescriptorAnnotations',
             'sessionMeshDescriptorAnnotations.ngram',
+            'learningMaterialAttachments',
+            'learningMaterialAttachments.ngram',
         ];
 
         $shouldFields = [
             'courseTitle',
             'courseTerms',
             'courseObjectives',
-            'courseLearningMaterials',
+            'courseLearningMaterialTitles',
+            'courseLearningMaterialDescriptions',
             'sessionTitle',
             'sessionDescription',
             'sessionType',
             'sessionTerms',
             'sessionObjectives',
-            'sessionLearningMaterials',
+            'sessionLearningMaterialTitles',
+            'sessionLearningMaterialDescriptions',
+            'learningMaterialAttachments',
         ];
 
         $mustMatch = array_map(function ($field) use ($query) {
@@ -382,6 +397,9 @@ class Search extends ElasticSearchBase
                 if (strpos($field, 'meshdescriptor') !== false) {
                     $field = 'meshdescriptors';
                 }
+                if (strpos($field, 'learningmaterial') !== false) {
+                    $field = 'learningmaterials';
+                }
 
                 return $field;
             }, $item['courseMatches']);
@@ -390,6 +408,9 @@ class Search extends ElasticSearchBase
                 $field = strtolower(substr($split[0], strlen('session')));
                 if (strpos($field, 'meshdescriptor') !== false) {
                     $field = 'meshdescriptors';
+                }
+                if (strpos($field, 'learningmaterial') !== false) {
+                    $field = 'learningmaterials';
                 }
 
                 return $field;

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -72,7 +72,7 @@ class Search extends ElasticSearchBase
 
         $params = [
             'type' => '_doc',
-            'index' => self::PUBLIC_CURRICULUM_INDEX,
+            'index' => self::CURRICULUM_INDEX,
             'body' => [
                 'suggest' => $suggest,
                 "_source" => [

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -145,7 +145,7 @@ class Search extends ElasticSearchBase
 
         $params = [
             'type' => '_doc',
-            'index' => self::PRIVATE_USER_INDEX,
+            'index' => self::USER_INDEX,
             'size' => $size,
             'body' => [
                 'suggest' => $suggest,
@@ -221,7 +221,7 @@ class Search extends ElasticSearchBase
         }
         $params = [
             'type' => '_doc',
-            'index' => self::PUBLIC_MESH_INDEX,
+            'index' => self::MESH_INDEX,
             'body' => [
                 'query' => [
                     'query_string' => [

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -266,6 +266,8 @@ class Search extends ElasticSearchBase
             'courseMeshDescriptorNames.ngram',
             'courseMeshDescriptorAnnotations',
             'courseMeshDescriptorAnnotations.ngram',
+            'courseLearningMaterialAttachments',
+            'courseLearningMaterialAttachments.ngram',
             'sessionId',
             'sessionTitle',
             'sessionTitle.ngram',
@@ -287,8 +289,8 @@ class Search extends ElasticSearchBase
             'sessionMeshDescriptorNames.ngram',
             'sessionMeshDescriptorAnnotations',
             'sessionMeshDescriptorAnnotations.ngram',
-            'learningMaterialAttachments',
-            'learningMaterialAttachments.ngram',
+            'sessionLearningMaterialAttachments',
+            'sessionLearningMaterialAttachments.ngram',
         ];
 
         $shouldFields = [
@@ -297,6 +299,7 @@ class Search extends ElasticSearchBase
             'courseObjectives',
             'courseLearningMaterialTitles',
             'courseLearningMaterialDescriptions',
+            'courseLearningMaterialAttachments',
             'sessionTitle',
             'sessionDescription',
             'sessionType',
@@ -304,7 +307,7 @@ class Search extends ElasticSearchBase
             'sessionObjectives',
             'sessionLearningMaterialTitles',
             'sessionLearningMaterialDescriptions',
-            'learningMaterialAttachments',
+            'sessionLearningMaterialAttachments',
         ];
 
         $mustMatch = array_map(function ($field) use ($query) {

--- a/symfony.lock
+++ b/symfony.lock
@@ -288,18 +288,6 @@
     "react/promise": {
         "version": "v2.7.1"
     },
-    "sebastian/comparator": {
-        "version": "3.0.2"
-    },
-    "sebastian/diff": {
-        "version": "3.0.2"
-    },
-    "sebastian/exporter": {
-        "version": "3.1.2"
-    },
-    "sebastian/recursion-context": {
-        "version": "3.0.0"
-    },
     "sensiolabs/security-checker": {
         "version": "4.0",
         "recipe": {
@@ -317,6 +305,15 @@
     },
     "sentry/sentry": {
         "version": "2.1.0"
+    },
+    "setasign/fpdf": {
+        "version": "1.8.1"
+    },
+    "setasign/fpdi": {
+        "version": "v2.2.0"
+    },
+    "setasign/fpdi-fpdf": {
+        "version": "v2.2.0"
     },
     "squizlabs/php_codesniffer": {
         "version": "3.0",

--- a/tests/Entity/DTO/LearningMaterialDTOTest.php
+++ b/tests/Entity/DTO/LearningMaterialDTOTest.php
@@ -75,10 +75,11 @@ class LearningMaterialDTOTest extends TestCase
         $this->dto->token = 'aaabbbcccdddeee';
         $this->dto->uploadDate = '12/12/2012';
         $this->dto->userRole = 1;
+        $this->dto->relativePath = 'path/to/material';
 
         $props = array_keys(get_object_vars($this->dto));
         foreach ($props as $prop) {
-            $this->assertNotNull($this->dto->$prop);
+            $this->assertNotNull($this->dto->$prop, "${prop} is set");
         }
 
         $this->dto->clearMaterial();
@@ -94,12 +95,13 @@ class LearningMaterialDTOTest extends TestCase
                 'link',
                 'mimetype',
                 'originalAuthor',
-                'token'
+                'token',
+                'relativePath',
                 ])
             ) {
-                $this->assertNull($this->dto->$prop);
+                $this->assertNull($this->dto->$prop, "${prop} is cleared");
             } else {
-                $this->assertNotNull($this->dto->$prop);
+                $this->assertNotNull($this->dto->$prop, "${prop} is not cleared");
             }
         }
     }

--- a/tests/Entity/DTO/LearningMaterialDTOTest.php
+++ b/tests/Entity/DTO/LearningMaterialDTOTest.php
@@ -36,6 +36,7 @@ class LearningMaterialDTOTest extends TestCase
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -101,7 +101,7 @@ class IndexTest extends TestCase
             'body' => [
                 [
                     'index' => [
-                        '_index' => ElasticSearchBase::PRIVATE_USER_INDEX,
+                        '_index' => ElasticSearchBase::USER_INDEX,
                         '_type' => '_doc',
                         '_id' => $user1->id
                     ]
@@ -121,7 +121,7 @@ class IndexTest extends TestCase
                 ],
                 [
                     'index' => [
-                        '_index' => ElasticSearchBase::PRIVATE_USER_INDEX,
+                        '_index' => ElasticSearchBase::USER_INDEX,
                         '_type' => '_doc',
                         '_id' => $user2->id
                     ]

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -240,7 +240,7 @@ class IndexTest extends TestCase
     public function testIndexCourseWithNoSessions()
     {
         $this->client = m::mock(Client::class);
-        $obj =$this->createWithHost();
+        $obj = $this->createWithHost();
         $course1 = m::mock(IndexableCourse::class);
         $course1->shouldReceive('createIndexObjects')->once()->andReturn([]);
 

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -15,6 +15,7 @@ use App\Tests\TestCase;
 use Elasticsearch\Client;
 use Ilios\MeSH\Model\Descriptor;
 use Mockery as m;
+use Psr\Log\LoggerInterface;
 
 class IndexTest extends TestCase
 {
@@ -33,6 +34,11 @@ class IndexTest extends TestCase
      */
     private $config;
 
+    /**
+     * @var m\LegacyMockInterface|m\MockInterface|LoggerInterface
+     */
+    private $logger;
+
     public function setup()
     {
         $this->fileSystem = m::mock(IliosFileSystem::class);
@@ -41,14 +47,15 @@ class IndexTest extends TestCase
         $this->config->shouldReceive('get')
             ->with('elasticsearch_upload_limit')
             ->andReturn(8000000);
+        $this->logger = m::mock(LoggerInterface::class);
     }
     public function tearDown()
     {
         unset($this->fileSystem);
         unset($this->client);
         unset($this->config);
+        unset($this->logger);
     }
-
 
     public function testSetup()
     {
@@ -287,11 +294,11 @@ class IndexTest extends TestCase
 
     protected function createWithHost()
     {
-        return new Index($this->fileSystem, $this->config, $this->client);
+        return new Index($this->fileSystem, $this->config, $this->logger, $this->client);
     }
 
     protected function createWithoutHost()
     {
-        return new Index($this->fileSystem, $this->config, null);
+        return new Index($this->fileSystem, $this->config, $this->logger, null);
     }
 }

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -9,8 +9,8 @@ use App\Entity\DTO\CourseDTO;
 use App\Entity\DTO\UserDTO;
 use App\Entity\User;
 use App\Service\Config;
-use App\Service\IliosFileSystem;
 use App\Service\Index;
+use App\Service\NonCachingIliosFileSystem;
 use App\Tests\TestCase;
 use Elasticsearch\Client;
 use Ilios\MeSH\Model\Descriptor;
@@ -20,7 +20,7 @@ use Psr\Log\LoggerInterface;
 class IndexTest extends TestCase
 {
     /**
-     * @var IliosFileSystem|m\MockInterface
+     * @var NonCachingIliosFileSystem|m\MockInterface
      */
     private $fileSystem;
 
@@ -41,7 +41,7 @@ class IndexTest extends TestCase
 
     public function setup()
     {
-        $this->fileSystem = m::mock(IliosFileSystem::class);
+        $this->fileSystem = m::mock(NonCachingIliosFileSystem::class);
         $this->client = m::mock(Client::class);
         $this->config = m::mock(Config::class);
         $this->config->shouldReceive('get')

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -8,6 +8,7 @@ use App\Entity\Course;
 use App\Entity\DTO\CourseDTO;
 use App\Entity\DTO\UserDTO;
 use App\Entity\User;
+use App\Service\Config;
 use App\Service\IliosFileSystem;
 use App\Service\Index;
 use App\Tests\TestCase;
@@ -21,20 +22,31 @@ class IndexTest extends TestCase
      * @var IliosFileSystem|m\MockInterface
      */
     private $fileSystem;
+
     /**
      * @var Client|m\MockInterface
      */
     private $client;
 
+    /**
+     * @var Config|m\MockInterface
+     */
+    private $config;
+
     public function setup()
     {
         $this->fileSystem = m::mock(IliosFileSystem::class);
         $this->client = m::mock(Client::class);
+        $this->config = m::mock(Config::class);
+        $this->config->shouldReceive('get')
+            ->with('elasticsearch_upload_limit')
+            ->andReturn(8000000);
     }
     public function tearDown()
     {
         unset($this->fileSystem);
         unset($this->client);
+        unset($this->config);
     }
 
 
@@ -275,11 +287,11 @@ class IndexTest extends TestCase
 
     protected function createWithHost()
     {
-        return new Index($this->fileSystem, $this->client);
+        return new Index($this->fileSystem, $this->config, $this->client);
     }
 
     protected function createWithoutHost()
     {
-        return new Index($this->fileSystem, null);
+        return new Index($this->fileSystem, $this->config, null);
     }
 }

--- a/tests/Service/IndexTest.php
+++ b/tests/Service/IndexTest.php
@@ -185,7 +185,7 @@ class IndexTest extends TestCase
             'body' => [
                 [
                     'index' => [
-                        '_index' => ElasticSearchBase::PUBLIC_CURRICULUM_INDEX,
+                        '_index' => ElasticSearchBase::CURRICULUM_INDEX,
                         '_type' => '_doc',
                         '_id' => 1
                     ]
@@ -195,7 +195,7 @@ class IndexTest extends TestCase
                 ],
                 [
                     'index' => [
-                        '_index' => ElasticSearchBase::PUBLIC_CURRICULUM_INDEX,
+                        '_index' => ElasticSearchBase::CURRICULUM_INDEX,
                         '_type' => '_doc',
                         '_id' => 2
                     ]
@@ -205,7 +205,7 @@ class IndexTest extends TestCase
                 ],
                 [
                     'index' => [
-                        '_index' => ElasticSearchBase::PUBLIC_CURRICULUM_INDEX,
+                        '_index' => ElasticSearchBase::CURRICULUM_INDEX,
                         '_type' => '_doc',
                         '_id' => 3
                     ]


### PR DESCRIPTION
This creates a new index for learning materials and then uses the elasticsearch attachment plugin to parse binary files and insert their test into that index. We then scan this index when indexing courses and add the data to the curriculum index to make it searchable.

Wip:
- [x] Not currently updating when LMs are updated (need to pay particular attention to session / courses removing or adding a material, especially if that material is already indexed as indexing the LMs doesn't trigger indexing the courses. I think we may be able to just update the `courses` or `sessions` id's and not need to re-trigger parsing the file.
- [x] Maybe rename all the indexes to remove public/private since they are all private now and searches should go through the API.
- [x] Test with real materials on AWS. This is to ensure that the plugin actually works as it is expected to there as well as ensuring that we don't hit resource limits with real data.
- [x] Exclude large files from being indexed (also look at how many of these there are). Possibly exclude by type since movies and images can't be indexed anyway.

Fixes #2669 
