### PR TITLE
Fix MeshDescriptor JSON API By Query endpoint

### DIFF
--- a/src/Controller/API/MeshDescriptors.php
+++ b/src/Controller/API/MeshDescriptors.php
@@ -42,7 +42,7 @@ class MeshDescriptors extends ReadOnlyController
         $parameters = ApiRequestParser::extractParameters($request);
 
         if (null !== $q && '' !== $q) {
-            $dtos = $this->manager->findMeshDescriptorsByQ(
+            $dtos = $this->manager->findMeshDescriptorDtosByQ(
                 $q,
                 $parameters['orderBy'],
                 $parameters['limit'],

--- a/src/Entity/Manager/MeshDescriptorManager.php
+++ b/src/Entity/Manager/MeshDescriptorManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity\Manager;
 
+use App\Entity\DTO\MeshDescriptorDTO;
 use App\Service\MeshDescriptorSetTransmogrifier;
 use App\Entity\MeshDescriptorInterface;
 use App\Entity\Repository\MeshDescriptorRepository;
@@ -37,22 +38,17 @@ class MeshDescriptorManager extends BaseManager
     }
 
     /**
-     * @param string $q
-     * @param array $orderBy
-     * @param int $limit
-     * @param int $offset
-     *
-     * @return MeshDescriptorInterface[]
+     * @return MeshDescriptorDTO[]
      */
-    public function findMeshDescriptorsByQ(
-        $q,
-        array $orderBy = null,
-        $limit = null,
-        $offset = null
-    ) {
+    public function findMeshDescriptorDtosByQ(
+        string $q,
+        ?array $orderBy,
+        ?int $limit,
+        ?int $offset
+    ): array {
         /** @var MeshDescriptorRepository $repository */
         $repository = $this->getRepository();
-        return $repository->findByQ($q, $orderBy, $limit, $offset);
+        return $repository->findDTOsByQ($q, $orderBy, $limit, $offset);
     }
 
     /**

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -181,6 +181,20 @@ class LearningMaterialTest extends ReadWriteEndpointTest
     }
 
     /**
+     * @dataProvider qsToTest
+     */
+    public function testFindByQJsonApi(string $q, array $dataKeys)
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $expectedData = array_map(function ($i) use ($all) {
+            return $all[$i];
+        }, $dataKeys);
+        $filters = ['q' => $q];
+        $this->jsonApiFilterTest($filters, $expectedData);
+    }
+
+    /**
      * Ensure offset and limit work
      */
     public function testFindByQWithLimit()
@@ -215,6 +229,16 @@ class LearningMaterialTest extends ReadWriteEndpointTest
         $this->filterTest($filters, [$all[0]]);
         $filters = ['q' => 'lm', 'offset' => 3, 'limit' => 1];
         $this->filterTest($filters, [$all[3]]);
+    }
+
+    public function testFindByQWithOffsetAndLimitJsonApi()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['title'], 'offset' => 0, 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'lm', 'offset' => 3, 'limit' => 1];
+        $this->jsonApiFilterTest($filters, [$all[3]]);
     }
 
     /**

--- a/tests/Endpoints/MeshDescriptorTest.php
+++ b/tests/Endpoints/MeshDescriptorTest.php
@@ -97,6 +97,20 @@ class MeshDescriptorTest extends AbstractMeshTest
     }
 
     /**
+     * @dataProvider qsToTest
+     */
+    public function testFindByQJsonApi(string $q, array $dataKeys)
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $expectedData = array_map(function ($i) use ($all) {
+            return $all[$i];
+        }, $dataKeys);
+        $filters = ['q' => $q];
+        $this->jsonApiFilterTest($filters, $expectedData);
+    }
+
+    /**
      * Ensure offset and limit work
      */
     public function testFindByQWithLimit()
@@ -131,5 +145,15 @@ class MeshDescriptorTest extends AbstractMeshTest
         $this->filterTest($filters, [$all[0]]);
         $filters = ['q' => 'desc', 'offset' => 1, 'limit' => 1];
         $this->filterTest($filters, [$all[1]]);
+    }
+
+    public function testFindByQWithOffsetAndLimitJsonApi()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['name'], 'offset' => 0, 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'desc', 'offset' => 1, 'limit' => 1];
+        $this->jsonApiFilterTest($filters, [$all[1]]);
     }
 }

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -185,6 +185,20 @@ class UserTest extends ReadWriteEndpointTest
     }
 
     /**
+     * @dataProvider qsToTest
+     */
+    public function testFindByQJsonApi(string $q, array $dataKeys)
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $expectedData = array_map(function ($i) use ($all) {
+            return $all[$i];
+        }, $dataKeys);
+        $filters = ['q' => $q];
+        $this->jsonApiFilterTest($filters, $expectedData);
+    }
+
+    /**
      * Ensure offset and limit work
      */
     public function testFindByQWithLimit()
@@ -219,6 +233,16 @@ class UserTest extends ReadWriteEndpointTest
         $this->filterTest($filters, [$all[0]]);
         $filters = ['q' => 'school.edu', 'offset' => 2, 'limit' => 2];
         $this->filterTest($filters, [$all[2], $all[3]]);
+    }
+
+    public function testFindByQWithOffsetAndLimitJsonApi()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['firstName'], 'offset' => 0, 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'school.edu', 'offset' => 2, 'limit' => 2];
+        $this->jsonApiFilterTest($filters, [$all[2], $all[3]]);
     }
 
     public function findUsersWithRoleOne()

--- a/tests/GetEndpointTestable.php
+++ b/tests/GetEndpointTestable.php
@@ -27,6 +27,7 @@ trait GetEndpointTestable
         $this->getAllTest();
         $this->getAllWithLimitAndOffsetTest();
         $this->getAllJsonApiTest();
+        $this->getAllWithLimitAndOffsetJsonApiTest();
     }
 
     /**


### PR DESCRIPTION
This was returning entities which aren't encodable into JSON api format.
Return DTOs instead and add tests for all the other endpoints that take
a q.

Fixes #2912