### PR TITLE
Remove the default LM index replica

### DIFF
--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -140,6 +140,10 @@ class LearningMaterials extends ElasticSearchBase
     public static function getMapping(): array
     {
         return [
+            'settings' => [
+                'number_of_shards' => 1,
+                'number_of_replicas' => 0,
+            ],
             'mappings' => [
                 '_meta' => [
                     'version' => '1',


### PR DESCRIPTION
If we don't specify this it ends up being 1 shared and 1 replica, we
don't really need the replica (or at least we don't know yet if we do)
so it should be disabled for now.