### PR TITLE
Use symfony auto migrating password hash

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -52,6 +52,8 @@ security:
       id: App\Service\SessionUserProvider
   encoders:
     App\Classes\SessionUserInterface:
-      algorithm: bcrypt
+      algorithm: auto
+      migrate_from:
+        - bcrypt
     ilios_legacy_encoder:
       id: App\Form\Encoder

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -207,7 +207,7 @@ class AddUserCommand extends Command
             $sessionUser = $this->sessionUserProvider->createSessionUserFromUser($user);
 
             $encodedPassword = $this->encoder->encodePassword($sessionUser, $userRecord['password']);
-            $authentication->setPasswordBcrypt($encodedPassword);
+            $authentication->setPasswordHash($encodedPassword);
 
             $this->authenticationManager->update($authentication);
 

--- a/src/Command/ChangePasswordCommand.php
+++ b/src/Command/ChangePasswordCommand.php
@@ -107,7 +107,7 @@ class ChangePasswordCommand extends Command
         $sessionUser = $this->sessionUserProvider->createSessionUserFromUser($user);
 
         $encodedPassword = $this->encoder->encodePassword($sessionUser, $password);
-        $authentication->setPasswordBcrypt($encodedPassword);
+        $authentication->setPasswordHash($encodedPassword);
 
         $this->authenticationManager->update($authentication);
 

--- a/src/Command/InstallFirstUserCommand.php
+++ b/src/Command/InstallFirstUserCommand.php
@@ -201,7 +201,7 @@ class InstallFirstUserCommand extends Command
         $encodedPassword = $this->passwordEncoder->encodePassword($sessionUser, self::PASSWORD);
 
         $authentication->setUsername(self::USERNAME);
-        $authentication->setPasswordBcrypt($encodedPassword);
+        $authentication->setPasswordHash($encodedPassword);
         $this->authenticationManager->update($authentication);
 
         $output->writeln('Success!');

--- a/src/Controller/AuthenticationController.php
+++ b/src/Controller/AuthenticationController.php
@@ -113,7 +113,7 @@ class AuthenticationController extends ApiController
         }
 
         foreach ($encodedPasswords as $userId => $password) {
-            $entitiesByUserId[$userId]->setPasswordBcrypt($password);
+            $entitiesByUserId[$userId]->setPasswordHash($password);
         }
         $entities = array_values($entitiesByUserId);
 
@@ -165,7 +165,7 @@ class AuthenticationController extends ApiController
         $serializer = $this->getSerializer();
         $serializer->deserialize($json, get_class($entity), 'json', ['object_to_populate' => $entity]);
         if (isset($encodedPassword)) {
-            $entity->setPasswordBcrypt($encodedPassword);
+            $entity->setPasswordHash($encodedPassword);
         }
         $this->validateAndAuthorizeEntities([$entity], $permission);
 

--- a/src/Entity/Authentication.php
+++ b/src/Entity/Authentication.php
@@ -68,18 +68,18 @@ class Authentication implements AuthenticationInterface
     private $passwordSha256;
 
     /**
-     * @ORM\Column(name="password_bcrypt", type="string", nullable=true)
+     * @ORM\Column(name="password_hash", type="string", nullable=true)
      * @var string
      *
      * @Assert\Type(type="string")
      * @Assert\Length(
      *      min = 1,
-     *      max = 64,
+     *      max = 255,
      *     allowEmptyString = true
      * )
      *
      */
-    private $passwordBcrypt;
+    private $passwordHash;
 
     /**
      * @ORM\Column(name="invalidate_token_issued_before", type="datetime", nullable=true)
@@ -127,20 +127,20 @@ class Authentication implements AuthenticationInterface
     /**
      * @inheritdoc
      */
-    public function setPasswordBcrypt($passwordBcrypt)
+    public function setPasswordHash($passwordHash)
     {
-        if ($passwordBcrypt) {
+        if ($passwordHash) {
             $this->setPasswordSha256(null);
         }
-        $this->passwordBcrypt = $passwordBcrypt;
+        $this->passwordHash = $passwordHash;
     }
 
     /**
      * @inheritdoc
      */
-    public function getPasswordBcrypt()
+    public function getPasswordHash()
     {
-        return $this->passwordBcrypt;
+        return $this->passwordHash;
     }
 
     /**
@@ -148,7 +148,7 @@ class Authentication implements AuthenticationInterface
      */
     public function getPassword()
     {
-        $newPassword = $this->getPasswordBcrypt();
+        $newPassword = $this->getPasswordHash();
         $legacyPassword = $this->getPasswordSha256();
         return $newPassword ? $newPassword : $legacyPassword;
     }

--- a/src/Entity/AuthenticationInterface.php
+++ b/src/Entity/AuthenticationInterface.php
@@ -34,12 +34,12 @@ interface AuthenticationInterface extends LoggableEntityInterface
     /**
      * @param string $passwordBcrypt
      */
-    public function setPasswordBcrypt($passwordBcrypt);
+    public function setPasswordHash($passwordBcrypt);
 
     /**
      * @return string
      */
-    public function getPasswordBcrypt();
+    public function getPasswordHash();
 
     /**
      * @return string

--- a/src/Form/Encoder.php
+++ b/src/Form/Encoder.php
@@ -6,6 +6,7 @@ namespace App\Form;
 
 use App\Service\Config;
 use Symfony\Component\Security\Core\Encoder\BasePasswordEncoder;
+use Exception;
 
 /**
  * Class Encoder
@@ -17,9 +18,6 @@ class Encoder extends BasePasswordEncoder
      */
     protected $config;
 
-    /**
-     * @param string $salt
-     */
     public function __construct(Config $config)
     {
         $this->config = $config;
@@ -27,7 +25,7 @@ class Encoder extends BasePasswordEncoder
 
     public function encodePassword($raw, $salt)
     {
-        throw new \Exception("Do not use this legacy encoder to encode new passwords");
+        throw new Exception("Do not use this legacy encoder to encode new passwords");
     }
 
     public function isPasswordValid($encoded, $raw, $salt)

--- a/src/Migrations/Version20200115050155.php
+++ b/src/Migrations/Version20200115050155.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200114000000 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Change name of password field so it can be used by any algorithm';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE authentication CHANGE password_bcrypt password_hash VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE authentication CHANGE password_hash password_bcrypt VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`');
+    }
+}

