### PR TITLE
Serve web app manifest correctly

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -59,40 +59,45 @@ DirectoryIndex index.php
         # and the client accepts brotli.
         RewriteCond "%{HTTP:Accept-encoding}" "br"
         RewriteCond "%{REQUEST_FILENAME}\.br" "-s"
-        RewriteRule "^(.*)\.(js|css|svg|txt)"              "$1\.$2\.br" [QSA]
+        RewriteRule "^(.*)\.(js|css|svg|txt|webmanifest)"              "$1\.$2\.br" [QSA]
 
         # Serve correct content types, and prevent double compression.
         RewriteRule "\.css\.br$" "-" [T=text/css,E=no-brotli:1,E=no-gzip:1]
         RewriteRule "\.js\.br$"  "-" [T=text/javascript,E=no-brotli:1,E=no-gzip:1]
         RewriteRule "\.svg\.br$"  "-" [T=image/svg+xml,E=no-brotli:1,E=no-gzip:1]
         RewriteRule "\.txt\.br$"  "-" [T=text/plain,E=no-brotli:1,E=no-gzip:1]
+        RewriteRule "\.webmanifest\.br$"  "-" [T=application/manifest+json,E=no-brotli:1,E=no-gzip:1]
 
 
         # Serve gzip compressed CSS and JS files if they exist
         # and the client accepts gzip.
         RewriteCond "%{HTTP:Accept-encoding}" "gzip"
         RewriteCond "%{REQUEST_FILENAME}\.gz" "-s"
-        RewriteRule "^(.*)\.(js|css|svg|txt)"              "$1\.$2\.gz" [QSA]
+        RewriteRule "^(.*)\.(js|css|svg|txt|webmanifest)"              "$1\.$2\.gz" [QSA]
 
         # Serve correct content types, and prevent double compression.
         RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1,E=no-brotli:1]
         RewriteRule "\.js\.gz$"  "-" [T=text/javascript,E=no-gzip:1,E=no-brotli:1]
         RewriteRule "\.svg\.gz$"  "-" [T=image/svg+xml,E=no-gzip:1,E=no-brotli:1]
         RewriteRule "\.txt\.gz$"  "-" [T=text/plain,E=no-gzip:1,E=no-brotli:1]
+        RewriteRule "\.webmanifest\.gz$"  "-" [T=application/manifest+json,E=no-brotli:1,E=no-gzip:1]
 
 
-        <FilesMatch "(\.js\.br|\.css\.br|\.svg\.br|\.txt\.br)$">
+        <FilesMatch "(\.js\.br|\.css\.br|\.svg\.br|\.txt\.br|.webmanifest\.br)$">
           # Serve correct encoding type.
           Header append Content-Encoding br
+          RemoveLanguage .br
+
 
           # Force proxies to cache brotli &
           # non-brotli css/js files separately.
           Header append Vary Accept-Encoding
         </FilesMatch>
 
-        <FilesMatch "(\.js\.gz|\.css\.gz|\.svg\.gz|\.txt\.gz)$">
+        <FilesMatch "(\.js\.gz|\.css\.gz|\.svg\.gz|\.txt\.gz|.webmanifest\.gz)$">
           # Serve correct encoding type.
           Header append Content-Encoding gzip
+          RemoveLanguage .gz
 
           # Force proxies to cache brotli &
           # non-brotli css/js files separately.

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -148,7 +148,7 @@ class IndexController extends AbstractController
         $links = [];
         foreach ($json->link as $obj) {
             $arr = [
-                'href' => ltrim($obj->href, '/'),
+                'href' => $obj->href,
             ];
             switch ($obj->rel) {
                 case 'preload':
@@ -172,7 +172,7 @@ class IndexController extends AbstractController
 
         $scripts = array_map(function ($obj) {
             return [
-                'src' => property_exists($obj, 'src') ? ltrim($obj->src, '/') : null,
+                'src' => property_exists($obj, 'src') ? $obj->src : null,
                 'content' => property_exists($obj, 'content') ? $obj->content : null,
             ];
         }, $json->script);


### PR DESCRIPTION
Removing the leading slash from our links was causing visitors to
/courses/742 to download the file /courses/742/manifest.webmanifest
which would then return the index page and fail. I wasn't able to
determine the purpose of removing that slash and after removing it all
paths appear to be correct.

I also ensured that the .webmanifest file would be served compressed
correctly.

Found and correct apache sending a Content-Language: br/gz header when
those files were served. Since our static assets are never going to be
in a different language removing those fixed the issue.