### PR TITLE
Only include side loaded data once

### DIFF
--- a/src/Classes/JsonApiData.php
+++ b/src/Classes/JsonApiData.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Classes;
+
+use App\Normalizer\JsonApiDTONormalizer;
+use App\Service\EntityManagerLookup;
+
+class JsonApiData
+{
+    protected $data = [];
+    protected $includes = [];
+    /**
+     * @var EntityManagerLookup
+     */
+    protected $entityManagerLookup;
+    /**
+     * @var JsonApiDTONormalizer
+     */
+    protected $normalizer;
+
+    public function __construct(
+        EntityManagerLookup $entityManagerLookup,
+        JsonApiDTONormalizer $normalizer,
+        array $data,
+        array $sideLoadFields
+    ) {
+        $this->entityManagerLookup = $entityManagerLookup;
+        $this->normalizer = $normalizer;
+        foreach ($data as $item) {
+            $shapedItem = $this->shapeItem($item);
+            $this->data[] = $shapedItem;
+            $this->extractSideLoadData($shapedItem['relationships'], $sideLoadFields);
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'data' => $this->data,
+            'included' => $this->includes
+        ];
+    }
+
+
+    protected function shapeItem(array $item): array
+    {
+        $data = [
+            'id' => (string) $item['id'],
+            'type' => $item['type'],
+            'attributes' => $item['attributes'],
+            'relationships' => [],
+        ];
+        foreach ($item['related'] as $name => $related) {
+            $relatedData = [];
+            $value = $related['value'];
+            if (is_array($value)) {
+                foreach ($value as $id) {
+                    $relatedData[] = [
+                        'type' => $related['type'],
+                        'id' => (string) $id
+                    ];
+                }
+                $data['relationships'][$name] = [
+                    'data' => $relatedData
+                ];
+            } else {
+                $data['relationships'][$name] = [
+                    'data' => [
+                        'type' => $related['type'],
+                        'id' => (string) $value
+                    ]
+                ];
+            }
+        }
+
+        return $data;
+    }
+
+    protected function getTypeForData(array $data): string
+    {
+        if (array_key_exists('type', $data)) {
+            return $data['type'];
+        }
+        return $this->getTypeForData($data[0]);
+    }
+
+    protected function getIdsForData(array $data): array
+    {
+        if (array_key_exists('id', $data)) {
+            return [$data['id']];
+        }
+        return array_map(function ($item) {
+            return $item['id'];
+        }, $data);
+    }
+
+    protected function extractSideLoadData(array $relationships, array $sideLoadFields): void
+    {
+        $keys = array_keys($sideLoadFields);
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $relationships)) {
+                $r = $relationships[$key];
+                $type = $this->getTypeForData($r['data']);
+                $ids = $this->getIdsForData($r['data']);
+
+                $this->sideLoad($type, $ids, $sideLoadFields[$key]);
+            }
+        }
+    }
+
+    protected function getIncludedIdsByType(): array
+    {
+        return array_reduce($this->includes, function (array $carry, array $item) {
+            $t = $item['type'];
+            if (!array_key_exists($t, $carry)) {
+                $carry[$t] = [];
+            }
+            $carry[$t][] = $item['id'];
+
+            return $carry;
+        }, []);
+    }
+
+    protected function sideLoad(string $type, array $ids, array $sideLoadFields): void
+    {
+        $alreadyIncluded = $this->getIncludedIdsByType();
+        $newIds = array_key_exists($type, $alreadyIncluded) ? array_diff($ids, $alreadyIncluded[$type]) : $ids;
+        if (count($newIds)) {
+            $manager = $this->entityManagerLookup->getManagerForEndpoint($type);
+            $dtos = $manager->findDTOsBy(['id' => $newIds]);
+            foreach ($dtos as $dto) {
+                $data = $this->normalizer->normalize($dto, 'json-api');
+                $shaped = $this->shapeItem($data);
+                $this->includes[] = $shaped;
+                $this->extractSideLoadData($shaped['relationships'], $sideLoadFields);
+            }
+        }
+    }
+}

