### PR TITLE
Clear validation deprecations

### DIFF
--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -76,7 +76,8 @@ class Alert implements AlertInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/AuditLog.php
+++ b/src/Entity/AuditLog.php
@@ -47,11 +47,10 @@ class AuditLog implements AuditLogInterface
     protected $action;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @ORM\Column(type="datetime")
      *
      * @Assert\NotBlank()
-     * @Assert\DateTime()
      *
      */
     protected $createdAt;
@@ -138,7 +137,7 @@ class AuditLog implements AuditLogInterface
     /**
      * Get createdAt
      *
-     * @return \DateTime
+     * @return DateTime
      */
     public function getCreatedAt()
     {
@@ -148,7 +147,7 @@ class AuditLog implements AuditLogInterface
     /**
      * {@inheritdoc}
      */
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setCreatedAt(DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
     }

--- a/src/Entity/Authentication.php
+++ b/src/Entity/Authentication.php
@@ -42,7 +42,8 @@ class Authentication implements AuthenticationInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 100
+     *      max = 100,
+     *     allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -57,7 +58,8 @@ class Authentication implements AuthenticationInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 64
+     *      max = 64,
+     *     allowEmptyString = true
      * )
      *
      */
@@ -70,7 +72,8 @@ class Authentication implements AuthenticationInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 64
+     *      max = 64,
+     *     allowEmptyString = true
      * )
      *
      */

