### PR TITLE
Return an exit code from every command

### DIFF
--- a/src/Command/AddDirectoryUserCommand.php
+++ b/src/Command/AddDirectoryUserCommand.php
@@ -148,5 +148,7 @@ class AddDirectoryUserCommand extends Command
         } else {
             $output->writeln('<comment>Canceled.</comment>');
         }
+
+        return 0;
     }
 }

--- a/src/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Command/AddNewStudentsToSchoolCommand.php
@@ -196,8 +196,12 @@ class AddNewStudentsToSchoolCommand extends Command
                     ' created.</info>'
                 );
             }
+
+            return 0;
         } else {
             $output->writeln('<comment>Update canceled.</comment>');
+
+            return 1;
         }
     }
 }

--- a/src/Command/AddRootUserCommand.php
+++ b/src/Command/AddRootUserCommand.php
@@ -62,5 +62,7 @@ class AddRootUserCommand extends Command
         $user->setRoot(true);
         $this->userManager->update($user, true, true);
         $output->writeln("User with id #{$userId} has been granted root-level privileges.");
+
+        return 0;
     }
 }

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -108,7 +108,6 @@ class AddUserCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
         $schoolId = $input->getOption('schoolId');
         if (!$schoolId) {
             $schoolTitles = [];
@@ -213,8 +212,11 @@ class AddUserCommand extends Command
             $output->writeln(
                 '<info>Success! New user #' . $user->getId() . ' ' . $user->getFirstAndLastName() . ' created.</info>'
             );
+            return 0;
         } else {
             $output->writeln('<comment>Canceled.</comment>');
+
+            return 1;
         }
     }
 

--- a/src/Command/AuditLogExportCommand.php
+++ b/src/Command/AuditLogExportCommand.php
@@ -77,7 +77,6 @@ class AuditLogExportCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
         $from = $input->getArgument('from');
         $to = $input->getArgument('to');
 
@@ -130,5 +129,7 @@ class AuditLogExportCommand extends Command
         }
 
         $this->logger->info('Finished Audit Log Export.');
+
+        return 0;
     }
 }

--- a/src/Command/ChangePasswordCommand.php
+++ b/src/Command/ChangePasswordCommand.php
@@ -110,5 +110,7 @@ class ChangePasswordCommand extends Command
         $this->authenticationManager->update($authentication);
 
         $output->writeln('<info>Password Changed.</info>');
+
+        return 0;
     }
 }

--- a/src/Command/ChangeUsernameCommand.php
+++ b/src/Command/ChangeUsernameCommand.php
@@ -92,5 +92,7 @@ class ChangeUsernameCommand extends Command
         $this->authenticationManager->update($authentication);
 
         $output->writeln('<info>Username Changed.</info>');
+
+        return 0;
     }
 }

--- a/src/Command/CheckS3PermissionsCommand.php
+++ b/src/Command/CheckS3PermissionsCommand.php
@@ -54,7 +54,7 @@ class CheckS3PermissionsCommand extends Command
 
         if (!$s3Url) {
             $output->writeln("<comment>No configuration found for storage_s3_url. Nothing to check.</comment>");
-            exit();
+            return 0;
         }
         try {
             $output->writeln("<info>Connecting to the filesystem and checking permissions.</info>");
@@ -62,7 +62,8 @@ class CheckS3PermissionsCommand extends Command
             $output->writeln("<info>All Systems Go!!</info>");
         } catch (IliosFilesystemException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
-            exit(1);
+
+            return 1;
         }
     }
 }

--- a/src/Command/CleanupS3FilesystemCacheCommand.php
+++ b/src/Command/CleanupS3FilesystemCacheCommand.php
@@ -60,7 +60,7 @@ class CleanupS3FilesystemCacheCommand extends Command
 
         if ($percentageFree > 30) {
             $output->writeln("<info>${percentageFree}% free space. Not cleaning up any files.</info>");
-            return;
+            return 0;
         }
         $output->writeln("<info>${percentageFree}% free space. Will cleanup old files...</info>");
         $contents = $this->filesystem->listContents(IliosFileSystem::HASHED_LM_DIRECTORY, true);
@@ -76,6 +76,8 @@ class CleanupS3FilesystemCacheCommand extends Command
         $output->writeln("<info>${deletedFiles} file(s) cleaned up!</info>");
         $percentageFree = $this->getFreeSpace();
         $output->writeln("<info>${percentageFree}% free space now.</info>");
