### PR TITLE
Protect against empty objectives

### DIFF
--- a/src/Controller/ProgramYearController.php
+++ b/src/Controller/ProgramYearController.php
@@ -128,7 +128,9 @@ class ProgramYearController extends ApiController
 
         array_walk($data, function (&$row) {
             foreach (['program_year_objective', 'mapped_course_objective'] as $key) {
-                $row[$key] = strip_tags($row[$key]);
+                if ($row[$key]) {
+                    $row[$key] = strip_tags($row[$key]);
+                }
             }
             $row['matriculation_year'] = $row['matriculation_year'] . ' - ' . ($row['matriculation_year'] + 1);
         });


### PR DESCRIPTION
We can't strip_tags on null it causes a strict type error.

Fixes #2826 
Refs #2759