### PR TITLE
Store uploaded files in the shared file system

### DIFF
--- a/src/Controller/UploadController.php
+++ b/src/Controller/UploadController.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Service\TemporaryFileSystem;
+use App\RelationshipVoter\IliosFileSystem as IFSVoter;
+use App\Service\IliosFileSystem;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,10 +20,10 @@ class UploadController extends AbstractController
 
     public function uploadAction(
         Request $request,
-        TemporaryFileSystem $temporaryFileSystem,
+        IliosFileSystem $iliosFileSystem,
         AuthorizationCheckerInterface $authorizationChecker
     ) {
-        if (! $authorizationChecker->isGranted('create', $temporaryFileSystem)) {
+        if (! $authorizationChecker->isGranted(IFSVoter::CREATE_TEMPORARY_FILE, $iliosFileSystem)) {
             throw $this->createAccessDeniedException('Unauthorized access!');
         }
 
@@ -35,13 +36,13 @@ class UploadController extends AbstractController
             ), JsonResponse::HTTP_BAD_REQUEST);
         }
         if (!$uploadedFile->isValid()) {
-            return new JsonResponse(array('errors' => 'File failed to upload'), JsonResponse::HTTP_BAD_REQUEST);
+            return new JsonResponse(['errors' => 'File failed to upload'], JsonResponse::HTTP_BAD_REQUEST);
         }
-        $hash = $temporaryFileSystem->storeFile($uploadedFile);
-        $response = array(
+        $hash = $iliosFileSystem->storeUploadedTemporaryFile($uploadedFile);
+        $response = [
             'filename' => $uploadedFile->getClientOriginalName(),
             'fileHash' => $hash
-        );
+        ];
         return new JsonResponse($response, JsonResponse::HTTP_OK);
     }
 }

--- a/src/RelationshipVoter/IliosFileSystem.php
+++ b/src/RelationshipVoter/IliosFileSystem.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\RelationshipVoter;
+
+use App\Service\IliosFileSystem as FileSystem;
+use App\Classes\SessionUserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class IliosFileSystem extends Voter
+{
+    public const CREATE_TEMPORARY_FILE = 'create_temporary_file';
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports($attribute, $subject)
+    {
+        return $subject instanceof FileSystem && in_array($attribute, [self::CREATE_TEMPORARY_FILE]);
+    }
+
+    /**
+     * @param string $attribute
+     * @param TemporaryFileSystem $fileSystem
+     * @param TokenInterface $token
+     * @return bool
+     */
+    protected function voteOnAttribute($attribute, $fileSystem, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        return $user->performsNonLearnerFunction();
+    }
+}

--- a/src/Service/TemporaryFileSystem.php
+++ b/src/Service/TemporaryFileSystem.php
@@ -58,7 +58,7 @@ class TemporaryFileSystem
      * @param  string $contents
      * @return File
      */
-    public function createFile(string $contents)
+    public function createFile(string $contents): File
     {
         $hash = md5($contents);
         $path = $this->getPath($hash);

--- a/tests/Service/IliosFileSystemTest.php
+++ b/tests/Service/IliosFileSystemTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Filesystem\Filesystem as SymfonyFileSystem;
 use Symfony\Component\HttpFoundation\File\File;
 use App\Service\IliosFileSystem;
 use App\Tests\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class IliosFileSystemTest extends TestCase
 {
@@ -194,5 +195,24 @@ class IliosFileSystemTest extends TestCase
         $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(true);
         $this->fileSystem->shouldReceive('put')->with($lockFilePath, 'LOCK');
         $this->iliosFileSystem->createLock($name);
+    }
+
+    public function testStoreUploadedTemporaryFile()
+    {
+        $path = __FILE__;
+        $file = m::mock(UploadedFile::class)
+            ->shouldReceive('getPathname')->andReturn($path)->getMock();
+        $this->fileSystem->shouldReceive('putStream');
+        $this->iliosFileSystem->storeUploadedTemporaryFile($file);
+    }
+
+    public function testGetUploadedTemporaryFileContents()
+    {
+        $hash = md5_file(__FILE__);
+        $testContents = file_get_contents(__FILE__);
+        $this->fileSystem->shouldReceive('has')->with("tmp/${hash}")->andReturn(true);
+        $this->fileSystem->shouldReceive('readAndDelete')->with("tmp/${hash}")->andReturn($testContents);
+        $contents = $this->iliosFileSystem->getUploadedTemporaryFileContentsAndRemoveFile($hash);
+        $this->assertSame($contents, $testContents);
     }
 }


### PR DESCRIPTION
Learning materials are uploaded into a temporary file system on whatever
server the user happens to hit. On distributed systems this makes it a
random chance of catching the system which contains the file when you
want to save it.

This change stores these uploaded files on the official FS (S3, shared
drive) which is already setup to be shared among machines. Thus ensuring
that tmp files are available when users want to attach them to a
learning material.