### PR TITLE
moves migrations into the App namespace.

### DIFF
--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,6 +1,4 @@
 doctrine_migrations:
     dir_name: '%kernel.project_dir%/src/Migrations'
-    # namespace is arbitrary but should be different from App\Migrations
-    # as migrations classes should NOT be autoloaded
     name: Ilios Migrations
-    namespace: Ilios\Migrations
+    namespace: App\Migrations

--- a/src/Migrations/Version20150805000000.php
+++ b/src/Migrations/Version20150805000000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150813184053.php
+++ b/src/Migrations/Version20150813184053.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150819000940.php
+++ b/src/Migrations/Version20150819000940.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150819181346.php
+++ b/src/Migrations/Version20150819181346.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150819200000.php
+++ b/src/Migrations/Version20150819200000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150819234126.php
+++ b/src/Migrations/Version20150819234126.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150820013804.php
+++ b/src/Migrations/Version20150820013804.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150820020125.php
+++ b/src/Migrations/Version20150820020125.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150826120000.php
+++ b/src/Migrations/Version20150826120000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Schema\Schema;
  */
 class Version20150826120000 extends AbstractMigration
 {
-    
+
     /**
      * @param Schema $schema
      */
@@ -39,7 +39,7 @@ class Version20150826120000 extends AbstractMigration
         $this->addSql('ALTER TABLE mesh_term DROP PRIMARY KEY');
         $this->addSql('ALTER TABLE mesh_term ADD mesh_term_id INT PRIMARY KEY AUTO_INCREMENT NOT NULL');
         $this->addSql('CREATE UNIQUE INDEX mesh_term_uid_name ON mesh_term (mesh_term_uid, name)');
-        
+
         $this->addSql('ALTER TABLE `mesh_tree_x_descriptor` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci');
         $this->addSql('ALTER TABLE `mesh_tree_x_descriptor` DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci');
         $this->addSql('CREATE INDEX IDX_A7706041CDB3C93B ON mesh_tree_x_descriptor (mesh_descriptor_uid)');
@@ -80,8 +80,8 @@ class Version20150826120000 extends AbstractMigration
             'CHANGE mesh_descriptor_uid mesh_descriptor_uid ' .
             'VARCHAR(9) NOT NULL COLLATE utf8_unicode_ci'
         );
-        
-        
+
+
         $this->addSql('ALTER TABLE mesh_term MODIFY mesh_term_id INT NOT NULL');
         $this->addSql('ALTER TABLE mesh_term DROP PRIMARY KEY');
         $this->addSql('ALTER TABLE mesh_term DROP mesh_term_id');

--- a/src/Migrations/Version20150826130000.php
+++ b/src/Migrations/Version20150826130000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
@@ -29,7 +29,7 @@ class Version20150826130000 extends AbstractMigration
             $insertSql .= implode(',', $values);
             unset($values);
         }
-        
+
         $this->addSql('DROP INDEX IDX_100AC50F17293A95 ON mesh_concept_x_term');
         $this->addSql('TRUNCATE mesh_concept_x_term');
         $this->addSql('ALTER TABLE mesh_concept_x_term DROP PRIMARY KEY');
@@ -73,12 +73,12 @@ class Version20150826130000 extends AbstractMigration
             $insertSql .= implode(',', $values);
             unset($values);
         }
-        
+
         $this->addSql('TRUNCATE mesh_concept_x_term');
         $this->addSql('ALTER TABLE mesh_concept_x_term DROP FOREIGN KEY FK_100AC50F928873C');
         $this->addSql('ALTER TABLE mesh_concept_x_term DROP FOREIGN KEY FK_100AC50FE34D9FF5');
         $this->addSql('DROP INDEX IDX_100AC50F928873C ON mesh_concept_x_term');
-        
+
         $this->addSql('ALTER TABLE mesh_concept_x_term DROP PRIMARY KEY');
         $this->addSql(
             'ALTER TABLE mesh_concept_x_term ' .

--- a/src/Migrations/Version20150826201107.php
+++ b/src/Migrations/Version20150826201107.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150826215733.php
+++ b/src/Migrations/Version20150826215733.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
@@ -35,7 +35,7 @@ class Version20150826215733 extends AbstractMigration
             'REFERENCES session (session_id) ON DELETE CASCADE'
         );
         $this->addSql('CREATE UNIQUE INDEX UNIQ_8C070D9613FECDF ON ilm_session_facet (session_id)');
-        
+
         $this->addSql('ALTER TABLE session DROP FOREIGN KEY FK_D044D5D4504270C1');
         $this->addSql('DROP INDEX UNIQ_D044D5D4504270C1 ON session');
         $this->addSql('DROP INDEX session_ibfk_3 ON session');

