### PR TITLE
Fix saving records with a password

### DIFF
--- a/src/Controller/API/Authentications.php
+++ b/src/Controller/API/Authentications.php
@@ -310,10 +310,6 @@ class Authentications
             $entity->setPasswordHash($encodedPassword);
         }
 
-
-
-        $requestParser->extractEntityFromPutRequest($request, $entity, 'authtntications');
-
         $errors = $validator->validate($entity);
         if (count($errors) > 0) {
             $errorsString = (string) $errors;

--- a/tests/DataLoader/AuthenticationData.php
+++ b/tests/DataLoader/AuthenticationData.php
@@ -53,4 +53,17 @@ class AuthenticationData extends AbstractDataLoader
     {
         return AuthenticationDTO::class;
     }
+
+    /**
+     * Overwrite this so that password will be included in the request when it is set
+     * even though password isn't an exposed property of the DTO
+     */
+    protected function buildJsonApiObject(array $arr, string $dtoClass): array
+    {
+        $rhett = parent::buildJsonApiObject($arr, $dtoClass);
+        if (array_key_exists('password', $arr)) {
+            $rhett['attributes']['password'] = $arr['password'];
+        }
+        return $rhett;
+    }
 }

--- a/tests/Endpoints/AuthenticationTest.php
+++ b/tests/Endpoints/AuthenticationTest.php
@@ -44,6 +44,7 @@ class AuthenticationTest extends ReadWriteEndpointTest
     {
         return [
             'username' => ['username', $this->getFaker()->text(100)],
+            'password' => ['password', $this->getFaker()->password],
         ];
     }
 


### PR DESCRIPTION
We were double parsing the request for JSON:API data and the second time
the password wasn't filtered out as it is supposed to be. This wasn't
caught in tests because passwords were being removed before being sent
as they aren't public properties.