### PR TITLE
List ENV values when listing config values

### DIFF
--- a/src/Command/ListConfigValuesCommand.php
+++ b/src/Command/ListConfigValuesCommand.php
@@ -89,6 +89,11 @@ class ListConfigValuesCommand extends Command
           ['Kernel Secret', $this->kernelSecret],
           ['Database URL', $this->databaseUrl],
         ];
+        foreach ($_ENV as $key => $value) {
+            if (strpos($key, "ILIOS_") === 0) {
+                $rows[] = [$key, $value];
+            }
+        }
         $table = new Table($output);
         $table->setHeaderTitle('Environment Values');
         $table->setHeaders(['Name', 'Value']);


### PR DESCRIPTION
Makes it much easier to see what is going into the config if we can see the ENVs that override everything else.