### PR TITLE
Fix nested includes

### DIFF
--- a/src/Service/ApiResponseBuilder.php
+++ b/src/Service/ApiResponseBuilder.php
@@ -156,7 +156,7 @@ class ApiResponseBuilder
                 if (!array_key_exists($key, $carry)) {
                     $carry[$key] = [];
                 }
-                $carry[$key] = array_merge($carry[$key], $tree[$key]);
+                $carry[$key] = array_merge_recursive($carry[$key], $tree[$key]);
 
                 return $carry;
             },

--- a/src/Service/ApiResponseBuilder.php
+++ b/src/Service/ApiResponseBuilder.php
@@ -151,15 +151,7 @@ class ApiResponseBuilder
         };
         return array_reduce(
             array_map($dotToTree, $fields),
-            function (array $carry, array $tree) {
-                $key = array_key_first($tree);
-                if (!array_key_exists($key, $carry)) {
-                    $carry[$key] = [];
-                }
-                $carry[$key] = array_merge_recursive($carry[$key], $tree[$key]);
-
-                return $carry;
-            },
+            'array_merge_recursive',
             []
         );
     }

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -716,4 +716,28 @@ class CourseTest extends ReadWriteEndpointTest
             $this->assertArrayNotHasKey('competency', $arr);
         }
     }
+
+    public function testIncludeBothProgramYearProgramAndObjectivesWithCohort()
+    {
+        $includes = $this->getJsonApiIncludes(
+            'courses',
+            '1',
+            'cohorts.programYear.program,cohorts.programYear.programYearObjectives.objective'
+        );
+
+
+        $this->assertArrayHasKey('programYears', $includes);
+        $this->assertArrayHasKey('programs', $includes);
+        $this->assertArrayHasKey('programYearObjectives', $includes);
+        $this->assertArrayHasKey('objectives', $includes);
+
+        $this->assertIsArray($includes['programYears']);
+        $this->assertEquals(["1"], $includes['programYears']);
+        $this->assertIsArray($includes['programs']);
+        $this->assertEquals(["1"], $includes['programs']);
+        $this->assertIsArray($includes['programYearObjectives']);
+        $this->assertEquals(["1"], $includes['programYearObjectives']);
+        $this->assertIsArray($includes['objectives']);
+        $this->assertEquals(["1"], $includes['objectives']);
+    }
 }

--- a/tests/Service/ApiResponseBuilderTest.php
+++ b/tests/Service/ApiResponseBuilderTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\ApiResponseBuilder;
+use App\Service\EndpointResponseNamer;
+use App\Tests\TestCase;
+use Mockery as m;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class ApiResponseBuilderTest extends TestCase
+{
+    /**
+     * @var ApiResponseBuilder
+     */
+    private $obj;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->obj = new ApiResponseBuilder(
+            m::mock(SerializerInterface::class),
+            m::mock(EndpointResponseNamer::class),
+        );
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->obj);
+    }
+
+    public function testDoubleTopLevelTree()
+    {
+        $input = 'cohorts.programYear.program,cohorts.programYear.programYearObjectives.objective';
+        $tree = $this->obj->extractJsonApiSideLoadFields($input);
+        $expected = [
+            'cohorts' => [
+                'programYear' => [
+                    'program' => [],
+                    'programYearObjectives' => [
+                        'objective' => []
+                    ]
+                ],
+            ]
+        ];
+        $this->assertEquals($expected, $tree);
+    }
+
+    public function testDoubleDeepLevelTree()
+    {
+        $input = 'cohorts.programYear.program.school,cohorts.programYear.program.directors';
+        $tree = $this->obj->extractJsonApiSideLoadFields($input);
+        $expected = [
+            'cohorts' => [
+                'programYear' => [
+                    'program' => [
+                        'school' => [],
+                        'directors' => [],
+                    ],
+                ],
+            ]
+        ];
+        $this->assertEquals($expected, $tree);
+    }
+}

--- a/tests/Service/ApiResponseBuilderTest.php
+++ b/tests/Service/ApiResponseBuilderTest.php
@@ -32,6 +32,40 @@ class ApiResponseBuilderTest extends TestCase
         unset($this->obj);
     }
 
