### PR TITLE
Trim down .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,4 @@
-/.web-server-pid
-/app/config/parameters.yml
 /build/
-/phpunit.xml
-/var/*
-!/var/cache
-/var/cache/*
-!var/cache/.gitkeep
-/var/log/*
-!/var/sessions
-/var/sessions/*
-!var/sessions/.gitkeep
-!var/SymfonyRequirements.php
-/vendor/
-/web/bundles/
-.vagrant
-sauce_connect.log
 FakeTestFiles
 
 ###> squizlabs/php_codesniffer ###


### PR DESCRIPTION
Some cruft has built up here, many of these things are now ignored and
managed by symfony flex recipes, the rest we're not using any more.