### PR TITLE
Pass single attribute to authorization check

### DIFF
--- a/src/Controller/CoursesController.php
+++ b/src/Controller/CoursesController.php
@@ -108,7 +108,7 @@ class CoursesController extends ApiController
             throw new NotFoundHttpException(sprintf('The resource \'%s\' was not found.', $id));
         }
 
-        if (! $this->authorizationChecker->isGranted([AbstractVoter::EDIT], $course)) {
+        if (! $this->authorizationChecker->isGranted(AbstractVoter::EDIT, $course)) {
             throw $this->createAccessDeniedException('Unauthorized access!');
         }
 

--- a/src/Controller/CurriculumInventoryReportController.php
+++ b/src/Controller/CurriculumInventoryReportController.php
@@ -139,7 +139,7 @@ class CurriculumInventoryReportController extends ApiController
             throw new NotFoundHttpException(sprintf('The resource \'%s\' was not found.', $id));
         }
 
-        if (! $this->authorizationChecker->isGranted([AbstractVoter::ROLLOVER], $report)) {
+        if (! $this->authorizationChecker->isGranted(AbstractVoter::ROLLOVER, $report)) {
             throw $this->createAccessDeniedException('Unauthorized access!');
         }
 
@@ -177,7 +177,7 @@ class CurriculumInventoryReportController extends ApiController
             throw new NotFoundHttpException(sprintf('The resource \'%s\' was not found.', $id));
         }
 
-        if (! $this->authorizationChecker->isGranted([AbstractVoter::VIEW], $report)) {
+        if (! $this->authorizationChecker->isGranted(AbstractVoter::VIEW, $report)) {
             throw $this->createAccessDeniedException('Unauthorized access!');
         }
 


### PR DESCRIPTION
Passing an array of attributes to this method was deprecated in Symfony
4.4. We weren't actually using that feature though, just using an array
as a container for a single attribute.