### PR TITLE
Add a shim layer for v1 API objectives

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -491,6 +491,23 @@ ilios_api_permissions_410:
     object: 'permissions'
     id: '(?i)[a-z0-9\-]+'
 
+ilios_api_objective_get:
+  path:     /api/{version}/{object}/{id}
+  controller: App\Controller\ObjectiveController::get
+  methods:  [GET]
+  requirements:
+    version: "%ilios_api_valid_api_versions%"
+    object: 'objectives'
+    id: '\d+'
+
+ilios_api_objective_getAll:
+  path:     /api/{version}/{object}
+  controller: App\Controller\ObjectiveController::getAll
+  methods:  [GET]
+  requirements:
+    version: "%ilios_api_valid_api_versions%"
+    object: 'objectives'
+
 ilios_api_programyears_post:
   path:     /api/{version}/{object}
   controller: App\Controller\ProgramYearController::postAction

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,7 +16,7 @@ parameters:
       objectives,offerings,pendinguserupdates,permissions,programs,programyears,programyearobjectives,programyearstewards,reports,
       sessionlearningmaterials,sessiondescriptions,sessionlearningmaterials,sessions,sessionobjectives,sessiontypes,schoolconfigs,schools,
       terms,usermadereminders,userroles,users,vocabularies
-    ilios_api_valid_api_versions: 'v1'
+    ilios_api_valid_api_versions: 'v1|v2'
     sentry_dsn: https://c70286fb157048be9ebc6e918e8c2b79@sentry.io/1323198
 
 services:
@@ -104,6 +104,9 @@ services:
       public: true
       arguments:
         $class: 'App\Entity\CourseLearningMaterial'
+    App\Entity\Manager\CourseObjectiveManager:
+      arguments:
+        $class: 'App\Entity\CourseObjective'
     App\Entity\Manager\CurriculumInventoryAcademicLevelManager:
       public: true
       arguments:
@@ -156,6 +159,9 @@ services:
       public: true
       arguments:
         $class: 'App\Entity\ProgramYear'
+    App\Entity\Manager\ProgramYearObjectiveManager:
+      arguments:
+        $class: 'App\Entity\ProgramYearObjective'
     App\Entity\Manager\ProgramYearStewardManager:
       public: true
       arguments:
@@ -181,6 +187,9 @@ services:
       public: true
       arguments:
         $class: 'App\Entity\SessionLearningMaterial'
+    App\Entity\Manager\SessionObjectiveManager:
+      arguments:
+        $class: 'App\Entity\SessionObjective'
     App\Entity\Manager\UserManager:
       public: true
       arguments:

--- a/config/services/virtual-managers.yaml
+++ b/config/services/virtual-managers.yaml
@@ -29,10 +29,6 @@ services:
         class: App\Entity\Manager\BaseManager
         arguments:
             $class: 'App\Entity\CourseClerkshipType'
-    App\Entity\Manager\CourseObjectiveManager:
-        class: App\Entity\Manager\BaseManager
-        arguments:
-            $class: 'App\Entity\CourseObjective'
     App\Entity\Manager\DepartmentManager:
         class: App\Entity\Manager\BaseManager
         arguments:
@@ -81,18 +77,10 @@ services:
         class: App\Entity\Manager\BaseManager
         arguments:
             $class: 'App\Entity\Program'
-    App\Entity\Manager\ProgramYearObjectiveManager:
-        class: App\Entity\Manager\BaseManager
-        arguments:
-            $class: 'App\Entity\ProgramYearObjective'
     App\Entity\Manager\ReportManager:
         class: App\Entity\Manager\BaseManager
         arguments:
             $class: 'App\Entity\Report'
-    App\Entity\Manager\SessionObjectiveManager:
-        class: App\Entity\Manager\BaseManager
-        arguments:
-            $class: 'App\Entity\SessionObjective'
     App\Entity\Manager\SessionTypeManager:
         class: App\Entity\Manager\BaseManager
         arguments:

