### PR TITLE
Added option to specifiy schools in teaching reminders

### DIFF
--- a/src/Command/SendTeachingRemindersCommand.php
+++ b/src/Command/SendTeachingRemindersCommand.php
@@ -138,6 +138,12 @@ class SendTeachingRemindersCommand extends Command
                 "The name of the reminder's sender."
             )
             ->addOption(
+                'schools',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                "Only Send Reminders for this comma seperated list of school ids."
+            )
+            ->addOption(
                 'dry-run',
                 null,
                 InputOption::VALUE_NONE,
@@ -165,15 +171,19 @@ class SendTeachingRemindersCommand extends Command
         $subject = $input->getOption('subject');
         $isDryRun = $input->getOption('dry-run');
         $senderName = $input->getOption('sender_name');
+        $schools = $input->getOption('schools');
         $from = $sender;
         if ($senderName) {
             $from = [$sender => $senderName];
         }
-
-        $allSchoolIds = $this->schoolManager->getIds();
+        if ($schools) {
+            $schoolIds = array_map('intval', str_getcsv($schools));
+        } else {
+            $schoolIds = $this->schoolManager->getIds();
+        }
 
         // get all applicable offerings.
-        $offerings = $this->offeringManager->getOfferingsForTeachingReminders($daysInAdvance, $allSchoolIds);
+        $offerings = $this->offeringManager->getOfferingsForTeachingReminders($daysInAdvance, $schoolIds);
 
         if (!count($offerings)) {
             $output->writeln('<info>No offerings with pending teaching reminders found.</info>');

--- a/src/Entity/Manager/OfferingManager.php
+++ b/src/Entity/Manager/OfferingManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity\Manager;
 
+use App\Entity\Repository\OfferingRepository;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use App\Entity\OfferingInterface;
@@ -15,39 +16,11 @@ class OfferingManager extends BaseManager
 {
     /**
      * Retrieves offerings starting X days from now.
-     *
-     * @param int $daysInAdvance Days in advance from now.
-     * @return Collection|OfferingInterface[]
      */
-    public function getOfferingsForTeachingReminders($daysInAdvance)
+    public function getOfferingsForTeachingReminders(int $daysInAdvance, array $schoolIds): array
     {
-        $now = time();
-        $startDate = new \DateTime();
-        $startDate->setTimezone(new \DateTimeZone('UTC'));
-        $startDate->setTimestamp($now);
-        $startDate->modify("midnight +{$daysInAdvance} days");
-
-        $daysInAdvance++;
-        $endDate = new \DateTime();
-        $endDate->setTimezone(new \DateTimeZone('UTC'));
-        $endDate->setTimestamp($now);
-        $endDate->modify("midnight +{$daysInAdvance} days");
-
-        $criteria = Criteria::create();
-        $expr = Criteria::expr();
-        $criteria->where(
-            $expr->andX(
-                $expr->gte('startDate', $startDate),
-                $expr->lt('startDate', $endDate)
-            )
-        );
-        $offerings = $this->getRepository()->matching($criteria);
-
-        // filter out any offerings belonging to unpublished sessions and courses
-        $offerings = $offerings->filter(function (OfferingInterface $offering) {
-            return ($offering->getSession()->isPublished() && $offering->getSession()->getCourse()->isPublished());
-        });
-
-        return $offerings;
+        /** @var OfferingRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->getOfferingsForTeachingReminders($daysInAdvance, $schoolIds);
     }
 }

--- a/src/Entity/Manager/SchoolManager.php
+++ b/src/Entity/Manager/SchoolManager.php
@@ -113,4 +113,16 @@ class SchoolManager extends BaseManager
         $repository = $this->getRepository();
         return $repository->addPreAndPostRequisites($id, $events);
     }
+
+    /**
+     * Get all the IDs for every school
+     *
+     * @return int[]
+     */
+    public function getIds(): array
+    {
+        /** @var SchoolRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->getIds();
+    }
 }

--- a/src/Entity/Repository/OfferingRepository.php
+++ b/src/Entity/Repository/OfferingRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity\Repository;
 
+use App\Entity\Offering;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\AbstractQuery;
@@ -87,6 +88,43 @@ class OfferingRepository extends EntityRepository implements DTORepositoryInterf
             }
         }
         return array_values($offeringDTOs);
+    }
+
+    public function getOfferingsForTeachingReminders(int $daysInAdvance, array $schoolIds): array
+    {
+        $now = time();
+        $startDate = new \DateTime();
+        $startDate->setTimezone(new \DateTimeZone('UTC'));
+        $startDate->setTimestamp($now);
+        $startDate->modify("midnight +{$daysInAdvance} days");
+
+        $daysInAdvance++;
+        $endDate = new \DateTime();
+        $endDate->setTimezone(new \DateTimeZone('UTC'));
+        $endDate->setTimestamp($now);
+        $endDate->modify("midnight +{$daysInAdvance} days");
+
+        $qb = $this->_em->createQueryBuilder();
+        $exp = $qb->expr();
+
+        $qb->select('DISTINCT offering')->from(Offering::class, 'offering')
+            ->join('offering.session', 'session')
+            ->join('session.course', 'course')
+            ->join('course.school', 'school')
+            ->where($exp->andX(
+                $exp->gte('offering.startDate', ':startDate'),
+                $exp->lt('offering.startDate', ':endDate')
+            ))
+            ->andWhere($qb->expr()->in('school.id', ':schools'))
+            ->andWhere($qb->expr()->eq('session.published', true))
+            ->andWhere($qb->expr()->eq('course.published', true))
+            ->andWhere($qb->expr()->in('school.id', ':schools'))
+            ->orderBy('offering.id')
+            ->setParameter(':schools', $schoolIds)
+            ->setParameter(':startDate', $startDate)
+            ->setParameter(':endDate', $endDate);
+
+        return $qb->getQuery()->getResult();
     }
 
 

--- a/src/Entity/Repository/OfferingRepository.php
+++ b/src/Entity/Repository/OfferingRepository.php
@@ -115,7 +115,6 @@ class OfferingRepository extends EntityRepository implements DTORepositoryInterf
                 $exp->gte('offering.startDate', ':startDate'),
                 $exp->lt('offering.startDate', ':endDate')
             ))
-            ->andWhere($qb->expr()->in('school.id', ':schools'))
             ->andWhere($qb->expr()->eq('session.published', true))
             ->andWhere($qb->expr()->eq('course.published', true))
             ->andWhere($qb->expr()->in('school.id', ':schools'))

--- a/src/Entity/Repository/SchoolRepository.php
+++ b/src/Entity/Repository/SchoolRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity\Repository;
 
+use App\Entity\School;
 use App\Entity\Session;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\DBAL\Types\Type as DoctrineType;
@@ -334,6 +335,19 @@ class SchoolRepository extends EntityRepository implements DTORepositoryInterfac
     {
         $events = $this->attachPreRequisitesToEvents($id, $events);
         return $this->attachPostRequisitesToEvents($id, $events);
+    }
+
+    /**
+     * Get all the IDs
+     *
+     * @return int[]
+     */
+    public function getIds(): array
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->addSelect('x.id')->from(School::class, 'x');
+        $results = $qb->getQuery()->getScalarResult();
+        return array_map('intval', array_column($results, 'id'));
     }
 
     /**

--- a/tests/Command/SendTeachingRemindersCommandTest.php
+++ b/tests/Command/SendTeachingRemindersCommandTest.php
@@ -60,7 +60,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     protected $timezone;
 
     /**
-     * @var m\MockInterface
+     * @var m\MockInterface|Filesystem
      */
     protected $fs;
 
@@ -72,27 +72,8 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $offering = $this->createOffering();
-
-        $this->fakeOfferingManager = $this
-            ->getMockBuilder(OfferingManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->fakeOfferingManager
-            ->method('getOfferingsForTeachingReminders')
-            ->will($this->returnValueMap(
-                [
-                    [ 7, [1], [ $offering ] ],
-                    [ 10, [1], [] ],
-                ]
-            ));
-        $this->fakeSchoolManager = $this
-            ->getMockBuilder(SchoolManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->fakeSchoolManager
-            ->method('getIds')
-            ->will($this->returnValue([1]));
+        $this->fakeOfferingManager = m::mock(OfferingManager::class);
+        $this->fakeSchoolManager = m::mock(SchoolManager::class);
         $this->testDir = sys_get_temp_dir();
 
         $this->fs = m::mock(Filesystem::class);
@@ -138,6 +119,11 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
         $sender = 'foo@bar.edu';
         $baseUrl = 'https://ilios.bar.edu';
 
+        $offering = $this->createOffering();
+        $this->fakeOfferingManager->shouldReceive('getOfferingsForTeachingReminders')
+            ->with(7, [1])->andReturn([$offering]);
+        $this->fakeSchoolManager->shouldReceive('getIds')->andReturn([1]);
+
         $this->fs->shouldReceive('exists')->with(
             $this->testDir . '/custom/templates/email/TEST_' . SendTeachingRemindersCommand::DEFAULT_TEMPLATE_NAME
         )->once()->andReturn(false);
@@ -147,9 +133,6 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
             'base_url' => $baseUrl,
             '--dry-run' => true,
         ]);
-
-        /** @var OfferingInterface $offering */
-        $offering = $this->fakeOfferingManager->getOfferingsForTeachingReminders(7, [1])[0];
 
         $output = $this->commandTester->getDisplay();
 
@@ -227,6 +210,9 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     {
         $sender = 'foo@bar.edu';
         $baseUrl = 'https://ilios.bar.edu';
+        $this->fakeOfferingManager->shouldReceive('getOfferingsForTeachingReminders')
+            ->with(10, [1])->andReturn([]);
+        $this->fakeSchoolManager->shouldReceive('getIds')->andReturn([1]);
 
         $this->commandTester->execute([
             'sender' => $sender,
@@ -249,6 +235,11 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
         $name = 'Horst Krause';
         $subject = "Custom email subject";
         $baseUrl = 'https://ilios.bar.edu';
+        $offering = $this->createOffering();
+        $this->fakeOfferingManager->shouldReceive('getOfferingsForTeachingReminders')
+            ->with(7, [1])->andReturn([$offering]);
+        $this->fakeSchoolManager->shouldReceive('getIds')->andReturn([1]);
+
 
         $this->fs->shouldReceive('exists')->with(
             $this->testDir . '/custom/templates/email/TEST_' . SendTeachingRemindersCommand::DEFAULT_TEMPLATE_NAME
@@ -276,9 +267,10 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
         $name = 'Horst Krause';
         $subject = "Custom email subject";
         $baseUrl = 'https://ilios.bar.edu';
-
-        /* @var OfferingInterface $offering */
-        $offering = $this->fakeOfferingManager->getOfferingsForTeachingReminders(7, [1])[0];
+        $offering = $this->createOffering();
+        $this->fakeOfferingManager->shouldReceive('getOfferingsForTeachingReminders')
+            ->with(7, [1])->andReturn([$offering]);
+        $this->fakeSchoolManager->shouldReceive('getIds')->andReturn([1]);
 
         /** @var UserInterface $instructor */
         foreach ($offering->getAllInstructors()->toArray() as $instructor) {
@@ -316,6 +308,10 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
         $sender = 'foo@bar.edu';
         $subject = "Custom email subject";
         $baseUrl = 'https://ilios.bar.edu';
+        $offering = $this->createOffering();
+        $this->fakeOfferingManager->shouldReceive('getOfferingsForTeachingReminders')
+            ->with(7, [1])->andReturn([$offering]);
+        $this->fakeSchoolManager->shouldReceive('getIds')->andReturn([1]);
 
         $this->fs->shouldReceive('exists')->with(
             $this->testDir . '/custom/templates/email/TEST_' . SendTeachingRemindersCommand::DEFAULT_TEMPLATE_NAME
@@ -339,9 +335,11 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
      */
     public function testExecuteSchoolTitleEndsWithS()
     {
+        $offering = $this->createOffering();
+        $this->fakeOfferingManager->shouldReceive('getOfferingsForTeachingReminders')
+            ->with(7, [1])->andReturn([$offering]);
+        $this->fakeSchoolManager->shouldReceive('getIds')->andReturn([1]);
         $schoolTitle = 'Global Health Sciences';
-        /** @var OfferingInterface $offering */
-        $offering = $this->fakeOfferingManager->getOfferingsForTeachingReminders(7, [1])[0];
         $offering->getSession()->getCourse()->getSchool()->setTitle($schoolTitle);
 
         $sender = 'foo@bar.edu';
@@ -372,6 +370,10 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     {
         $sender = 'foo@bar.edu';
         $baseUrl = 'https://ilios.bar.edu';
+        $offering = $this->createOffering();
+        $this->fakeOfferingManager->shouldReceive('getOfferingsForTeachingReminders')
+            ->with(7, [1])->andReturn([$offering]);
+        $this->fakeSchoolManager->shouldReceive('getIds')->andReturn([1]);
 
         $this->fs->shouldReceive('exists')->with(
             $this->testDir . '/custom/templates/email/TEST_' . SendTeachingRemindersCommand::DEFAULT_TEMPLATE_NAME
@@ -426,11 +428,9 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
     }
 
     /**
-     * @return OfferingInterface
-     *
      * @todo This is truly in bad form. Refactor fixture loading out. [ST 2015/09/25]
      */
-    protected function createOffering()
+    protected function createOffering(): OfferingInterface
     {
         $school = new School();
         $school->setId(1);

--- a/tests/Entity/Manager/OfferingManagerTest.php
+++ b/tests/Entity/Manager/OfferingManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity\Manager;
 
+use App\Entity\School;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
@@ -69,23 +70,23 @@ class OfferingManagerTest extends TestCase
 
         $session->setPublished(true);
         $course->setPublished(true);
-        $offerings  = $manager->getOfferingsForTeachingReminders(10);
+        $offerings  = $manager->getOfferingsForTeachingReminders(10, [1]);
         $this->assertEquals(1, $offerings->count());
         $this->assertEquals($offering, $offerings->first());
 
         $session->setPublished(false);
         $course->setPublished(true);
-        $offerings  = $manager->getOfferingsForTeachingReminders(10);
+        $offerings  = $manager->getOfferingsForTeachingReminders(10, [1]);
         $this->assertEquals(0, $offerings->count());
 
         $session->setPublished(true);
         $course->setPublished(false);
-        $offerings  = $manager->getOfferingsForTeachingReminders(10);
+        $offerings  = $manager->getOfferingsForTeachingReminders(10, [1]);
         $this->assertEquals(0, $offerings->count());
 
         $session->setPublished(false);
         $course->setPublished(false);
-        $offerings  = $manager->getOfferingsForTeachingReminders(10);
+        $offerings  = $manager->getOfferingsForTeachingReminders(10, [1]);
         $this->assertEquals(0, $offerings->count());
     }
 }

--- a/tests/Entity/Manager/OfferingManagerTest.php
+++ b/tests/Entity/Manager/OfferingManagerTest.php
@@ -4,15 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity\Manager;
 
-use App\Entity\School;
 use Doctrine\Bundle\DoctrineBundle\Registry;
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
-use App\Entity\Course;
 use App\Entity\Manager\OfferingManager;
 use App\Entity\Offering;
 use App\Entity\Repository\DTORepositoryInterface;
-use App\Entity\Session;
 use Mockery as m;
 use App\Tests\TestCase;
 
@@ -40,53 +36,5 @@ class OfferingManagerTest extends TestCase
         $entity = m::mock(Offering::class);
         $manager = new OfferingManager($registry, Offering::class);
         $manager->delete($entity);
-    }
-
-    /**
-     * @covers \App\Entity\Manager\OfferingManager::getOfferingsForTeachingReminders
-     */
-    public function testGetOfferingsForTeachingReminders()
-    {
-        $offering = new Offering();
-        $session  = new Session();
-        $offering->setSession($session);
-        $course = new Course();
-        $session->setCourse($course);
-
-        $em = m::mock(EntityManager::class);
-        $repository = m::mock(DTORepositoryInterface::class)
-            ->shouldReceive('matching')
-            ->andReturn(new ArrayCollection([$offering]))
-            ->mock();
-
-        $registry = m::mock(Registry::class)
-            ->shouldReceive('getManagerForClass')
-            ->andReturn($em)
-            ->shouldReceive('getRepository')
-            ->andReturn($repository)
-            ->mock();
-
-        $manager = new OfferingManager($registry, Offering::class);
-
-        $session->setPublished(true);
-        $course->setPublished(true);
-        $offerings  = $manager->getOfferingsForTeachingReminders(10, [1]);
-        $this->assertEquals(1, $offerings->count());
-        $this->assertEquals($offering, $offerings->first());
-
-        $session->setPublished(false);
-        $course->setPublished(true);
-        $offerings  = $manager->getOfferingsForTeachingReminders(10, [1]);
-        $this->assertEquals(0, $offerings->count());
-
-        $session->setPublished(true);
-        $course->setPublished(false);
-        $offerings  = $manager->getOfferingsForTeachingReminders(10, [1]);
-        $this->assertEquals(0, $offerings->count());
-
-        $session->setPublished(false);
-        $course->setPublished(false);
-        $offerings  = $manager->getOfferingsForTeachingReminders(10, [1]);
-        $this->assertEquals(0, $offerings->count());
     }
 }


### PR DESCRIPTION
Added a `--schools 1,2,4` option to the command that will allow us to split up reminder jobs so that each school can use their own outgoing email address and subject for the teaching reminder emails along with a school specific template for the content.

Fixes #2168