### PR TITLE
Add type checking to return value

### DIFF
--- a/src/Service/IliosFileSystem.php
+++ b/src/Service/IliosFileSystem.php
@@ -254,7 +254,12 @@ class IliosFileSystem
     {
         $relativePath = $this->getTemporaryFilePath($hash);
         if ($this->fileSystem->has($relativePath)) {
-            return $this->fileSystem->readAndDelete($relativePath);
+            $result = $this->fileSystem->readAndDelete($relativePath);
+            if ($result === false) {
+                throw new \Exception("Unable to read temporary file ${hash}");
+            }
+
+            return $result;
         }
 
         return null;


### PR DESCRIPTION
When this fails with false it throws an exception before that boolean is
an invalid return type. Convert it to an exception instead.

Fixes #2873
Fixes #2870