### PR TITLE
Handle root file requests better

### DIFF
--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -79,7 +79,7 @@ class IndexController extends AbstractController
      */
     public function getAction(Request $request, $fileName, $versionedStaticFile = false)
     {
-        if ('index.html' === $fileName || empty($fileName)) {
+        if ('index.html' === $fileName || '/' === $fileName || empty($fileName)) {
             return $this->getIndex($request);
         }
 
@@ -184,7 +184,7 @@ class IndexController extends AbstractController
     {
         $assetsPath = $this->getParameter('kernel.cache_dir') . UpdateFrontendCommand::FRONTEND_DIRECTORY;
         $path = $assetsPath . $fileName;
-        if ($this->fs->exists($path)) {
+        if ($this->fs->exists($path) && is_readable($path) && !is_dir($path)) {
             return $path;
         }
 


### PR DESCRIPTION
This seems to only come from IE8, but sometimes we get a stray `/`
request which was falling through our current set up checks and causing
an error.

Fixes #2810 which has more debug information attached in the Sentry error. I wasn't able to reproduce this error in browserstack with Windows XP / IE8, so I'm only guessing at the solution here.