### PR TITLE
Fix path for dependabot

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -15,5 +15,5 @@ update_configs:
           dependency_type: all
           update_type: all
   - package_manager: github_actions
-    directory: "/.github/workflows/"
+    directory: "/"
     update_schedule: daily


### PR DESCRIPTION
The bot knows where to look, just give it the root directory.

Fixes #2824