--- a/src/Service/EndpointResponseNamer.php
+++ b/src/Service/EndpointResponseNamer.php
@@ -8,6 +8,8 @@ use Doctrine\Inflector\Inflector;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 /**
  * Class EndpointResponseNamer
@@ -29,14 +31,24 @@ class EndpointResponseNamer
     protected $inflector;
 
     /**
+     * @var CacheInterface
+     */
+    protected $appCache;
+
+    private const LIST_CACHE_KEY = 'endpoint-response-namer-entity-list';
+
+    /**
      * EndpointResponseNamer constructor.
      * Extracts the entity path from the Kernel
      * @param KernelInterface $kernel
+     * @param Inflector $inflector
+     * @param CacheInterface $appCache
      */
-    public function __construct(KernelInterface $kernel, Inflector $inflector)
+    public function __construct(KernelInterface $kernel, Inflector $inflector, CacheInterface $appCache)
     {
         $this->pathToEntities = $kernel->getProjectDir() . '/src/Entity';
         $this->inflector = $inflector;
+        $this->appCache = $appCache;
     }
 
     /**
@@ -67,25 +79,28 @@ class EndpointResponseNamer
 
     /**
      * Create a list of all the plural and singular names for entities
-     * @return array
      */
-    protected function getEntityList()
+    protected function getEntityList(): array
     {
-        $finder = new Finder();
-        $files = $finder->in($this->pathToEntities)->files()->notName('*Interface.php')->sortByName();
+        $pathToEntities = $this->pathToEntities;
+        $inflector = $this->inflector;
+        return $this->appCache->get(self::LIST_CACHE_KEY, function () use ($pathToEntities, $inflector) {
+            $finder = new Finder();
+            $files = $finder->in($pathToEntities)->files()->notName('*Interface.php')->sortByName();
 
-        $list = [];
-        /** @var SplFileInfo $file */
-        foreach ($files as $file) {
-            $name = $file->getBasename('.php');
-            $plural = $this->inflector->pluralize($name);
-            $key = strtolower($plural);
-            $list[$key] = [
-                'plural' => $this->inflector->camelize($plural),
-                'singular' => $this->inflector->camelize($name),
-            ];
-        }
+            $list = [];
+            /** @var SplFileInfo $file */
+            foreach ($files as $file) {
+                $name = $file->getBasename('.php');
+                $plural = $inflector->pluralize($name);
+                $key = strtolower($plural);
+                $list[$key] = [
+                    'plural' => $inflector->camelize($plural),
+                    'singular' => $inflector->camelize($name),
+                ];
+            }
 
-        return $list;
+            return $list;
+        });
     }
 }

--- a/src/Service/JsonApiDataShaper.php
+++ b/src/Service/JsonApiDataShaper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Classes\JsonApiData;
 use App\Normalizer\JsonApiDTONormalizer;
 
 class JsonApiDataShaper
