### PR TITLE
Add explicit cookie properties

### DIFF
--- a/src/Controller/CurriculumInventoryDownloadController.php
+++ b/src/Controller/CurriculumInventoryDownloadController.php
@@ -55,8 +55,10 @@ class CurriculumInventoryDownloadController extends AbstractController
             0,
             '/',
             null,
+            null,
             false,
-            false
+            false,
+            Cookie::SAMESITE_LAX
         );
         $response->headers->setCookie($cookie);
         return $response;


### PR DESCRIPTION
Setting secure to null allows symfony to detect if HTTPS is running
and set the cookie to https only. The same site policy of lax is the new
default in most browsers, it allows this cookie to be used between
origins (as is the case when the API and frontend are on different
domains.)