+    public function testSimpleTree()
+    {
+        $input = 'cohorts,objective';
+        $tree = $this->obj->extractJsonApiSideLoadFields($input);
+        $expected = [
+            'cohorts' => [],
+            'objective' => [],
+        ];
+        $this->assertEquals($expected, $tree);
+    }
+
+    public function testTwoLevelTree()
+    {
+        $input = 'cohorts.green,objective.green';
+        $tree = $this->obj->extractJsonApiSideLoadFields($input);
+        $expected = [
+            'cohorts' => [
+                'green' => []
+            ],
+            'objective' => [
+                'green' => []
+            ],
+        ];
+        $this->assertEquals($expected, $tree);
+    }
+
+    public function testEmptyTree()
+    {
+        $input = '';
+        $tree = $this->obj->extractJsonApiSideLoadFields($input);
+        $expected = [];
+        $this->assertEquals($expected, $tree);
+    }
+
     public function testDoubleTopLevelTree()
     {
         $input = 'cohorts.programYear.program,cohorts.programYear.programYearObjectives.objective';
@@ -60,6 +94,78 @@ class ApiResponseBuilderTest extends TestCase
                         'school' => [],
                         'directors' => [],
                     ],
+                ],
+            ]
+        ];
+        $this->assertEquals($expected, $tree);
+    }
+
+    public function testCourseSessionTree()
+    {
+        $sessionRelationships = [
+            'learningMaterials.learningMaterial.owningUser',
+            'sessionObjectives.objective.parents',
+            'sessionObjectives.objective.meshDescriptors',
+            'sessionObjectives.terms.vocabulary',
+            'offerings.learners',
+            'offerings.instructors',
+            'offerings.instructorGroups.users',
+            'offerings.learnerGroups.users',
+            'ilmSession.learners',
+            'ilmSession.instructors',
+            'ilmSession.instructorGroups.users',
+            'ilmSession.learnerGroups.users',
+            'sessionDescription',
+            'terms.vocabulary',
+            'meshDescriptors.trees',
+        ];
+        $input = array_reduce($sessionRelationships, function ($carry, $item) {
+            return "${carry}sessions.${item},";
+        }, '');
+
+        $tree = $this->obj->extractJsonApiSideLoadFields($input);
+        $expected = [
+            'sessions' => [
+                'learningMaterials' => [
+                    'learningMaterial' => [
+                        'owningUser' => [],
+                    ]
+                ],
+                'sessionObjectives' => [
+                    'objective' => [
+                        'parents' => [],
+                        'meshDescriptors' => [],
+                    ],
+                    'terms' => [
+                        'vocabulary' => []
+                    ],
+                ],
+                'offerings' => [
+                    'learners' => [],
+                    'instructors' => [],
+                    'instructorGroups' => [
+                        'users' => []
+                    ],
+                    'learnerGroups' => [
+                        'users' => []
+                    ]
+                ],
+                'ilmSession' => [
+                    'learners' => [],
+                    'instructors' => [],
+                    'instructorGroups' => [
+                        'users' => []
+                    ],
+                    'learnerGroups' => [
+                        'users' => []
+                    ]
+                ],
+                'sessionDescription' => [],
+                'terms' => [
+                    'vocabulary' => []
+                ],
+                'meshDescriptors' => [
+                    'trees' => []
                 ],
             ]
         ];


### PR DESCRIPTION
`array_merge` only takes the top key and discards everything else, for our deeply nested include trees we need to merge the entire array.

For example `cohorts.programYear.program,cohorts.programYear.programYearObjectives.objective` was returning
```php
[
'cohorts' => [
  'programYear' => [
    'programYearObjectives' => [
      'objective' => []
    ]
  ],
]
           
```

instead of 
```php
[
'cohorts' => [
  'programYear' => [
    'programs' => [],
    'programYearObjectives' => [
      'objective' => []
    ]
  ],
]
```
As the second level `programYear` was overwriting the first. Thankfully PHP has `array_merge_recursive` which does exactly what we need!

Added a test to the course endpoint as well for the entire integration chain and made it re-usable figuring we'd have more of these some day.

