### PR TITLE
CI: run tests in smaller groups

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,8 @@ jobs:
     - script: bin/console security:check
 - template: .azure/phpunit-job-template.yaml
   parameters:
-    name: not_api_tests
-    testCommand: " --exclude-group api_1,api_2,api_3,api_4,api_5"
+    name: all_other_tests
+    testCommand: " --exclude-group api_1,api_2,api_3,api_4,api_5,mesh_data_import,cli,model"
     image: $(IMAGE)
     dependsOn: code_style_and_security
 - job: test_migrations_against_mysql
@@ -62,7 +62,7 @@ jobs:
     testCommand: "--group api_1"
     image: $(IMAGE)
     dependsOn:
-    - PHPUnit_not_api_tests
+    - PHPUnit_all_other_tests
     - test_migrations_against_mysql
 - template: .azure/phpunit-job-template.yaml
   parameters:
@@ -70,7 +70,7 @@ jobs:
     testCommand: "--group api_2"
     image: $(IMAGE)
     dependsOn:
-    - PHPUnit_not_api_tests
+    - PHPUnit_all_other_tests
     - test_migrations_against_mysql
 - template: .azure/phpunit-job-template.yaml
   parameters:
@@ -78,7 +78,7 @@ jobs:
     testCommand: "--group api_3"
     image: $(IMAGE)
     dependsOn:
-    - PHPUnit_not_api_tests
+    - PHPUnit_all_other_tests
     - test_migrations_against_mysql
 - template: .azure/phpunit-job-template.yaml
   parameters:
@@ -86,7 +86,7 @@ jobs:
     testCommand: "--group api_4"
     image: $(IMAGE)
     dependsOn:
-    - PHPUnit_not_api_tests
+    - PHPUnit_all_other_tests
     - test_migrations_against_mysql
 - template: .azure/phpunit-job-template.yaml
   parameters:
@@ -94,11 +94,38 @@ jobs:
     testCommand: "--group api_5"
     image: $(IMAGE)
     dependsOn:
-    - PHPUnit_not_api_tests
+    - PHPUnit_all_other_tests
     - test_migrations_against_mysql
+- template: .azure/phpunit-job-template.yaml
+  parameters:
+    name: cli
+    testCommand: "--group cli"
+    image: $(IMAGE)
+    dependsOn:
+      - PHPUnit_all_other_tests
+      - test_migrations_against_mysql
+- template: .azure/phpunit-job-template.yaml
+  parameters:
+    name: mesh_data_import
+    testCommand: "--group mesh_data_import"
+    image: $(IMAGE)
+    dependsOn:
+      - PHPUnit_all_other_tests
+      - test_migrations_against_mysql
+- template: .azure/phpunit-job-template.yaml
+  parameters:
+    name: model
+    testCommand: "--group model"
+    image: $(IMAGE)
+    dependsOn:
+      - PHPUnit_all_other_tests
+      - test_migrations_against_mysql
 - job: publish_test_results
   dependsOn:
-  - PHPUnit_not_api_tests
+  - PHPUnit_cli
+  - PHPUnit_model
+  - PHPUnit_mesh_data_import
+  - PHPUnit_all_other_tests
   - PHPUnit_api_1
   - PHPUnit_api_2
   - PHPUnit_api_3
@@ -115,7 +142,7 @@ jobs:
       displayName: 'Publish Test Results'
       inputs:
         testResultsFormat: 'JUnit'
-        testResultsFiles: '**/*.xml' 
+        testResultsFiles: '**/*.xml'
         searchFolder: "$(System.DefaultWorkingDirectory)/"
         mergeTestResults: true
 - job: build_and_run_container

--- a/tests/Command/AddDirectoryUserCommandTest.php
+++ b/tests/Command/AddDirectoryUserCommandTest.php
@@ -10,20 +10,21 @@ use Mockery as m;
 
 /**
  * Class AddDirectoryUserCommandTest
+ * @group cli
  */
 class AddDirectoryUserCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
     const COMMAND_NAME = 'ilios:add-directory-user';
-    
+
     protected $userManager;
     protected $authenticationManager;
     protected $schoolManager;
     protected $commandTester;
     protected $questionHelper;
     protected $directory;
-    
+
     public function setUp()
     {
         $this->userManager = m::mock('App\Entity\Manager\UserManager');
@@ -57,7 +58,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
         unset($this->commandTester);
         unset($this->questionHelper);
     }
-    
+
     public function testExecute()
     {
         $school = m::mock('App\Entity\SchoolInterface');
@@ -79,7 +80,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
             ->shouldReceive('getFirstAndLastName')->andReturn('Test Person')
             ->mock();
         $authentication->shouldReceive('setUser')->with($user);
-        
+
         $this->userManager->shouldReceive('findOneBy')->with(array('campusId' => 'abc'))->andReturn(false);
         $this->schoolManager->shouldReceive('findOneBy')->with(array('id' => 1))->andReturn($school);
         $this->userManager->shouldReceive('create')->andReturn($user);
@@ -96,14 +97,14 @@ class AddDirectoryUserCommandTest extends KernelTestCase
         ];
         $this->directory->shouldReceive('findByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
         $this->commandTester->setInputs(['Yes']);
-        
+
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME,
             'campusId'         => 'abc',
             'schoolId'         => '1',
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/abc\s+\| first\s+\| last\s+\| email\s+\| abc123\s+\| phone/',
@@ -115,7 +116,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
         );
     }
 
-    
+
     public function testBadCampusId()
     {
         $user = m::mock('App\Entity\UserInterface')
@@ -129,7 +130,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
             'schoolId'         => '1'
         ));
     }
-    
+
     public function testBadSchoolId()
     {
         $this->userManager->shouldReceive('findOneBy')->with(array('campusId' => 1))->andReturn(null);
@@ -141,7 +142,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
             'schoolId'         => '1'
         ));
     }
-    
+
     public function testUserRequired()
     {
         $this->expectException(\RuntimeException::class);
@@ -150,7 +151,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
             'schoolId'         => '1'
         ));
     }
-    
+
     public function testSchoolRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -15,12 +15,13 @@ use Mockery as m;
 
 /**
  * Class AddNewStudentsToSchoolCommandTest
+ * @group cli
  */
 class AddNewStudentsToSchoolCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:add-students';
-    
+
     protected $userManager;
     protected $userRoleManager;
     protected $schoolManager;
@@ -28,7 +29,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
     protected $commandTester;
     protected $questionHelper;
     protected $directory;