--- a/src/Entity/Competency.php
+++ b/src/Entity/Competency.php
@@ -55,7 +55,8 @@ class Competency implements CompetencyInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 200
+     *      max = 200,
+     *     allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/Course.php
+++ b/src/Entity/Course.php
@@ -143,8 +143,9 @@ class Course implements CourseInterface
      *
      * @Assert\Type(type="string")
      * @Assert\Length(
-     *      min = 1,
-     *      max = 255
+     *     min = 1,
+     *     max = 255,
+     *     allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/CourseLearningMaterial.php
+++ b/src/Entity/CourseLearningMaterial.php
@@ -51,8 +51,9 @@ class CourseLearningMaterial implements CourseLearningMaterialInterface
      *
      * @Assert\Type(type="string")
      * @Assert\Length(
-     *      min = 1,
-     *      max = 65000
+     *     min = 1,
+     *     max = 65000,
+     *     allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/CurriculumInventoryAcademicLevel.php
+++ b/src/Entity/CurriculumInventoryAcademicLevel.php
@@ -77,8 +77,9 @@ class CurriculumInventoryAcademicLevel implements CurriculumInventoryAcademicLev
      *
      * @Assert\Type(type="string")
      * @Assert\Length(
-     *      min = 1,
-     *      max = 65000
+     *     min = 1,
+     *     max = 65000,
+     *     allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/CurriculumInventoryReport.php
+++ b/src/Entity/CurriculumInventoryReport.php
@@ -62,7 +62,8 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
     * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 200
+     *      max = 200,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -78,7 +79,8 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
     * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -186,7 +188,8 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 64
+     *      max = 64,
+     *      allowEmptyString = true
      * )
      */
     protected $token;

--- a/src/Entity/CurriculumInventorySequence.php
+++ b/src/Entity/CurriculumInventorySequence.php
@@ -65,7 +65,8 @@ class CurriculumInventorySequence implements CurriculumInventorySequenceInterfac
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/CurriculumInventorySequenceBlock.php
+++ b/src/Entity/CurriculumInventorySequenceBlock.php
@@ -67,7 +67,8 @@ class CurriculumInventorySequenceBlock implements CurriculumInventorySequenceBlo
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/IlmSession.php
+++ b/src/Entity/IlmSession.php
@@ -9,11 +9,11 @@ use App\Traits\LearnerGroupsEntity;
 use App\Traits\LearnersEntity;
 use App\Traits\SessionConsolidationEntity;
 use App\Annotation as IS;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Validator\Constraints as Assert;
 use App\Traits\IdentifiableEntity;
 use App\Traits\StringableIdEntity;
+use DateTime;
 
 /**
  * Class IlmSession
@@ -86,12 +86,11 @@ class IlmSession implements IlmSessionInterface
     protected $hours;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      *
      * @ORM\Column(name="due_date", type="datetime")
      *
      * @Assert\NotBlank()
-     * @Assert\DateTime()
      *
      * @IS\Expose
      * @IS\Type("dateTime")
@@ -202,15 +201,15 @@ class IlmSession implements IlmSessionInterface
     }
 
     /**
-     * @param \DateTime $dueDate
+     * @param DateTime $dueDate
      */
-    public function setDueDate(\DateTime $dueDate = null)
+    public function setDueDate(DateTime $dueDate = null)
     {
         $this->dueDate = $dueDate;
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime
      */
     public function getDueDate()
     {

--- a/src/Entity/LearnerGroup.php
+++ b/src/Entity/LearnerGroup.php
@@ -75,7 +75,8 @@ class LearnerGroup implements LearnerGroupInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 100
+     *      max = 100,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/LearningMaterial.php
+++ b/src/Entity/LearningMaterial.php
@@ -73,7 +73,8 @@ class LearningMaterial implements LearningMaterialInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -104,7 +105,8 @@ class LearningMaterial implements LearningMaterialInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 80
+     *      max = 80,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -120,7 +122,8 @@ class LearningMaterial implements LearningMaterialInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 64
+     *      max = 64,
+     *      allowEmptyString = true
      * )
      */
     protected $token;
@@ -205,7 +208,8 @@ class LearningMaterial implements LearningMaterialInterface
      * @Assert\Length(
      *      min = 1,
      *      max = 512,
-     *      groups={"citation"}
+     *      groups={"citation"},
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -250,7 +254,8 @@ class LearningMaterial implements LearningMaterialInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/MeshConcept.php
+++ b/src/Entity/MeshConcept.php
@@ -80,7 +80,8 @@ class MeshConcept implements MeshConceptInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -96,7 +97,8 @@ class MeshConcept implements MeshConceptInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 512
+     *      max = 512,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -112,7 +114,8 @@ class MeshConcept implements MeshConceptInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 30
+     *      max = 30,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/MeshDescriptor.php
+++ b/src/Entity/MeshDescriptor.php
@@ -45,7 +45,8 @@ class MeshDescriptor implements MeshDescriptorInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 12
+     *      max = 12,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -62,7 +63,8 @@ class MeshDescriptor implements MeshDescriptorInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 192
+     *      max = 192,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -78,7 +80,8 @@ class MeshDescriptor implements MeshDescriptorInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/MeshTerm.php
+++ b/src/Entity/MeshTerm.php
@@ -91,7 +91,8 @@ class MeshTerm implements MeshTermInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 12
+     *      max = 12,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/Offering.php
+++ b/src/Entity/Offering.php
@@ -79,7 +79,8 @@ class Offering implements OfferingInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 255
+     *      max = 255,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/Program.php
+++ b/src/Entity/Program.php
@@ -72,7 +72,8 @@ class Program implements ProgramInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 10
+     *      max = 10,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/Report.php
+++ b/src/Entity/Report.php
@@ -47,7 +47,8 @@ class Report implements ReportInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 240
+     *      max = 240,
+     *      allowEmptyString = true
      * )
      *
      *
@@ -107,7 +108,8 @@ class Report implements ReportInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 32
+     *      max = 32,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -123,7 +125,8 @@ class Report implements ReportInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 14
+     *      max = 14,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/School.php
+++ b/src/Entity/School.php
@@ -87,7 +87,8 @@ class School implements SchoolInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 8
+     *      max = 8,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/Session.php
+++ b/src/Entity/Session.php
@@ -174,7 +174,8 @@ class Session implements SessionInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/SessionDescription.php
+++ b/src/Entity/SessionDescription.php
@@ -69,7 +69,8 @@ class SessionDescription implements SessionDescriptionInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/SessionLearningMaterial.php
+++ b/src/Entity/SessionLearningMaterial.php
@@ -57,7 +57,8 @@ class SessionLearningMaterial implements SessionLearningMaterialInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -73,7 +73,8 @@ class Term implements TermInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 65000
+     *      max = 65000,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -96,7 +96,8 @@ class User implements UserInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 20
+     *      max = 20,
+     *      allowEmptyString = true
      * )
      * @IS\Expose
      * @IS\Type("string")
@@ -111,7 +112,8 @@ class User implements UserInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 200
+     *      max = 200,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -127,7 +129,8 @@ class User implements UserInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 30
+     *      max = 30,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -141,9 +144,7 @@ class User implements UserInterface
      * @ORM\Column(name="email", type="string", length=100)
      *
      * @Assert\Email
-     *
      * @Assert\NotBlank()
-     *
      * @Assert\Length(
      *      min = 1,
      *      max = 100
@@ -163,7 +164,8 @@ class User implements UserInterface
      *
      * @Assert\Length(
      *      min = 1,
-     *      max = 100
+     *      max = 100,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -205,7 +207,8 @@ class User implements UserInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 16
+     *      max = 16,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose
@@ -221,7 +224,8 @@ class User implements UserInterface
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 16
+     *      max = 16,
+     *      allowEmptyString = true
      * )
      *
      * @IS\Expose


### PR DESCRIPTION
Fixing two deprecations in our validations.

1) DateTime is going away
2) The way Length works with empty strings is changing in Symfony 5