### PR TITLE
Fix course PUT route

### DIFF
--- a/src/Controller/API/Courses.php
+++ b/src/Controller/API/Courses.php
@@ -89,7 +89,7 @@ class Courses extends ReadWriteController
     /**
      * Modifies a single object in the API.  Can also create and
      * object if it does not yet exist.
-     * @Route("/{id}<\d>", methods={"PUT"})
+     * @Route("/{id}", methods={"PUT"})
      */
     public function put(
         string $version,


### PR DESCRIPTION
The check if this is a number doesn't work with a URL so there is no
route to PUT a course. Removing the check fixes that issue.

Fixes #2915