### PR TITLE
Fix frontend install in cache warmup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,20 @@ services:
         image: ilios/mysql-demo
         ports:
             - "13306:3306"
+#    web:
+#        build: ./
+#        environment:
+#            - APP_ENV=dev
+#            - APP_DEBUG=true
+#            - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
+#            - ILIOS_REQUIRE_SECURE_CONNECTION=false
+#            - ILIOS_ERROR_CAPTURE_ENABLED=false
+#            - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
+#            - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+#        ports:
+#            - "8000:80"
+#        volumes:
+#            - ./:/var/www/ilios:delegated
     elasticsearch:
         build: ./docker/elasticsearch-dev
         environment:

--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -183,6 +183,7 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
                 $version = $releaseVersion;
             }
             $this->downloadAndExtractArchive(self::PRODUCTION, $version);
+            $this->copyStaticFilesIntoPublicDirectory();
         } catch (Exception $e) {
             print "\n\n**Warning: Unable to load frontend. Please run ilios:maintenance:update-frontend again.**\n\n\n";
         }


### PR DESCRIPTION
Missing this second step in the warmup command means that the frontend
wasn't actually installed.

I also added back in a commented out section for docker-composer.yaml
making it a bit easier to test things like this when needed.