### PR TITLE
Fix @covers annotations

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Report Code Coverage
 
 on:
   schedule:
-    - cron: '46 2 * * 6' # weekly, on Saturday Morning night
+    - cron: '46 2 * * *' # daily at 2:46am
 
 env:
   ILIOS_MAILER_URL: null://localhost

--- a/tests/Classes/PermissionMatrixTest.php
+++ b/tests/Classes/PermissionMatrixTest.php
@@ -9,7 +9,7 @@ use App\Tests\TestCase;
 
 /**
  * Class PermissionMatrixTest
- * @package App\Tests\Classes
+ * @coversDefaultClass \App\Classes\PermissionMatrix
  */
 class PermissionMatrixTest extends TestCase
 {
@@ -37,9 +37,9 @@ class PermissionMatrixTest extends TestCase
     }
 
     /**
-     * @covers PermissionMatrix::setPermission
-     * @covers PermissionMatrix::hasPermission
-     * @covers PermissionMatrix::getPermittedRoles
+     * @covers ::setPermission
+     * @covers ::hasPermission
+     * @covers ::getPermittedRoles
      */
     public function testHasPermission()
     {
@@ -65,7 +65,7 @@ class PermissionMatrixTest extends TestCase
     }
 
     /**
-     * @covers PermissionMatrix::getPermittedRoles
+     * @covers ::getPermittedRoles
      */
     public function testGetPermittedRoles()
     {

--- a/tests/Classes/SchoolEventTest.php
+++ b/tests/Classes/SchoolEventTest.php
@@ -14,7 +14,7 @@ use DateTime;
 /**
  * Class SchoolEventTest
  * @package App\Tests\Classes
- * @covers \App\Classes\SchoolEvent
+ * @coversDefaultClass \App\Classes\SchoolEvent
  */
 class SchoolEventTest extends TestCase
 {
@@ -40,7 +40,7 @@ class SchoolEventTest extends TestCase
         unset($this->schoolEvent);
     }
     /**
-     * @covers SchoolEvent::createFromCalendarEvent
+     * @covers ::createFromCalendarEvent
      */
     public function testCreateFromCalendarEvent()
     {
@@ -75,7 +75,7 @@ class SchoolEventTest extends TestCase
     }
 
     /**
-     * @covers SchoolEvent::clearDataForUnprivilegedUsers
+     * @covers ::clearDataForUnprivilegedUsers
      */
     public function testClearDataForUnprivilegedUsers()
     {

--- a/tests/Classes/SessionUserTest.php
+++ b/tests/Classes/SessionUserTest.php
@@ -18,7 +18,7 @@ use function Sentry\withScope;
 
 /**
  * Class SessionUserTest
- * @package App\Tests\Classes
+ * @coversDefaultClass \App\Classes\SessionUser
  */
 class SessionUserTest extends TestCase
 {
@@ -78,7 +78,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingCourse
+     * @covers ::isDirectingCourse
      */
     public function testIsDirectingCourse()
     {
@@ -90,7 +90,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingCourse
+     * @covers ::isDirectingCourse
      */
     public function testIsNotDirectingCourse()
     {
@@ -101,7 +101,7 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isDirectingCourse(1));
     }
     /**
-     * @covers SessionUser::isDirectingProgramLinkedToCourse
+     * @covers ::isDirectingProgramLinkedToCourse
      */
     public function testIsDirectingProgramLinkedToCourse()
     {
@@ -113,7 +113,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingProgramLinkedToCourse
+     * @covers ::isDirectingProgramLinkedToCourse
      */
     public function testIsNotDirectingProgramLinkedToCourse()
     {
@@ -125,7 +125,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringCourse
+     * @covers ::isAdministeringCourse
      */
     public function testIsAdministeringCourse()
     {
@@ -137,7 +137,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringCourse
+     * @covers ::isAdministeringCourse
      */
     public function testIsNotAdministeringCourse()
     {
@@ -149,7 +149,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingSchool
+     * @covers ::isDirectingSchool
      */
     public function testIsDirectingSchool()
     {
@@ -159,7 +159,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingSchool
+     * @covers ::isDirectingSchool
      */
     public function testIsNotDirectingSchool()
     {
@@ -169,7 +169,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringSchool
+     * @covers ::isAdministeringSchool
      */
     public function testIsAdministeringSchool()
     {
@@ -179,7 +179,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringSchool
+     * @covers ::isAdministeringSchool
      */
     public function testIsNotAdministeringSchool()
     {
@@ -189,7 +189,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingCourseInSchool
+     * @covers ::isDirectingCourseInSchool
      */
     public function testIsDirectingCourseInSchool()
     {
@@ -201,7 +201,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingCourseInSchool
+     * @covers ::isDirectingCourseInSchool
      */
     public function testIsNotDirectingCourseInSchool()
     {
@@ -213,7 +213,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringCourseInSchool
+     * @covers ::isAdministeringCourseInSchool
      */
     public function testIsAdministeringCourseInSchool()
     {
@@ -225,7 +225,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringCourseInSchool
+     * @covers ::isAdministeringCourseInSchool
      */
     public function testIsNotAdministeringCourseInSchool()
     {
@@ -237,7 +237,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringSessionInSchool
+     * @covers ::isAdministeringSessionInSchool
      */
     public function testIsAdministeringSessionInSchool()
     {
@@ -249,7 +249,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringSessionInSchool
+     * @covers ::isAdministeringSessionInSchool
      */
     public function testIsNotAdministeringSessionInSchool()
     {
@@ -261,7 +261,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isTeachingCourseInSchool
+     * @covers ::isTeachingCourseInSchool
      */
     public function testIsTeachingCourseInSchool()
     {
@@ -273,7 +273,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isTeachingCourseInSchool
+     * @covers ::isTeachingCourseInSchool
      */
     public function testIsNotTeachingCourseInSchool()
     {
@@ -285,7 +285,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isTeachingCourse
+     * @covers ::isTeachingCourse
      */
     public function testIsTeachingCourse()
     {
@@ -297,7 +297,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isTeachingCourse
+     * @covers ::isTeachingCourse
      */
     public function testIsNotTeachingCourse()
     {
@@ -309,7 +309,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringSessionInCourse
+     * @covers ::isAdministeringSessionInCourse
      */
     public function testIsAdministeringSessionInCourse()
     {
@@ -321,7 +321,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringSessionInCourse
+     * @covers ::isAdministeringSessionInCourse
      */
     public function testIsNotAdministeringSessionInCourse()
     {
@@ -333,7 +333,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringSession
+     * @covers ::isAdministeringSession
      */
     public function testIsAdministeringSession()
     {
@@ -345,7 +345,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringSession
+     * @covers ::isAdministeringSession
      */
     public function testIsNotAdministeringSession()
     {
@@ -357,7 +357,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isTeachingSession
+     * @covers ::isTeachingSession
      */
     public function testIsTeachingSession()
     {
@@ -369,7 +369,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isTeachingSession
+     * @covers ::isTeachingSession
      */
     public function testIsNotTeachingSession()
     {
@@ -381,7 +381,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isInstructingOffering
+     * @covers ::isInstructingOffering
      */
     public function testIsInstructingOffering()
     {
@@ -393,7 +393,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isInstructingOffering
+     * @covers ::isInstructingOffering
      */
     public function testIsNotInstructingOffering()
     {
@@ -405,7 +405,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isInstructingIlm
+     * @covers ::isInstructingIlm
      */
     public function testIsInstructingIlm()
     {
@@ -417,7 +417,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isInstructingIlm
+     * @covers ::isInstructingIlm
      */
     public function testIsNotInstructingIlm()
     {
@@ -429,7 +429,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingProgram
+     * @covers ::isDirectingProgram
      */
     public function testIsDirectingProgram()
     {
@@ -441,7 +441,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingProgram
+     * @covers ::isDirectingProgram
      */
     public function testIsNotDirectingProgram()
     {
@@ -453,7 +453,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingProgramYear
+     * @covers ::isDirectingProgramYear
      */
     public function testIsDirectingProgramYear()
     {
@@ -465,7 +465,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingProgramYear
+     * @covers ::isDirectingProgramYear
      */
     public function testIsNotDirectingProgramYear()
     {
@@ -477,7 +477,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingProgramYearInProgram
+     * @covers ::isDirectingProgramYearInProgram
      */
     public function testIsDirectingProgramYearInProgram()
     {
@@ -489,7 +489,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isDirectingProgramYearInProgram
+     * @covers ::isDirectingProgramYearInProgram
      */
     public function testIsNotDirectingProgramYearInProgram()
     {
@@ -501,7 +501,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringCurriculumInventoryReport
+     * @covers ::isAdministeringCurriculumInventoryReport
      */
     public function testIsAdministeringCurriculumInventoryReport()
     {
@@ -513,7 +513,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringCurriculumInventoryReport
+     * @covers ::isAdministeringCurriculumInventoryReport
      */
     public function testIsNotAdministeringCurriculumInventoryReport()
     {
@@ -525,7 +525,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringCurriculumInventoryReportInSchool
+     * @covers ::isAdministeringCurriculumInventoryReportInSchool
      */
     public function testIsAdministeringCurriculumInventoryReportInSchool()
     {
@@ -537,7 +537,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isAdministeringCurriculumInventoryReportInSchool
+     * @covers ::isAdministeringCurriculumInventoryReportInSchool
      */
     public function testIsNotAdministeringCurriculumInventoryReportInSchool()
     {
@@ -549,7 +549,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isInLearnerGroup()
+     * @covers ::isInLearnerGroup()
      */
     public function testIsInLearnerGroup()
     {
@@ -561,7 +561,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::isInLearnerGroup()
+     * @covers ::isInLearnerGroup()
      */
     public function testIsNotInLearnerGroup()
     {
@@ -574,7 +574,7 @@ class SessionUserTest extends TestCase
 
 
     /**
-     * @covers SessionUser::rolesInSchool
+     * @covers ::rolesInSchool
      */
     public function testRolesInSchool()
     {
@@ -625,7 +625,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::rolesInCourse
+     * @covers ::rolesInCourse
      */
     public function testRolesInCourse()
     {
@@ -655,7 +655,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::rolesInSession
+     * @covers ::rolesInSession
      */
     public function testRolesInSession()
     {
@@ -673,7 +673,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::rolesInProgram
+     * @covers ::rolesInProgram
      */
     public function testRolesInProgram()
     {
@@ -691,7 +691,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::rolesInProgramYear
+     * @covers ::rolesInProgramYear
      */
     public function testRolesInProgramYear()
     {
@@ -705,7 +705,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::rolesInCurriculumInventoryReport
+     * @covers ::rolesInCurriculumInventoryReport
      */
     public function testRolesInCurriculumInventoryReport()
     {
@@ -719,7 +719,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsRoot()
     {
@@ -729,7 +729,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsCourseDirector()
     {
@@ -742,7 +742,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsCourseAdministrator()
     {
@@ -759,7 +759,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsSchoolDirector()
     {
@@ -780,7 +780,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsSchoolAdministrator()
     {
@@ -805,7 +805,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsInInstructorGroups()
     {
@@ -834,7 +834,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsTeachingInCourses()
     {
@@ -867,7 +867,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsSessionAdministrator()
     {
@@ -904,7 +904,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsInstructingInSessions()
     {
@@ -941,7 +941,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsProgramDirector()
     {
@@ -982,7 +982,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsProgramYearDirector()
     {
@@ -1027,7 +1027,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testPerformsNonLearnerFunctionIfUserIsCurriculumInventoryReportAdministrator()
     {
@@ -1076,7 +1076,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::performsNonLearnerFunction()
+     * @covers ::performsNonLearnerFunction()
      */
     public function testDoesNotPerformNonLearnerFunction()
     {
@@ -1125,7 +1125,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getDirectedCourseIds
+     * @covers ::getDirectedCourseIds
      */
     public function testGetDirectedCourseIds()
     {
@@ -1138,7 +1138,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getAdministeredCourseIds
+     * @covers ::getAdministeredCourseIds
      */
     public function testGetAdministeredCourseIds()
     {
@@ -1151,7 +1151,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getCourseIdsLinkedToProgramsDirectedByUser
+     * @covers ::getCourseIdsLinkedToProgramsDirectedByUser
      */
     public function getCourseIdsLinkedToProgramsDirectedByUser()
     {
@@ -1164,7 +1164,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getDirectedSchoolIds
+     * @covers ::getDirectedSchoolIds
      */
     public function testGetDirectedSchoolIds()
     {
@@ -1177,7 +1177,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getAdministeredSchoolIds
+     * @covers ::getAdministeredSchoolIds
      */
     public function testGetAdministeredSchoolIds()
     {
@@ -1190,7 +1190,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getDirectedCourseSchoolIds
+     * @covers ::getDirectedCourseSchoolIds
      */
     public function testGetDirectedCourseSchoolIds()
     {
@@ -1203,7 +1203,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getAdministeredCourseSchoolIds
+     * @covers ::getAdministeredCourseSchoolIds
      */
     public function testGetAdministeredCourseSchoolIds()
     {
@@ -1216,7 +1216,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getAdministeredSessionSchoolIds
+     * @covers ::getAdministeredSessionSchoolIds
      */
     public function testGetAdministeredSessionSchoolIds()
     {
@@ -1229,7 +1229,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getAdministeredSessionCourseIds
+     * @covers ::getAdministeredSessionCourseIds
      */
     public function testGetAdministeredSessionCourseIds()
     {
@@ -1242,7 +1242,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getTaughtCourseIds
+     * @covers ::getTaughtCourseIds
      */
     public function testGetTaughtCourseIds()
     {
@@ -1255,7 +1255,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getAdministeredSessionIds
+     * @covers ::getAdministeredSessionIds
      */
     public function testGetAdministeredSessionIds()
     {
@@ -1268,7 +1268,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getInstructedSessionIds
+     * @covers ::getInstructedSessionIds
      */
     public function testGetInstructedSessionIds()
     {
@@ -1281,7 +1281,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getInstructedOfferingIds
+     * @covers ::getInstructedOfferingIds
      */
     public function testGetInstructedOfferingIds()
     {
@@ -1295,7 +1295,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getInstructedIlmIds
+     * @covers ::getInstructedIlmIds
      */
     public function testGetInstructedIlmIds()
     {
@@ -1309,7 +1309,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getTaughtCourseSchoolIds
+     * @covers ::getTaughtCourseSchoolIds
      */
     public function testGetTaughtCourseSchoolIds()
     {
@@ -1322,7 +1322,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getDirectedProgramIds
+     * @covers ::getDirectedProgramIds
      */
     public function testGetDirectedProgramIds()
     {
@@ -1335,7 +1335,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getDirectedProgramYearIds
+     * @covers ::getDirectedProgramYearIds
      */
     public function testGetDirectedProgramYearIds()
     {
@@ -1348,7 +1348,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getDirectedProgramYearProgramIds
+     * @covers ::getDirectedProgramYearProgramIds
      */
     public function testGetDirectedProgramYearProgramIds()
     {
@@ -1361,7 +1361,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getAdministeredCurriculumInventoryReportIds
+     * @covers ::getAdministeredCurriculumInventoryReportIds
      */
     public function testGetAdministeredCurriculumInventoryReportIds()
     {
@@ -1374,7 +1374,7 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers SessionUser::getAdministeredCurriculumInventoryReportSchoolIds
+     * @covers ::getAdministeredCurriculumInventoryReportSchoolIds
      */
     public function testGetAdministeredCurriculumInventoryReportSchoolIds()
     {

--- a/tests/Classes/UserEventTest.php
+++ b/tests/Classes/UserEventTest.php
@@ -40,7 +40,7 @@ class UserEventTest extends TestCase
     }
 
     /**
-     * @covers CalendarEvent::removeMaterialsInDraft
+     * @covers \App\Classes\CalendarEvent::removeMaterialsInDraft
      */
     public function testRemoveMaterialsInDraft()
     {
@@ -60,7 +60,7 @@ class UserEventTest extends TestCase
     }
 
     /**
-     * @covers UserEvent::createFromCalendarEvent
+     * @covers \App\Classes\UserEvent::createFromCalendarEvent
      */
     public function testCreateFromCalendarEvent()
     {

--- a/tests/Classes/UserMaterialTest.php
+++ b/tests/Classes/UserMaterialTest.php
@@ -11,6 +11,7 @@ use App\Tests\TestCase;
  * Class UserMaterialTest
  * @package App\Tests\Classes
  * @covers \App\Classes\UserMaterial
+ * @coversDefaultClass \App\Classes\UserMaterial
  */
 class UserMaterialTest extends TestCase
 {
@@ -61,7 +62,7 @@ class UserMaterialTest extends TestCase
 
 
     /**
-     * @covers UserMaterial::clearMaterial
+     * @covers ::clearMaterial
      */
     public function testClearMaterial()
     {
@@ -71,7 +72,7 @@ class UserMaterialTest extends TestCase
     }
 
     /**
-     * @covers UserMaterial::clearTimedMaterial
+     * @covers ::clearTimedMaterial
      */
     public function testClearTimedMaterialWithNoDates()
     {
@@ -81,7 +82,7 @@ class UserMaterialTest extends TestCase
     }
 
     /**
-     * @covers UserMaterial::clearTimedMaterial
+     * @covers ::clearTimedMaterial
      */
     public function testClearTimedMaterialWithStartDateAndInRange()
     {
@@ -92,7 +93,7 @@ class UserMaterialTest extends TestCase
     }
 
     /**
-     * @covers UserMaterial::clearTimedMaterial
+     * @covers ::clearTimedMaterial
      */
     public function testClearTimedMaterialWithStartDateAndOutOfRange()
     {
@@ -103,7 +104,7 @@ class UserMaterialTest extends TestCase
     }
 
     /**
-     * @covers UserMaterial::clearTimedMaterial
+     * @covers ::clearTimedMaterial
      */
     public function testClearTimedMaterialWithEndDateAndInRange()
     {
@@ -114,7 +115,7 @@ class UserMaterialTest extends TestCase
     }
 
     /**
-     * @covers UserMaterial::clearTimedMaterial
+     * @covers ::clearTimedMaterial
      */
     public function testClearTimedMaterialWithEndDateAndOutOfRange()
     {
@@ -125,7 +126,7 @@ class UserMaterialTest extends TestCase
     }
 
     /**
-     * @covers UserMaterial::clearTimedMaterial
+     * @covers ::clearTimedMaterial
      */
     public function testClearTimedMaterialWithStartEndDateAndInRange()
     {
@@ -137,7 +138,7 @@ class UserMaterialTest extends TestCase
     }
 
     /**
-     * @covers UserMaterial::clearTimedMaterial
+     * @covers ::clearTimedMaterial
      */
     public function testClearTimedMaterialWithStartEndDateAndOutOfRange()
     {

--- a/tests/Command/ExportMeshUniverseCommandTest.php
+++ b/tests/Command/ExportMeshUniverseCommandTest.php
@@ -70,7 +70,7 @@ class ExportMeshUniverseCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers ExportMeshUniverseCommand::execute
+     * @covers \App\Command\ExportMeshUniverseCommand::execute
      */
     public function testExecute()
     {

--- a/tests/Command/ImportMeshUniverseCommandTest.php
+++ b/tests/Command/ImportMeshUniverseCommandTest.php
@@ -19,6 +19,7 @@ use Mockery as m;
  * Class ImportMeshUniverseCommandTest
  * @package App\Tests\Command
  * @group cli
+ * @coversDefaultClass \App\Command\ImportMeshUniverseCommand
  */
 class ImportMeshUniverseCommandTest extends KernelTestCase
 {
@@ -81,7 +82,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers ImportMeshUniverseCommand::execute
+     * @covers ::execute
      */
     public function testNoArgs()
     {
@@ -104,7 +105,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers ImportMeshUniverseCommand::execute
+     * @covers ::execute
      */
     public function testGivenFilePath()
     {
@@ -126,7 +127,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers ImportMeshUniverseCommand::execute
+     * @covers ::execute
      */
     public function testGivenUrl()
     {
@@ -148,7 +149,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers ImportMeshUniverseCommand::execute
+     * @covers ::execute
      */
     public function testYear2020()
     {
@@ -171,7 +172,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers ImportMeshUniverseCommand::execute
+     * @covers ::execute
      */
     public function testYear2019()
     {
@@ -194,7 +195,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers ImportMeshUniverseCommand::execute
+     * @covers ::execute
      */
     public function testInvalidGivenYear()
     {
@@ -214,7 +215,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     }
 
     /**
-     * @covers ImportMeshUniverseCommand::execute
+     * @covers ::execute
      */
     public function testIndexesResults()
     {

--- a/tests/Entity/ApplicationConfigTest.php
+++ b/tests/Entity/ApplicationConfigTest.php
@@ -27,7 +27,7 @@ class ApplicationConfigTest extends EntityBase
     }
 
     /**
-     * @covers \App\Entity\ApplicationConfig::__construct
+     * @covers \App\Entity\ApplicationConfig
      */
     public function testConstructor()
     {

--- a/tests/Entity/SchoolConfigTest.php
+++ b/tests/Entity/SchoolConfigTest.php
@@ -27,7 +27,7 @@ class SchoolConfigTest extends EntityBase
     }
 
     /**
-     * @covers \App\Entity\SchoolConfig::__construct
+     * @covers \App\Entity\SchoolConfig
      */
     public function testConstructor()
     {

--- a/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
+++ b/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 /**
  * Class ElevatedPermissionsViewDtoVoterTest
  * @package App\Tests\RelationshipVoter
+ * @coversDefaultClass \App\RelationshipVoter\ElevatedPermissionsViewDTOVoter
+
  */
 class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
 {
@@ -46,7 +48,7 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
 
     /**
      * @dataProvider dtoProvider
-     * @covers ElevatedPermissionsViewDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      */
     public function testCanViewDTO($class)
     {
@@ -58,7 +60,7 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
 
     /**
      * @dataProvider dtoProvider
-     * @covers ElevatedPermissionsViewDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      */
     public function testRootCanViewDTO($class)
     {
@@ -70,7 +72,7 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
 
     /**
      * @dataProvider dtoProvider
-     * @covers ElevatedPermissionsViewDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      */
     public function testCanNotViewDTO($class)
     {

--- a/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -50,6 +50,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 /**
  * Class GreenlightViewDtoVoterTest
  * @package App\Tests\RelationshipVoter
+ * @coversDefaultClass \App\RelationshipVoter\GreenlightViewDTOVoter
  */
 class GreenlightViewDtoVoterTest extends AbstractBase
 {
@@ -108,7 +109,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
 
     /**
      * @dataProvider canViewDTOProvider
-     * @covers GreenlightViewDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      * @param string $class The fully qualified class name.
      */
     public function testCanViewDTO($class)

--- a/tests/RelationshipVoter/LearnerGroupDTOVoterTest.php
+++ b/tests/RelationshipVoter/LearnerGroupDTOVoterTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 /**
  * Class LearnerGroupDTOVoterTest
  * @package App\Tests\RelationshipVoter
+ * @coversDefaultClass \App\RelationshipVoter\LearnerGroupDTOVoter
  */
 class LearnerGroupDTOVoterTest extends AbstractBase
 {
@@ -28,7 +29,7 @@ class LearnerGroupDTOVoterTest extends AbstractBase
     }
 
     /**
-     * @covers LearnerGroupDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      */
     public function testRootCanViewDTO()
     {
@@ -39,7 +40,7 @@ class LearnerGroupDTOVoterTest extends AbstractBase
     }
 
     /**
-     * @covers LearnerGroupDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      */
     public function testUserCanViewDTO()
     {
@@ -52,7 +53,7 @@ class LearnerGroupDTOVoterTest extends AbstractBase
     }
 
     /**
-     * @covers LearnerGroupDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      */
     public function testCanNotViewDTO()
     {

--- a/tests/RelationshipVoter/ReportDTOVoterTest.php
+++ b/tests/RelationshipVoter/ReportDTOVoterTest.php
@@ -14,6 +14,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 /**
  * Class ReportDTOVoterTest
  * @package App\Tests\RelationshipVoter
+ * @coversDefaultClass \App\RelationshipVoter\ReportDTOVoter
+
  */
 class ReportDTOVoterTest extends AbstractBase
 {
@@ -28,7 +30,7 @@ class ReportDTOVoterTest extends AbstractBase
     }
 
     /**
-     * @covers ReportDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      */
     public function testCanViewDTO()
     {
@@ -42,7 +44,7 @@ class ReportDTOVoterTest extends AbstractBase
     }
 
     /**
-     * @covers ReportDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      */
     public function testRootCanViewDTO()
     {
@@ -53,7 +55,7 @@ class ReportDTOVoterTest extends AbstractBase
     }
 
     /**
-     * @covers ReportDTOVoter::voteOnAttribute()
+     * @covers ::voteOnAttribute()
      */
     public function testCanNotViewDTO()
     {

--- a/tests/Service/ChangeAlertHandlerTest.php
+++ b/tests/Service/ChangeAlertHandlerTest.php
@@ -22,6 +22,7 @@ use App\Tests\TestCase;
 /**
  * Class ChangeAlertHandlerTest
  * @package App\Tests\Service
+ * @coversDefaultClass \App\Service\ChangeAlertHandler
  */
 class ChangeAlertHandlerTest extends TestCase
 {
@@ -73,7 +74,7 @@ class ChangeAlertHandlerTest extends TestCase
     }
 
     /**
-     * @covers ChangeAlertHandler::createAlertForNewOffering()
+     * @covers ::createAlertForNewOffering()
      */
     public function testCreateAlertForNewOffering()
     {
@@ -116,7 +117,7 @@ class ChangeAlertHandlerTest extends TestCase
     }
 
     /**
-     * @covers ChangeAlertHandler::createOrUpdateAlertForUpdatedOffering()
+     * @covers ::createOrUpdateAlertForUpdatedOffering()
      */
     public function testCreateOrUpdateAlertForUpdatedOfferingExistingAlert()
     {
@@ -201,7 +202,7 @@ class ChangeAlertHandlerTest extends TestCase
     }
 
     /**
-     * @covers ChangeAlertHandler::createOrUpdateAlertForUpdatedOffering()
+     * @covers ::createOrUpdateAlertForUpdatedOffering()
      */
     public function testCreateOrUpdateAlertForUpdatedOfferingNewAlert()
     {

--- a/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
+++ b/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
@@ -22,6 +22,7 @@ use Mockery as m;
 /**
  * Class VerificationPreviewBuilderTest
  * @package App\Tests\Service\CurriculumInventory
+ * @coversDefaultClass \App\Service\CurriculumInventory\VerificationPreviewBuilder
  */
 class VerificationPreviewBuilderTest extends TestCase
 {
@@ -378,7 +379,7 @@ class VerificationPreviewBuilderTest extends TestCase
     }
 
     /**
-     * @covers VerificationPreviewBuilder::getAllEventsWithAssessmentsTaggedAsFormativeOrSummative
+     * @covers ::getAllEventsWithAssessmentsTaggedAsFormativeOrSummative
      */
     public function testGetAllEventsWithAssessmentsTaggedAsFormativeOrSummative()
     {
@@ -415,7 +416,7 @@ class VerificationPreviewBuilderTest extends TestCase
     }
 
     /**
-     * @covers VerificationPreviewBuilder::getAllResourceTypes
+     * @covers ::getAllResourceTypes
      */
     public function testGetAllResourceTypes()
     {
@@ -445,7 +446,7 @@ class VerificationPreviewBuilderTest extends TestCase
     }
 
     /**
-     * @covers VerificationPreviewBuilder::getClerkshipSequenceBlockAssessmentMethods
+     * @covers ::getClerkshipSequenceBlockAssessmentMethods
      */
     public function testGetClerkshipSequenceBlockAssessmentMethods()
     {
@@ -583,7 +584,7 @@ class VerificationPreviewBuilderTest extends TestCase
     }
 
     /**
-     * @covers VerificationPreviewBuilder::getClerkshipSequenceBlockInstructionalTime
+     * @covers ::getClerkshipSequenceBlockInstructionalTime
      */
     public function testGetClerkshipSequenceBlockInstructionalTime()
     {
@@ -703,7 +704,7 @@ class VerificationPreviewBuilderTest extends TestCase
     }
 
     /**
-     * @covers VerificationPreviewBuilder::getInstructionalMethodCounts
+     * @covers ::getInstructionalMethodCounts
      */
     public function testGetInstructionalMethodCounts()
     {
@@ -744,7 +745,7 @@ class VerificationPreviewBuilderTest extends TestCase
     }
 
     /**
-     * @covers VerificationPreviewBuilder::getNonClerkshipSequenceBlockAssessmentMethods
+     * @covers ::getNonClerkshipSequenceBlockAssessmentMethods
      */
     public function testGetNonClerkshipSequenceBlockAssessmentMethods()
     {
@@ -885,7 +886,7 @@ class VerificationPreviewBuilderTest extends TestCase
     }
 
     /**
-     * @covers VerificationPreviewBuilder::getNonClerkshipSequenceBlockInstructionalTime
+     * @covers ::getNonClerkshipSequenceBlockInstructionalTime
      */
     public function testGetNonClerkshipSequenceBlockInstructionalTime()
     {
@@ -1005,7 +1006,7 @@ class VerificationPreviewBuilderTest extends TestCase
 
      */
     /**
-     * @covers VerificationPreviewBuilder::getPrimaryInstructionalMethodsByNonClerkshipSequenceBlock
+     * @covers ::getPrimaryInstructionalMethodsByNonClerkshipSequenceBlock
      */
     public function testGetPrimaryInstructionalMethodsByNonClerkshipSequenceBlock()
     {
@@ -1123,7 +1124,7 @@ class VerificationPreviewBuilderTest extends TestCase
     }
 
     /**
-     * @covers VerificationPreviewBuilder::getProgramExpectationsMappedToPcrs
+     * @covers ::getProgramExpectationsMappedToPcrs
      */
     public function testGetProgramExpectationsMappedToPcrs()
     {
@@ -1181,7 +1182,7 @@ class VerificationPreviewBuilderTest extends TestCase
     }
 
     /**
-     * @covers VerificationPreviewBuilder::build
+     * @covers ::build
      */
     public function testBuild()
     {

--- a/tests/Service/DefaultPermissionMatrixTest.php
+++ b/tests/Service/DefaultPermissionMatrixTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
 /**
  * Class DefaultPermissionMatrixTest
  * @package App\Tests\Service
- * @covers DefaultPermissionMatrix
+ * @covers \App\Service\DefaultPermissionMatrix
  */
 class DefaultPermissionMatrixTest extends TestCase
 {

--- a/tests/Service/MeshDescriptorSetTransmogrifierTest.php
+++ b/tests/Service/MeshDescriptorSetTransmogrifierTest.php
@@ -13,6 +13,10 @@ use Ilios\MeSH\Model\DescriptorSet;
 use Ilios\MeSH\Model\Reference;
 use Ilios\MeSH\Model\Term;
 
+/**
+ * Class MeshDescriptorSetTransmogrifierTest
+ * @coversDefaultClass \App\Service\MeshDescriptorSetTransmogrifier
+ */
 class MeshDescriptorSetTransmogrifierTest extends TestCase
 {
     /**
@@ -39,7 +43,7 @@ class MeshDescriptorSetTransmogrifierTest extends TestCase
     }
 
     /**
-     * @covers MeshDescriptorSetTransmogrifier::transmogrify
+     * @covers ::transmogrify
      */
     public function testTransmogrify()
     {
@@ -162,7 +166,7 @@ class MeshDescriptorSetTransmogrifierTest extends TestCase
     }
 
     /**
-     * @covers MeshDescriptorSetTransmogrifier::hashTerm
+     * @covers ::hashTerm
      */
     public function testHashTerm()
     {

--- a/tests/Service/PermissionCheckerTest.php
+++ b/tests/Service/PermissionCheckerTest.php
@@ -19,6 +19,7 @@ use Mockery as m;
 /**
  * Class PermissionCheckerTest
  * @package App\Tests\Service
+ * @coversDefaultClass \App\Service\PermissionChecker
  */
 class PermissionCheckerTest extends TestCase
 {
@@ -53,7 +54,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCourse()
+     * @covers ::canUpdateCourse()
      */
     public function testCanUpdateAllCourses()
     {
@@ -84,7 +85,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCourse()
+     * @covers ::canUpdateCourse()
      */
     public function testCanUpdateTheirCourses()
     {
@@ -126,7 +127,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCourse()
+     * @covers ::canUpdateCourse()
      */
     public function testCanNotUpdateCourses()
     {
@@ -168,7 +169,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCourse()
+     * @covers ::canUpdateCourse()
      */
     public function testCanNotUpdateLockedCourses()
     {
@@ -182,7 +183,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCourse()
+     * @covers ::canUpdateCourse()
      */
     public function testCanNotUpdateArchivedCourses()
     {
@@ -196,7 +197,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCourse()
+     * @covers ::canDeleteCourse()
      */
     public function testCanDeleteAllCourses()
     {
@@ -228,7 +229,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCourse()
+     * @covers ::canDeleteCourse()
      */
     public function testCanDeleteTheirCourses()
     {
@@ -270,7 +271,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCourse()
+     * @covers ::canDeleteCourse()
      */
     public function testCanNotDeleteCourses()
     {
@@ -312,7 +313,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCourse()
+     * @covers ::canDeleteCourse()
      */
     public function testCanNotDeleteLockedCourses()
     {
@@ -326,7 +327,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCourse()
+     * @covers ::canDeleteCourse()
      */
     public function testCanNotDeleteArchivedCourses()
     {
@@ -340,7 +341,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateCourse()
+     * @covers ::canCreateCourse()
      */
     public function testCanCreateCourse()
     {
@@ -365,7 +366,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateCourse()
+     * @covers ::canCreateCourse()
      */
     public function testCanNotCreateCourse()
     {
@@ -390,7 +391,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUnlockCourse()
+     * @covers ::canUnlockCourse()
      */
     public function testCanUnlockAllCourses()
     {
@@ -420,7 +421,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUnlockCourse()
+     * @covers ::canUnlockCourse()
      */
     public function testCanUnlockTheirCourses()
     {
@@ -460,7 +461,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUnlockCourse()
+     * @covers ::canUnlockCourse()
      */
     public function testCanNotUnlockCourses()
     {
@@ -501,7 +502,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUnlockCourse()
+     * @covers ::canUnlockCourse()
      */
     public function testCanNotUnlockCourseIfCourseIsArchived()
     {
@@ -514,7 +515,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canLockCourse()
+     * @covers ::canLockCourse()
      */
     public function testCanLockAllCourses()
     {
@@ -544,7 +545,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canLockCourse()
+     * @covers ::canLockCourse()
      */
     public function testCanLockTheirCourses()
     {
@@ -584,7 +585,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canLockCourse()
+     * @covers ::canLockCourse()
      */
     public function testCanNotLockCourses()
     {
@@ -625,7 +626,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUnlockCourse()
+     * @covers ::canUnlockCourse()
      */
     public function testCanNotLockCourseIfCourseIsArchived()
     {
@@ -638,7 +639,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canArchiveCourse()
+     * @covers ::canArchiveCourse()
      */
     public function testCanArchiveAllCourses()
     {
@@ -667,7 +668,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canArchiveCourse()
+     * @covers ::canArchiveCourse()
      */
     public function testCanArchiveTheirCourses()
     {
@@ -706,7 +707,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canArchiveCourse()
+     * @covers ::canArchiveCourse()
      */
     public function testCanNotArchiveCourses()
     {
@@ -746,7 +747,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSession()
+     * @covers ::canUpdateSession()
      */
     public function testCanUpdateAllSessions()
     {
@@ -781,7 +782,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSession()
+     * @covers ::canUpdateSession()
      */
     public function testCanUpdateTheirSessions()
     {
@@ -826,7 +827,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSession()
+     * @covers ::canUpdateSession()
      */
     public function testCanUpdateSessionsIfUserCanUpdateCourse()
     {
@@ -884,7 +885,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSession()
+     * @covers ::canUpdateSession()
      */
     public function testCanNotUpdateSessions()
     {
@@ -950,7 +951,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSession()
+     * @covers ::canUpdateSession()
      */
     public function testCanNotUpdateSessionsInLockedCourse()
     {
@@ -966,7 +967,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSession()
+     * @covers ::canUpdateSession()
      */
     public function testCanNotUpdateSessionsInArchivedCourse()
     {
@@ -982,7 +983,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSession()
+     * @covers ::canDeleteSession()
      */
     public function testCanDeleteAllSessions()
     {
@@ -1017,7 +1018,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSession()
+     * @covers ::canDeleteSession()
      */
     public function testCanDeleteTheirSessions()
     {
@@ -1063,7 +1064,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSession()
+     * @covers ::canDeleteSession()
      */
     public function testCanDeleteSessionsIfUserCanUpdateCourse()
     {
@@ -1119,7 +1120,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSession()
+     * @covers ::canDeleteSession()
      */
     public function testCanNotDeleteSessions()
     {
@@ -1185,7 +1186,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSession()
+     * @covers ::canDeleteSession()
      */
     public function testCanNotDeleteSessionsInLockedCourse()
     {
@@ -1201,7 +1202,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSession()
+     * @covers ::canDeleteSession()
      */
     public function testCanNotDeleteSessionsInArchivedCourse()
     {
@@ -1217,7 +1218,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateSession()
+     * @covers ::canCreateSession()
      */
     public function testCanCreateSession()
     {
@@ -1247,7 +1248,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateSession()
+     * @covers ::canCreateSession()
      */
     public function testCanCreateSessionIfUserCanUpdateCourse()
     {
@@ -1285,7 +1286,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateSession()
+     * @covers ::canCreateSession()
      */
     public function testCanNotCreateSession()
     {
@@ -1335,7 +1336,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateSession()
+     * @covers ::canCreateSession()
      */
     public function testCanNotCreateSessionInLockedCourse()
     {
@@ -1349,7 +1350,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateSession()
+     * @covers ::canCreateSession()
      */
     public function testCanNotCreateSessionInArchivedCourse()
     {
@@ -1363,7 +1364,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSessionType()
+     * @covers ::canUpdateSessionType()
      */
     public function testCanUpdateSessionType()
     {
@@ -1386,7 +1387,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSessionType()
+     * @covers ::canUpdateSessionType()
      */
     public function testCanNotUpdateSessionType()
     {
@@ -1409,7 +1410,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSessionType()
+     * @covers ::canDeleteSessionType()
      */
     public function testCanDeleteSessionType()
     {
@@ -1432,7 +1433,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSessionType()
+     * @covers ::canDeleteSessionType()
      */
     public function testCanNotDeleteSessionType()
     {
@@ -1455,7 +1456,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateSessionType()
+     * @covers ::canCreateSessionType()
      */
     public function testCanCreateSessionType()
     {
@@ -1478,7 +1479,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateSessionType()
+     * @covers ::canCreateSessionType()
      */
     public function testCanNotCreateSessionType()
     {
@@ -1501,7 +1502,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateDepartment()
+     * @covers ::canUpdateDepartment()
      */
     public function testCanUpdateDepartment()
     {
@@ -1524,7 +1525,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateDepartment()
+     * @covers ::canUpdateDepartment()
      */
     public function testCanNotUpdateDepartment()
     {
@@ -1547,7 +1548,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteDepartment()
+     * @covers ::canDeleteDepartment()
      */
     public function testCanDeleteDepartment()
     {
@@ -1570,7 +1571,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteDepartment()
+     * @covers ::canDeleteDepartment()
      */
     public function testCanNotDeleteDepartment()
     {
@@ -1593,7 +1594,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateDepartment()
+     * @covers ::canCreateDepartment()
      */
     public function testCanCreateDepartment()
     {
@@ -1616,7 +1617,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateDepartment()
+     * @covers ::canCreateDepartment()
      */
     public function testCanNotCreateDepartment()
     {
@@ -1639,7 +1640,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateProgram()
+     * @covers ::canUpdateProgram()
      */
     public function testCanUpdateAllPrograms()
     {
@@ -1663,7 +1664,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateProgram()
+     * @covers ::canUpdateProgram()
      */
     public function testCanUpdateTheirPrograms()
     {
@@ -1699,7 +1700,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateProgram()
+     * @covers ::canUpdateProgram()
      */
     public function testCanNotUpdatePrograms()
     {
@@ -1735,7 +1736,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteProgram()
+     * @covers ::canDeleteProgram()
      */
     public function testCanDeleteAllPrograms()
     {
@@ -1759,7 +1760,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteProgram()
+     * @covers ::canDeleteProgram()
      */
     public function testCanDeleteTheirPrograms()
     {
@@ -1795,7 +1796,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteProgram()
+     * @covers ::canDeleteProgram()
      */
     public function testCanNotDeletePrograms()
     {
@@ -1831,7 +1832,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateProgram()
+     * @covers ::canCreateProgram()
      */
     public function testCanCreateProgram()
     {
@@ -1854,7 +1855,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateProgram()
+     * @covers ::canCreateProgram()
      */
     public function testCanNotCreateProgram()
     {
@@ -1877,7 +1878,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateProgramYear()
+     * @covers ::canUpdateProgramYear()
      */
     public function testCanUpdateAllProgramYears()
     {
@@ -1909,7 +1910,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateProgramYear()
+     * @covers ::canUpdateProgramYear()
      */
     public function testCanUpdateTheirProgramYears()
     {
@@ -1951,7 +1952,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateProgramYear()
+     * @covers ::canUpdateProgramYear()
      */
     public function testCanUpdateProgramYearsIfUserCanUpdateProgram()
     {
@@ -2005,7 +2006,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateProgramYear()
+     * @covers ::canUpdateProgramYear()
      */
     public function testCanNotUpdateProgramYears()
     {
@@ -2069,7 +2070,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateProgramYear()
+     * @covers ::canUpdateProgramYear()
      */
     public function testCanNotUpdateLockedProgramYears()
     {
@@ -2083,7 +2084,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateProgramYear()
+     * @covers ::canUpdateProgramYear()
      */
     public function testCanNotUpdateArchivedProgramYears()
     {
@@ -2097,7 +2098,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteProgramYear()
+     * @covers ::canDeleteProgramYear()
      */
     public function testCanDeleteAllProgramYears()
     {
@@ -2129,7 +2130,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteProgramYear()
+     * @covers ::canDeleteProgramYear()
      */
     public function testCanDeleteTheirProgramYears()
     {
@@ -2171,7 +2172,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteProgramYear()
+     * @covers ::canDeleteProgramYear()
      */
     public function testCanDeleteProgramYearsIfUserCanUpdateProgram()
     {
@@ -2226,7 +2227,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteProgramYear()
+     * @covers ::canDeleteProgramYear()
      */
     public function testCanNotDeleteProgramYears()
     {
@@ -2290,7 +2291,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteProgramYear()
+     * @covers ::canDeleteProgramYear()
      */
     public function testCanNotDeleteLockedProgramYears()
     {
@@ -2304,7 +2305,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteProgramYear()
+     * @covers ::canDeleteProgramYear()
      */
     public function testCanNotDeleteArchivedProgramYears()
     {
@@ -2318,7 +2319,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateProgramYear()
+     * @covers ::canCreateProgramYear()
      */
     public function testCanCreateProgramYear()
     {
@@ -2348,7 +2349,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateProgramYear()
+     * @covers ::canCreateProgramYear()
      */
     public function testCanCreateProgramYearIfUserCanUpdateProgram()
     {
@@ -2386,7 +2387,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateProgramYear()
+     * @covers ::canCreateProgramYear()
      */
     public function testCanNotCreateProgramYear()
     {
@@ -2435,7 +2436,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canLockProgramYear()
+     * @covers ::canLockProgramYear()
      */
     public function testCanLockAllProgramYears()
     {
@@ -2466,7 +2467,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canLockProgramYear()
+     * @covers ::canLockProgramYear()
      */
     public function testCanLockTheirProgramYears()
     {
@@ -2507,7 +2508,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canLockProgramYear()
+     * @covers ::canLockProgramYear()
      */
     public function testCanLockProgramYearsIfUserCanUpdateProgram()
     {
@@ -2560,7 +2561,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canLockProgramYear()
+     * @covers ::canLockProgramYear()
      */
     public function testCanNotLockProgramYearIfProgramYearIsArchived()
     {
@@ -2573,7 +2574,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUnlockProgramYear()
+     * @covers ::canUnlockProgramYear()
      */
     public function testCanUnlockAllProgramYears()
     {
@@ -2604,7 +2605,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUnlockProgramYear()
+     * @covers ::canUnlockProgramYear()
      */
     public function testCanUnlockTheirProgramYears()
     {
@@ -2645,7 +2646,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUnlockProgramYear()
+     * @covers ::canUnlockProgramYear()
      */
     public function testCanUnlockProgramYearsIfUserCanUpdateProgram()
     {
@@ -2698,7 +2699,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUnlockProgramYear()
+     * @covers ::canUnlockProgramYear()
      */
     public function testCanNotUnlockProgramYearIfProgramYearIsArchived()
     {
@@ -2711,7 +2712,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canArchiveProgramYear()
+     * @covers ::canArchiveProgramYear()
      */
     public function testCanArchiveAllProgramYears()
     {
@@ -2741,7 +2742,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canArchiveProgramYear()
+     * @covers ::canArchiveProgramYear()
      */
     public function testCanArchiveTheirProgramYears()
     {
@@ -2781,7 +2782,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canArchiveProgramYear()
+     * @covers ::canArchiveProgramYear()
      */
     public function testCanArchiveProgramYearsIfUserCanUpdateProgram()
     {
@@ -2833,7 +2834,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSchoolConfig()
+     * @covers ::canUpdateSchoolConfig()
      */
     public function testCanUpdateSchoolConfig()
     {
@@ -2856,7 +2857,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSchoolConfig()
+     * @covers ::canUpdateSchoolConfig()
      */
     public function testCanNotUpdateSchoolConfig()
     {
@@ -2879,7 +2880,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSchoolConfig()
+     * @covers ::canDeleteSchoolConfig()
      */
     public function testCanDeleteSchoolConfig()
     {
@@ -2902,7 +2903,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteSchoolConfig()
+     * @covers ::canDeleteSchoolConfig()
      */
     public function testCanNotDeleteSchoolConfig()
     {
@@ -2925,7 +2926,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateSchoolConfig()
+     * @covers ::canCreateSchoolConfig()
      */
     public function testCanCreateSchoolConfig()
     {
@@ -2948,7 +2949,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateSchoolConfig()
+     * @covers ::canCreateSchoolConfig()
      */
     public function testCanNotCreateSchoolConfig()
     {
@@ -2971,7 +2972,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSchool()
+     * @covers ::canUpdateSchool()
      */
     public function testCanUpdateSchool()
     {
@@ -2994,7 +2995,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateSchool()
+     * @covers ::canUpdateSchool()
      */
     public function testCanNotUpdateSchool()
     {
@@ -3017,7 +3018,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCompetency()
+     * @covers ::canUpdateCompetency()
      */
     public function testCanUpdateCompetency()
     {
@@ -3040,7 +3041,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCompetency()
+     * @covers ::canUpdateCompetency()
      */
     public function testCanNotUpdateCompetency()
     {
@@ -3063,7 +3064,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCompetency()
+     * @covers ::canDeleteCompetency()
      */
     public function testCanDeleteCompetency()
     {
@@ -3086,7 +3087,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCompetency()
+     * @covers ::canDeleteCompetency()
      */
     public function testCanNotDeleteCompetency()
     {
@@ -3109,7 +3110,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateCompetency()
+     * @covers ::canCreateCompetency()
      */
     public function testCanCreateCompetency()
     {
@@ -3132,7 +3133,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateCompetency()
+     * @covers ::canCreateCompetency()
      */
     public function testCanNotCreateCompetency()
     {
@@ -3155,7 +3156,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateVocabulary()
+     * @covers ::canUpdateVocabulary()
      */
     public function testCanUpdateVocabulary()
     {
@@ -3178,7 +3179,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateVocabulary()
+     * @covers ::canUpdateVocabulary()
      */
     public function testCanNotUpdateVocabulary()
     {
@@ -3201,7 +3202,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteVocabulary()
+     * @covers ::canDeleteVocabulary()
      */
     public function testCanDeleteVocabulary()
     {
@@ -3224,7 +3225,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteVocabulary()
+     * @covers ::canDeleteVocabulary()
      */
     public function testCanNotDeleteVocabulary()
     {
@@ -3247,7 +3248,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateVocabulary()
+     * @covers ::canCreateVocabulary()
      */
     public function testCanCreateVocabulary()
     {
@@ -3270,7 +3271,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateVocabulary()
+     * @covers ::canCreateVocabulary()
      */
     public function testCanNotCreateVocabulary()
     {
@@ -3293,7 +3294,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateTerm()
+     * @covers ::canUpdateTerm()
      */
     public function testCanUpdateTerm()
     {
@@ -3316,7 +3317,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateTerm()
+     * @covers ::canUpdateTerm()
      */
     public function testCanNotUpdateTerm()
     {
@@ -3339,7 +3340,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteTerm()
+     * @covers ::canDeleteTerm()
      */
     public function testCanDeleteTerm()
     {
@@ -3362,7 +3363,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteTerm()
+     * @covers ::canDeleteTerm()
      */
     public function testCanNotDeleteTerm()
     {
@@ -3385,7 +3386,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateTerm()
+     * @covers ::canCreateTerm()
      */
     public function testCanCreateTerm()
     {
@@ -3408,7 +3409,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateTerm()
+     * @covers ::canCreateTerm()
      */
     public function testCanNotCreateTerm()
     {
@@ -3431,7 +3432,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateInstructorGroup()
+     * @covers ::canUpdateInstructorGroup()
      */
     public function testCanUpdateInstructorGroup()
     {
@@ -3454,7 +3455,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateInstructorGroup()
+     * @covers ::canUpdateInstructorGroup()
      */
     public function testCanNotUpdateInstructorGroup()
     {
@@ -3477,7 +3478,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteInstructorGroup()
+     * @covers ::canDeleteInstructorGroup()
      */
     public function testCanDeleteInstructorGroup()
     {
@@ -3500,7 +3501,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteInstructorGroup()
+     * @covers ::canDeleteInstructorGroup()
      */
     public function testCanNotDeleteInstructorGroup()
     {
@@ -3523,7 +3524,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateInstructorGroup()
+     * @covers ::canCreateInstructorGroup()
      */
     public function testCanCreateInstructorGroup()
     {
@@ -3546,7 +3547,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateInstructorGroup()
+     * @covers ::canCreateInstructorGroup()
      */
     public function testCanNotCreateInstructorGroup()
     {
@@ -3569,7 +3570,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCurriculumInventoryReport()
+     * @covers ::canUpdateCurriculumInventoryReport()
      */
     public function testCanUpdateAllCurriculumInventoryReports()
     {
@@ -3595,7 +3596,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCurriculumInventoryReport()
+     * @covers ::canUpdateCurriculumInventoryReport()
      */
     public function testCanUpdateTheirCurriculumInventoryReports()
     {
@@ -3632,7 +3633,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCurriculumInventoryReport()
+     * @covers ::canUpdateCurriculumInventoryReport()
      */
     public function testCanNotUpdateCurriculumInventoryReport()
     {
@@ -3669,7 +3670,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCurriculumInventoryReport()
+     * @covers ::canDeleteCurriculumInventoryReport()
      */
     public function testCanDeleteAllCurriculumInventoryReports()
     {
@@ -3695,7 +3696,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCurriculumInventoryReport()
+     * @covers ::canDeleteCurriculumInventoryReport()
      */
     public function testCanDeleteTheirCurriculumInventoryReports()
     {
@@ -3732,7 +3733,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCurriculumInventoryReport()
+     * @covers ::canDeleteCurriculumInventoryReport()
      */
     public function testCanNotDeleteCurriculumInventoryReport()
     {
@@ -3769,7 +3770,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateCurriculumInventoryReport()
+     * @covers ::canCreateCurriculumInventoryReport()
      */
     public function testCanCreateCurriculumInventoryReport()
     {
@@ -3792,7 +3793,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateCurriculumInventoryReport()
+     * @covers ::canCreateCurriculumInventoryReport()
      */
     public function testCanNotCreateCurriculumInventoryReport()
     {
@@ -3815,7 +3816,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCurriculumInventoryInstitution()
+     * @covers ::canUpdateCurriculumInventoryInstitution()
      */
     public function testCanUpdateCurriculumInventoryInstitution()
     {
@@ -3838,7 +3839,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateCurriculumInventoryInstitution()
+     * @covers ::canUpdateCurriculumInventoryInstitution()
      */
     public function testCanNotUpdateCurriculumInventoryInstitution()
     {
@@ -3861,7 +3862,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCurriculumInventoryInstitution()
+     * @covers ::canDeleteCurriculumInventoryInstitution()
      */
     public function testCanDeleteCurriculumInventoryInstitution()
     {
@@ -3884,7 +3885,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteCurriculumInventoryInstitution()
+     * @covers ::canDeleteCurriculumInventoryInstitution()
      */
     public function testCanNotDeleteCurriculumInventoryInstitution()
     {
@@ -3907,7 +3908,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateCurriculumInventoryInstitution()
+     * @covers ::canCreateCurriculumInventoryInstitution()
      */
     public function testCanCreateCurriculumInventoryInstitution()
     {
@@ -3930,7 +3931,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateCurriculumInventoryInstitution()
+     * @covers ::canCreateCurriculumInventoryInstitution()
      */
     public function testCanNotCreateCurriculumInventoryInstitution()
     {
@@ -3953,7 +3954,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateLearnerGroup()
+     * @covers ::canUpdateLearnerGroup()
      */
     public function testCanUpdateLearnerGroup()
     {
@@ -3976,7 +3977,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateLearnerGroup()
+     * @covers ::canUpdateLearnerGroup()
      */
     public function testCanNotUpdateLearnerGroup()
     {
@@ -3999,7 +4000,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteLearnerGroup()
+     * @covers ::canDeleteLearnerGroup()
      */
     public function testCanDeleteLearnerGroup()
     {
@@ -4022,7 +4023,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteLearnerGroup()
+     * @covers ::canDeleteLearnerGroup()
      */
     public function testCanNotDeleteLearnerGroup()
     {
@@ -4045,7 +4046,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateLearnerGroup()
+     * @covers ::canCreateLearnerGroup()
      */
     public function testCanCreateLearnerGroup()
     {
@@ -4068,7 +4069,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateLearnerGroup()
+     * @covers ::canCreateLearnerGroup()
      */
     public function testCanNotCreateLearnerGroup()
     {
@@ -4091,7 +4092,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateUser()
+     * @covers ::canUpdateUser()
      */
     public function testCanUpdateUser()
     {
@@ -4114,7 +4115,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canUpdateUser()
+     * @covers ::canUpdateUser()
      */
     public function testCanNotUpdateUser()
     {
@@ -4137,7 +4138,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteUser()
+     * @covers ::canDeleteUser()
      */
     public function testCanDeleteUser()
     {
@@ -4160,7 +4161,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canDeleteUser()
+     * @covers ::canDeleteUser()
      */
     public function testCanNotDeleteUser()
     {
@@ -4183,7 +4184,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateUser()
+     * @covers ::canCreateUser()
      */
     public function testCanCreateUser()
     {
@@ -4206,7 +4207,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateUser()
+     * @covers ::canCreateUser()
      */
     public function testCanNotCreateUser()
     {
@@ -4230,7 +4231,7 @@ class PermissionCheckerTest extends TestCase
 
 
     /**
-     * @covers PermissionChecker::canViewLearnerGroup()
+     * @covers ::canViewLearnerGroup()
      */
     public function testCanViewLearnerGroupIfUseIsInLearnerGroup()
     {
@@ -4247,7 +4248,7 @@ class PermissionCheckerTest extends TestCase
 
 
     /**
-     * @covers PermissionChecker::canViewLearnerGroup()
+     * @covers ::canViewLearnerGroup()
      */
     public function testCanViewLearnerGroupIfUserPerformsNonLearnerFunction()
     {
@@ -4266,7 +4267,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canViewLearnerGroup()
+     * @covers ::canViewLearnerGroup()
      */
     public function testCanNotViewLearnerGroup()
     {
@@ -4285,7 +4286,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateUsersInAnySchool()
+     * @covers ::canCreateUsersInAnySchool()
      */
     public function testCanCreateUsersInAnySchool()
     {
@@ -4293,7 +4294,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateOrUpdateUsersInAnySchool()
+     * @covers ::canCreateOrUpdateUsersInAnySchool()
      */
     public function testCanCreateOrUpdateUsersInAnySchool()
     {
@@ -4301,7 +4302,7 @@ class PermissionCheckerTest extends TestCase
     }
 
     /**
-     * @covers PermissionChecker::canCreateCurriculumInventoryReportInAnySchool()
+     * @covers ::canCreateCurriculumInventoryReportInAnySchool()
      */
     public function testCanCreateCurriculumInventoryReportUserInAnySchool()
     {

--- a/tests/Service/ReportRolloverTest.php
+++ b/tests/Service/ReportRolloverTest.php
@@ -22,6 +22,7 @@ use Mockery as m;
 
 /**
  * Class ReportRolloverTest
+ * @coversDefaultClass \App\Service\CurriculumInventory\ReportRollover
  */
 class ReportRolloverTest extends TestCase
 {
@@ -164,7 +165,7 @@ class ReportRolloverTest extends TestCase
         return [[ $report ]];
     }
     /**
-     * @covers ReportRollover::rollover
+     * @covers ::rollover
      * @dataProvider reportProvider
      * @param CurriculumInventoryReport $report
      */
@@ -218,7 +219,7 @@ class ReportRolloverTest extends TestCase
     }
 
     /**
-     * @covers ReportRollover::rollover
+     * @covers ::rollover
      * @dataProvider reportProvider
      * @param CurriculumInventoryReport $report
      */
@@ -229,7 +230,7 @@ class ReportRolloverTest extends TestCase
     }
 
     /**
-     * @covers ReportRollover::rollover
+     * @covers ::rollover
      * @dataProvider reportProvider
      * @param CurriculumInventoryReport $report
      */
@@ -240,7 +241,7 @@ class ReportRolloverTest extends TestCase
     }
 
     /**
-     * @covers ReportRollover::rollover
+     * @covers ::rollover
      * @dataProvider reportProvider
      * @param CurriculumInventoryReport $report
      */


### PR DESCRIPTION
PHPUnit doesn't accept anything but a fully qualified name here, it does
provide the @coversDefaultClass annotation which avoids repeating the
name endlessly in tests.