### PR TITLE
Option to disable caching when fetching files

### DIFF
--- a/src/Classes/LocalCachingFilesystemDecorator.php
+++ b/src/Classes/LocalCachingFilesystemDecorator.php
@@ -54,6 +54,14 @@ class LocalCachingFilesystemDecorator implements FilesystemInterface
     }
 
     /**
+     * Check if the cache is enabled
+     */
+    public function isCacheEnabled() : bool
+    {
+        return $this->cacheEnabled;
+    }
+
+    /**
      * Wrapped delete for removing possibly missing files from the local cache
      * @param $path
      */

--- a/src/Service/IliosFileSystem.php
+++ b/src/Service/IliosFileSystem.php
@@ -88,16 +88,27 @@ class IliosFileSystem
 
     /**
      * Get a File from a hash
-     * @param  string $relativePath
+     * @param string $relativePath
+     * @param bool $cacheResults
      * @return string | bool
+     * @throws FileNotFoundException
      */
-    public function getFileContents(string $relativePath)
+    public function getFileContents(string $relativePath, $cacheResults = true)
     {
+        $reEnableCache = false;
+        $contents = false;
+        if (!$cacheResults && $this->fileSystem instanceof LocalCachingFilesystemDecorator) {
+            $reEnableCache = $this->fileSystem->isCacheEnabled();
+            $this->fileSystem->disableCache();
+        }
         if ($this->fileSystem->has($relativePath)) {
-            return $this->fileSystem->read($relativePath);
+            $contents = $this->fileSystem->read($relativePath);
+        }
+        if ($reEnableCache) {
+            $this->fileSystem->enableCache();
         }
 
-        return false;
+        return $contents;
     }
 
     /**

--- a/src/Service/IliosFileSystem.php
+++ b/src/Service/IliosFileSystem.php
@@ -63,7 +63,7 @@ class IliosFileSystem
 
         return $relativePath;
     }
-    
+
     /**
      * Store a learning material file and return the relativePath
      * @param File $file
@@ -75,7 +75,7 @@ class IliosFileSystem
 
         return self::HASHED_LM_DIRECTORY . '/' . substr($hash, 0, 2) . '/' . $hash;
     }
-    
+
     /**
      * Remove a file from the filesystem by hash
      * @param  string $relativePath
@@ -88,27 +88,16 @@ class IliosFileSystem
 
     /**
      * Get a File from a hash
-     * @param string $relativePath
-     * @param bool $cacheResults
+     * @param  string $relativePath
      * @return string | bool
-     * @throws FileNotFoundException
      */
-    public function getFileContents(string $relativePath, $cacheResults = true)
+    public function getFileContents(string $relativePath)
     {
-        $reEnableCache = false;
-        $contents = false;
-        if (!$cacheResults && $this->fileSystem instanceof LocalCachingFilesystemDecorator) {
-            $reEnableCache = $this->fileSystem->isCacheEnabled();
-            $this->fileSystem->disableCache();
-        }
         if ($this->fileSystem->has($relativePath)) {
-            $contents = $this->fileSystem->read($relativePath);
-        }
-        if ($reEnableCache) {
-            $this->fileSystem->enableCache();
+            return $this->fileSystem->read($relativePath);
         }
 
-        return $contents;
+        return false;
     }
 
     /**

--- a/src/Service/NonCachingIliosFileSystem.php
+++ b/src/Service/NonCachingIliosFileSystem.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Service;
+
+class NonCachingIliosFileSystem extends IliosFileSystem
+{
+    public function __construct(FilesystemFactory $factory)
+    {
+        $fileSystem = $factory->getNonCachingFilesystem();
+        parent::__construct($fileSystem);
+    }
+}


### PR DESCRIPTION
We need this when indexing learning materials, it allows a single file
retrieval to be made without storing that file in the cache.

refs #2672