### PR TITLE
Fix limit and offset type errors

### DIFF
--- a/src/Service/ApiRequestParser.php
+++ b/src/Service/ApiRequestParser.php
@@ -42,8 +42,8 @@ class ApiRequestParser
     public static function extractParameters(Request $request): array
     {
         $parameters = [
-            'offset' => $request->query->get('offset'),
-            'limit' => $request->query->get('limit'),
+            'offset' => $request->query->has('offset') ? (int) $request->query->get('offset') : null,
+            'limit' => $request->query->has('limit') ? (int) $request->query->get('limit') : null,
             'orderBy' => $request->query->get('order_by'),
             'criteria' => []
         ];

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -181,6 +181,43 @@ class LearningMaterialTest extends ReadWriteEndpointTest
     }
 
     /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithLimit()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['title'], 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'lm', 'limit' => 2];
+        $this->filterTest($filters, [$all[0], $all[1]]);
+    }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithOffset()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['title'], 'offset' => 0];
+        $this->filterTest($filters, [$all[0]]);
+    }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithOffsetAndLimit()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['title'], 'offset' => 0, 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'lm', 'offset' => 3, 'limit' => 1];
+        $this->filterTest($filters, [$all[3]]);
+    }
+
+    /**
      * @covers \App\Controller\LearningMaterialController::getAllAction
      */
     public function testFindByQAsLearner()

--- a/tests/Endpoints/MeshDescriptorTest.php
+++ b/tests/Endpoints/MeshDescriptorTest.php
@@ -95,4 +95,41 @@ class MeshDescriptorTest extends AbstractMeshTest
         $filters = ['q' => $q];
         $this->filterTest($filters, $expectedData);
     }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithLimit()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['name'], 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'desc', 'limit' => 2];
+        $this->filterTest($filters, [$all[0], $all[1]]);
+    }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithOffset()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['name'], 'offset' => 0];
+        $this->filterTest($filters, [$all[0]]);
+    }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithOffsetAndLimit()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['name'], 'offset' => 0, 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'desc', 'offset' => 1, 'limit' => 1];
+        $this->filterTest($filters, [$all[1]]);
+    }
 }

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -184,6 +184,43 @@ class UserTest extends ReadWriteEndpointTest
         $this->filterTest($filters, $expectedData);
     }
 
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithLimit()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['firstName'], 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'school.edu', 'limit' => 2];
+        $this->filterTest($filters, [$all[0], $all[1]]);
+    }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithOffset()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['firstName'], 'offset' => 0];
+        $this->filterTest($filters, [$all[0]]);
+    }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithOffsetAndLimit()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['firstName'], 'offset' => 0, 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'school.edu', 'offset' => 2, 'limit' => 2];
+        $this->filterTest($filters, [$all[2], $all[3]]);
+    }
+
     public function findUsersWithRoleOne()
     {
         $dataLoader = $this->getDataLoader();

--- a/tests/GetEndpointTestable.php
+++ b/tests/GetEndpointTestable.php
@@ -25,6 +25,7 @@ trait GetEndpointTestable
     public function testGetAll()
     {
         $this->getAllTest();
+        $this->getAllWithLimitAndOffsetTest();
         $this->getAllJsonApiTest();
     }
 


### PR DESCRIPTION
These are expected to be ints or null so when they are sent in the
request we need to cast them from strings.

Fixes #2910