### PR TITLE
Add dependency management for action versions

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -14,4 +14,6 @@ update_configs:
       - match:
           dependency_type: all
           update_type: all
-
+  - package_manager: github_actions
+    directory: "/.github/workflows/"
+    update_schedule: daily


### PR DESCRIPTION
This will update the workflows we have with actions dependencies when
those dependencies are updated.


I have no idea if this is going to work, seems to be undocumented, but in the source code since December for dependabot. I think we'll just have to merge and find out.