### PR TITLE
[BREAKING] Update Flex Recipes for Symfony 4.4

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # In all environments, the following files are loaded if they exist,
-# the later taking precedence over the former:
+# the latter taking precedence over the former:
 #
 #  * .env                contains default values for the environment variables needed by the app
 #  * .env.local          uncommitted file with local overrides
@@ -12,19 +12,24 @@
 #
 # Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
+# https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
 
 # Copy to .env.local before making changes
-
 APP_ENV=prod
 ILIOS_SECRET=NotSecretChangeMe
 
 # Default language for Ilios (supported: en, fr, es)
 ILIOS_LOCALE=en
 
-# Configure your db driver and server_version in config/packages/doctrine.yaml
-ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
-ILIOS_DATABASE_MYSQL_VERSION=5.7
+###> doctrine/doctrine-bundle ###
+# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
+# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7
+###< doctrine/doctrine-bundle ###
+
 
 # For Gmail as a transport, use: "gmail://username:password@localhost"
 # For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="

--- a/.env.dev
+++ b/.env.dev
@@ -4,7 +4,7 @@
 ILIOS_SECRET=NotSecretChangeMe
 
 # Configure your db driver and server_version in config/packages/doctrine.yaml
-ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
+ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7
 
 # Delivery is disabled by default via "null://localhost"
 ILIOS_MAILER_URL=null://localhost

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,6 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
-ILIOS_SECRET='s$cretf0rt3st'
+ILIOS_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 
 ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp/ilios
@@ -13,3 +13,4 @@ ILIOS_ELASTICSEARCH_HOSTS=null
 ILIOS_STORAGE_S3_URL=null
 
 ILIOS_MAILER_URL=null://localhost
+PANTHER_APP_ENV=panther

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ FakeTestFiles
 
 ###> symfony/phpunit-bridge ###
 .phpunit
+.phpunit.result.cache
 /phpunit.xml
 ###< symfony/phpunit-bridge ###
 
@@ -31,6 +32,7 @@ FakeTestFiles
 /.env.local
 /.env.local.php
 /.env.*.local
+/config/secrets/prod/prod.decrypt.private.php
 /public/bundles/
 /var/
 /vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ ENV \
 COMPOSER_HOME=/tmp \
 COMPOSER_ALLOW_SUPERUSER=true \
 APP_ENV=prod \
-ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios \
-ILIOS_DATABASE_MYSQL_VERSION=5.7 \
+ILIOS_DATABASE_URL="mysql://ilios:ilios@db/ilios?serverVersion=5.7" \
 ILIOS_MAILER_URL=null://localhost \
 ILIOS_LOCALE=en \
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,8 +48,7 @@ jobs:
   pool:
     vmImage: $(IMAGE)
   variables:
-    ILIOS_DATABASE_URL: mysql://ilios_user:ilios_password@127.0.0.1:33060/ilios
-    ILIOS_DATABASE_MYSQL_VERSION: 5.7
+    ILIOS_DATABASE_URL: mysql://ilios_user:ilios_password@127.0.0.1:33060/ilios?serverVersion=5.7
   steps:
   - template: .azure/install-steps-template.yaml
   - script: bin/console doctrine:database:drop --force

--- a/bin/console
+++ b/bin/console
@@ -4,7 +4,7 @@
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 
 if (false === in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
     echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.\PHP_SAPI.' SAPI'.\PHP_EOL;

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -6,12 +6,6 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
     exit(1);
 }
 
-if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
-    putenv('SYMFONY_PHPUNIT_VERSION=7.5');
-}
-if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
-    putenv('SYMFONY_PHPUNIT_REMOVE=');
-}
 if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
     putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
 }

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,15 +1,19 @@
 <?php
 
 use Symfony\Component\Dotenv\Dotenv;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-use Doctrine\Common\Annotations\AnnotationReader;