@@ -25,42 +26,8 @@ class JsonApiDataShaper
 
     public function shapeData(array $data, array $sideLoadFields): array
     {
-        $items = array_map(function (array $item) use ($sideLoadFields) {
-            return $this->shapeItem($item, $sideLoadFields);
-        }, $data);
-
-        $shapedItems = array_reduce($items, function (array $carry, array $item) {
-            $carry[] = $item['item'];
-
-            return $carry;
-        }, []);
-
-        $sideLoadsByType = array_reduce($items, function (array $carry, array $item) {
-            foreach ($item['sideLoad'] as $sideLoad) {
-                $name = $sideLoad['name'];
-                if (!array_key_exists($name, $carry)) {
-                    $carry[$name] = [
-                        'ids' => [],
-                        'sideLoadFields' => $sideLoad['sideLoad']
-                    ];
-                }
-                $carry[$name]['ids'][] = $sideLoad['id'];
-            }
-
-            return $carry;
-        }, []);
-
-
-        $includes = [];
-        foreach ($sideLoadsByType as $type => $arr) {
-            $sideLoads = $this->sideLoad($type, $arr['ids'], $arr['sideLoadFields']);
-            $includes = array_merge($includes, $sideLoads['data'], $sideLoads['included']);
-        }
-
-        return [
-            'data' => $shapedItems,
-            'included' => $includes
-        ];
+        $jsonApiData = new JsonApiData($this->entityManagerLookup, $this->normalizer, $data, $sideLoadFields);
+        return $jsonApiData->toArray();
     }
 
     /**
@@ -92,69 +59,5 @@ class JsonApiDataShaper
         }
 
         return $rhett;
-    }
-
-    protected function shapeItem(array $item, array $sideLoadFields): array
-    {
-        $sideLoad = [];
-
-        $data = [
-            'id' => (string) $item['id'],
-            'type' => $item['type'],
-            'attributes' => $item['attributes'],
-            'relationships' => [],
-        ];
-        foreach ($item['related'] as $name => $related) {
-            $relatedData = [];
-            $value = $related['value'];
-            if (is_array($value)) {
-                foreach ($value as $id) {
-                    $relatedData[] = [
-                        'type' => $related['type'],
-                        'id' => (string) $id
-                    ];
-                    if (array_key_exists($name, $sideLoadFields)) {
-                        $sideLoad[] = [
-                            'name' => $related['type'],
-                            'id' => $id,
-                            'sideLoad' => $sideLoadFields[$name],
-                        ];
-                    }
-                }
-                $data['relationships'][$name] = [
-                    'data' => $relatedData
-                ];
-            } else {
-                $data['relationships'][$name] = [
-                    'data' => [
-                        'type' => $related['type'],
-                        'id' => (string) $value
-                    ]
-                ];
-                if (array_key_exists($name, $sideLoadFields)) {
-                    $sideLoad[] = [
-                        'name' => $related['type'],
-                        'id' => $value,
-                        'sideLoad' => $sideLoadFields[$name],
-                    ];
-                }
-            }
-        }
-
-        return [
-            'item' => $data,
-            'sideLoad' => $sideLoad
-        ];
-    }
-
-    protected function sideLoad(string $type, array $ids, array $sideLoadFields): array
-    {
-        $manager = $this->entityManagerLookup->getManagerForEndpoint($type);
-        $dtos = $manager->findDTOsBy(['id' => $ids]);
-        $data = [];
-        foreach ($dtos as $dto) {
-            $data[] = $this->normalizer->normalize($dto, 'json-api');
-        }
-        return $this->shapeData($data, $sideLoadFields);
     }
 }

--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -383,6 +383,7 @@ abstract class AbstractEndpointTest extends WebTestCase
                 $carry[$obj->type] = [];
             }
             $carry[$obj->type][] = $obj->id;
+            sort($carry[$obj->type]);
 
             return $carry;
         }, []);

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -725,19 +725,89 @@ class CourseTest extends ReadWriteEndpointTest
             'cohorts.programYear.program,cohorts.programYear.programYearObjectives.objective'
         );
 
-
         $this->assertArrayHasKey('programYears', $includes);
         $this->assertArrayHasKey('programs', $includes);
         $this->assertArrayHasKey('programYearObjectives', $includes);
         $this->assertArrayHasKey('objectives', $includes);
 
         $this->assertIsArray($includes['programYears']);
-        $this->assertEquals(["1"], $includes['programYears']);
+        $this->assertEquals(['1'], $includes['programYears']);
         $this->assertIsArray($includes['programs']);
-        $this->assertEquals(["1"], $includes['programs']);
+        $this->assertEquals(['1'], $includes['programs']);
         $this->assertIsArray($includes['programYearObjectives']);
-        $this->assertEquals(["1"], $includes['programYearObjectives']);
+        $this->assertEquals(['1'], $includes['programYearObjectives']);
         $this->assertIsArray($includes['objectives']);
-        $this->assertEquals(["1"], $includes['objectives']);
+        $this->assertEquals(['1'], $includes['objectives']);
+    }
+
+    public function testIncludeSessionDetails()
+    {
+        $sessionRelationships = [
+            'learningMaterials.learningMaterial.owningUser',
+            'sessionObjectives.objective.parents',
+            'sessionObjectives.objective.meshDescriptors',
+            'sessionObjectives.terms.vocabulary',
+            'offerings.learners',
+            'offerings.instructors',
+            'offerings.instructorGroups.users',
+            'offerings.learnerGroups.users',
+            'ilmSession.learners',
+            'ilmSession.instructors',
+            'ilmSession.instructorGroups.users',
+            'ilmSession.learnerGroups.users',
+            'sessionDescription',
+            'terms.vocabulary',
+            'meshDescriptors.trees',
+        ];
+        $sessionIncludes = array_reduce($sessionRelationships, function ($carry, $item) {
+            return "${carry}sessions.${item},";
+        }, '');
+
+        $includes = $this->getJsonApiIncludes(
+            'courses',
+            '1',
+            $sessionIncludes
+        );
+
+        $this->assertArrayHasKey('sessions', $includes);
+        $this->assertArrayHasKey('terms', $includes);
+        $this->assertArrayHasKey('vocabularies', $includes);
+        $this->assertArrayHasKey('sessionObjectives', $includes);
+        $this->assertArrayHasKey('objectives', $includes);
+        $this->assertArrayHasKey('meshDescriptors', $includes);
+        $this->assertArrayHasKey('sessionDescriptions', $includes);
+        $this->assertArrayHasKey('sessionLearningMaterials', $includes);
+        $this->assertArrayHasKey('learningMaterials', $includes);
+        $this->assertArrayHasKey('users', $includes);
+        $this->assertArrayHasKey('offerings', $includes);
+        $this->assertArrayHasKey('learnerGroups', $includes);
+        $this->assertArrayHasKey('instructorGroups', $includes);
+
+        $this->assertIsArray($includes['sessions']);
+        $this->assertEquals(['1', '2'], $includes['sessions']);
+        $this->assertIsArray($includes['terms']);
+        $this->assertEquals(['1', '2', '3', '4', '5'], $includes['terms']);
+        $this->assertIsArray($includes['vocabularies']);
+        $this->assertEquals(['1', '2'], $includes['vocabularies']);
+        $this->assertIsArray($includes['sessionObjectives']);
+        $this->assertEquals(['1'], $includes['sessionObjectives']);
+        $this->assertIsArray($includes['objectives']);
+        $this->assertEquals(['2', '3'], $includes['objectives']);
+        $this->assertIsArray($includes['meshDescriptors']);
+        $this->assertEquals(['abc1'], $includes['meshDescriptors']);
+        $this->assertIsArray($includes['sessionDescriptions']);
+        $this->assertEquals(['1', '2'], $includes['sessionDescriptions']);
+        $this->assertIsArray($includes['sessionLearningMaterials']);
+        $this->assertEquals(['1'], $includes['sessionLearningMaterials']);
+        $this->assertIsArray($includes['learningMaterials']);
+        $this->assertEquals(['1'], $includes['learningMaterials']);
+        $this->assertIsArray($includes['users']);
+        $this->assertEquals(['1', '2', '4', '5'], $includes['users']);
+        $this->assertIsArray($includes['offerings']);
+        $this->assertEquals(['1', '2', '3', '4', '5'], $includes['offerings']);
+        $this->assertIsArray($includes['learnerGroups']);
+        $this->assertEquals(['1', '2', '5'], $includes['learnerGroups']);
+        $this->assertIsArray($includes['instructorGroups']);
+        $this->assertEquals(['1', '2'], $includes['instructorGroups']);
     }
 }


### PR DESCRIPTION
When the same data was side loaded twice two copies were being sent to the client. For example `course/1?include=terms.vocabulary,sessions.terms.vocabulary` would include each vocabulary twice and any term that was attached to both the session and the course twice. In the case of loading all of the sessions for a large course this was as much as 500kb of extra data for the client to parse and then ignore.

This change makes the data more aware of itself as it is built allowing for some [significant optimization](https://blackfire.io/profiles/compare/0d91af83-e298-4b3a-9b33-f988be5065bb/graph) as less DB queries are performed and less memory is used making requests 20% faster.