-    
+
     public function setUp()
     {
         $this->userManager = m::mock(UserManager::class);
@@ -36,7 +37,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
         $this->schoolManager = m::mock(SchoolManager::class);
         $this->authenticationManager = m::mock(AuthenticationManager::class);
         $this->directory = m::mock(Directory::class);
-        
+
         $command = new AddNewStudentsToSchoolCommand(
             $this->userManager,
             $this->schoolManager,
@@ -64,7 +65,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
         unset($this->directory);
         unset($this->commandTester);
     }
-    
+
     public function testExecute()
     {
         $fakeDirectoryUser1 = [
@@ -113,7 +114,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
             ->andReturn([$fakeDirectoryUser1, $fakeDirectoryUser2]);
         $this->userManager->shouldReceive('getAllCampusIds')
             ->andReturn(['abc2']);
-            
+
         $this->userManager->shouldReceive('create')->andReturn($user);
         $this->userManager
             ->shouldReceive('update')
@@ -133,20 +134,20 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
 
         $this->authenticationManager->shouldReceive('create')->andReturn($authentication);
         $this->authenticationManager->shouldReceive('update')->with($authentication, false);
-        
+
         $this->commandTester->setInputs(['Yes']);
         $this->commandTester->execute(array(
             'command'   => self::COMMAND_NAME,
             'schoolId'    => 1,
             'filter'    => 'FILTER',
         ));
-        
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Found 2 students in the directory./',
             $output
         );
-        
+
         $this->assertRegExp(
             '/There are 1 new students to be added to school 1./',
             $output
@@ -164,7 +165,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testBadSchoolId()
     {
         $this->schoolManager->shouldReceive('findOneBy')->with(array('id' => 1))->andReturn(null);
@@ -175,7 +176,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
             'schoolId'         => '1'
         ));
     }
-    
+
     public function testFilterRequired()
     {
         $this->expectException(\RuntimeException::class);
@@ -184,7 +185,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
             'schoolId'         => '1'
         ));
     }
-    
+
     public function testSchoolRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/AddRootUserCommandTest.php
+++ b/tests/Command/AddRootUserCommandTest.php
@@ -11,6 +11,7 @@ use Mockery as m;
  * Tests the Add Root User command.
  *
  * Class AddRootUserCommandTest
