### PR TITLE
Add some light caching of database configuration values

### DIFF
--- a/src/Entity/Manager/ApplicationConfigManager.php
+++ b/src/Entity/Manager/ApplicationConfigManager.php
@@ -12,11 +12,30 @@ use App\Entity\Repository\ApplicationConfigRepository;
  */
 class ApplicationConfigManager extends BaseManager
 {
+    protected $cache;
+
+    protected function buildCache()
+    {
+        if (!$this->cache) {
+            $this->cache = [];
+
+            /** @var ApplicationConfigRepository $repository */
+            $repository = $this->getRepository();
+            $configs = $repository->getAllValues();
+
+            foreach ($configs as ['name' => $name, 'value' => $value]) {
+                $this->cache[$name] = $value;
+            }
+        }
+    }
+
     public function getValue($name)
     {
-        /** @var ApplicationConfigRepository $repository */
-        $repository = $this->getRepository();
+        $this->buildCache();
+        if (array_key_exists($name, $this->cache)) {
+            return $this->cache[$name];
+        }
 
-        return $repository->getValue($name);
+        return null;
     }
 }

--- a/src/Entity/Repository/ApplicationConfigRepository.php
+++ b/src/Entity/Repository/ApplicationConfigRepository.php
@@ -56,25 +56,14 @@ class ApplicationConfigRepository extends EntityRepository implements DTOReposit
     }
 
     /**
-     * Get a value from the application_config table by name
-     *
-     * @param $name
-     * @return mixed|null
+     * Get every configuration value
      */
-    public function getValue($name)
+    public function getAllValues(): array
     {
         $qb = $this->_em->createQueryBuilder();
-        $qb->select('x.value')->from('App\Entity\ApplicationConfig', 'x')
-            ->where($qb->expr()->eq('x.name', ':name'))
-            ->setParameter('name', $name);
+        $qb->select('x.value, x.name')->from(ApplicationConfig::class, 'x');
 
-        try {
-            $result = $qb->getQuery()->getSingleScalarResult();
-        } catch (NoResultException $e) {
-            $result = null;
-        }
-
-        return $result;
+        return $qb->getQuery()->getArrayResult();
     }
 
     /**


### PR DESCRIPTION
Each request loads 9-15 of these and each load was making a DB query to
get the value. Loading them all at once saves about 100ms on each
request which is a substantial speed improvement over several
requests.