+
+        return 0;
     }
 
     protected function getFreeSpace()

--- a/src/Command/CleanupStringsCommand.php
+++ b/src/Command/CleanupStringsCommand.php
@@ -138,6 +138,8 @@ class CleanupStringsCommand extends Command
         if ($input->getOption('session-description')) {
             $this->purifySessionDescription($output);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/CreateUserTokenCommand.php
+++ b/src/Command/CreateUserTokenCommand.php
@@ -79,5 +79,7 @@ class CreateUserTokenCommand extends Command
         
         $output->writeln('Success!');
         $output->writeln('Token ' . $jwt);
+
+        return 0;
     }
 }

--- a/src/Command/CrossingGuardCommand.php
+++ b/src/Command/CrossingGuardCommand.php
@@ -67,5 +67,7 @@ class CrossingGuardCommand extends Command
         $output->writeln('');
         $output->writeln("<info>${message} </info>");
         $output->writeln('');
+
+        return 0;
     }
 }

--- a/src/Command/FindUserCommand.php
+++ b/src/Command/FindUserCommand.php
@@ -72,5 +72,7 @@ class FindUserCommand extends Command
             ->setRows($rows)
         ;
         $table->render();
+
+        return 0;
     }
 }

--- a/src/Command/FixLearningMaterialMimeTypesCommand.php
+++ b/src/Command/FixLearningMaterialMimeTypesCommand.php
@@ -146,8 +146,12 @@ class FixLearningMaterialMimeTypesCommand extends Command
                     $output->writeln("<error>${message}</error>");
                 }
             }
+
+            return 0;
         } else {
             $output->writeln('<comment>Update canceled.</comment>');
+
+            return 1;
         }
     }
 

--- a/src/Command/GenerateCurriculumInventoryVerificationPreviewCommand.php
+++ b/src/Command/GenerateCurriculumInventoryVerificationPreviewCommand.php
@@ -87,6 +87,8 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
             $preview['all_events_with_assessments_tagged_as_formative_or_summative']
         );
         $this->printAllResourceTypesTable($output, $preview['all_resource_types']);