+ * @group cli
  */
 class AddRootUserCommandTest extends KernelTestCase
 {

--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 /**
  * Class AddUserCommandTest
+ * @group cli
  */
 class AddUserCommandTest extends KernelTestCase
 {

--- a/tests/Command/AuditLogExportCommandTest.php
+++ b/tests/Command/AuditLogExportCommandTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @link http://symfony.com/doc/current/components/console/introduction.html#testing-commands
  * @link http://symfony.com/doc/current/cookbook/console/console_command.html#testing-commands
  * @link http://www.ardianys.com/2013/04/symfony2-test-console-command-which-use.html
+ * @group cli
  */
 class AuditLogExportCommandTest extends KernelTestCase
 {

--- a/tests/Command/ChangePasswordCommandTest.php
+++ b/tests/Command/ChangePasswordCommandTest.php
@@ -15,6 +15,11 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
+/**
+ * Class ChangePasswordCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class ChangePasswordCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -67,7 +72,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         unset($this->sessionUserProvider);
         unset($this->commandTester);
     }
-    
+
     public function testChangePassword()
     {
         $user = m::mock(UserInterface::class);
@@ -89,8 +94,8 @@ class ChangePasswordCommandTest extends KernelTestCase
             'command'      => self::COMMAND_NAME,
             'userId'         => '1'
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Password Changed/',
@@ -139,7 +144,7 @@ class ChangePasswordCommandTest extends KernelTestCase
             'userId'         => '1'
         ));
     }
-    
+
     public function testUserRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/ChangeUsernameCommandTest.php
+++ b/tests/Command/ChangeUsernameCommandTest.php
@@ -11,6 +11,11 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class ChangeUsernameCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class ChangeUsernameCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -49,7 +54,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         unset($this->authenticationManager);
         unset($this->commandTester);
     }
-    
+
     public function testChangeUsername()
     {
         $user = m::mock(UserInterface::class);
@@ -67,8 +72,8 @@ class ChangeUsernameCommandTest extends KernelTestCase
             'command'      => self::COMMAND_NAME,
             'userId'         => '1'
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Username Changed/',
@@ -214,7 +219,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
             'userId'         => '1'
         ));
     }
-    
+
     public function testUserRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/CleanupS3FilesystemCacheCommandTest.php
+++ b/tests/Command/CleanupS3FilesystemCacheCommandTest.php
@@ -11,6 +11,11 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class CleanupS3FilesystemCacheCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class CleanupS3FilesystemCacheCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -52,7 +57,7 @@ class CleanupS3FilesystemCacheCommandTest extends KernelTestCase
         unset($this->diskSpace);
         unset($this->commandTester);
     }
-    
+
     public function testPlentyOfFreeSpaceDoesNothing()
     {
         $this->diskSpace->shouldReceive('freeSpace')->once()->with(self::CACHE_DIR)->andReturn(80);

--- a/tests/Command/CleanupStringsCommandTest.php
+++ b/tests/Command/CleanupStringsCommandTest.php
@@ -8,11 +8,16 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class CleanupStringsCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class CleanupStringsCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:cleanup-strings';
-    
+
     protected $purifier;
     protected $em;
     protected $objectiveManager;
@@ -68,7 +73,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         unset($this->sessionDescriptionManager);
         unset($this->commandTester);
     }
-    
+
     public function testObjectiveTitle()
     {
         $cleanObjective = m::mock('App\Entity\ObjectiveInterface')
@@ -93,8 +98,8 @@ class CleanupStringsCommandTest extends KernelTestCase
             'command'           => self::COMMAND_NAME,
             '--objective-title' => true
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/1 Objective Titles updated/',

--- a/tests/Command/CreateUserTokenCommandTest.php
+++ b/tests/Command/CreateUserTokenCommandTest.php
@@ -8,19 +8,24 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class CreateUserTokenCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class CreateUserTokenCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:create-user-token';
-    
+
     protected $userManager;
     protected $commandTester;
-    
+
     public function setUp()
     {
         $this->userManager = m::mock('App\Entity\Manager\UserManager');
         $this->jwtManager = m::mock(JsonWebTokenManager::class);
-        
+
         $command = new CreateUserTokenCommand($this->userManager, $this->jwtManager);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
@@ -37,46 +42,46 @@ class CreateUserTokenCommandTest extends KernelTestCase
         unset($this->userManager);
         unset($this->commandTester);
     }
-    
+
     public function testNewDefaultToken()
     {
         $user = m::mock('App\Entity\UserInterface');
         $this->userManager->shouldReceive('findOneBy')->with(array('id' => 1))->andReturn($user);
         $this->jwtManager->shouldReceive('createJwtFromUser')->with($user, 'PT8H')->andReturn('123JWT');
-        
+
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME,
             'userId'         => '1'
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Token 123JWT/',
             $output
         );
     }
-    
+
     public function testNewTTLToken()
     {
         $user = m::mock('App\Entity\UserInterface');
         $this->userManager->shouldReceive('findOneBy')->with(array('id' => 1))->andReturn($user);
         $this->jwtManager->shouldReceive('createJwtFromUser')->with($user, '108Franks')->andReturn('123JWT');
-        
+
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME,
             'userId'       => '1',
             '--ttl'        => '108Franks'
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Token 123JWT/',
             $output
         );
     }
-    
+
     public function testBadUserId()
     {
         $this->userManager->shouldReceive('findOneBy')->with(array('id' => 1))->andReturn(null);
@@ -86,7 +91,7 @@ class CreateUserTokenCommandTest extends KernelTestCase
             'userId'         => '1'
         ));
     }
-    
+
     public function testUserRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/CrossingGuardCommandTest.php
+++ b/tests/Command/CrossingGuardCommandTest.php
@@ -10,6 +10,7 @@ use Mockery as m;
 
 /**
  * Class CrossingGuardCommandTest
+ * @group cli
  */
 class CrossingGuardCommandTest extends KernelTestCase
 {
@@ -18,7 +19,7 @@ class CrossingGuardCommandTest extends KernelTestCase
 
     protected $crossingGuard;
     protected $commandTester;
-    
+
     public function setUp()
     {
         $this->crossingGuard = m::mock(CrossingGuard::class);
@@ -41,7 +42,7 @@ class CrossingGuardCommandTest extends KernelTestCase
         unset($this->crossingGuard);
         unset($this->commandTester);
     }
-    
+
     public function testEnable()
     {
         $this->crossingGuard->shouldReceive('enable')->once();

--- a/tests/Command/FindUserCommandTest.php
+++ b/tests/Command/FindUserCommandTest.php
@@ -8,14 +8,19 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class FindUserCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class FindUserCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:find-user';
-    
+
     protected $commandTester;
     protected $directory;
-    
+
     public function setUp()
     {
         $this->directory = m::mock(Directory::class);
@@ -35,7 +40,7 @@ class FindUserCommandTest extends KernelTestCase
         unset($this->directory);
         unset($this->commandTester);
     }
-    
+
     public function testExecute()
     {
         $fakeDirectoryUser = [
@@ -46,20 +51,20 @@ class FindUserCommandTest extends KernelTestCase
             'campusId' => 'abc',
         ];
         $this->directory->shouldReceive('find')->with(array('a', 'b'))->andReturn(array($fakeDirectoryUser));
-        
+
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME,
             'searchTerms'         => array('a', 'b')
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/abc\s+\| first\s+\| last\s+\| email\s+\| phone/',
             $output
         );
     }
-    
+
     public function testTermRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
+++ b/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
@@ -12,11 +12,16 @@ use Mockery as m;
 use App\Service\IliosFileSystem;
 use Symfony\Component\HttpFoundation\File\File;
 
+/**
+ * Class FixLearningMaterialMimeTypesCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:fix-mime-types';
-    
+
     protected $iliosFileSystem;
     protected $temporaryFileSystem;
     protected $learningMaterialManager;
@@ -49,7 +54,7 @@ class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
         unset($this->learningMaterialManager);
         unset($this->commandTester);
     }
-    
+
     public function testFixCitationType()
     {
         $this->learningMaterialManager->shouldReceive('getTotalLearningMaterialCount')

--- a/tests/Command/ImportMeshUniverseCommandTest.php
+++ b/tests/Command/ImportMeshUniverseCommandTest.php
@@ -16,6 +16,7 @@ use Mockery as m;
 /**
  * Class ImportMeshUniverseCommandTest
  * @package App\Tests\Command
+ * @group cli
  */
 class ImportMeshUniverseCommandTest extends KernelTestCase
 {

--- a/tests/Command/InstallFirstUserCommandTest.php
+++ b/tests/Command/InstallFirstUserCommandTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 /**
  * Class InstallFirstUserCommandTest
+ * @group cli
  */
 class InstallFirstUserCommandTest extends KernelTestCase
 {

--- a/tests/Command/InvalidateUserTokenCommandTest.php
+++ b/tests/Command/InvalidateUserTokenCommandTest.php
@@ -11,21 +11,22 @@ use \DateTime;
 
 /**
  * Class InvalidateUserTokenCommandTest
+ * @group cli
  */
 class InvalidateUserTokenCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:invalidate-user-tokens';
-    
+
     protected $userManager;
     protected $authenticationManager;
     protected $commandTester;
-    
+
     public function setUp()
     {
         $this->userManager = m::mock('App\Entity\Manager\UserManager');
         $this->authenticationManager = m::mock('App\Entity\Manager\AuthenticationManager');
-        
+
         $command = new InvalidateUserTokenCommand($this->userManager, $this->authenticationManager);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
@@ -43,7 +44,7 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
         unset($this->authenticationManager);
         unset($this->commandTester);
     }
-    
+
     public function testHappyPathExecute()
     {
         $now = new DateTime();
@@ -60,13 +61,13 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
             'command'      => self::COMMAND_NAME,
             'userId'         => '1'
         ));
-        
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/All the tokens for somebody great issued before Today at [0-9:APM\s]+ UTC have been invalidated./',
             $output
         );
-        
+
         preg_match('/[0-9:APM\s]+ UTC/', $output, $matches);
         $time = trim($matches[0]);
         $since = new DateTime($time);
@@ -75,7 +76,7 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
             $diff > 1
         );
     }
-    
+
     public function testNoAuthenticationForUser()
     {
         $authentication = m::mock('App\Entity\AuthenticationInterface')
@@ -94,14 +95,14 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
             'command'      => self::COMMAND_NAME,
             'userId'         => '1'
         ));
-        
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/All the tokens for somebody great issued before Today at [0-9:APM\s]+ UTC have been invalidated./',
             $output
         );
     }
-    
+
     public function testBadUserId()
     {
         $this->userManager->shouldReceive('findOneBy')->with(array('id' => 1))->andReturn(null);
@@ -111,7 +112,7 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
             'userId'         => '1'
         ));
     }
-    
+
     public function testUserRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/ListConfigValuesCommandTest.php
+++ b/tests/Command/ListConfigValuesCommandTest.php
@@ -10,14 +10,19 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class ListConfigValuesCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class ListConfigValuesCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:list-config-values';
-    
+
     protected $commandTester;
     protected $applicationConfigManager;
-    
+
     public function setUp()
     {
         $this->applicationConfigManager = m::mock(ApplicationConfigManager::class);
@@ -42,7 +47,7 @@ class ListConfigValuesCommandTest extends KernelTestCase
         unset($this->applicationConfigManager);
         unset($this->commandTester);
     }
