### PR TITLE
Ensure setup is always run

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,6 +120,26 @@ jobs:
     dependsOn:
       - PHPUnit_all_other_tests
       - test_migrations_against_mysql
+- job: PHPUnit_twice
+  dependsOn:
+    - PHPUnit_all_other_tests
+    - test_migrations_against_mysql
+  pool:
+    vmImage: $(IMAGE)
+  steps:
+    - template: .azure/install-steps-template.yaml
+    - script: bin/phpunit -c phpunit.xml.dist --log-junit build/junit-twice1.xml --group twice
+      displayName: PHPUnit Twice 1st run
+    - script: bin/phpunit -c phpunit.xml.dist --log-junit build/junit-twice2.xml --group twice
+      displayName: PHPUnit Twice 2nd run
+    - task: CopyFiles@2
+      inputs:
+        contents: build/junit-twice2.xml
+        targetFolder: $(Build.ArtifactStagingDirectory)
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathtoPublish: $(Build.ArtifactStagingDirectory)
+        artifactName: BuildOutput
 - job: publish_test_results
   dependsOn:
   - PHPUnit_cli
@@ -131,6 +151,7 @@ jobs:
   - PHPUnit_api_3
   - PHPUnit_api_4
   - PHPUnit_api_5
+  - PHPUnit_twice
   steps:
     - checkout: none #skip checking out the default repository resource
     - task: DownloadBuildArtifacts@0

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -18,6 +18,22 @@ class Kernel extends BaseKernel
 
     private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
+    /**
+     * Hook into creation and __wakeup of the symfony kernel in order to
+     * make our own customizations.
+     *
+     * @param string $environment
+     * @param bool $debug
+     */
+    public function __construct(string $environment, bool $debug)
+    {
+        // Force a UTC timezone on everyone
+        date_default_timezone_set('UTC');
+        parent::__construct($environment, $debug);
+
+        self::loadInflectionRules();
+    }
+
     public function registerBundles(): iterable
     {
         $contents = require $this->getProjectDir() . '/config/bundles.php';
@@ -53,14 +69,6 @@ class Kernel extends BaseKernel
         $routes->import($confDir . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
-    }
-
-    protected function build(ContainerBuilder $container)
-    {
-        // Force a UTC timezone on everyone
-        date_default_timezone_set('UTC');
-        self::loadInflectionRules();
-        parent::build($container);
     }
 
     /**

--- a/tests/Endpoints/AamcPcrsTest.php
+++ b/tests/Endpoints/AamcPcrsTest.php
@@ -66,6 +66,9 @@ class AamcPcrsTest extends ReadWriteEndpointTest
         $this->relatedPostDataTest($data, $postData, 'aamcPcrses', 'competencies');
     }
 
+    /**
+     * @group twice
+     */
     public function testCamelCaseInflection()
     {
         $singular = 'aamcPcrs';


### PR DESCRIPTION
Prevents issues where the container already exists and is not
re-created. Specifically looking at the Inflector::rules we have in
src/Kernel.php to ensure they're run every time.