--- a/src/Controller/ObjectiveController.php
+++ b/src/Controller/ObjectiveController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\DTO\ObjectiveDTO;
+use App\Entity\DTO\ObjectiveV1DTO;
+use App\Entity\Manager\CourseObjectiveManager;
+use App\Entity\Manager\ObjectiveManager;
+use App\Entity\Manager\ProgramYearObjectiveManager;
+use App\Entity\Manager\SessionObjectiveManager;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Class ObjectiveController
+ * @package App\Controller
+ */
+class ObjectiveController extends ApiController
+{
+    /**
+     * @var CourseObjectiveManager
+     */
+    protected $courseObjectiveManager;
+
+    /**
+     * @var ProgramYearObjectiveManager
+     */
+    protected $programYearObjectiveManager;
+
+    /**
+     * @var SessionObjectiveManager
+     */
+    protected $sessionObjectiveManager;
+
+    /**
+     * @required
+     */
+    public function setup(
+        ObjectiveManager $objectiveManager,
+        CourseObjectiveManager $courseObjectiveManager,
+        ProgramYearObjectiveManager $programYearObjectiveManager,
+        SessionObjectiveManager $sessionObjectiveManager
+    ) {
+        $this->courseObjectiveManager = $courseObjectiveManager;
+        $this->programYearObjectiveManager = $programYearObjectiveManager;
+        $this->sessionObjectiveManager = $sessionObjectiveManager;
+    }
+
+    public function get($version, $object, $id)
+    {
+        $manager = $this->getManager($object);
+        $dto = $manager->findDTOBy(['id' => $id]);
+
+        if (! $dto) {
+            $name = ucfirst($this->getSingularResponseKey($object));
+            throw new NotFoundHttpException(sprintf("%s with id '%s' was not found.", $name, $id));
+        }
+
+        if ($version === 'v1') {
+            $dto = new ObjectiveV1DTO(
+                $dto,
+                $this->courseObjectiveManager,
+                $this->programYearObjectiveManager,
+                $this->sessionObjectiveManager
+            );
+        }
+
+        return $this->resultsToResponse([$dto], $this->getPluralResponseKey($object), Response::HTTP_OK);
+    }
+
+    public function getAll(
+        $version,
+        $object,
+        Request $request
+    ) {
+        $parameters = $this->extractParameters($request);
+        $manager = $this->getManager($object);
+        $result = $manager->findDTOsBy(
+            $parameters['criteria'],
+            $parameters['orderBy'],
+            $parameters['limit'],
+            $parameters['offset']
+        );
+        $courseObjectiveManager = $this->courseObjectiveManager;
+        $programYearObjectiveManager = $this->programYearObjectiveManager;
+        $sessionObjectiveManager = $this->sessionObjectiveManager;
+
+        if ($version === 'v1') {
+            $result = array_map(function (ObjectiveDTO $objectiveDTO) use (
+                $courseObjectiveManager,
+                $programYearObjectiveManager,
+                $sessionObjectiveManager
+            ) {
+                return new ObjectiveV1DTO(
+                    $objectiveDTO,
+                    $courseObjectiveManager,
+                    $programYearObjectiveManager,
+                    $sessionObjectiveManager
+                );
+            }, $result);
+        }
+
+        return $this->resultsToResponse($result, $this->getPluralResponseKey($object), Response::HTTP_OK);
+    }
+}

