### PR TITLE
Use display name for events

### DIFF
--- a/src/Traits/CalendarEventRepository.php
+++ b/src/Traits/CalendarEventRepository.php
@@ -6,6 +6,7 @@ namespace App\Traits;
 
 use App\Entity\Course;
 use App\Entity\Session;
+use App\Entity\User;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
 use App\Classes\CalendarEvent;
@@ -127,8 +128,8 @@ trait CalendarEventRepository
         }
 
         $qb = $em->createQueryBuilder();
-        $qb->select('o.id AS oId, u.id AS userId, u.firstName, u.lastName')
-            ->from('App\Entity\User', 'u');
+        $qb->select('o.id AS oId, u.id AS userId, u.firstName, u.lastName, u.displayName')
+            ->from(User::class, 'u');
         $qb->leftJoin('u.instructedOfferings', 'o');
         $qb->where(
             $qb->expr()->in('o.id', ':offerings')
@@ -138,8 +139,8 @@ trait CalendarEventRepository
 
 
         $qb = $em->createQueryBuilder();
-        $qb->select('o.id AS oId, u.id AS userId, u.firstName, u.lastName')
-            ->from('App\Entity\User', 'u');
+        $qb->select('o.id AS oId, u.id AS userId, u.firstName, u.lastName, u.displayName')
+            ->from(User::class, 'u');
         $qb->leftJoin('u.instructorGroups', 'ig');
         $qb->leftJoin('ig.offerings', 'o');
         $qb->where(
@@ -155,7 +156,8 @@ trait CalendarEventRepository
             if (! array_key_exists($result['oId'], $offeringInstructors)) {
                 $offeringInstructors[$result['oId']] = [];
             }
-            $offeringInstructors[$result['oId']][$result['userId']] = $result['firstName'] . ' ' . $result['lastName'];
+            $name = $result['displayName'] ?? $result['firstName'] . ' ' . $result['lastName'];
+            $offeringInstructors[$result['oId']][$result['userId']] = $name;
         }
         return $offeringInstructors;
     }
@@ -174,8 +176,8 @@ trait CalendarEventRepository
         }
 
         $qb = $em->createQueryBuilder();
-        $qb->select('ilm.id AS ilmId, u.id AS userId, u.firstName, u.lastName')
-            ->from('App\Entity\User', 'u');
+        $qb->select('ilm.id AS ilmId, u.id AS userId, u.firstName, u.lastName, u.displayName')
+            ->from(User::class, 'u');
         $qb->leftJoin('u.instructorIlmSessions', 'ilm');
         $qb->where(
             $qb->expr()->in('ilm.id', ':ilms')
@@ -184,8 +186,8 @@ trait CalendarEventRepository
         $instructedIlms = $qb->getQuery()->getArrayResult();
 
         $qb = $em->createQueryBuilder();
-        $qb->select('ilm.id AS ilmId, u.id AS userId, u.firstName, u.lastName')
-            ->from('App\Entity\User', 'u');
+        $qb->select('ilm.id AS ilmId, u.id AS userId, u.firstName, u.lastName, u.displayName')
+            ->from(User::class, 'u');
         $qb->leftJoin('u.instructorGroups', 'ig');
         $qb->leftJoin('ig.ilmSessions', 'ilm');
         $qb->where(
@@ -201,7 +203,8 @@ trait CalendarEventRepository
             if (! array_key_exists($result['ilmId'], $ilmInstructors)) {
                 $ilmInstructors[$result['ilmId']] = [];
             }
-            $ilmInstructors[$result['ilmId']][$result['userId']] = $result['firstName'] . ' ' . $result['lastName'];
+            $name = $result['displayName'] ?? $result['firstName'] . ' ' . $result['lastName'];
+            $ilmInstructors[$result['ilmId']][$result['userId']] = $name;
         }
         return $ilmInstructors;
     }

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -11,6 +11,7 @@ use App\Tests\DataLoader\IlmSessionData;
 use App\Tests\DataLoader\OfferingData;
 use App\Tests\DataLoader\SchoolData;
 use App\Tests\DataLoader\SessionData;
+use App\Tests\DataLoader\UserData;
 use App\Tests\AbstractEndpointTest;
 use DateTime;
 
@@ -548,6 +549,19 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($sessionId, $events[0]['session']);
         $this->assertEquals(2, $events[1]['offering']);
         $this->assertEquals($sessionId, $events[1]['session']);
+    }
+
+    public function testAttachedInstructorsUseDisplayName()
+    {
+        $school = $this->getContainer()->get(SchoolData::class)->getOne();
+        $events = $this->getEvents($school['id'], 0, 100000000000);
+        $users = $this->getContainer()->get(UserData::class)->getAll();
+
+        $this->assertEquals($events[0]['offering'], 3);
+
+        $this->assertEquals(2, count($events[0]['instructors']));
+        $this->assertEquals($users[1]['displayName'], $events[0]['instructors'][0]);
+        $this->assertEquals($users[3]['displayName'], $events[0]['instructors'][1]);
     }
 
     protected function getEvents($schoolId, $from, $to, $userId = null)

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -12,6 +12,7 @@ use App\Tests\DataLoader\OfferingData;
 use App\Tests\DataLoader\SessionData;
 use App\Tests\DataLoader\SessionDescriptionData;
 use App\Tests\DataLoader\SessionTypeData;
+use App\Tests\DataLoader\UserData;
 use App\Tests\AbstractEndpointTest;
 use DateTime;
 
@@ -1011,6 +1012,24 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEquals($sessionId, $events[0]['session']);
         $this->assertEquals(2, $events[1]['offering']);
         $this->assertEquals($sessionId, $events[1]['session']);
+    }
+
+    public function testAttachedInstructorsUseDisplayName()
+    {
+        $userId = 2;
+        $events = $this->getEvents(
+            $userId,
+            0,
+            100000000000,
+            $this->getTokenForUser($this->kernelBrowser, $userId)
+        );
+        $users = $this->getContainer()->get(UserData::class)->getAll();
+
+        $this->assertEquals($events[0]['offering'], 3);
+
+        $this->assertEquals(2, count($events[0]['instructors']));
+        $this->assertEquals($users[1]['displayName'], $events[0]['instructors'][0]);
+        $this->assertEquals($users[3]['displayName'], $events[0]['instructors'][1]);
     }
 
     /**

--- a/tests/Endpoints/UsermaterialsTest.php
+++ b/tests/Endpoints/UsermaterialsTest.php
@@ -48,7 +48,7 @@ class UsermaterialsTest extends AbstractEndpointTest
         $this->assertEquals('1', $materials[0]['course']);
         $this->assertRegExp('/^firstCourse/', $materials[0]['courseTitle']);
         $this->assertEquals('2016-09-08T15:00:00+00:00', $materials[0]['firstOfferingDate']);
-        $this->assertEquals(['first first'], $materials[0]['instructors']);
+        $this->assertEquals(['disnom'], $materials[0]['instructors']);
         $this->assertFalse($materials[0]['isBlanked']);
 
         $this->assertEquals(15, count($materials[1]));


### PR DESCRIPTION
When an instructor has a display name we need to send it instead of a
first/last combo.

Fixes #2966