### PR TITLE
provides a better success message.

### DIFF
--- a/src/Monitor/NoDefaultSecret.php
+++ b/src/Monitor/NoDefaultSecret.php
@@ -35,7 +35,7 @@ class NoDefaultSecret implements CheckInterface
             );
         }
 
-        return new Success('ILIOS_SECRET not set do a default value');
+        return new Success('ILIOS_SECRET uses a non-default value');
     }
 
     /**


### PR DESCRIPTION
the previous message had a typo, `do` instead of `to`. 

this new one is more to the point, imo.