### PR TITLE
Correct namespace for ObjectManager

### DIFF
--- a/src/DataFixtures/ORM/AbstractFixture.php
+++ b/src/DataFixtures/ORM/AbstractFixture.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace App\DataFixtures\ORM;
 
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Common\DataFixtures\AbstractFixture as DataFixture;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use App\Service\DataimportFileLocator;
 use App\Traits\IdentifiableEntityInterface;
 
@@ -68,9 +69,12 @@ abstract class AbstractFixture extends DataFixture implements ORMFixtureInterfac
      */
     public function load(ObjectManager $manager)
     {
+        /** @var Connection $connection */
+        $connection = $manager->getConnection();
+
         // disable the SQL logger
         // @link http://stackoverflow.com/a/30924545
-        $manager->getConnection()->getConfiguration()->setSQLLogger(null);
+        $connection->getConfiguration()->setSQLLogger(null);
 
         $fileName = $this->getKey() . '.csv';
         $path = $this->dataimportFileLocator->getDataFilePath($fileName);
@@ -78,7 +82,7 @@ abstract class AbstractFixture extends DataFixture implements ORMFixtureInterfac
         // honor the given entity identifiers.
         // @link http://www.ens.ro/2012/07/03/symfony2-doctrine-force-entity-id-on-persist/
         $manager
-          ->getClassMetaData(get_class($this->createEntity()))
+          ->getClassMetadata(get_class($this->createEntity()))
           ->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
         $i = 0;

--- a/tests/Fixture/LoadAamcMethodData.php
+++ b/tests/Fixture/LoadAamcMethodData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\AamcMethod;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadAamcPcrsData.php
+++ b/tests/Fixture/LoadAamcPcrsData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\AamcPcrs;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadAamcResourceTypeData.php
+++ b/tests/Fixture/LoadAamcResourceTypeData.php
@@ -6,7 +6,7 @@ namespace App\Tests\Fixture;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use App\Entity\AamcResourceType;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/Fixture/LoadAlertChangeTypeData.php
+++ b/tests/Fixture/LoadAlertChangeTypeData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\AlertChangeType;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadAlertData.php
+++ b/tests/Fixture/LoadAlertData.php
@@ -8,7 +8,7 @@ use App\Entity\Alert;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadApplicationConfigData.php
+++ b/tests/Fixture/LoadApplicationConfigData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Tests\DataLoader\ApplicationConfigData;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use App\Entity\ApplicationConfig;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/Fixture/LoadAssessmentOptionData.php
+++ b/tests/Fixture/LoadAssessmentOptionData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\AssessmentOption;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadAuditLogData.php
+++ b/tests/Fixture/LoadAuditLogData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\AuditLog;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadAuthenticationData.php
+++ b/tests/Fixture/LoadAuthenticationData.php
@@ -8,7 +8,7 @@ use App\Entity\Authentication;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCohortData.php
+++ b/tests/Fixture/LoadCohortData.php
@@ -8,7 +8,7 @@ use App\Entity\Cohort;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCompetencyData.php
+++ b/tests/Fixture/LoadCompetencyData.php
@@ -8,7 +8,7 @@ use App\Entity\Competency;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCourseClerkshipTypeData.php
+++ b/tests/Fixture/LoadCourseClerkshipTypeData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\CourseClerkshipType;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCourseData.php
+++ b/tests/Fixture/LoadCourseData.php
@@ -8,7 +8,7 @@ use App\Entity\Course;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCourseLearningMaterialData.php
+++ b/tests/Fixture/LoadCourseLearningMaterialData.php
@@ -8,7 +8,7 @@ use App\Entity\CourseLearningMaterial;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCurriculumInventoryAcademicLevelData.php
+++ b/tests/Fixture/LoadCurriculumInventoryAcademicLevelData.php
@@ -8,7 +8,7 @@ use App\Entity\CurriculumInventoryAcademicLevel;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCurriculumInventoryExportData.php
+++ b/tests/Fixture/LoadCurriculumInventoryExportData.php
@@ -8,7 +8,7 @@ use App\Entity\CurriculumInventoryExport;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCurriculumInventoryInstitutionData.php
+++ b/tests/Fixture/LoadCurriculumInventoryInstitutionData.php
@@ -8,7 +8,7 @@ use App\Entity\CurriculumInventoryInstitution;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCurriculumInventoryReportData.php
+++ b/tests/Fixture/LoadCurriculumInventoryReportData.php
@@ -8,7 +8,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use App\Entity\CurriculumInventoryReport;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCurriculumInventorySequenceBlockData.php
+++ b/tests/Fixture/LoadCurriculumInventorySequenceBlockData.php
@@ -8,7 +8,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use App\Entity\CurriculumInventorySequenceBlock;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadCurriculumInventorySequenceData.php
+++ b/tests/Fixture/LoadCurriculumInventorySequenceData.php
@@ -8,7 +8,7 @@ use App\Entity\CurriculumInventorySequence;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadDepartmentData.php
+++ b/tests/Fixture/LoadDepartmentData.php
@@ -8,7 +8,7 @@ use App\Entity\Department;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadIlmSessionData.php
+++ b/tests/Fixture/LoadIlmSessionData.php
@@ -8,7 +8,7 @@ use App\Entity\IlmSession;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use App\Tests\DataLoader\IlmSessionData;

--- a/tests/Fixture/LoadIngestionExceptionData.php
+++ b/tests/Fixture/LoadIngestionExceptionData.php
@@ -8,7 +8,7 @@ use App\Entity\IngestionException;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadInstructorGroupData.php
+++ b/tests/Fixture/LoadInstructorGroupData.php
@@ -8,7 +8,7 @@ use App\Entity\InstructorGroup;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadLearnerGroupData.php
+++ b/tests/Fixture/LoadLearnerGroupData.php
@@ -8,7 +8,7 @@ use App\Entity\LearnerGroup;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadLearningMaterialData.php
+++ b/tests/Fixture/LoadLearningMaterialData.php
@@ -9,7 +9,7 @@ use App\Service\Config;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;

--- a/tests/Fixture/LoadLearningMaterialStatusData.php
+++ b/tests/Fixture/LoadLearningMaterialStatusData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\LearningMaterialStatus;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadLearningMaterialUserRoleData.php
+++ b/tests/Fixture/LoadLearningMaterialUserRoleData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\LearningMaterialUserRole;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadMeshConceptData.php
+++ b/tests/Fixture/LoadMeshConceptData.php
@@ -8,7 +8,7 @@ use App\Entity\MeshConcept;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadMeshDescriptorData.php
+++ b/tests/Fixture/LoadMeshDescriptorData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\MeshDescriptor;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadMeshPreviousIndexingData.php
+++ b/tests/Fixture/LoadMeshPreviousIndexingData.php
@@ -8,7 +8,7 @@ use App\Entity\MeshPreviousIndexing;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadMeshQualifierData.php
+++ b/tests/Fixture/LoadMeshQualifierData.php
@@ -8,7 +8,7 @@ use App\Entity\MeshQualifier;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadMeshTermData.php
+++ b/tests/Fixture/LoadMeshTermData.php
@@ -8,7 +8,7 @@ use App\Entity\MeshTerm;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadMeshTreeData.php
+++ b/tests/Fixture/LoadMeshTreeData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\MeshTree;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/Fixture/LoadObjectiveData.php
+++ b/tests/Fixture/LoadObjectiveData.php
@@ -8,7 +8,7 @@ use App\Entity\Objective;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadOfferingData.php
+++ b/tests/Fixture/LoadOfferingData.php
@@ -8,7 +8,7 @@ use App\Entity\Offering;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadPendingUserUpdateData.php
+++ b/tests/Fixture/LoadPendingUserUpdateData.php
@@ -8,7 +8,7 @@ use App\Entity\PendingUserUpdate;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadProgramData.php
+++ b/tests/Fixture/LoadProgramData.php
@@ -8,7 +8,7 @@ use App\Entity\Program;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadProgramYearData.php
+++ b/tests/Fixture/LoadProgramYearData.php
@@ -8,7 +8,7 @@ use App\Entity\ProgramYear;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadProgramYearStewardData.php
+++ b/tests/Fixture/LoadProgramYearStewardData.php
@@ -8,7 +8,7 @@ use App\Entity\ProgramYearSteward;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadReportData.php
+++ b/tests/Fixture/LoadReportData.php
@@ -8,7 +8,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use App\Entity\Report;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadSchoolConfigData.php
+++ b/tests/Fixture/LoadSchoolConfigData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use App\Entity\SchoolConfig;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/Fixture/LoadSchoolData.php
+++ b/tests/Fixture/LoadSchoolData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\School;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadSessionData.php
+++ b/tests/Fixture/LoadSessionData.php
@@ -8,7 +8,7 @@ use App\Entity\Session;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadSessionDescriptionData.php
+++ b/tests/Fixture/LoadSessionDescriptionData.php
@@ -8,7 +8,7 @@ use App\Entity\SessionDescription;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadSessionLearningMaterialData.php
+++ b/tests/Fixture/LoadSessionLearningMaterialData.php
@@ -8,7 +8,7 @@ use App\Entity\SessionLearningMaterial;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadSessionTypeData.php
+++ b/tests/Fixture/LoadSessionTypeData.php
@@ -8,7 +8,7 @@ use App\Entity\SessionType;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadTermData.php
+++ b/tests/Fixture/LoadTermData.php
@@ -8,7 +8,7 @@ use App\Entity\Term;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadUserData.php
+++ b/tests/Fixture/LoadUserData.php
@@ -8,7 +8,7 @@ use App\Entity\User;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadUserRoleData.php
+++ b/tests/Fixture/LoadUserRoleData.php
@@ -7,7 +7,7 @@ namespace App\Tests\Fixture;
 use App\Entity\UserRole;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixture/LoadVocabularyData.php
+++ b/tests/Fixture/LoadVocabularyData.php
@@ -8,7 +8,7 @@ use App\Entity\Vocabulary;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 


### PR DESCRIPTION
This class was moved from DoctrineCommon.