-
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')) {
-    $_ENV += $env;
+if (
+    is_array($env = @include dirname(__DIR__) . '/.env.local.php') &&
+    ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV']
+) {
+    foreach ($env as $k => $v) {
+        $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
+    }
 } elseif (!class_exists(Dotenv::class)) {
     throw new RuntimeException(
         'Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.'
@@ -22,8 +26,10 @@ if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')) {
 $_SERVER += $_ENV;
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
-$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] ||
-    filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var(
+    $_SERVER['APP_DEBUG'],
+    FILTER_VALIDATE_BOOLEAN
+) ? '1' : '0';
 
 AnnotationReader::addGlobalIgnoredName('covers');
 AnnotationReader::addGlobalIgnoredName('group');

--- a/config/packages/dev/doctrine.yaml
+++ b/config/packages/dev/doctrine.yaml
@@ -1,5 +1,4 @@
 doctrine:
   dbal:
-    url: '%env(ILIOS_DATABASE_URL)%'
+    url: '%env(resolve:ILIOS_DATABASE_URL)%'
     driver:   'pdo_mysql'
-    server_version: '%env(ILIOS_DATABASE_MYSQL_VERSION)%'

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,15 +1,5 @@
-parameters:
-    # Adds a fallback DATABASE_URL if the env var is not set.
-    # This allows you to run cache:warmup even if your
-    # environment variables are not available yet.
-    # You should not need to change this value.
-    env(ILIOS_DATABASE_URL): ''
-    env(ILIOS_DATABASE_MYSQL_VERSION): '5.7'
-
 doctrine:
     dbal:
-        # configure these for your database server
-        driver: 'pdo_mysql'
         charset: utf8mb4
         default_table_options:
             charset: utf8mb4

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,16 +1,19 @@
-parameters:
-  env(ILIOS_SECRET):
-
 framework:
-  secret: '%env(ILIOS_SECRET)%'
-  http_method_override: true
+    secret: '%env(ILIOS_SECRET)%'
+    http_method_override: true
+    #csrf_protection: true
 
-  # Enables session support. Note that the session will ONLY be started if you read or write from it.
-  # Remove or comment this section to explicitly disable session support.
-  session:
-    handler_id: ~
-    cookie_secure: auto
-    cookie_samesite: lax
+    # Enables session support. Note that the session will ONLY be started if you read or write from it.
+    # Remove or comment this section to explicitly disable session support.
+    session:
+        handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax
 
-  php_errors:
-    log: true
+    #esi: true
+    #fragments: true
+    php_errors:
+        log: true
+
+
+

--- a/config/packages/prod/doctrine.yaml
+++ b/config/packages/prod/doctrine.yaml
@@ -1,31 +1,18 @@
 doctrine:
     dbal:
-        url: '%env(ILIOS_DATABASE_URL)%'
+        url: '%env(resolve:ILIOS_DATABASE_URL)%'
         driver:   'pdo_mysql'
-        server_version: '%env(ILIOS_DATABASE_MYSQL_VERSION)%'
     orm:
         auto_generate_proxy_classes: false
         metadata_cache_driver:
-            type: service
-            id: doctrine.system_cache_provider
+            type: pool
+            pool: doctrine.system_cache_pool
         query_cache_driver:
-            type: service
-            id: doctrine.system_cache_provider
+            type: pool
+            pool: doctrine.system_cache_pool
         result_cache_driver:
-            type: service
-            id: doctrine.result_cache_provider
-
-services:
-    doctrine.result_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
-        public: false
-        arguments:
-            - '@doctrine.result_cache_pool'
-    doctrine.system_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
-        public: false
-        arguments:
-            - '@doctrine.system_cache_pool'
+            type: pool
+            pool: doctrine.result_cache_pool
 
 framework:
     cache:

--- a/config/packages/prod/framework.yaml
+++ b/config/packages/prod/framework.yaml
@@ -1,0 +1,2 @@
+framework:
+  error_controller:  App\Controller\ExceptionController

--- a/config/packages/prod/routing.yaml
+++ b/config/packages/prod/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        strict_requirements: null

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -1,4 +1,3 @@
 framework:
     router:
-        strict_requirements: ~
         utf8: true

--- a/config/packages/security_checker.yaml
+++ b/config/packages/security_checker.yaml
@@ -3,6 +3,6 @@ services:
         autowire: true
         autoconfigure: true
 
-    SensioLabs\Security\SecurityChecker: ~
+    SensioLabs\Security\SecurityChecker: null
 
-    SensioLabs\Security\Command\SecurityCheckerCommand: ~
+    SensioLabs\Security\Command\SecurityCheckerCommand: null

--- a/config/packages/swiftmailer.yaml
+++ b/config/packages/swiftmailer.yaml
@@ -1,6 +1,3 @@
-parameters:
-    env(ILIOS_MAILER_URL):
-
 swiftmailer:
     url: '%env(ILIOS_MAILER_URL)%'
     spool: { type: 'memory' }

--- a/config/packages/test/twig.yaml
+++ b/config/packages/test/twig.yaml
@@ -1,0 +1,2 @@
+twig:
+    strict_variables: true

--- a/config/packages/test/validator.yaml
+++ b/config/packages/test/validator.yaml
@@ -1,3 +1,3 @@
 framework:
     validation:
-        not_compromised_password: true
+        not_compromised_password: false

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -2,6 +2,6 @@ twig:
     default_path: '%kernel.project_dir%/templates'
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
-    exception_controller:  App\Controller\ExceptionController::showAction
+    exception_controller:  null
     paths:
         '%kernel.project_dir%/custom/templates': ~

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,5 +1,3 @@
-framework:
-
 twig:
     default_path: '%kernel.project_dir%/templates'
     debug: '%kernel.debug%'

--- a/config/packages/validator.yaml
+++ b/config/packages/validator.yaml
@@ -4,5 +4,5 @@ framework:
 
         # Enables validator auto-mapping support.
         # For instance, basic validation constraints will be inferred from Doctrine's metadata.
-#        auto_mapping:
-#            App\Entity\: []
+        #auto_mapping:
+        #    App\Entity\: []

--- a/config/routes/dev/framework.yaml
+++ b/config/routes/dev/framework.yaml
@@ -1,0 +1,3 @@
+_errors:
+    resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+    prefix: /_error

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         environment:
             - APP_ENV=dev
             - APP_DEBUG=true
-            - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios
+            - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
             - ILIOS_REQUIRE_SECURE_CONNECTION=false
             - ILIOS_ERROR_CAPTURE_ENABLED=false
             - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch

--- a/docs/env_vars_and_config.md
+++ b/docs/env_vars_and_config.md
@@ -13,11 +13,8 @@ APP_ENV=prod
 # The authentication should be set to whichever type of user authentication you use (`form`,`cas`,`shibboleth`,`ldap`):
 ILIOS_AUTHENTICATION_TYPE=form
 
-# The database connection settings, in url format (eg, mysql://{username}:{password}@{database-hostname}/{database_name}:
-ILIOS_DATABASE_URL="mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db"
-
-# The version of the MySQL database server you are using:
-ILIOS_DATABASE_MYSQL_VERSION=5.7
+# The database connection settings, in url format (eg, mysql://{username}:{password}@{database-hostname}/{database_name}?serverVersion={version}:
+ILIOS_DATABASE_URL="mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=5.7"
 
 # The locale of the Ilios instance (which language to use: `en`,`fr`,`es`):
 ILIOS_LOCALE=en

--- a/docs/env_vars_and_config.md
+++ b/docs/env_vars_and_config.md
@@ -55,8 +55,7 @@ HOME=/home/ilios_user
 ILIOS_MAILER_URL=smtp://smtp-relay.example.com:25?encryption=ssl&auth_mode=login&username=ilios_mail_user&password=Passw0rd
 ILIOS_AUTHENTICATION_TYPE=form
 ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials
-ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db
-ILIOS_DATABASE_MYSQL_VERSION=5.7
+ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=5.7
 ILIOS_LOCALE=en
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt
 APP_ENV=prod
@@ -81,8 +80,7 @@ export APP_ENV=prod
 export ILIOS_MAILER_URL=smtp://smtp-relay.example.com:25?encryption=ssl&auth_mode=login&username=ilios_mail_user&password=Passw0rd
 export ILIOS_AUTHENTICATION_TYPE=form
 export ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials
-export ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db
-export ILIOS_DATABASE_MYSQL_VERSION=5.7
+export ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=5.7
 export ILIOS_LOCALE=en
 export ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt
 ```
@@ -100,8 +98,7 @@ APP_ENV=prod
 ILIOS_MAILER_URL=smtp://smtp-relay.example.com:25?encryption=ssl&auth_mode=login&username=ilios_mail_user&password=Passw0rd
 ILIOS_AUTHENTICATION_TYPE=form
 ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials
-ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db
-ILIOS_DATABASE_MYSQL_VERSION=5.7
+ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=5.7
 ILIOS_LOCALE=en
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt
 
@@ -116,7 +113,7 @@ Note that doing it this way will only set the ENV variables for the duration of 
 While it is technically possible to set all of the ENV vars at the command line on the same line when you run the `bin/setup` command, we do not recommend this approach.  However, if you choose to do so, it would look something like this:
 
 ```bash
-APP_ENV=prod ILIOS_MAILER_URL=smtp://smtp-relay.example.com:25?encryption=ssl&auth_mode=login&username=ilios_mail_user&password=Passw0rd ILIOS_AUTHENTICATION_TYPE=form ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db ILIOS_DATABASE_MYSQL_VERSION=5.7 ILIOS_LOCALE=en ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt bin/setup
+APP_ENV=prod ILIOS_MAILER_URL=smtp://smtp-relay.example.com:25?encryption=ssl&auth_mode=login&username=ilios_mail_user&password=Passw0rd ILIOS_AUTHENTICATION_TYPE=form ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=5.7 ILIOS_LOCALE=en ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt bin/setup
 ```
 Furthermore, as was the case in Example #2, the ENV vars set in this way only persist for the duration of the execution of the command being run.
   
@@ -133,8 +130,7 @@ APP_ENV=prod
 ILIOS_MAILER_URL=smtp://smtp-relay.example.com:25?encryption=ssl&auth_mode=login&username=ilios_mail_user&password=Passw0rd
 ILIOS_AUTHENTICATION_TYPE=form
 ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials
-ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db
-ILIOS_DATABASE_MYSQL_VERSION=5.7
+ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=5.7
 ILIOS_LOCALE=en
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt
 ``` 
@@ -144,8 +140,7 @@ ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt
 In order to set runtime environment variables within the Apache httpd web service configuration itself, you will need to enable the `mod_env` Apache module and set the `SetEnv` directives in the appropriate section(s) of your httpd configuration files as shown:
 
 ```
-SetEnv ILIOS_DATABASE_URL mysql://ilios_db_user:Pa$$w0rd@db-host1/ilios_db
-SetEnv ILIOS_DATABASE_MYSQL_VERSION 5.7
+SetEnv ILIOS_DATABASE_URL mysql://ilios_db_user:Pa$$w0rd@db-host1/ilios_db?serverVersion=5.7
 SetEnv ILIOS_DATABASE_PORT 3306
 SetEnv ILIOS_MAILER_URL smtp://smtp-relay.example.com:25?encryption=ssl&auth_mode=login&username=ilios_mail_user&password=Passw0rd
 SetEnv ILIOS_LOCALE en
@@ -156,14 +151,13 @@ SetEnv ILIOS_SECRET ThisTokenIsNotSoSecretChangeIt
 If you are running more than one Ilios instance (eg, production and staging instances) on a single Apache httpd server using multiple VirtualHost configurations, certain variables will collide (eg, `ILIOS_DATABASE_URL`), so these will need to be set conditionally.  In order to do this, you will need to install/enable the `mod_setenvif` Apache module and set the 'SetEnvIf' directives in the appropriate section(s) of your httpd configuration files as shown.  Note that the values shared between the two instances are set using `SetEnv`, while the conditional values are set with `SetEnvIf` and require a specific condition to be true in order to be set.  
 
 ```
-SetEnv ILIOS_DATABASE_MYSQL_VERSION 5.7
 SetEnv ILIOS_MAILER_URL smtp://smtp-relay.example.com:25?encryption=ssl&auth_mode=login&username=ilios_mail_user&password=Passw0rd
 SetEnv ILIOS_LOCALE en
 
-SetEnvIf Host "ilios-staging\.example\.com" ILIOS_DATABASE_URL=SetEnv ILIOS_DATABASE_URL mysql://ilios_staging_db_user:Stag1ngPassw0rd@db-host1/ilios_stage_db
+SetEnvIf Host "ilios-staging\.example\.com" ILIOS_DATABASE_URL=SetEnv ILIOS_DATABASE_URL mysql://ilios_staging_db_user:Stag1ngPassw0rd@db-host1/ilios_stage_db?serverVersion=5.7
 SetEnvIf Host "ilios-staging\.example\.com ILIOS_SECRET=ST@G1nGS3CRET12345
 
-SetEnvIf Host "ilios-production\.example\.com" ILIOS_DATABASE_URL=mysql://ilios_production_db_user:Pr0duct10nPassw0rd@/db-host1/ilios_production_db
+SetEnvIf Host "ilios-production\.example\.com" ILIOS_DATABASE_URL=mysql://ilios_production_db_user:Pr0duct10nPassw0rd@/db-host1/ilios_production_db?serverVersion=5.7
 SetEnvIf Host "ilios-production\.example\.com ILIOS_SECRET=PR0DUCT10nS3CRET12345
 ```
 
@@ -185,7 +179,6 @@ If you are missing anything, the output will let you know by returning a message
 FAIL ENV variables:
 Missing:
 ILIOS_DATABASE_URL
-ILIOS_DATABASE_MYSQL_VERSION
 ILIOS_MAILER_URL
 ILIOS_LOCALE
 ILIOS_SECRET
@@ -254,8 +247,7 @@ APP_ENV=prod
 ILIOS_MAILER_URL=smtp://smtp-relay.example.com:25
 ILIOS_AUTHENTICATION_TYPE=form
 ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials
-ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db
-ILIOS_DATABASE_MYSQL_VERSION=5.7
+ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=5.7
 ILIOS_LOCALE=en
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt
 ```

--- a/docs/update.md
+++ b/docs/update.md
@@ -50,6 +50,12 @@ sudo -u apache bin/console doctrine:migrations:migrate --env=prod --no-interacti
 
 ## Version-specific steps
 
+### Upgrading to Ilios 3.71.0
+
+1. The `ILIOS_DATABASE_MYSQL_VERSION` parameter has been removed, instead the MySQL version should be specified in the `ILIOS_DATABASE_URL`
+as `?serverVersion=5.7`. for example 
+`ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7`.
+
 ### Upgrading to Ilios 3.69.1
 
 1. A new asynchronous queue service has been added. You must run `bin/console messenger:setup-transports` to set it up.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="bin/.phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="config/bootstrap.php"
 >
     <php>
+        <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
     </php>
 
     <testsuites>
-        <testsuite name="Ilios Test Suite">
+        <testsuite name="Ilios">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -27,12 +27,12 @@ DirectoryIndex index.php
     # work in environments without path prefix as well, providing a safe, one-size
     # fits all solution. But as you do not need it in this case, you can comment
     # the following 2 lines to eliminate the overhead.
-    RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.*)::\2$
-    RewriteRule ^(.*) - [E=BASE:%1]
+    RewriteCond %{REQUEST_URI}::$0 ^(/.+)/(.*)::\2$
+    RewriteRule .* - [E=BASE:%1]
 
     # Sets the HTTP_AUTHORIZATION header removed by Apache