--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -322,7 +322,7 @@ class AddUserCommandTest extends KernelTestCase
 
         $authentication = m::mock(AuthenticationInterface::class)
             ->shouldReceive('setUsername')->with('abc123')
-            ->shouldReceive('setPasswordBcrypt')->with('hashBlurb')
+            ->shouldReceive('setPasswordHash')->with('hashBlurb')
             ->shouldReceive('getUser')->andReturn($user)
             ->mock();
 

--- a/tests/Command/ChangePasswordCommandTest.php
+++ b/tests/Command/ChangePasswordCommandTest.php
@@ -90,7 +90,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         $this->sessionUserProvider->shouldReceive('createSessionUserFromUser')->with($user)->andReturn($sessionUser);
 
         $this->encoder->shouldReceive('encodePassword')->with($sessionUser, '123456789')->andReturn('abc');
-        $authentication->shouldReceive('setPasswordBcrypt')->with('abc')->once();
+        $authentication->shouldReceive('setPasswordHash')->with('abc')->once();
 
         $this->authenticationManager->shouldReceive('update')->with($authentication);
 
@@ -122,7 +122,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         $this->sessionUserProvider->shouldReceive('createSessionUserFromUser')->with($user)->andReturn($sessionUser);
 
         $this->encoder->shouldReceive('encodePassword')->with($sessionUser, '123456789')->andReturn('abc');
-        $authentication->shouldReceive('setPasswordBcrypt')->with('abc')->once();
+        $authentication->shouldReceive('setPasswordHash')->with('abc')->once();
 
         $this->authenticationManager->shouldReceive('update')->with($authentication);
 

--- a/tests/Command/InstallFirstUserCommandTest.php
+++ b/tests/Command/InstallFirstUserCommandTest.php
@@ -156,7 +156,7 @@ class InstallFirstUserCommandTest extends KernelTestCase
             ->mock();
         $authentication = m::mock('App\Entity\AuthenticationInterface')
             ->shouldReceive('setUsername')->with('first_user')
-            ->shouldReceive('setPasswordBcrypt')->with('hashBlurb')
+            ->shouldReceive('setPasswordHash')->with('hashBlurb')
             ->shouldReceive('getUser')->andReturn($user)
             ->shouldReceive('setUser')
             ->mock();

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -191,7 +191,7 @@ class AuthControllerTest extends WebTestCase
         $authentication = $legacyUser->getAuthentication();
         $this->assertTrue($authentication->isLegacyAccount());
         $this->assertNotEmpty($authentication->getPasswordSha256());
-        $this->assertEmpty($authentication->getPasswordBcrypt());
+        $this->assertEmpty($authentication->getPasswordHash());
 
 
         $client->request('POST', '/auth/login', [], [], [], json_encode([
@@ -222,7 +222,7 @@ class AuthControllerTest extends WebTestCase
         $authentication = $legacyUser->getAuthentication();
         $this->assertFalse($authentication->isLegacyAccount());
         $this->assertEmpty($authentication->getPasswordSha256());
-        $this->assertNotEmpty($authentication->getPasswordBcrypt());
+        $this->assertNotEmpty($authentication->getPasswordHash());
     }
 
     public function testWhoAmI()

--- a/tests/Fixture/LoadAuthenticationData.php
+++ b/tests/Fixture/LoadAuthenticationData.php
@@ -34,7 +34,7 @@ class LoadAuthenticationData extends AbstractFixture implements
             $entity = new Authentication();
             $entity->setUsername($arr['username']);
             $entity->setPasswordSha256($arr['passwordSha256']);
-            $entity->setPasswordBcrypt($arr['passwordBcrypt']);
+            $entity->setPasswordHash($arr['passwordBcrypt']);
             $entity->setUser($this->getReference('users' . $arr['user']));
 
             $manager->persist($entity);

--- a/tests/Service/FormAuthenticationTest.php
+++ b/tests/Service/FormAuthenticationTest.php
@@ -181,6 +181,7 @@ class FormAuthenticationTest extends TestCase
         $authenticationEntity = m::mock('App\Entity\AuthenticationInterface')
             ->shouldReceive('getUser')->andReturn($user)
             ->shouldReceive('isLegacyAccount')->andReturn(false)->mock();
+        $this->encoder->shouldReceive('needsRehash')->with($sessionUser)->andReturn(false);
         $this->authManager->shouldReceive('findAuthenticationByUsername')
             ->with('abc')->andReturn($authenticationEntity);
         $this->sessionUserProvider->shouldReceive('createSessionUserFromUser')->with($user)->andReturn($sessionUser);


### PR DESCRIPTION
In symfony 4.3 a [new auto encoder configuration](https://symfony.com/blog/new-in-symfony-4-4-password-migrations) was introduced which will
use the best hash configuration available at the time. In Symfony 4.4 it gained the
ability to migrate users into the new hash algorithm each time they
login.

As any account currently using the bcrypt hash will get updated to a brand
new configuration I've also modified the DB column from password_bcrypt
to password_hash and removed length checking to ensure there is room for
any future hash output.