--- a/src/Migrations/Version20150828223306.php
+++ b/src/Migrations/Version20150828223306.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150901000000.php
+++ b/src/Migrations/Version20150901000000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
@@ -43,7 +43,7 @@ class Version20150901000000 extends AbstractMigration
         $this->addSql('ALTER TABLE user MODIFY `school_id` int(11) DEFAULT NULL AFTER user_id');
         $this->addSql('ALTER TABLE user MODIFY `primary_cohort_id` int(11) DEFAULT NULL AFTER school_id');
         $this->addSql('ALTER TABLE user_made_reminder MODIFY `user_id` int(11) DEFAULT NULL AFTER user_made_reminder_id');
-        
+
         //drop and add these keys to put them in the correct order
         //this is a superficial change to bring the DB schemas into line
         $this->addSql('ALTER TABLE `course_learning_material` DROP FOREIGN KEY `FK_F841D788591CC992`');
@@ -55,7 +55,7 @@ class Version20150901000000 extends AbstractMigration
         $this->addSql('ALTER TABLE `program_year` DROP FOREIGN KEY `FK_B664263056C92BE0`');
         $this->addSql('ALTER TABLE `program_year` ADD CONSTRAINT `FK_B664263056C92BE0` FOREIGN KEY (`publish_event_id`) REFERENCES `publish_event` (`publish_event_id`)');
         $this->addSql('ALTER TABLE `program_year` ADD CONSTRAINT `FK_B66426303EB8070A` FOREIGN KEY (`program_id`) REFERENCES `program` (`program_id`)');
-        
+
         $this->addSql('ALTER TABLE `session_learning_material` DROP FOREIGN KEY `FK_9BE2AF8D613FECDF`');
         $this->addSql('ALTER TABLE `session_learning_material` DROP FOREIGN KEY `FK_9BE2AF8DC1D99609`');
         $this->addSql('ALTER TABLE `session_learning_material` ADD CONSTRAINT `FK_9BE2AF8D613FECDF` FOREIGN KEY (`session_id`) REFERENCES `session` (`session_id`)');

--- a/src/Migrations/Version20150903000000.php
+++ b/src/Migrations/Version20150903000000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150909231235.php
+++ b/src/Migrations/Version20150909231235.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150914052024.php
+++ b/src/Migrations/Version20150914052024.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
@@ -17,7 +17,7 @@ class Version20150914052024 extends AbstractMigration
     public function up(Schema $schema) : void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-        
+
         $this->addSql('UPDATE authentication SET username=eppn WHERE eppn IS NOT NULL');
         $this->addSql('DROP INDEX UNIQ_FEB4C9FDFC7885D4 ON authentication');
         $this->addSql('ALTER TABLE authentication DROP eppn');

--- a/src/Migrations/Version20150914210711.php
+++ b/src/Migrations/Version20150914210711.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20150916173024.php
+++ b/src/Migrations/Version20150916173024.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
@@ -22,7 +22,7 @@ class Version20150916173024 extends AbstractMigration
         );
 
         $this->addSql('ALTER TABLE `user` ADD ics_feed_key VARCHAR(64) NOT NULL');
-        
+
         $sql = 'SELECT user_id FROM `user`';
         $rows = $this->connection->executeQuery($sql)->fetchAll();
         if (count($rows)) {
@@ -33,16 +33,16 @@ class Version20150916173024 extends AbstractMigration
 
                 return "WHEN {$arr['user_id']} THEN '{$key}'";
             }, $rows);
-            
+
             //bulk update all the records to avoide a mess in the output
             $sql = 'UPDATE `user` SET ics_feed_key = (CASE user_id ';
             $sql .= implode(' ', $updates);
-            
+
             $sql .= 'END)';
-            
+
             $this->addSql($sql);
         }
-        
+
         $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649AAB338A6 ON `user` (ics_feed_key)');
     }
 
@@ -55,7 +55,7 @@ class Version20150916173024 extends AbstractMigration
             $this->connection->getDatabasePlatform()->getName() != 'mysql',
             'Migration can only be executed safely on \'mysql\'.'
         );
-        
+
         $this->addSql('ALTER TABLE `user` DROP INDEX UNIQ_8D93D649AAB338A6');
         $this->addSql('ALTER TABLE `user` DROP ics_feed_key');
     }