-    RewriteCond %{HTTP:Authorization} .
-    RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    RewriteCond %{HTTP:Authorization} .+
+    RewriteRule ^ - [E=HTTP_AUTHORIZATION:%0]
 
     # Redirect to URI without front controller to prevent duplicate content
     # (with and without `/index.php`). Only do this redirect on the initial
@@ -45,15 +45,13 @@ DirectoryIndex index.php
     # - disable this feature by commenting the following 2 lines or
     # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
     #   following RewriteCond (best solution)
-    RewriteCond %{ENV:REDIRECT_STATUS} ^$
+    RewriteCond %{ENV:REDIRECT_STATUS} =""
     RewriteRule ^index\.php(?:/(.*)|$) %{ENV:BASE}/$1 [R=301,L]
 
     # If the requested filename exists, simply serve it.
     # We only want to let Apache serve files and not directories.
-    RewriteCond %{REQUEST_FILENAME} -f
-    RewriteRule ^ - [L]
-
     # Rewrite all other queries to the front controller.
+    RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ %{ENV:BASE}/index.php [L]
 </IfModule>
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,7 @@
 <?php
 
 use App\Kernel;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
 require dirname(__DIR__).'/config/bootstrap.php';

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -34,11 +34,12 @@ class Kernel extends BaseKernel
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $container->addResource(new FileResource($this->getProjectDir() . '/config/bundles.php'));
-        $container->setParameter('container.dumper.inline_class_loader', true);
+        $container->setParameter('container.dumper.inline_class_loader', \PHP_VERSION_ID < 70400 || $this->debug);
+        $container->setParameter('container.dumper.inline_factories', true);
         $confDir = $this->getProjectDir() . '/config';
 
         $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{packages}/' . $this->environment . '/**/*' . self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir . '/{packages}/' . $this->environment . '/*' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');
     }
@@ -47,7 +48,7 @@ class Kernel extends BaseKernel
     {
         $confDir = $this->getProjectDir() . '/config';
 
-        $routes->import($confDir . '/{routes}/' . $this->environment . '/**/*' . self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
     }