-    
+
     public function testExecute()
     {
         $mockConfig = m::mock(ApplicationConfig::class);

--- a/tests/Command/ListRootUsersCommandTest.php
+++ b/tests/Command/ListRootUsersCommandTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace App\Tests\Command;
 
-
 use App\Command\ListRootUsersCommand;
 use App\Entity\DTO\UserDTO;
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/tests/Command/ListRootUsersCommandTest.php
+++ b/tests/Command/ListRootUsersCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Tests\Command;
 
+
 use App\Command\ListRootUsersCommand;
 use App\Entity\DTO\UserDTO;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -12,6 +13,7 @@ use Mockery as m;
  * Tests the List Root Users command.
  *
  * Class ListRootUsersCommandTest
+ * @group cli
  */
 class ListRootUsersCommandTest extends KernelTestCase
 {

--- a/tests/Command/ListSchoolConfigValuesCommandTest.php
+++ b/tests/Command/ListSchoolConfigValuesCommandTest.php
@@ -10,11 +10,16 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class ListSchoolConfigValuesCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class ListSchoolConfigValuesCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:list-school-config-values';
-    
+
     protected $commandTester;
     protected $schoolManager;
     protected $schoolConfigManager;
@@ -40,7 +45,7 @@ class ListSchoolConfigValuesCommandTest extends KernelTestCase
         unset($this->schoolConfigManager);
         unset($this->commandTester);
     }
-    
+
     public function testExecute()
     {
         $mockSchool = m::mock(SchoolInterface::class);

--- a/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
+++ b/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
@@ -10,15 +10,20 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 use Symfony\Component\HttpFoundation\File\File;
 
+/**
+ * Class MigrateIlios2LearningMaterialsCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:migrate-learning-materials';
-    
+
     protected $symfonyFileSystem;
     protected $iliosFileSystem;
     protected $learningMaterialManager;
-    
+
     public function setUp()
     {
         $this->symfonyFileSystem = m::mock('Symfony\Component\Filesystem\Filesystem');
@@ -48,7 +53,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
         unset($this->directory);
         unset($this->learningMaterialManager);
     }
-    
+
     public function testExecute()
     {
         $this->symfonyFileSystem
@@ -75,13 +80,13 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
             }))->andReturn('newrelativepath')->once()
         ;
         $this->commandTester->setInputs(['Yes']);
-        
+
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME,
             'pathToIlios2'         => __DIR__ . '/'
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Ready to copy 1 learning materials. Shall we continue?/',
@@ -92,13 +97,13 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithBadRelativePath()
     {
         $this->symfonyFileSystem
             ->shouldReceive('exists')->with('path')->andReturn(true)
             ->shouldReceive('exists')->with('path/pathtofile')->andReturn(false);
-        
+
         $lm = m::mock('App\Entity\LearningMaterial')
             ->shouldReceive('getRelativePath')->andReturn('/pathtofile')->once()
             ->mock();
@@ -124,7 +129,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testBadIlios2Path()
     {
         $this->symfonyFileSystem->shouldReceive('exists')->with('badpath')->andReturn(false);
@@ -134,7 +139,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
             'pathToIlios2'         => 'badpath'
         ));
     }
-    
+
     public function testIlios2PathRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/RemoveRootUserCommandTest.php
+++ b/tests/Command/RemoveRootUserCommandTest.php
@@ -11,6 +11,7 @@ use Mockery as m;
  * Tests the Remove Root User command.
  *
  * Class RemoveRootUserCommandTest
+ * @group cli
  */
 class RemoveRootUserCommandTest extends KernelTestCase
 {

--- a/tests/Command/RolloverCourseCommandTest.php
+++ b/tests/Command/RolloverCourseCommandTest.php
@@ -12,6 +12,7 @@ use Mockery as m;
 
 /**
  * Class RolloverCourseCommandTest
+ * @group cli
  */
 class RolloverCourseCommandTest extends KernelTestCase
 {

--- a/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
+++ b/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
@@ -12,6 +12,7 @@ use Mockery as m;
 
 /**
  * Class RolloverCurriculumInventoryReportCommandTest
+ * @group cli
  */
 class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
 {

--- a/tests/Command/SendChangeAlertsCommandTest.php
+++ b/tests/Command/SendChangeAlertsCommandTest.php
@@ -35,6 +35,7 @@ use Twig\Environment;
  * Send Change Alerts command test.
  *
  * Class SendChangeAlertsCommandTest
+ * @group cli
  */
 class SendChangeAlertsCommandTest extends KernelTestCase
 {

--- a/tests/Command/SendTeachingRemindersCommandTest.php
+++ b/tests/Command/SendTeachingRemindersCommandTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * Send Teaching Reminder command test.
  *
  * Class SendTeachingRemindersCommandTest
+ * @group cli
  */
 class SendTeachingRemindersCommandTest extends KernelTestCase
 {

--- a/tests/Command/SendTestEmailCommandTest.php
+++ b/tests/Command/SendTestEmailCommandTest.php
@@ -7,6 +7,11 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class SendTestEmailCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class SendTestEmailCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/tests/Command/SetConfigValueCommandTest.php
+++ b/tests/Command/SetConfigValueCommandTest.php
@@ -10,14 +10,19 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class SetConfigValueCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class SetConfigValueCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:set-config-value';
-    
+
     protected $commandTester;
     protected $applicationConfigManager;
-    
+
     public function setUp()
     {
         $this->applicationConfigManager = m::mock(ApplicationConfigManager::class);
@@ -37,7 +42,7 @@ class SetConfigValueCommandTest extends KernelTestCase
         unset($this->applicationConfigManager);
         unset($this->commandTester);
     }
-    
+
     public function testSaveExistingConfig()
     {
         $mockConfig = m::mock(ApplicationConfig::class);
@@ -70,7 +75,7 @@ class SetConfigValueCommandTest extends KernelTestCase
             'value'        => 'bar',
         ));
     }
-    
+
     public function testNameRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/SetSchoolConfigValueCommandTest.php
+++ b/tests/Command/SetSchoolConfigValueCommandTest.php
@@ -11,11 +11,16 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class SetSchoolConfigValueCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class SetSchoolConfigValueCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:set-school-config-value';
-    
+
     protected $commandTester;
     protected $schoolManager;
     protected $schoolConfigManager;
@@ -41,7 +46,7 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
         unset($this->schoolConfigManager);
         unset($this->commandTester);
     }
-    
+
     public function testSaveExistingConfig()
     {
         $mockSchool = m::mock(SchoolInterface::class);
@@ -87,7 +92,7 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
             'value' => 'bar',
         ));
     }
-    
+
     public function testNameRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/SetupAuthenticationCommandTest.php
+++ b/tests/Command/SetupAuthenticationCommandTest.php
@@ -12,6 +12,7 @@ use Mockery as m;
 
 /**
  * Class SetupAuthenticationCommandTest
+ * @group cli
  */
 class SetupAuthenticationCommandTest extends KernelTestCase
 {

--- a/tests/Command/SyncAllUsersCommandTest.php
+++ b/tests/Command/SyncAllUsersCommandTest.php
@@ -14,6 +14,7 @@ use Mockery as m;
 
 /**
  * Class SyncAllUsersCommandTest
+ * @group cli
  */
 class SyncAllUsersCommandTest extends KernelTestCase
 {
@@ -46,7 +47,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
      * @var m\Mock
      */
     protected $em;
-    
+
     public function setUp()
     {
         $this->userManager = m::mock('App\Entity\Manager\UserManager');
@@ -54,7 +55,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->pendingUserUpdateManager = m::mock('App\Entity\Manager\PendingUserUpdateManager');
         $this->directory = m::mock(Directory::class);
         $this->em = m::mock(EntityManagerInterface::class);
-        
+
         $command = new SyncAllUsersCommand(
             $this->userManager,
             $this->authenticationManager,
@@ -68,7 +69,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $commandInApp = $application->find(self::COMMAND_NAME);
         $this->commandTester = new CommandTester($commandInApp);
         $this->questionHelper = $command->getHelper('question');
-        
+
         $this->pendingUserUpdateManager->shouldReceive('removeAllPendingUserUpdates')->once();
         $this->userManager->shouldReceive('resetExaminedFlagForAllUsers')->once();
     }
@@ -85,7 +86,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
         unset($this->em);
         unset($this->commandTester);
     }
-    
+
     public function testExecuteUserWithNoChanges()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -135,8 +136,8 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Comparing User #42 first last \(email\) to directory user by campus ID abc./',
@@ -147,7 +148,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithFirstNameChange()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -192,14 +193,14 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('update')->with($user, false)->once();
-                
+
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Updating first name from "first" to "new-first"./',
@@ -210,7 +211,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithLastNameChange()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -255,14 +256,14 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('update')->with($user, false)->once();
-                
+
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Updating last name from "last" to "new-last"./',
@@ -273,7 +274,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithPhoneNumberChange()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -318,14 +319,14 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('update')->with($user, false)->once();
-                
+
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Updating phone number from "phone" to "new-phone"./',
@@ -336,7 +337,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithEmailChange()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -388,14 +389,14 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->pendingUserUpdateManager->shouldReceive('create')->andReturn($update)->once();
         $this->pendingUserUpdateManager->shouldReceive('update')->with($update, false)->once();
-                
+
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Email address "email" differs from "new-email" logging for further action./',
@@ -406,7 +407,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithEmailCaseChange()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -457,8 +458,8 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Updating email from "email" to "EMAIL" since the only difference was the case./',
@@ -532,7 +533,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithUsernameChange()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -577,15 +578,15 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->andReturn([])
             ->once();
         $this->userManager->shouldReceive('update')->with($user, false)->once();
-                
+
         $this->authenticationManager->shouldReceive('update')->with($authentication, false)->once();
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Updating username from "abc123" to "new-abc123"./',
@@ -596,8 +597,8 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
-    
+
+
     public function testExecuteWithNoAuthenticationDataChange()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -653,8 +654,8 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Updating username from "" to "abc123"./',
@@ -669,7 +670,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithMultipleUserMatches()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -728,8 +729,8 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Multiple accounts exist for the same campus ID \(abc\)\.  None of them will be updated./',
@@ -740,7 +741,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithEmptyFirstName()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -783,8 +784,8 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/firstName is required and it is missing from record with campus ID \(abc\)\.  User will not be updated./',
@@ -795,7 +796,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithEmptyLastName()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -838,8 +839,8 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/lastName is required and it is missing from record with campus ID \(abc\)\.  User will not be updated./',
@@ -850,7 +851,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithEmptyEmail()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -893,8 +894,8 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/email is required and it is missing from record with campus ID \(abc\)\.  User will not be updated./',
@@ -905,7 +906,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithEmptyUsernamelName()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -948,8 +949,8 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/username is required and it is missing from record with campus ID \(abc\)\.  User will not be updated./',
@@ -960,7 +961,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteWithUserNotInTheDirectory()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -990,20 +991,20 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->with(m::hasKey('examined'), m::any())->andReturn([])
             ->andReturn([$user])
             ->once();
-        
+
         $update = m::mock('App\Entity\PendingUserUpdate')
             ->shouldReceive('setType')->with('missingFromDirectory')->once()
             ->shouldReceive('setUser')->with($user)->once()
             ->mock();
         $this->pendingUserUpdateManager->shouldReceive('create')->andReturn($update)->once();
         $this->pendingUserUpdateManager->shouldReceive('update')->with($update, false)->once();
-        
+
         $this->em->shouldReceive('flush')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/User #42 missing person email abc not found in the directory.  Logged for further study/',
@@ -1014,7 +1015,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testExecuteEmailChangeDoesNotChangeOthers()
     {
         $this->userManager->shouldReceive('getAllCampusIds')
@@ -1066,13 +1067,13 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->pendingUserUpdateManager->shouldReceive('create')->andReturn($update)->once();
         $this->pendingUserUpdateManager->shouldReceive('update')->with($update, false)->once();
-                
+
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Completed sync process 1 users found in the directory; 0 users updated./',

--- a/tests/Command/SyncFormerStudentsCommandTest.php
+++ b/tests/Command/SyncFormerStudentsCommandTest.php
@@ -12,23 +12,28 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 use Mockery as m;
 
+/**
+ * Class SyncFormerStudentsCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class SyncFormerStudentsCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:sync-former-students';
-    
+
     protected $userManager;
     protected $userRoleManager;
     protected $commandTester;
     protected $questionHelper;
     protected $directory;
-    
+
     public function setUp()
     {
         $this->userManager = m::mock(UserManager::class);
         $this->userRoleManager = m::mock(UserRoleManager::class);
         $this->directory = m::mock(Directory::class);
-        
+
         $command = new SyncFormerStudentsCommand($this->userManager, $this->userRoleManager, $this->directory);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
@@ -48,7 +53,7 @@ class SyncFormerStudentsCommandTest extends KernelTestCase
         unset($this->directory);
         unset($this->commandTester);
     }
-    
+
     public function testExecute()
     {
         $fakeDirectoryUser1 = [
@@ -92,19 +97,19 @@ class SyncFormerStudentsCommandTest extends KernelTestCase
         $this->userRoleManager
             ->shouldReceive('update')
             ->with($role);
-        
+
         $this->commandTester->setInputs(['Yes']);
         $this->commandTester->execute(array(
             'command'   => self::COMMAND_NAME,
             'filter'    => 'FILTER'
         ));
-        
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Found 2 former students in the directory./',
             $output
         );
-        
+
         $this->assertRegExp(
             '/There are 1 students in Ilios who will be marked as a Former Student./',
             $output
@@ -122,7 +127,7 @@ class SyncFormerStudentsCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testFilterRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/SyncUserCommandTest.php
+++ b/tests/Command/SyncUserCommandTest.php
@@ -16,26 +16,27 @@ use Mockery as m;
 
 /**
  * Class SyncUserCommandTest
+ * @group cli
  */
 class SyncUserCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:sync-user';
-    
+
     protected $userManager;
     protected $authenticationManager;
     protected $pendingUserUpdateManager;
     protected $commandTester;
     protected $questionHelper;
     protected $directory;
-    
+
     public function setUp()
     {
         $this->userManager = m::mock(UserManager::class);
         $this->authenticationManager = m::mock(AuthenticationManager::class);
         $this->pendingUserUpdateManager = m::mock(PendingUserUpdateManager::class);
         $this->directory = m::mock(Directory::class);
-        
+
         $command = new SyncUserCommand(
             $this->userManager,
             $this->authenticationManager,
@@ -61,7 +62,7 @@ class SyncUserCommandTest extends KernelTestCase
         unset($this->directory);
         unset($this->commandTester);
     }
-    
+
     public function testExecute()
     {
         $authentication = m::mock(AuthenticationInterface::class)
@@ -98,13 +99,13 @@ class SyncUserCommandTest extends KernelTestCase
         ];
         $this->directory->shouldReceive('findByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
         $this->commandTester->setInputs(['Yes']);
-        
+
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME,
             'userId'         => '1'
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Ilios User\s+\| abc\s+\| old-first\s+\| old-last\s+\| old-display\s+\| old-email\s+\| old-phone/',
@@ -115,7 +116,7 @@ class SyncUserCommandTest extends KernelTestCase
             $output
         );
     }
-    
+
     public function testBadUserId()
     {
         $this->userManager->shouldReceive('findOneBy')->with(array('id' => 1))->andReturn(null);
@@ -125,7 +126,7 @@ class SyncUserCommandTest extends KernelTestCase
             'userId' => '1'
         ));
     }
-    
+
     public function testUserRequired()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Command/UpdateFrontendCommandTest.php
+++ b/tests/Command/UpdateFrontendCommandTest.php
@@ -14,12 +14,17 @@ use Symfony\Component\Filesystem\Filesystem as SymfonyFileSystem;
 use Mockery as m;
 use Symfony\Component\Finder\Finder;
 
+/**
+ * Class UpdateFrontendCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class UpdateFrontendCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:update-frontend';
     const TEST_API_VERSION = '33.14-test';
-    
+
     protected $commandTester;
     protected $fetch;
     protected $fs;
@@ -79,7 +84,7 @@ class UpdateFrontendCommandTest extends KernelTestCase
         unset($this->archive);
         unset($this->finder);
     }
-    
+
     public function testExecute()
     {
         $fileName = self::TEST_API_VERSION . '/' . UpdateFrontendCommand::ARCHIVE_FILE_NAME;

--- a/tests/Command/ValidateLearningMaterialPathsCommandTest.php
+++ b/tests/Command/ValidateLearningMaterialPathsCommandTest.php
@@ -8,15 +8,20 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
+/**
+ * Class ValidateLearningMaterialPathsCommandTest
+ * @package App\Tests\Command
+ * @group cli
+ */
 class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
     const COMMAND_NAME = 'ilios:validate-learning-materials';
-    
+
     protected $iliosFileSystem;
     protected $learningMaterialManager;
     protected $commandTester;
-    
+
     public function setUp()
     {
         $this->iliosFileSystem = m::mock(IliosFileSystem::class);
@@ -41,7 +46,7 @@ class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
         unset($this->iliosFileSystem);
         unset($this->learningMaterialManager);
     }
-    
+
     public function testExecute()
     {
         $goodLm = m::mock('App\Entity\LearningMaterial');
@@ -62,8 +67,8 @@ class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
         $this->commandTester->execute(array(
             'command'      => self::COMMAND_NAME
         ));
-        
-        
+
+
         $output = $this->commandTester->getDisplay();
         $this->assertRegExp(
             '/Validated 1 learning materials file path/',

--- a/tests/Entity/AamcMethodTest.php
+++ b/tests/Entity/AamcMethodTest.php
@@ -5,6 +5,7 @@ use App\Entity\AamcMethod;
 
 /**
  * Tests for Entity AamcMethod
+ * @group model
  */
 class AamcMethodTest extends EntityBase
 {

--- a/tests/Entity/AamcPcrsTest.php
+++ b/tests/Entity/AamcPcrsTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity AamcPcrs
+ * @group model
  */
 class AamcPcrsTest extends EntityBase
 {

--- a/tests/Entity/AamcResourceTypeTest.php
+++ b/tests/Entity/AamcResourceTypeTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity AamcResourceType
+ * @group model
  */
 class AamcResourceTypeTest extends EntityBase
 {

--- a/tests/Entity/AlertChangeTypeTest.php
+++ b/tests/Entity/AlertChangeTypeTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity AlertChangeType
+ * @group model
  */
 class AlertChangeTypeTest extends EntityBase
 {

--- a/tests/Entity/AlertTest.php
+++ b/tests/Entity/AlertTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Alert
+ * @group model
  */
 class AlertTest extends EntityBase
 {

--- a/tests/Entity/ApplicationConfigTest.php
+++ b/tests/Entity/ApplicationConfigTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for ApplicationConfig entity.
+ * @group model
  */
 class ApplicationConfigTest extends EntityBase
 {

--- a/tests/Entity/AssessmentOptionTest.php
+++ b/tests/Entity/AssessmentOptionTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity AssessmentOption
+ * @group model
  */
 class AssessmentOptionTest extends EntityBase
 {

--- a/tests/Entity/AuditLogTest.php
+++ b/tests/Entity/AuditLogTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity AuditLog
+ * @group model
  */
 class AuditLogTest extends EntityBase
 {

--- a/tests/Entity/AuthenticationTest.php
+++ b/tests/Entity/AuthenticationTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Authentication
+ * @group model
  */
 class AuthenticationTest extends EntityBase
 {
@@ -21,7 +22,7 @@ class AuthenticationTest extends EntityBase
     {
         $this->object = new Authentication;
     }
-    
+
     /**
      * @covers \App\Entity\Authentication::setUsername
      * @covers \App\Entity\Authentication::getUsername

--- a/tests/Entity/CohortTest.php
+++ b/tests/Entity/CohortTest.php
@@ -9,6 +9,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Cohort
+ * @group model
  */
 class CohortTest extends EntityBase
 {

--- a/tests/Entity/CompetencyTest.php
+++ b/tests/Entity/CompetencyTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Competency
+ * @group model
  */
 class CompetencyTest extends EntityBase
 {

--- a/tests/Entity/CourseClerkshipTypeTest.php
+++ b/tests/Entity/CourseClerkshipTypeTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity CourseClerkshipType
+ * @group model
  */
 class CourseClerkshipTypeTest extends EntityBase
 {

--- a/tests/Entity/CourseLearningMaterialTest.php
+++ b/tests/Entity/CourseLearningMaterialTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity CourseLearningMaterial
+ * @group model
  */
 class CourseLearningMaterialTest extends EntityBase
 {

--- a/tests/Entity/CourseTest.php
+++ b/tests/Entity/CourseTest.php
@@ -7,6 +7,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Course
+ * @group model
  */
 class CourseTest extends EntityBase
 {

--- a/tests/Entity/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/Entity/CurriculumInventoryAcademicLevelTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity CurriculumInventoryAcademicLevel
+ * @group model
  */
 class CurriculumInventoryAcademicLevelTest extends EntityBase
 {

--- a/tests/Entity/CurriculumInventoryExportTest.php
+++ b/tests/Entity/CurriculumInventoryExportTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity CurriculumInventoryExport
+ * @group model
  */
 class CurriculumInventoryExportTest extends EntityBase
 {
@@ -28,11 +29,11 @@ class CurriculumInventoryExportTest extends EntityBase
             'document',
         );
         $this->validateNotBlanks($notBlank);
-        
+
         $this->object->setDocument('text file super large test');
         $this->validate(0);
     }
-    
+
     /**
      * @covers \App\Entity\Session::__construct
      */

--- a/tests/Entity/CurriculumInventoryInstitutionTest.php
+++ b/tests/Entity/CurriculumInventoryInstitutionTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity CurriculumInventoryInstitution
+ * @group model
  */
 class CurriculumInventoryInstitutionTest extends EntityBase
 {

--- a/tests/Entity/CurriculumInventoryReportTest.php
+++ b/tests/Entity/CurriculumInventoryReportTest.php
@@ -8,6 +8,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity CurriculumInventoryReport
+ * @group model
  */
 class CurriculumInventoryReportTest extends EntityBase
 {

--- a/tests/Entity/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Entity/CurriculumInventorySequenceBlockTest.php
@@ -8,6 +8,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity CurriculumInventorySequenceBlock
+ * @group model
  */
 class CurriculumInventorySequenceBlockTest extends EntityBase
 {

--- a/tests/Entity/CurriculumInventorySequenceTest.php
+++ b/tests/Entity/CurriculumInventorySequenceTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity CurriculumInventorySequence
+ * @group model
  */
 class CurriculumInventorySequenceTest extends EntityBase
 {

--- a/tests/Entity/DTO/LearningMaterialDTOTest.php
+++ b/tests/Entity/DTO/LearningMaterialDTOTest.php
@@ -5,6 +5,11 @@ namespace App\Tests\Entity\DTO;
 use App\Entity\DTO\LearningMaterialDTO;
 use App\Tests\TestCase;
 
+/**
+ * Class LearningMaterialDTOTest
+ * @package App\Tests\Entity\DTO
+ * @group model
+ */
 class LearningMaterialDTOTest extends TestCase
 {
     /**

--- a/tests/Entity/DepartmentTest.php
+++ b/tests/Entity/DepartmentTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Department
+ * @group model
  */
 class DepartmentTest extends EntityBase
 {

--- a/tests/Entity/EntityBase.php
+++ b/tests/Entity/EntityBase.php
@@ -10,6 +10,7 @@ use App\Tests\TestCase;
 
 /**
  * Class EntityBase
+ * @group model
  */
 class EntityBase extends TestCase
 {

--- a/tests/Entity/IlmSessionTest.php
+++ b/tests/Entity/IlmSessionTest.php
@@ -7,6 +7,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity IlmSession
+ * @group model
  */
 class IlmSessionTest extends EntityBase
 {

--- a/tests/Entity/IngestionExceptionTest.php
+++ b/tests/Entity/IngestionExceptionTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity IngestionException
+ * @group model
  */
 class IngestionExceptionTest extends EntityBase
 {

--- a/tests/Entity/InstructorGroupTest.php
+++ b/tests/Entity/InstructorGroupTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity InstructorGroup
+ * @group model
  */
 class InstructorGroupTest extends EntityBase
 {

--- a/tests/Entity/LearnerGroupTest.php
+++ b/tests/Entity/LearnerGroupTest.php
@@ -10,6 +10,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity LearnerGroup
+ * @group model
  */
 class LearnerGroupTest extends EntityBase
 {

--- a/tests/Entity/LearningMaterialStatusTest.php
+++ b/tests/Entity/LearningMaterialStatusTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity LearningMaterialStatus
+ * @group model
  */
 class LearningMaterialStatusTest extends EntityBase
 {

--- a/tests/Entity/LearningMaterialTest.php
+++ b/tests/Entity/LearningMaterialTest.php
@@ -12,6 +12,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity LearningMaterial
+ * @group model
  */
 class LearningMaterialTest extends EntityBase
 {

--- a/tests/Entity/LearningMaterialUserRoleTest.php
+++ b/tests/Entity/LearningMaterialUserRoleTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity LearningMaterialUserRole
+ * @group model
  */
 class LearningMaterialUserRoleTest extends EntityBase
 {

--- a/tests/Entity/Manager/CourseManagerTest.php
+++ b/tests/Entity/Manager/CourseManagerTest.php
@@ -7,6 +7,7 @@ use App\Tests\TestCase;
 
 /**
  * Class CourseManagerTest
+ * @group model
  */
 class CourseManagerTest extends TestCase
 {
@@ -25,7 +26,7 @@ class CourseManagerTest extends TestCase
             ->shouldReceive('getRepository')
             ->andReturn($repository)
             ->mock();
-        
+
         $entity = m::mock($class);
         $manager = new CourseManager($registry, $class);
         $manager->delete($entity);

--- a/tests/Entity/Manager/CurriculumInventoryReportManagerTest.php
+++ b/tests/Entity/Manager/CurriculumInventoryReportManagerTest.php
@@ -12,6 +12,7 @@ use App\Tests\TestCase;
 /**
  * Class CurriculumInventoryReportManagerTest
  * @package App\Tests\Entity\Manager
+ * @group model
  */
 class CurriculumInventoryReportManagerTest extends TestCase
 {

--- a/tests/Entity/Manager/OfferingManagerTest.php
+++ b/tests/Entity/Manager/OfferingManagerTest.php
@@ -13,7 +13,8 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * Tests for Entity AamcMethod
+ * Tests for Offering manager.
+ * @group model
  */
 class OfferingManagerTest extends TestCase
 {
@@ -31,7 +32,7 @@ class OfferingManagerTest extends TestCase
             ->shouldReceive('getRepository')
             ->andReturn($repository)
             ->mock();
-        
+
         $entity = m::mock(Offering::class);
         $manager = new OfferingManager($registry, Offering::class);
         $manager->delete($entity);

--- a/tests/Entity/Manager/SchoolManagerTest.php
+++ b/tests/Entity/Manager/SchoolManagerTest.php
@@ -8,10 +8,11 @@ use App\Tests\TestCase;
 
 /**
  * Class SchoolManagerTest
+ * @group model
  */
 class SchoolManagerTest extends TestCase
 {
-    
+
     /**
      * @covers \App\Entity\Manager\SchoolManager::delete
      */
@@ -27,7 +28,7 @@ class SchoolManagerTest extends TestCase
             ->shouldReceive('getRepository')
             ->andReturn($repository)
             ->mock();
-        
+
         $entity = m::mock($class);
         $manager = new SchoolManager($registry, $class, m::mock(UserMaterialFactory::class));
         $manager->delete($entity);

--- a/tests/Entity/MeshConceptTest.php
+++ b/tests/Entity/MeshConceptTest.php
@@ -6,6 +6,7 @@ use DateTime;
 
 /**
  * Tests for Entity MeshConcept
+ * @group model
  */
 class MeshConceptTest extends EntityBase
 {

--- a/tests/Entity/MeshDescriptorTest.php
+++ b/tests/Entity/MeshDescriptorTest.php
@@ -12,6 +12,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity MeshDescriptor
+ * @group model
  */
 class MeshDescriptorTest extends EntityBase
 {

--- a/tests/Entity/MeshPreviousIndexingTest.php
+++ b/tests/Entity/MeshPreviousIndexingTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity MeshPreviousIndexing
+ * @group model
  */
 class MeshPreviousIndexingTest extends EntityBase
 {

--- a/tests/Entity/MeshQualifierTest.php
+++ b/tests/Entity/MeshQualifierTest.php
@@ -6,6 +6,7 @@ use DateTime;
 
 /**
  * Tests for Entity MeshQualifier
+ * @group model
  */
 class MeshQualifierTest extends EntityBase
 {

--- a/tests/Entity/MeshTermTest.php
+++ b/tests/Entity/MeshTermTest.php
@@ -6,6 +6,7 @@ use DateTime;
 
 /**
  * Tests for Entity MeshTerm
+ * @group model
  */
 class MeshTermTest extends EntityBase
 {

--- a/tests/Entity/MeshTreeTest.php
+++ b/tests/Entity/MeshTreeTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity MeshTree
+ * @group model
  */
 class MeshTreeTest extends EntityBase
 {
@@ -32,7 +33,7 @@ class MeshTreeTest extends EntityBase
         $this->object->setTreeNumber('junk');
         $this->validate(0);
     }
-    
+
     /**
      * @covers \App\Entity\MeshTree::setTreeNumber
      * @covers \App\Entity\MeshTree::getTreeNumber

--- a/tests/Entity/ObjectiveTest.php
+++ b/tests/Entity/ObjectiveTest.php
@@ -8,6 +8,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Objective
+ * @group model
  */
 class ObjectiveTest extends EntityBase
 {

--- a/tests/Entity/OfferingTest.php
+++ b/tests/Entity/OfferingTest.php
@@ -9,6 +9,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Offering
+ * @group model
  */
 class OfferingTest extends EntityBase
 {

--- a/tests/Entity/PendingUserUpdateTest.php
+++ b/tests/Entity/PendingUserUpdateTest.php
@@ -7,6 +7,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity PendingUserUpdate
+ * @group model
  */
 class PendingUserUpdateTest extends EntityBase
 {
@@ -80,7 +81,7 @@ class PendingUserUpdateTest extends EntityBase
     {
         $this->basicSetTest('value', 'string');
     }
-    
+
     /**
      * @covers \App\Entity\PendingUserUpdate::setUser
      * @covers \App\Entity\PendingUserUpdate::getUser

--- a/tests/Entity/ProgramTest.php
+++ b/tests/Entity/ProgramTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Program
+ * @group model
  */
 class ProgramTest extends EntityBase
 {

--- a/tests/Entity/ProgramYearStewardTest.php
+++ b/tests/Entity/ProgramYearStewardTest.php
@@ -9,6 +9,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity ProgramYearSteward
+ * @group model
  */
 class ProgramYearStewardTest extends EntityBase
 {

--- a/tests/Entity/ProgramYearTest.php
+++ b/tests/Entity/ProgramYearTest.php
@@ -8,6 +8,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity ProgramYear
+ * @group model
  */
 class ProgramYearTest extends EntityBase
 {

--- a/tests/Entity/ReportTest.php
+++ b/tests/Entity/ReportTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Report
+ * @group model
  */
 class ReportTest extends EntityBase
 {
@@ -21,7 +22,7 @@ class ReportTest extends EntityBase
     {
         $this->object = new Report;
     }
-    
+
     /**
      * @covers \App\Entity\Session::__construct
      */

--- a/tests/Entity/SchoolConfigTest.php
+++ b/tests/Entity/SchoolConfigTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for SchoolConfig entity.
+ * @group model
  */
 class SchoolConfigTest extends EntityBase
 {

--- a/tests/Entity/SchoolTest.php
+++ b/tests/Entity/SchoolTest.php
@@ -7,6 +7,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity School
+ * @group model
  */
 class SchoolTest extends EntityBase
 {

--- a/tests/Entity/SessionDescriptionTest.php
+++ b/tests/Entity/SessionDescriptionTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity SessionDescription
+ * @group model
  */
 class SessionDescriptionTest extends EntityBase
 {
@@ -21,7 +22,7 @@ class SessionDescriptionTest extends EntityBase
     {
         $this->object = new SessionDescription;
     }
-   
+
     /**
      * @covers \App\Entity\SessionDescription::setDescription
      * @covers \App\Entity\SessionDescription::getDescription

--- a/tests/Entity/SessionLearningMaterialTest.php
+++ b/tests/Entity/SessionLearningMaterialTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity SessionLearningMaterial
+ * @group model
  */
 class SessionLearningMaterialTest extends EntityBase
 {

--- a/tests/Entity/SessionTest.php
+++ b/tests/Entity/SessionTest.php
@@ -9,6 +9,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Session
+ * @group model
  */
 class SessionTest extends EntityBase
 {

--- a/tests/Entity/SessionTypeTest.php
+++ b/tests/Entity/SessionTypeTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity SessionType
+ * @group model
  */
 class SessionTypeTest extends EntityBase
 {

--- a/tests/Entity/TermTest.php
+++ b/tests/Entity/TermTest.php
@@ -8,6 +8,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Term
+ * @group model
  */
 class TermTest extends EntityBase
 {

--- a/tests/Entity/UserRoleTest.php
+++ b/tests/Entity/UserRoleTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity UserRole
+ * @group model
  */
 class UserRoleTest extends EntityBase
 {

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Tests for Entity Objective
+ * @group model
  */
 class UserTest extends EntityBase
 {

--- a/tests/Entity/VocabularyTest.php
+++ b/tests/Entity/VocabularyTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 
 /**
  * Tests for Entity Vocabulary
+ * @group model
  */
 class VocabularyTest extends EntityBase
 {


### PR DESCRIPTION
we're bumping up against azure's one hour limit on PHPUnit test runs. this breaks our test coverage up into smaller groups, in the hope to overcome this problem.