### PR TITLE
Replace Zend with Laminas

### DIFF
--- a/src/Monitor/Composer.php
+++ b/src/Monitor/Composer.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Monitor;
 
 use Composer\Autoload\ClassLoader;
-use ZendDiagnostics\Check\CheckInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\Success;
+use Laminas\Diagnostics\Check\CheckInterface;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
 
 class Composer implements CheckInterface
 {

--- a/src/Monitor/Frontend.php
+++ b/src/Monitor/Frontend.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Monitor;
 
 use App\Command\UpdateFrontendCommand;
-use ZendDiagnostics\Check\CheckInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\Success;
+use Laminas\Diagnostics\Check\CheckInterface;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
 
 class Frontend implements CheckInterface
 {

--- a/src/Monitor/IliosFileSystem.php
+++ b/src/Monitor/IliosFileSystem.php
@@ -7,10 +7,10 @@ namespace App\Monitor;
 use App\Exception\IliosFilesystemException;
 use App\Service\Config;
 use App\Service\IliosFileSystem as Filesystem;
-use ZendDiagnostics\Check\CheckInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\Success;
-use ZendDiagnostics\Result\Warning;
+use Laminas\Diagnostics\Check\CheckInterface;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
+use Laminas\Diagnostics\Result\Warning;
 
 class IliosFileSystem implements CheckInterface
 {

--- a/src/Monitor/NoDefaultSecret.php
+++ b/src/Monitor/NoDefaultSecret.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Monitor;
 
-use ZendDiagnostics\Check\CheckInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\ResultInterface;
-use ZendDiagnostics\Result\Success;
-use ZendDiagnostics\Result\Warning;
+use Laminas\Diagnostics\Check\CheckInterface;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\ResultInterface;
+use Laminas\Diagnostics\Result\Success;
+use Laminas\Diagnostics\Result\Warning;
 
 class NoDefaultSecret implements CheckInterface
 {

--- a/src/Monitor/PhpConfiguration.php
+++ b/src/Monitor/PhpConfiguration.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Monitor;
 
-use ZendDiagnostics\Check\CheckInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\Success;
-use ZendDiagnostics\Result\Warning;
+use Laminas\Diagnostics\Check\CheckInterface;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
+use Laminas\Diagnostics\Result\Warning;
 
 class PhpConfiguration implements CheckInterface
 {

--- a/src/Monitor/RequiredENV.php
+++ b/src/Monitor/RequiredENV.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Monitor;
 
-use ZendDiagnostics\Check\CheckInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\ResultInterface;
-use ZendDiagnostics\Result\Success;
+use Laminas\Diagnostics\Check\CheckInterface;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\ResultInterface;
+use Laminas\Diagnostics\Result\Success;
 
 class RequiredENV implements CheckInterface
 {

--- a/src/Monitor/Timezone.php
+++ b/src/Monitor/Timezone.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Monitor;
 
-use ZendDiagnostics\Check\CheckInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\ResultInterface;
-use ZendDiagnostics\Result\Success;
+use Laminas\Diagnostics\Check\CheckInterface;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\ResultInterface;
+use Laminas\Diagnostics\Result\Success;
 
 class Timezone implements CheckInterface
 {


### PR DESCRIPTION
Zend has transferred the framework to the linux foundation and it is
called Laminas now. Through the magic of composer and great upstream
packages this was mostly transparent to us, but we are interfacing with
this directly in our custom Monitor classes.

Refs #2727