### PR TITLE
Add PHP Compatibility Code Sniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,11 @@
     "symfony/yaml": "@stable"
   },
   "require-dev": {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
     "fzaninotto/faker": "@stable",
     "liip/test-fixtures-bundle": "~1.7.0",
     "mockery/mockery": "@stable",
+    "phpcompatibility/php-compatibility": "^9.3",
     "squizlabs/php_codesniffer": "@stable",
     "symfony/debug-pack": "^1.0",
     "symfony/profiler-pack": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df091488fb78dca722427f583f4854a2",
+    "content-hash": "1accb732e23dabf00af9a76ddaa1f6d0",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -8467,6 +8467,72 @@
     ],
     "packages-dev": [
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "^2|^3"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2020-01-29T20:22:20+00:00"
+        },
+        {
             "name": "fzaninotto/faker",
             "version": "v1.9.1",
             "source": {
@@ -8699,6 +8765,64 @@
                 "testing"
             ],
             "time": "2019-12-26T09:49:15+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
 
     <rule ref="PSR12"/>
     <rule ref="Generic.PHP.RequireStrictTypes"/>
+    <rule ref="PHPCompatibility"/>
 
     <file>bin/</file>
     <file>config/</file>

--- a/src/EventListener/LogEntityChanges.php
+++ b/src/EventListener/LogEntityChanges.php
@@ -88,7 +88,7 @@ class LogEntityChanges
         }
         $loggerQueue = $this->container->get(LoggerQueue::class);
         foreach ($updates as $arr) {
-            $valuesChanged = implode($arr['changes'], ',');
+            $valuesChanged = implode(',', $arr['changes']);
             $loggerQueue->add($arr['action'], $arr['entity'], $valuesChanged);
         }
     }

--- a/src/Migrations/Version20150826130000.php
+++ b/src/Migrations/Version20150826130000.php
@@ -26,7 +26,7 @@ class Version20150826130000 extends AbstractMigration
                 return '("' . $arr['mesh_term_id'] . '","' . $arr['mesh_concept_uid'] . '")';
             }, $rows);
             unset($rows);
-            $insertSql .= implode($values, ',');
+            $insertSql .= implode(',', $values);
             unset($values);
         }
         
@@ -70,7 +70,7 @@ class Version20150826130000 extends AbstractMigration
             }, $rows);
             $values = array_unique($values);
             unset($rows);
-            $insertSql .= implode($values, ',');
+            $insertSql .= implode(',', $values);
             unset($values);
         }
         

--- a/src/Migrations/Version20150916173024.php
+++ b/src/Migrations/Version20150916173024.php
@@ -36,7 +36,7 @@ class Version20150916173024 extends AbstractMigration
             
             //bulk update all the records to avoide a mess in the output
             $sql = 'UPDATE `user` SET ics_feed_key = (CASE user_id ';
-            $sql .= implode($updates, ' ');
+            $sql .= implode(' ', $updates);
             
             $sql .= 'END)';
             

--- a/src/Migrations/Version20160615223611.php
+++ b/src/Migrations/Version20160615223611.php
@@ -42,7 +42,7 @@ class Version20160615223611 extends AbstractMigration
 
             //bulk update all the records to avoide a mess in the output
             $sql = 'UPDATE `curriculum_inventory_report` SET `token` = (CASE report_id ';
-            $sql .= implode($updates, ' ');
+            $sql .= implode(' ', $updates);
             $sql .= 'END)';
 
             $this->addSql($sql);

--- a/src/Service/Directory.php
+++ b/src/Service/Directory.php
@@ -64,7 +64,7 @@ class Directory
 
         //Split into groups of 50 to avoid LDAP query length limits
         foreach (array_chunk($filterTerms, 50) as $terms) {
-            $filterTermsString = implode($terms, '');
+            $filterTermsString = implode('', $terms);
             $filter = "(|{$filterTermsString})";
 
             $users = array_merge($users, $this->ldapManager->search($filter));
@@ -90,7 +90,7 @@ class Directory
             $term = ldap_escape($term, "", LDAP_ESCAPE_FILTER);
             return "(|(sn={$term}*)(givenname={$term}*)(mail={$term}*)({$ldapCampusIdProperty}={$term}*))";
         }, $searchTerms);
-        $filterTermsString = implode($filterTerms, '');
+        $filterTermsString = implode('', $filterTerms);
         $filter = "(&{$filterTermsString})";
         $users = $this->ldapManager->search($filter);
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -8,6 +8,9 @@
     "danielstjules/stringy": {
         "version": "3.1.0"
     },
+    "dealerdirect/phpcodesniffer-composer-installer": {
+        "version": "v0.6.2"
+    },
     "doctrine/annotations": {
         "version": "1.0",
         "recipe": {
@@ -266,6 +269,9 @@
     },
     "php-http/promise": {
         "version": "v1.0.0"
+    },
+    "phpcompatibility/php-compatibility": {
+        "version": "9.3.5"
     },
     "phpdocumentor/reflection-common": {
         "version": "2.0.0"

--- a/tests/Service/IliosFileSystemTest.php
+++ b/tests/Service/IliosFileSystemTest.php
@@ -120,7 +120,7 @@ class IliosFileSystemTest extends TestCase
             $hashDirectory,
             $hash
         ];
-        return implode($parts, '/');
+        return implode('/', $parts);
     }
 
     protected function getTestFileLock($name)
@@ -129,7 +129,7 @@ class IliosFileSystemTest extends TestCase
             IliosFileSystem::LOCK_FILE_DIRECTORY,
             $name
         ];
-        return implode($parts, '/');
+        return implode('/', $parts);
     }
 
     public function testCreateLock()

--- a/tests/Service/NonCachingIliosFileSystemTest.php
+++ b/tests/Service/NonCachingIliosFileSystemTest.php
@@ -141,7 +141,7 @@ class NonCachingIliosFileSystemTest extends TestCase
             $hashDirectory,
             $hash
         ];
-        return implode($parts, '/');
+        return implode('/', $parts);
     }
 
     protected function getTestFileLock($name)
@@ -150,7 +150,7 @@ class NonCachingIliosFileSystemTest extends TestCase
             IliosFileSystem::LOCK_FILE_DIRECTORY,
             $name
         ];
-        return implode($parts, '/');
+        return implode('/', $parts);
     }
 
     public function testCreateLock()


### PR DESCRIPTION
Checks for things that are deprecated or removed in a released PHP version, in this case it cause places where the arguments were provided in the wrong order for `implode`.