### PR TITLE
Setup the inflector in the bootstrap file

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Doctrine\Common\Inflector\Inflector;
 use Symfony\Component\Dotenv\Dotenv;
 use Doctrine\Common\Annotations\AnnotationReader;
 
@@ -35,3 +36,17 @@ $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filt
 
 AnnotationReader::addGlobalIgnoredName('covers');
 AnnotationReader::addGlobalIgnoredName('group');
+
+/**
+ * Words which are difficult to inflect need custom
+ * rules.  We set these up here so they are consistent across the
+ * entire application.
+ */
+Inflector::rules('singular', [
+    'rules' => ['/^aamc(p)crses$/i' => 'aamc\1crs'],
+    'uninflected' => ['aamcpcrs'],
+]);
+Inflector::rules('plural', [
+    'rules' => ['/^aamc(p)crs$/i' => 'aamc\1crses'],
+    'uninflected' => ['aamcpcrses'],
+]);

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App;
 
-use Doctrine\Common\Inflector\Inflector;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
@@ -30,8 +29,6 @@ class Kernel extends BaseKernel
         // Force a UTC timezone on everyone
         date_default_timezone_set('UTC');
         parent::__construct($environment, $debug);
-
-        self::loadInflectionRules();
     }
 
     public function registerBundles(): iterable
@@ -69,22 +66,5 @@ class Kernel extends BaseKernel
         $routes->import($confDir . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
-    }
-
-    /**
-     * Words which are difficult to inflect need custom
-     * rules.  We set these up here so they are consistent across the
-     * entire application.
-     */
-    public static function loadInflectionRules()
-    {
-        Inflector::rules('singular', [
-            'rules' => ['/^aamc(p)crses$/i' => 'aamc\1crs'],
-            'uninflected' => ['aamcpcrs'],
-        ]);
-        Inflector::rules('plural', [
-            'rules' => ['/^aamc(p)crs$/i' => 'aamc\1crses'],
-            'uninflected' => ['aamcpcrses'],
-        ]);
     }
 }


### PR DESCRIPTION
Each time the kernel is created we were re-adding new rules to the
static inflector instance. In a test process where the kernel is created thousands of
times we're adding thousands of items which eventually overloads PHPs
regex parser and causes errors.

Instead of setting this when booting the kernel moving it to the
bootstrap file does the same work, but only once.

This is a fix for [code coverage failing](https://github.com/ilios/ilios/runs/473902951?check_suite_focus=true#step:5:118)