### PR TITLE
Remove deprecated filesize parameter

### DIFF
--- a/tests/Controller/UploadControllerTest.php
+++ b/tests/Controller/UploadControllerTest.php
@@ -32,8 +32,7 @@ class UploadControllerTest extends WebTestCase
         $this->fakeTestFile = new UploadedFile(
             $this->fakeTestFileDir . '/TESTFILE.txt',
             'TESTFILE.txt',
-            'text/plain',
-            filesize($this->fakeTestFileDir . '/TESTFILE.txt')
+            'text/plain'
         );
     }
 

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -244,8 +244,7 @@ class LearningMaterialTest extends ReadWriteEndpointTest
         $fakeTestFile = new UploadedFile(
             $fakeTestFileDir . '/TESTFILE.txt',
             'TESTFILE.txt',
-            'text/plain',
-            $filesize
+            'text/plain'
         );
         $this->makeJsonRequest(
             $this->kernelBrowser,


### PR DESCRIPTION
Passing the filesize into a an UploadFile is deprecated and will be
removed in symfony 5.0