--- a/src/Entity/DTO/ObjectiveV1DTO.php
+++ b/src/Entity/DTO/ObjectiveV1DTO.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\DTO;
+
+use App\Annotation as IS;
+use App\Entity\Manager\CourseObjectiveManager;
+use App\Entity\Manager\ProgramYearObjectiveManager;
+use App\Entity\Manager\SessionObjectiveManager;
+use App\Entity\DTO\ObjectiveDTO as CurrentDTO;
+
+/**
+ * Class ObjectiveDTO
+ * Data transfer object for a Objective
+ *
+ * @IS\DTO
+ */
+class ObjectiveV1DTO
+{
+    /**
+     * @var int
+     * @IS\Expose
+     * @IS\Type("integer")
+     */
+    public $id;
+
+    /**
+     * @var string
+     * @IS\Expose
+     * @IS\Type("string")
+     *
+     */
+    public $title;
+
+    /**
+     * @var int
+     * @IS\Expose
+     * @IS\Type("string")
+     *
+     */
+    public $competency;
+
+    /**
+     * @var int[]
+     * @IS\Expose
+     * @IS\Type("array<string>")
+     *
+     */
+    public $courses;
+
+    /**
+     * @var int[]
+     * @IS\Expose
+     * @IS\Type("array<string>")
+     *
+     */
+    public $programYears;
+
+    /**
+     * @var int[]
+     * @IS\Expose
+     * @IS\Type("array<string>")
+     *
+     */
+    public $sessions;
+
+    /**
+     * @var int[]
+     * @IS\Expose
+     * @IS\Type("array<string>")
+     *
+     */
+    public $parents;
+
+    /**
+     * @var int[]
+     * @IS\Expose
+     * @IS\Type("array<string>")
+     *
+     */
+    public $children;
+
+    /**
+     * @var int[]
+     * @IS\Expose
+     * @IS\Type("array<string>")
+     *
+     */
+    public $meshDescriptors;
+
+    /**
+     * @var int
+     * @IS\Expose
+     * @IS\Type("string")
+     *
+     */
+    public $ancestor;
+
+    /**
+     * @var int[]
+     * @IS\Expose
+     * @IS\Type("array<string>")
+     *
+     */
+    public $descendants;
+
+    /**
+     * @var int
+     * @IS\Expose
+     * @IS\Type("integer")
+     * @deprecated
+     *
+     */
+    public $position;
+
+    /**
+     * @var bool
+     * @IS\Expose
+     * @IS\Type("integer")
+     *
+     */
+    public $active;
+
+
+    public function __construct(
+        CurrentDTO $dto,
+        CourseObjectiveManager $courseObjectiveManager,
+        ProgramYearObjectiveManager $programYearObjectiveManager,
+        SessionObjectiveManager $sessionObjectiveManager
+    ) {
+
+        $this->id = $dto->id;
+        $this->title = $dto->title;
+        $this->active = $dto->active;
+
+        $this->courses = [];
+        $this->sessions = [];
+        $this->programYears = [];
+
+        if ($dto->courseObjectives) {
+            $courseObjectiveDtos = $courseObjectiveManager->findDTOsBy(['id' => $dto->courseObjectives]);
+            $this->courses = array_column($courseObjectiveDtos, 'course');
+            $this->position = $courseObjectiveDtos[0]->position;
+        }
+        if ($dto->programYearObjectives) {
+            $programYearObjectiveDtos = $programYearObjectiveManager->findDTOsBy(['id' => $dto->programYearObjectives]);
+            $this->programYears = array_column($programYearObjectiveDtos, 'programYear');
+            $this->position = $programYearObjectiveDtos[0]->position;
+        }
+        if ($dto->sessionObjectives) {
+            $sessionObjectiveDtos = $sessionObjectiveManager->findDTOsBy(['id' => $dto->sessionObjectives]);
+            $this->sessions = array_column($sessionObjectiveDtos, 'session');
+            $this->position = $sessionObjectiveDtos[0]->position;
+        }
+
+        $this->parents = $dto->parents;
+        $this->children = $dto->children;
+        $this->meshDescriptors = $dto->meshDescriptors;
+        $this->descendants = $dto->descendants;
+    }
+}

--- a/src/Entity/Manager/CourseObjectiveManager.php
+++ b/src/Entity/Manager/CourseObjectiveManager.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Manager;
+
+class CourseObjectiveManager extends BaseManager
+{
+}

--- a/src/Entity/Manager/ProgramYearObjectiveManager.php
+++ b/src/Entity/Manager/ProgramYearObjectiveManager.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Manager;
+
+class ProgramYearObjectiveManager extends BaseManager
+{
+}

--- a/src/Entity/Manager/SessionObjectiveManager.php
+++ b/src/Entity/Manager/SessionObjectiveManager.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Manager;
+
+class SessionObjectiveManager extends BaseManager
+{
+}

--- a/src/RelationshipVoter/GreenlightViewDTOVoter.php
+++ b/src/RelationshipVoter/GreenlightViewDTOVoter.php
@@ -44,6 +44,7 @@ use App\Entity\DTO\SessionObjectiveDTO;
 use App\Entity\DTO\SessionTypeDTO;
 use App\Entity\DTO\TermDTO;
 use App\Entity\DTO\UserRoleDTO;
+use App\Entity\DTO\ObjectiveV1DTO;
 use App\Entity\DTO\VocabularyDTO;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -85,6 +86,7 @@ class GreenlightViewDTOVoter extends AbstractVoter
                 || $subject instanceof MeshTermDTO
                 || $subject instanceof MeshTreeDTO
                 || $subject instanceof ObjectiveDTO
+                || $subject instanceof ObjectiveV1DTO
                 || $subject instanceof ProgramDTO
                 || $subject instanceof ProgramYearDTO
                 || $subject instanceof ProgramYearObjectiveDTO


### PR DESCRIPTION
To provide a longer on ramp for API users to make the transition to the
v2 objective API this allows v1 objectives to be read in their old
format.