### PR TITLE
Re-activate all objectives

### DIFF
--- a/src/Migrations/Version20200330062405.php
+++ b/src/Migrations/Version20200330062405.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200330062405 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Re-active all objectives';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('UPDATE objective SET active=1');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+    }
+}


### PR DESCRIPTION
No UI exists to deactivate objectives currently, but they were
defaulting to inactive when created. This was a mistake which can best
be fixed by re-activating any objectives that are currently inactive.