### PR TITLE
Split messages into two busses

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -21,8 +21,10 @@ framework:
        'App\Message\UserIndexRequest': async
        'App\Message\MeshDescriptorIndexRequest': async
 
+    default_bus: messenger.bus.default
     buses:
-      messenger.bus.default:
+      messenger.bus.default: ~
+      messenger.bus.index:
         middleware:
           # each time a message is handled, the Doctrine connection
           # is "pinged" and reconnected if it's closed.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -45,6 +45,13 @@ services:
         resource: '../src/Controller'
         tags: ['controller.service_arguments']
 
+    command_handlers:
+      namespace: App\MessageHandler\
+      resource: '%kernel.project_dir%/src/MessageHandler/*IndexHandler.php'
+      autoconfigure: false
+      tags:
+        - { name: messenger.message_handler, bus: messenger.bus.index }
+
     Ilios\MeSH\Parser:
 
     Alchemy\Zippy\Zippy:


### PR DESCRIPTION
The performance enhancing middleware for doctrine doesn't make sense
when it is called during synchronous dispatch operations and it breaks
the app as it closes the default open connection to the database and
kills all running transactions. Instead I've applied these only to index
handling which is what gets run on read.