### PR TITLE
Improve messenger configuration

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,22 +1,32 @@
 framework:
-    messenger:
-        failure_transport: failed
+  messenger:
+    failure_transport: failed
 
-        transports:
-            # https://symfony.com/doc/current/messenger.html#transport-configuration
-             async:
-               dsn: "doctrine://default"
-               options:
-                 queue_name: async
-                 auto_setup: false
-             failed:
-               dsn: "doctrine://default"
-               options:
-                 queue_name: failed
-                 auto_setup: false
+    transports:
+      # https://symfony.com/doc/current/messenger.html#transport-configuration
+       async:
+         dsn: "doctrine://default"
+         options:
+           queue_name: async
+           auto_setup: true
+       failed:
+         dsn: "doctrine://default"
+         options:
+           queue_name: failed
+           auto_setup: true
 
-        routing:
-            # Route your messages to the transports
-             'App\Message\CourseIndexRequest': async
-             'App\Message\UserIndexRequest': async
-             'App\Message\MeshDescriptorIndexRequest': async
+    routing:
+      # Route your messages to the transports
+       'App\Message\CourseIndexRequest': async
+       'App\Message\UserIndexRequest': async
+       'App\Message\MeshDescriptorIndexRequest': async
+
+    buses:
+      messenger.bus.default:
+        middleware:
+          # each time a message is handled, the Doctrine connection
+          # is "pinged" and reconnected if it's closed.
+          - doctrine_ping_connection
+
+          # After handling, the Doctrine connection is closed
+          - doctrine_close_connection


### PR DESCRIPTION
New features in symfony v4.3.5 make auto_setup useful and improve performance.
I've also enabled some two doctrine features which make it less likely
we'll hold onto lots of open connections.