### PR TITLE
don't break export if CI report description is NULL

### DIFF
--- a/src/Service/CurriculumInventory/Export/XmlPrinter.php
+++ b/src/Service/CurriculumInventory/Export/XmlPrinter.php
@@ -171,7 +171,7 @@ class XmlPrinter
         $languageNode = $dom->createElement('Language', 'en-US');
         $rootNode->appendChild($languageNode);
         $descriptionNode = $dom->createElement('Description');
-        $descriptionNode->appendChild($dom->createTextNode($report->getDescription()));
+        $descriptionNode->appendChild($dom->createTextNode($report->getDescription() ?: ''));
         $rootNode->appendChild($descriptionNode);
 
         if ($inventory['supporting_link']) {


### PR DESCRIPTION
i found this during click testing. 

side note: this area of the application is almost void of test coverage, let's add some whenever we get the time.