### PR TITLE
Require ext-curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,11 @@ ILIOS_TRACKING_CODE=UA-XXXXXXXX-1
 # configure Apache and the PHP extensions required for Ilios and delete the source files after install
 RUN \
     apt-get update \
-    && apt-get install sudo libldap2-dev zlib1g-dev libicu-dev libzip-dev libzip4 -y \
+    && apt-get install sudo libldap2-dev zlib1g-dev libicu-dev libzip-dev libzip4 libcurl4-gnutls-dev -y \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install zip \
+    && docker-php-ext-install curl \
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install intl \
     && pecl channel-update pecl.php.net \
@@ -64,7 +65,7 @@ RUN \
     && a2enmod rewrite socache_shmcb mpm_prefork http2 \
     && rm -rf /var/lib/apt/lists/* \
     # remove the apt source files to save space
-    && apt-get purge libldap2-dev zlib1g-dev libicu-dev -y \
+    && apt-get purge libldap2-dev zlib1g-dev libicu-dev libcurl4-gnutls-dev -y \
     && apt-get autoremove -y
 
 # copy configuration into the default locations

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "php": ">= 7.3",
     "ext-apcu": "*",
     "ext-ctype": "*",
+    "ext-curl": "*",
     "ext-dom": "*",
     "ext-iconv": "*",
     "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5848b5415794b9ab80ac7517bfc5565",
+    "content-hash": "0afac748c672474e579646014ac6bb62",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -9237,6 +9237,7 @@
         "php": ">= 7.3",
         "ext-apcu": "*",
         "ext-ctype": "*",
+        "ext-curl": "*",
         "ext-dom": "*",
         "ext-iconv": "*",
         "ext-json": "*",

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,6 +23,7 @@ PHP should configured with a 'memory_limit' setting of at least 386MB and have t
 * php-mbstring - for UTF-8 support
 * php-ldap - for ldap-connectivity support (when using LDAP)
 * php-xml
+* php-curl
 * php-pecl-apcu - caching
 * php-mysql - DB connectivity
 * php-mysqlnd - DB connectivity


### PR DESCRIPTION
This is needed for CAS (and probably other stuff, we should require it
to ensure it is present).