--- a/src/Migrations/Version20151004075931.php
+++ b/src/Migrations/Version20151004075931.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20151104175441.php
+++ b/src/Migrations/Version20151104175441.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20151106022409.php
+++ b/src/Migrations/Version20151106022409.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20151118233516.php
+++ b/src/Migrations/Version20151118233516.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20151125055054.php
+++ b/src/Migrations/Version20151125055054.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20151204220022.php
+++ b/src/Migrations/Version20151204220022.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160104231711.php
+++ b/src/Migrations/Version20160104231711.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160105002207.php
+++ b/src/Migrations/Version20160105002207.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160106190703.php
+++ b/src/Migrations/Version20160106190703.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160106235355.php
+++ b/src/Migrations/Version20160106235355.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160111222451.php
+++ b/src/Migrations/Version20160111222451.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160122173943.php
+++ b/src/Migrations/Version20160122173943.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160125235702.php
+++ b/src/Migrations/Version20160125235702.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160128223548.php
+++ b/src/Migrations/Version20160128223548.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160223211000.php
+++ b/src/Migrations/Version20160223211000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160303215618.php
+++ b/src/Migrations/Version20160303215618.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160308211000.php
+++ b/src/Migrations/Version20160308211000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160419233601.php
+++ b/src/Migrations/Version20160419233601.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160421221726.php
+++ b/src/Migrations/Version20160421221726.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160422180552.php
+++ b/src/Migrations/Version20160422180552.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160502233707.php
+++ b/src/Migrations/Version20160502233707.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160607171112.php
+++ b/src/Migrations/Version20160607171112.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160608010345.php
+++ b/src/Migrations/Version20160608010345.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160615223611.php
+++ b/src/Migrations/Version20160615223611.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160627210338.php
+++ b/src/Migrations/Version20160627210338.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160715212648.php
+++ b/src/Migrations/Version20160715212648.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160812180141.php
+++ b/src/Migrations/Version20160812180141.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160915043119.php
+++ b/src/Migrations/Version20160915043119.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160919224121.php
+++ b/src/Migrations/Version20160919224121.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20160921175624.php
+++ b/src/Migrations/Version20160921175624.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20161011223733.php
+++ b/src/Migrations/Version20161011223733.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20161012025413.php
+++ b/src/Migrations/Version20161012025413.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20161013164943.php
+++ b/src/Migrations/Version20161013164943.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20161013183010.php
+++ b/src/Migrations/Version20161013183010.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20161013205034.php
+++ b/src/Migrations/Version20161013205034.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20161014032909.php
+++ b/src/Migrations/Version20161014032909.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20161209191650.php
+++ b/src/Migrations/Version20161209191650.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170203161914.php
+++ b/src/Migrations/Version20170203161914.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170210175148.php
+++ b/src/Migrations/Version20170210175148.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170313212150.php
+++ b/src/Migrations/Version20170313212150.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170313223659.php
+++ b/src/Migrations/Version20170313223659.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170313230000.php
+++ b/src/Migrations/Version20170313230000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170314175718.php
+++ b/src/Migrations/Version20170314175718.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170428054237.php
+++ b/src/Migrations/Version20170428054237.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170510165532.php
+++ b/src/Migrations/Version20170510165532.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170818144244.php
+++ b/src/Migrations/Version20170818144244.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170824000000.php
+++ b/src/Migrations/Version20170824000000.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170905234026.php
+++ b/src/Migrations/Version20170905234026.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170906230101.php
+++ b/src/Migrations/Version20170906230101.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170913234324.php
+++ b/src/Migrations/Version20170913234324.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170915185745.php
+++ b/src/Migrations/Version20170915185745.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170917182423.php
+++ b/src/Migrations/Version20170917182423.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20170917183718.php
+++ b/src/Migrations/Version20170917183718.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20171207221415.php
+++ b/src/Migrations/Version20171207221415.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180102185950.php
+++ b/src/Migrations/Version20180102185950.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180307174249.php
+++ b/src/Migrations/Version20180307174249.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180309225012.php
+++ b/src/Migrations/Version20180309225012.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180313211111.php
+++ b/src/Migrations/Version20180313211111.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180320041519.php
+++ b/src/Migrations/Version20180320041519.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180323231620.php
+++ b/src/Migrations/Version20180323231620.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180323231630.php
+++ b/src/Migrations/Version20180323231630.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180326223500.php
+++ b/src/Migrations/Version20180326223500.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180514214501.php
+++ b/src/Migrations/Version20180514214501.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180617000000.php
+++ b/src/Migrations/Version20180617000000.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180803101835.php
+++ b/src/Migrations/Version20180803101835.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/src/Migrations/Version20180823181914.php
+++ b/src/Migrations/Version20180823181914.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20181219195341.php
+++ b/src/Migrations/Version20181219195341.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20181219202348.php
+++ b/src/Migrations/Version20181219202348.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20190201190000.php
+++ b/src/Migrations/Version20190201190000.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20190225000000.php
+++ b/src/Migrations/Version20190225000000.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20190307000000.php
+++ b/src/Migrations/Version20190307000000.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20190308004110.php
+++ b/src/Migrations/Version20190308004110.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20190513061851.php
+++ b/src/Migrations/Version20190513061851.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20190612212532.php
+++ b/src/Migrations/Version20190612212532.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20190711180817.php
+++ b/src/Migrations/Version20190711180817.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20191030201837.php
+++ b/src/Migrations/Version20191030201837.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20200115050155.php
+++ b/src/Migrations/Version20200115050155.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20200330062405.php
+++ b/src/Migrations/Version20200330062405.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Migrations/Version20200408232411.php
+++ b/src/Migrations/Version20200408232411.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ilios\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;


### PR DESCRIPTION
this is safe to do, since we've excluded the Migrations directory
from being auto-loaded in the services configuration.

for reference, see https://github.com/doctrine/DoctrineMigrationsBundle, issue 242.