### PR TITLE
Don't load the test kernel twice

### DIFF
--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Controller;
 
 use App\Entity\User;
+use App\Tests\Fixture\LoadAuthenticationData;
 use App\Tests\GetUrlTrait;
 use Firebase\JWT\JWT;
 use DateTime;
@@ -32,7 +33,7 @@ class AuthControllerTest extends WebTestCase
     {
         parent::setUp();
         $this->loadFixtures([
-            'App\Tests\Fixture\LoadAuthenticationData'
+            LoadAuthenticationData::class
         ]);
 
         $this->jwtKey = JsonWebTokenManager::PREPEND_KEY . $this->getContainer()->getParameter('kernel.secret');
@@ -325,7 +326,6 @@ class AuthControllerTest extends WebTestCase
         $response = $client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
 
-        $client = static::createClient();
         $this->makeJsonRequest(
             $client,
             'GET',

--- a/tests/Controller/DownloadControllerTest.php
+++ b/tests/Controller/DownloadControllerTest.php
@@ -39,6 +39,7 @@ class DownloadControllerTest extends WebTestCase
      */
     public function setUp()
     {
+        parent::setUp();
         $this->fixtures = $this->loadFixtures([
             LoadAuthenticationData::class,
             LoadOfferingData::class,
@@ -54,6 +55,7 @@ class DownloadControllerTest extends WebTestCase
      */
     public function tearDown(): void
     {
+        parent::tearDown();
         unset($this->fixtures);
     }
 

--- a/tests/Controller/ErrorControllerTest.php
+++ b/tests/Controller/ErrorControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Controller;
 
+use App\Tests\Fixture\LoadAuthenticationData;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,8 +18,9 @@ class ErrorControllerTest extends WebTestCase
 
     public function setUp()
     {
+        parent::setUp();
         $this->loadFixtures([
-            'App\Tests\Fixture\LoadAuthenticationData',
+            LoadAuthenticationData::class,
         ]);
     }
 

--- a/tests/Controller/UploadControllerTest.php
+++ b/tests/Controller/UploadControllerTest.php
@@ -39,6 +39,7 @@ class UploadControllerTest extends WebTestCase
 
     public function tearDown(): void
     {
+        parent::tearDown();
         $this->fs->remove($this->fakeTestFileDir);
         unset($this->fs);
         unset($this->fakeTestFile);

--- a/tests/Endpoints/CurrentSessionTest.php
+++ b/tests/Endpoints/CurrentSessionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Endpoints;
 
+use App\Tests\Fixture\LoadAuthenticationData;
+use App\Tests\Fixture\LoadUserData;
 use App\Tests\GetUrlTrait;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
@@ -35,16 +37,18 @@ class CurrentSessionTest extends WebTestCase
 
     public function setUp()
     {
+        parent::setUp();
         $this->kernelBrowser = self::createClient();
         $fixtures = [
-            'App\Tests\Fixture\LoadAuthenticationData',
-            'App\Tests\Fixture\LoadUserData',
+            LoadAuthenticationData::class,
+            LoadUserData::class,
         ];
         $this->fixtures = $this->loadFixtures($fixtures)->getReferenceRepository();
     }
 
     public function tearDown(): void
     {
+        parent::tearDown();
         unset($this->fixtures);
     }
 


### PR DESCRIPTION
This is deprecated in SF5. For most of these we weren't calling
`WebTestCase::teardown()` which cleans up the kernel for the next test.