--- a/src/Monitor/RequiredENV.php
+++ b/src/Monitor/RequiredENV.php
@@ -16,6 +16,7 @@ class RequiredENV implements CheckInterface
         'ILIOS_SECRET'
     ];
     private const INSTRUCTIONS_URL = 'https://github.com/ilios/ilios/blob/master/docs/env_vars_and_config.md';
+    private const UPDATE_URL = 'https://github.com/ilios/ilios/blob/master/docs/update.md';
 
     /**
      * Perform the actual check and return a ResultInterface
@@ -25,7 +26,7 @@ class RequiredENV implements CheckInterface
     public function check()
     {
         $missingVariables = array_filter(self::REQUIRED_ENV, function ($name) {
-            return !getenv($name);
+            return !getenv($name) && !isset($_ENV[$name]);
         });
 
         if (count($missingVariables)) {
@@ -33,6 +34,13 @@ class RequiredENV implements CheckInterface
 
             return new Failure(
                 "\nMissing:\n" . $missing . "\n For help see: \n " . self::INSTRUCTIONS_URL
+            );
+        }
+
+        if (getenv('ILIOS_DATABASE_MYSQL_VERSION') || isset($_ENV['ILIOS_DATABASE_MYSQL_VERSION'])) {
+            return new Failure(
+                "\nILIOS_DATABASE_MYSQL_VERSION should be migrated. See \n " . self::UPDATE_URL .
+                " for details.\n"
             );
         }
         return new Success('All required ENV variables are setup');

--- a/src/Monitor/RequiredENV.php
+++ b/src/Monitor/RequiredENV.php
@@ -11,7 +11,6 @@ class RequiredENV implements CheckInterface
 {
     private const REQUIRED_ENV = [
         'ILIOS_DATABASE_URL',
-        'ILIOS_DATABASE_MYSQL_VERSION',
         'ILIOS_MAILER_URL',
         'ILIOS_LOCALE',
         'ILIOS_SECRET'

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,6 +1,6 @@
 {
     "aws/aws-sdk-php": {
-        "version": "3.99.1"
+        "version": "3.130.3"
     },
     "clue/stream-filter": {
         "version": "v1.4.1"
@@ -21,27 +21,27 @@
         ]
     },
     "doctrine/cache": {
-        "version": "v1.8.0"
+        "version": "1.10.0"
     },
     "doctrine/collections": {
-        "version": "v1.6.1"
+        "version": "1.6.4"
     },
     "doctrine/common": {
-        "version": "v2.10.0"
+        "version": "v2.11.0"
     },
     "doctrine/data-fixtures": {
-        "version": "v1.3.1"
+        "version": "1.4.0"
     },
     "doctrine/dbal": {
-        "version": "v2.9.2"
+        "version": "v2.10.1"
     },
     "doctrine/doctrine-bundle": {
-        "version": "1.6",
+        "version": "2.0",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "1.6",
-            "ref": "02bc9e7994b70f4fda004131a0c78b7b1bf09789"
+            "version": "2.0",
+            "ref": "a9f2463b9f73efe74482f831f03a204a41328555"
         },
         "files": [
             "config/packages/doctrine.yaml",
@@ -76,25 +76,25 @@
         ]
     },
     "doctrine/event-manager": {
-        "version": "v1.0.0"
+        "version": "1.1.0"
     },
     "doctrine/inflector": {
-        "version": "v1.3.0"
+        "version": "1.3.1"
     },
     "doctrine/instantiator": {
-        "version": "1.2.0"
+        "version": "1.3.0"
     },
     "doctrine/lexer": {
-        "version": "v1.0.1"
+        "version": "1.2.0"
     },
     "doctrine/migrations": {
-        "version": "v1.8.1"
+        "version": "2.2.0"
     },
     "doctrine/orm": {
-        "version": "v2.6.3"
+        "version": "v2.7.0"
     },
     "doctrine/persistence": {
-        "version": "1.1.1"
+        "version": "1.3.3"
     },
     "doctrine/reflection": {
         "version": "v1.0.0"
@@ -115,13 +115,13 @@
         ]
     },
     "egulias/email-validator": {
-        "version": "2.1.8"
+        "version": "2.1.13"
     },
     "elasticsearch/elasticsearch": {
-        "version": "v6.7.1"
+        "version": "v7.5.0"
     },
     "eluceo/ical": {
-        "version": "0.15.0"
+        "version": "0.16.0"
     },
     "exercise/htmlpurifier-bundle": {
         "version": "0.2",
@@ -136,22 +136,22 @@
         ]
     },
     "ezyang/htmlpurifier": {
-        "version": "v4.10.0"
+        "version": "v4.12.0"
     },
     "firebase/php-jwt": {
         "version": "v5.0.0"
     },
     "fzaninotto/faker": {
-        "version": "v1.8.0"
+        "version": "v1.9.1"
     },
     "guzzlehttp/guzzle": {
-        "version": "6.3.3"
+        "version": "6.5.2"
     },
     "guzzlehttp/promises": {
         "version": "v1.3.1"
     },
     "guzzlehttp/psr7": {
-        "version": "1.5.2"
+        "version": "1.6.1"
     },
     "guzzlehttp/ringphp": {
         "version": "1.1.1"
@@ -169,7 +169,7 @@
         "version": "v2.0.1"
     },
     "jaybizzle/crawler-detect": {
-        "version": "v1.2.84"
+        "version": "v1.2.90"
     },
     "jdorn/sql-formatter": {
         "version": "v1.2.17"
@@ -178,10 +178,10 @@
         "version": "1.2"
     },
     "league/flysystem": {
-        "version": "1.0.52"
+        "version": "1.0.63"
     },
     "league/flysystem-aws-s3-v3": {
-        "version": "1.0.22"
+        "version": "1.0.23"
     },
     "league/flysystem-cached-adapter": {
         "version": "1.0.9"
@@ -202,16 +202,16 @@
         ]
     },
     "liip/test-fixtures-bundle": {
-        "version": "1.0.0-rc1"
+        "version": "1.6.0"
     },
     "mockery/mockery": {
-        "version": "1.2.0"
+        "version": "1.3.1"
     },
     "monolog/monolog": {
-        "version": "1.24.0"
+        "version": "1.25.3"
     },
     "mtdowling/jmespath.php": {
-        "version": "2.4.0"
+        "version": "2.5.0"
     },
     "nelmio/cors-bundle": {
         "version": "1.5",
@@ -219,32 +219,35 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "1.5",
-            "ref": "f0436fc35fca88eada758311f8de43bfb61f1980"
+            "ref": "6388de23860284db9acce0a7a5d9d13153bcb571"
         },
         "files": [
             "config/packages/nelmio_cors.yaml"
         ]
     },
+    "ocramius/package-versions": {
+        "version": "1.5.1"
+    },
     "ocramius/proxy-manager": {
-        "version": "2.2.2"
+        "version": "2.2.3"
     },
     "php": {
         "version": "7.3.0"
     },
     "php-http/client-common": {
-        "version": "1.9.1"
+        "version": "2.1.0"
+    },
+    "php-http/curl-client": {
+        "version": "2.1.0"
     },
     "php-http/discovery": {
-        "version": "1.6.1"
-    },
-    "php-http/guzzle6-adapter": {
-        "version": "v2.0.1"
+        "version": "1.7.4"
     },
     "php-http/httplug": {
-        "version": "v1.1.0"
+        "version": "2.1.0"
     },
     "php-http/message": {
-        "version": "1.7.2"
+        "version": "1.8.0"
     },
     "php-http/message-factory": {
         "version": "v1.0.2"
@@ -253,13 +256,13 @@
         "version": "v1.0.0"
     },
     "phpdocumentor/reflection-common": {
-        "version": "1.0.1"
+        "version": "2.0.0"
     },
     "phpdocumentor/reflection-docblock": {
-        "version": "4.3.1"
+        "version": "4.3.4"
     },
     "phpdocumentor/type-resolver": {
-        "version": "0.4.0"
+        "version": "1.0.1"
     },
     "psr/cache": {
         "version": "1.0.1"
@@ -280,10 +283,13 @@
         "version": "1.0.0"
     },
     "psr/log": {
-        "version": "1.1.0"
+        "version": "1.1.2"
     },
     "ralouphie/getallheaders": {
-        "version": "2.0.5"
+        "version": "3.0.3"
+    },
+    "ramsey/uuid": {
+        "version": "3.9.2"
     },
     "react/promise": {
         "version": "v2.7.1"
@@ -306,7 +312,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.0",
-            "ref": "05daf6b214e54aed4089f3480f944a67ac3a7889"
+            "ref": "160c9b600564faa1224e8f387d49ef13ceb8b793"
         },
         "files": [
             "config/packages/security_checker.yaml"
@@ -316,7 +322,7 @@
         "version": "2.0.4"
     },
     "sentry/sentry": {
-        "version": "2.1.0"
+        "version": "2.2.6"
     },
     "squizlabs/php_codesniffer": {
         "version": "3.0",
@@ -331,10 +337,10 @@
         ]
     },
     "swagger-api/swagger-ui": {
-        "version": "v3.22.2"
+        "version": "v3.24.3"
     },
     "swiftmailer/swiftmailer": {
-        "version": "v6.2.1"
+        "version": "v6.2.3"
     },
     "symfony/apache-pack": {
         "version": "1.0",
@@ -342,34 +348,34 @@
             "repo": "github.com/symfony/recipes-contrib",
             "branch": "master",
             "version": "1.0",
-            "ref": "c82bead70f9a4f656354a193df7bf0ca2114efa0"
+            "ref": "410b9325a37ef86f1e47262c61738f6202202bca"
         },
         "files": [
             "public/.htaccess"
         ]
     },
     "symfony/asset": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/browser-kit": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/cache": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/cache-contracts": {
-        "version": "v1.1.1"
+        "version": "v2.0.1"
     },
     "symfony/config": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/console": {
-        "version": "3.3",
+        "version": "4.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "3.3",
-            "ref": "482d233eb8de91ebd042992077bbd5838858890c"
+            "version": "4.4",
+            "ref": "fead3ab2e80622c61d13dac0d21a3430a45efae8"
         },
         "files": [
             "bin/console",
@@ -377,10 +383,10 @@
         ]
     },
     "symfony/css-selector": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/debug": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/debug-bundle": {
         "version": "4.1",
@@ -398,31 +404,31 @@
         "version": "v1.0.7"
     },
     "symfony/dependency-injection": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/doctrine-bridge": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/dom-crawler": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/dotenv": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/error-handler": {
-        "version": "v4.4.1"
+        "version": "v4.4.2"
     },
     "symfony/event-dispatcher": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/event-dispatcher-contracts": {
-        "version": "v1.1.1"
+        "version": "v1.1.7"
     },
     "symfony/filesystem": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/finder": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/flex": {
         "version": "1.0",
@@ -430,25 +436,26 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "1.0",
-            "ref": "dc3fc2e0334a4137c47cfd5a3ececc601fa61a0b"
+            "ref": "c0eeb50665f0f77226616b6038a9b06c03752d8e"
         },
         "files": [
             ".env"
         ]
     },
     "symfony/framework-bundle": {
-        "version": "4.2",
+        "version": "4.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "4.2",
-            "ref": "f64037a414de7d861f68e9b5b5c0e4f7425e2002"
+            "version": "4.4",
+            "ref": "23ecaccc551fe2f74baf613811ae529eb07762fa"
         },
         "files": [
             "config/bootstrap.php",
             "config/packages/cache.yaml",
             "config/packages/framework.yaml",
             "config/packages/test/framework.yaml",
+            "config/routes/dev/framework.yaml",
             "config/services.yaml",
             "public/index.php",
             "src/Controller/.gitignore",
@@ -456,22 +463,22 @@
         ]
     },
     "symfony/http-client": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/http-client-contracts": {
-        "version": "v1.1.1"
+        "version": "v2.0.1"
     },
     "symfony/http-foundation": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/http-kernel": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/inflector": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/lock": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/messenger": {
         "version": "4.3",
@@ -486,10 +493,10 @@
         ]
     },
     "symfony/mime": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/monolog-bridge": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/monolog-bundle": {
         "version": "3.3",
@@ -506,10 +513,10 @@
         ]
     },
     "symfony/options-resolver": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/orm-pack": {
-        "version": "v1.0.5"
+        "version": "v1.0.7"
     },
     "symfony/phpunit-bridge": {
         "version": "4.3",
@@ -517,7 +524,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.3",
-            "ref": "04ecbfb3121b7418265aee7b1b2151959ba430b9"
+            "ref": "170be6250b77b421f02e986e2853df86c7bd6516"
         },
         "files": [
             ".env.test",
@@ -528,28 +535,28 @@
         ]
     },
     "symfony/polyfill-intl-idn": {
-        "version": "v1.11.0"
+        "version": "v1.13.1"
     },
     "symfony/polyfill-mbstring": {
-        "version": "v1.11.0"
+        "version": "v1.13.1"
     },
     "symfony/polyfill-php72": {
-        "version": "v1.11.0"
+        "version": "v1.13.1"
     },
     "symfony/polyfill-php73": {
-        "version": "v1.11.0"
-    },
-    "symfony/polyfill-uuid": {
         "version": "v1.13.1"
+    },
+    "symfony/process": {
+        "version": "v4.4.2"
     },
     "symfony/profiler-pack": {
         "version": "v1.0.4"
     },
     "symfony/property-access": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/property-info": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/requirements-checker": {
         "version": "1.0",
@@ -566,50 +573,49 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.2",
-            "ref": "5374e24d508ba8fd6ba9eb15170255fdb778316a"
+            "ref": "683dcb08707ba8d41b7e34adb0344bfd68d248a7"
         },
         "files": [
-            "config/packages/dev/routing.yaml",
+            "config/packages/prod/routing.yaml",
             "config/packages/routing.yaml",
-            "config/packages/test/routing.yaml",
             "config/routes.yaml"
         ]
     },
     "symfony/security-bundle": {
-        "version": "3.3",
+        "version": "4.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "3.3",
-            "ref": "9a2034eca6d83d9cda632014e06995b8d9d9fd09"
+            "version": "4.4",
+            "ref": "30efd98dd3b4ead6e9ad4713b1efc43bbe94bf77"
         },
         "files": [
             "config/packages/security.yaml"
         ]
     },
     "symfony/security-core": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/security-csrf": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/security-guard": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/security-http": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/serializer": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/serializer-pack": {
         "version": "v1.0.2"
     },
     "symfony/service-contracts": {
-        "version": "v1.1.2"
+        "version": "v2.0.1"
     },
     "symfony/stopwatch": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/swiftmailer-bundle": {
         "version": "2.5",
@@ -617,7 +623,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "2.5",
-            "ref": "3db029c03e452b4a23f7fc45cec7c922c2247eb8"
+            "ref": "ae4d22af30bbd484506bc1817c5a3ef72c855b93"
         },
         "files": [
             "config/packages/dev/swiftmailer.yaml",
@@ -626,25 +632,25 @@
         ]
     },
     "symfony/test-pack": {
-        "version": "v1.0.5"
+        "version": "v1.0.6"
     },
     "symfony/translation-contracts": {
-        "version": "v1.1.2"
+        "version": "v2.0.1"
     },
     "symfony/twig-bridge": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/twig-bundle": {
-        "version": "3.3",
+        "version": "4.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "3.3",
-            "ref": "369b5b29dc52b2c190002825ae7ec24ab6f962dd"
+            "version": "4.4",
+            "ref": "15a41bbd66a1323d09824a189b485c126bbefa51"
         },
         "files": [
+            "config/packages/test/twig.yaml",
             "config/packages/twig.yaml",
-            "config/routes/dev/twig.yaml",
             "templates/base.html.twig"
         ]
     },
@@ -654,7 +660,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.3",
-            "ref": "48a8e5ef925e82aa7d665c887cd1fa60f8b7921d"
+            "ref": "d902da3e4952f18d3bf05aab29512eb61cabd869"
         },
         "files": [
             "config/packages/test/validator.yaml",
@@ -662,13 +668,13 @@
         ]
     },
     "symfony/var-dumper": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/var-exporter": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/web-link": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "symfony/web-profiler-bundle": {
         "version": "3.3",
@@ -685,21 +691,24 @@
         ]
     },
     "symfony/yaml": {
-        "version": "v4.3.0"
+        "version": "v4.4.2"
     },
     "twig/twig": {
-        "version": "v2.11.1"
+        "version": "v3.0.1"
     },
     "webmozart/assert": {
-        "version": "1.4.0"
+        "version": "1.6.0"
     },
     "zendframework/zend-code": {
-        "version": "3.3.1"
+        "version": "3.4.1"
+    },
+    "zendframework/zend-diactoros": {
+        "version": "2.2.1"
     },
     "zendframework/zend-eventmanager": {
         "version": "3.2.1"
     },
     "zendframework/zenddiagnostics": {
-        "version": "v1.5.0"
+        "version": "v1.6.0"
     }
 }

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -390,7 +390,7 @@ class CourseTest extends ReadWriteEndpointTest
         $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
         $data = json_decode($response->getContent(), true);
-        $this->assertContains('Courses cannot be rolled over to a new year before', $data['message']);
+        $this->assertContains('Courses cannot be rolled over to a new year before', $data['detail']);
     }
 
     public function testRolloverIlmSessions()


### PR DESCRIPTION
This complements #2736 and updates all of our flex configuration to the new Symfony defaults except in areas where we have customized the configuration to meet our specific needs.

It includes a breaking change to the way the database version is provided. It is now included in the `ILIOS_DATABASE_URL` parameter. I've added migration directions to that effect.