+
+        return 0;
     }
 
     /**

--- a/src/Command/GenerateEndpointTestCommand.php
+++ b/src/Command/GenerateEndpointTestCommand.php
@@ -115,6 +115,6 @@ class GenerateEndpointTestCommand extends Command
 
         print $content;
 
-        exit();
+        return 0;
     }
 }

--- a/src/Command/GenerateSwaggerApiDefinitionYamlCommand.php
+++ b/src/Command/GenerateSwaggerApiDefinitionYamlCommand.php
@@ -103,6 +103,6 @@ class GenerateSwaggerApiDefinitionYamlCommand extends Command
 
         print $content;
 
-        exit();
+        return 0;
     }
 }

--- a/src/Command/GenerateSwaggerApiPathYamlCommand.php
+++ b/src/Command/GenerateSwaggerApiPathYamlCommand.php
@@ -62,6 +62,6 @@ class GenerateSwaggerApiPathYamlCommand extends Command
 
         print $content;
 
-        exit();
+        return 0;
     }
 }

--- a/src/Command/ImportMeshUniverseCommand.php
+++ b/src/Command/ImportMeshUniverseCommand.php
@@ -137,6 +137,8 @@ class ImportMeshUniverseCommand extends Command
         $output->writeln('');
         $output->writeln("Finished MeSH universe import in ${duration} seconds.");
         $this->release();
+
+        return 0;
     }
 
     /**

--- a/src/Command/InstallFirstUserCommand.php
+++ b/src/Command/InstallFirstUserCommand.php
@@ -206,5 +206,7 @@ class InstallFirstUserCommand extends Command
         $output->writeln('A user account has been created.');
         $output->writeln(sprintf("You may now log in as '%s' with the password '%s'.", self::USERNAME, self::PASSWORD));
         $output->writeln('Please change this password as soon as possible.');
+
+        return 0;
     }
 }

--- a/src/Command/InvalidateUserTokenCommand.php
+++ b/src/Command/InvalidateUserTokenCommand.php
@@ -82,5 +82,7 @@ class InvalidateUserTokenCommand extends Command
             ' issued before Today at ' . $now->format('g:i:s A e') .
             ' have been invalidated.'
         );
+
+        return 0;
     }
 }

--- a/src/Command/ListConfigValuesCommand.php
+++ b/src/Command/ListConfigValuesCommand.php
@@ -92,5 +92,7 @@ class ListConfigValuesCommand extends Command
         $table->setHeaders(array('Name', 'Value'));
         $table->setRows($rows);
         $table->render();
+
+        return 0;
     }
 }

--- a/src/Command/ListRootUsersCommand.php
+++ b/src/Command/ListRootUsersCommand.php
@@ -51,7 +51,7 @@ class ListRootUsersCommand extends Command
 
         if (empty($users)) {
             $output->writeln("No users with root-level privileges found.");
-            return;
+            return 0;
         }
 
         $rows = array_map(function ($dto) {
@@ -71,5 +71,7 @@ class ListRootUsersCommand extends Command
             ->setRows($rows)
         ;
         $table->render();
+
+        return 0;
     }
 }

--- a/src/Command/ListSchoolConfigValuesCommand.php
+++ b/src/Command/ListSchoolConfigValuesCommand.php
@@ -84,5 +84,7 @@ class ListSchoolConfigValuesCommand extends Command
                 }, $configs));
             $table->render();
         }
+
+        return 0;
     }
 }

--- a/src/Command/MigrateIlios2LearningMaterialsCommand.php
+++ b/src/Command/MigrateIlios2LearningMaterialsCommand.php
@@ -128,5 +128,7 @@ class MigrateIlios2LearningMaterialsCommand extends Command
         } else {
             $output->writeln('<comment>Migration canceled.</comment>');
         }
+
+        return 0;
     }
 }

--- a/src/Command/PopulateIndexCommand.php
+++ b/src/Command/PopulateIndexCommand.php
@@ -95,6 +95,8 @@ class PopulateIndexCommand extends Command
 //        $this->populateLearningMaterials($output);
         $this->populateCourses($output);
         $this->populateMesh($output);
+
+        return 0;
     }
 
     protected function populateUsers(OutputInterface $output)

--- a/src/Command/RemoveRootUserCommand.php
+++ b/src/Command/RemoveRootUserCommand.php
@@ -62,5 +62,7 @@ class RemoveRootUserCommand extends Command
         $user->setRoot(false);
         $this->userManager->update($user, true, true);
         $output->writeln("Root-level privileges have been revoked from user with id #{$userId}.");
+
+        return 0;
     }
 }

--- a/src/Command/RolloverCourseCommand.php
+++ b/src/Command/RolloverCourseCommand.php
@@ -152,5 +152,7 @@ class RolloverCourseCommand extends Command
 
         //output message with the new courseId on success
         $output->writeln("This course has been rolled over. The new course id is {$newCourse->getId()}.");
+
+        return 0;
     }
 }

--- a/src/Command/RolloverCurriculumInventoryReportCommand.php
+++ b/src/Command/RolloverCurriculumInventoryReportCommand.php
@@ -96,5 +96,7 @@ class RolloverCurriculumInventoryReportCommand extends Command
 
         //output message with the new courseId on success
         $output->writeln("The given report has been rolled over. The new report id is {$newReport->getId()}.");
+
+        return 0;
     }
 }

--- a/src/Command/SendChangeAlertsCommand.php
+++ b/src/Command/SendChangeAlertsCommand.php
@@ -126,7 +126,7 @@ class SendChangeAlertsCommand extends Command
         $alerts = $this->alertManager->findBy(['dispatched' => false, 'tableName' => 'offering']);
         if (! count($alerts)) {
             $output->writeln("<info>No undispatched offering alerts found.</info>");
-            return;
+            return 0;
         }
 
         $templateCache = [];
@@ -232,6 +232,8 @@ class SendChangeAlertsCommand extends Command
             $output->writeln("<info>Sent {$sent} offering change alert notifications.</info>");
             $output->writeln("<info>Marked {$dispatched} offering change alerts as dispatched.</info>");
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/SendTeachingRemindersCommand.php
+++ b/src/Command/SendTeachingRemindersCommand.php
@@ -146,7 +146,7 @@ class SendTeachingRemindersCommand extends Command
             foreach ($errors as $error) {
                 $output->writeln("<error>{$error}</error>");
             }
-            return;
+            return 1;
         }
 
         $daysInAdvance = $input->getOption('days');
@@ -165,7 +165,7 @@ class SendTeachingRemindersCommand extends Command
 
         if ($offerings->isEmpty()) {
             $output->writeln('<info>No offerings with pending teaching reminders found.</info>');
-            return;
+            return 0;
         }
 
         // mail out a reminder per instructor per offering.
@@ -224,6 +224,8 @@ class SendTeachingRemindersCommand extends Command
         }
 
         $output->writeln("<info>Sent {$i} teaching reminders.</info>");
+
+        return 0;
     }
 
     /**

--- a/src/Command/SendTestEmailCommand.php
+++ b/src/Command/SendTestEmailCommand.php
@@ -63,5 +63,7 @@ class SendTestEmailCommand extends Command
             ->setContentType('text/plain')
             ->setBody('This is a test email from your ilios system.');
         $this->mailer->send($message);
+
+        return 0;
     }
 }

--- a/src/Command/SetConfigValueCommand.php
+++ b/src/Command/SetConfigValueCommand.php
@@ -73,5 +73,7 @@ class SetConfigValueCommand extends Command
         $this->applicationConfigManager->update($config, true);
 
         $output->writeln('<info>Done.</info>');
+
+        return 0;
     }
 }

--- a/src/Command/SetupAuthenticationCommand.php
+++ b/src/Command/SetupAuthenticationCommand.php
@@ -87,6 +87,8 @@ class SetupAuthenticationCommand extends Command
         $this->applicationConfigManager->flush();
 
         $output->writeln('<info>Authentication Setup Successfully!</info>');
+
+        return 0;
     }
 
     protected function setupForm(): array

--- a/src/Command/SyncAllUsersCommand.php
+++ b/src/Command/SyncAllUsersCommand.php
@@ -267,6 +267,8 @@ class SyncAllUsersCommand extends Command
             "<info>Completed sync process {$totalRecords} users found in the directory; " .
             "{$updated} users updated.</info>"
         );
+
+        return 0;
     }
 
     protected function validateDirectoryRecord(array $record, OutputInterface $output)

--- a/src/Command/SyncFormerStudentsCommand.php
+++ b/src/Command/SyncFormerStudentsCommand.php
@@ -128,8 +128,12 @@ class SyncFormerStudentsCommand extends Command
             $this->userRoleManager->update($formerStudentRole);
             
             $output->writeln('<info>Former students updated successfully!</info>');
+
+            return 0;
         } else {
             $output->writeln('<comment>Update canceled,</comment>');
+
+            return 1;
         }
     }
 }

--- a/src/Command/SyncUserCommand.php
+++ b/src/Command/SyncUserCommand.php
@@ -89,7 +89,7 @@ class SyncUserCommand extends Command
         
         if (!$userRecord) {
             $output->writeln('<error>Unable to find ' . $user->getCampusId() . ' in the directory.');
-            return;
+            return 1;
         }
         
         $table = new Table($output);
@@ -103,7 +103,7 @@ class SyncUserCommand extends Command
                 'Email',
                 'Phone Number'
             ])
-            ->setRows(array(
+            ->setRows([
                 [
                     'Ilios User',
                     $user->getCampusId(),
@@ -122,7 +122,7 @@ class SyncUserCommand extends Command
                     $userRecord['email'],
                     $userRecord['telephoneNumber']
                 ]
-            ))
+            ])
         ;
         $table->render();
         
@@ -156,8 +156,12 @@ class SyncUserCommand extends Command
             }
 
             $output->writeln('<info>User updated successfully!</info>');
+
+            return 0;
         } else {
             $output->writeln('<comment>Update canceled.</comment>');
+
+            return 1;
         }
     }
 }

--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -151,8 +151,12 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
             }
             $this->downloadAndExtractArchive($environment, $versionOverride);
             $output->writeln("<info>Frontend updated successfully${message}!</info>");
+
+            return 0;
         } catch (Exception $e) {
             $output->writeln("<error>No matching frontend found${message}!</error>");
+
+            return 1;
         }
     }
 

--- a/src/Command/ValidateLearningMaterialPathsCommand.php
+++ b/src/Command/ValidateLearningMaterialPathsCommand.php
@@ -101,6 +101,10 @@ class ValidateLearningMaterialPathsCommand extends Command
                 ->setRows($rows)
             ;
             $table->render();
+
+            return 1;
         }
+
+        return 0;
     }
 }


### PR DESCRIPTION
Not returning some kind of an int for commands is deprecated in Symfony
4.4 and will throw an exception in 5.0. In most cases we were returning
a void which I replaced with a 0 for success.