### PR TITLE
Handle LM decoration during serialization

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -373,6 +373,10 @@ services:
     Symfony\Component\Serializer\SerializerInterface:
       factory:   ['App\Service\SerializerFactory', createSerializer]
 
+    App\Service\JsonApiDataShaper:
+      calls:
+        - [ setNormalizer, ['@Symfony\Component\Serializer\Normalizer\NormalizerInterface'] ]
+
     App\Monitor\Timezone:
       autoconfigure: false
       tags:

--- a/src/Classes/JsonApiData.php
+++ b/src/Classes/JsonApiData.php
@@ -4,28 +4,20 @@ declare(strict_types=1);
 
 namespace App\Classes;
 
-use App\Normalizer\JsonApiDTONormalizer;
 use App\Service\EntityManagerLookup;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class JsonApiData
 {
-    protected $data = [];
-    protected $includes = [];
-    protected $sideLoadCandidates = [];
-
-    /**
-     * @var EntityManagerLookup
-     */
-    protected $entityManagerLookup;
-
-    /**
-     * @var JsonApiDTONormalizer
-     */
-    protected $normalizer;
+    protected array $data = [];
+    protected array $includes = [];
+    protected array $sideLoadCandidates = [];
+    protected EntityManagerLookup $entityManagerLookup;
+    protected NormalizerInterface $normalizer;
 
     public function __construct(
         EntityManagerLookup $entityManagerLookup,
-        JsonApiDTONormalizer $normalizer,
+        NormalizerInterface $normalizer,
         array $data,
         array $sideLoadFields
     ) {

--- a/src/Controller/API/CurriculumInventoryReports.php
+++ b/src/Controller/API/CurriculumInventoryReports.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\API;
 
+use App\Entity\CurriculumInventoryReport;
 use App\Entity\CurriculumInventoryReportInterface;
 use App\Entity\Manager\CurriculumInventoryAcademicLevelManager;
 use App\Entity\Manager\CurriculumInventoryReportManager;
@@ -14,10 +15,8 @@ use App\Service\ApiRequestParser;
 use App\Service\ApiResponseBuilder;
 use App\Service\CurriculumInventory\ReportRollover;
 use App\Service\CurriculumInventory\VerificationPreviewBuilder;
-use App\Service\CurriculumInventoryReportDecoratorFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
@@ -25,98 +24,27 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Exception;
-use RuntimeException;
 
 /**
- * reports need to be decorated with their absolute file path
- * before they can be sent, otherwise the method bodies are copied from
- * the top level API Read and ReadWrite controllers
- *
  * @Route("/api/{version<v1|v3>}/curriculuminventoryreports")
  */
-class CurriculumInventoryReports
+class CurriculumInventoryReports extends ReadWriteController
 {
     /**
      * @var CurriculumInventoryReportManager
      */
     protected $manager;
-
-    /**
-     * @var string
-     */
-    protected $endpoint;
-    /**
-     * @var CurriculumInventoryReportDecoratorFactory
-     */
-    protected $factory;
+    protected CurriculumInventoryAcademicLevelManager $levelManager;
+    protected CurriculumInventorySequenceManager $sequenceManager;
 
     public function __construct(
         CurriculumInventoryReportManager $manager,
-        CurriculumInventoryReportDecoratorFactory $factory
+        CurriculumInventoryAcademicLevelManager $levelManager,
+        CurriculumInventorySequenceManager $sequenceManager
     ) {
-        $this->manager = $manager;
-        $this->endpoint = 'curriculuminventoryreports';
-        $this->factory = $factory;
-    }
-
-    /**
-     * Handles GET request for a single entity
-     * @Route("/{id}", methods={"GET"})
-     */
-    public function getOne(
-        string $version,
-        int $id,
-        Request $request,
-        AuthorizationCheckerInterface $authorizationChecker,
-        ApiResponseBuilder $builder
-    ): Response {
-        $dto = $this->manager->findDTOBy(['id' => $id]);
-
-        if (! $dto) {
-            throw new NotFoundHttpException(sprintf("%s/%s was not found.", $this->endpoint, $id));
-        }
-
-        $values =  [];
-
-        if ($authorizationChecker->isGranted(AbstractVoter::VIEW, $dto)) {
-            $values = [$this->factory->create($dto)];
-        }
-
-        return $builder->buildResponseForGetOneRequest($this->endpoint, $values, Response::HTTP_OK, $request);
-    }
-
-    /**
-     * Handles GET request for multiple entities
-     * @Route("", methods={"GET"})
-     */
-    public function getAll(
-        string $version,
-        Request $request,
-        AuthorizationCheckerInterface $authorizationChecker,
-        ApiResponseBuilder $builder
-    ): Response {
-        $parameters = ApiRequestParser::extractParameters($request);
-        $dtos = $this->manager->findDTOsBy(
-            $parameters['criteria'],
-            $parameters['orderBy'],
-            $parameters['limit'],
-            $parameters['offset']
-        );
-
-        $filteredResults = array_filter($dtos, function ($object) use ($authorizationChecker) {
-            return $authorizationChecker->isGranted(AbstractVoter::VIEW, $object);
-        });
-
-        $factory = $this->factory;
-        $values = array_map(function ($report) use ($factory) {
-            return $factory->create($report);
-        }, $filteredResults);
-
-        //Re-index numerically index the array
-        $values = array_values($values);
-
-        return $builder->buildResponseForGetAllRequest($this->endpoint, $values, Response::HTTP_OK, $request);
+        parent::__construct($manager, 'curriculuminventoryreports');
+        $this->levelManager = $levelManager;
+        $this->sequenceManager = $sequenceManager;
     }
 
     /**
@@ -131,11 +59,9 @@ class CurriculumInventoryReports
         ApiRequestParser $requestParser,
         ValidatorInterface $validator,
         AuthorizationCheckerInterface $authorizationChecker,
-        ApiResponseBuilder $builder,
-        CurriculumInventoryAcademicLevelManager $levelManager,
-        CurriculumInventorySequenceManager $sequenceManager
+        ApiResponseBuilder $builder
     ): Response {
-        $class = $this->manager->getClass() . '[]';
+        $class = CurriculumInventoryReport::class . '[]';
 
         $entities = $requestParser->extractEntitiesFromPostRequest($request, $class, $this->endpoint);
 
@@ -154,17 +80,17 @@ class CurriculumInventoryReports
         foreach ($entities as $entity) {
             // create academic years and sequence while at it.
             for ($i = 1, $n = 10; $i <= $n; $i++) {
-                $level = $levelManager->create();
+                $level = $this->levelManager->create();
                 $level->setLevel($i);
                 $level->setName('Year ' . $i); // @todo i18n 'Year'. [ST 2016/06/02]
                 $entity->addAcademicLevel($level);
                 $level->setReport($entity);
-                $levelManager->update($level, false);
+                $this->levelManager->update($level, false);
             }
-            $sequence = $sequenceManager->create();
+            $sequence = $this->sequenceManager->create();
             $entity->setSequence($sequence);
             $sequence->setReport($entity);
-            $sequenceManager->update($sequence, false);
+            $this->sequenceManager->update($sequence, false);
 
             $this->manager->update($entity, false);
         }
@@ -178,127 +104,9 @@ class CurriculumInventoryReports
 
         $this->manager->flush();
 
-        $factory = $this->factory;
-        $values = array_map(function ($report) use ($factory) {
-            return $factory->create($report);
-        }, $entities);
+        $dtos = $this->fetchDtosForEntities($entities);
 
-        return $builder->buildResponseForPostRequest($this->endpoint, $values, Response::HTTP_CREATED, $request);
-    }
-
-    /**
-     * Modifies a single object in the API.  Can also create and
-     * object if it does not yet exist.
-     * @Route("/{id}", methods={"PUT"})
-     */
-    public function put(
-        string $version,
-        int $id,
-        Request $request,
-        ApiRequestParser $requestParser,
-        ValidatorInterface $validator,
-        AuthorizationCheckerInterface $authorizationChecker,
-        ApiResponseBuilder $builder
-    ): Response {
-        $entity = $this->manager->findOneBy(['id' => $id]);
-
-        if ($entity) {
-            $code = Response::HTTP_OK;
-            $permission = AbstractVoter::EDIT;
-        } else {
-            $entity = $this->manager->create();
-            $code = Response::HTTP_CREATED;
-            $permission = AbstractVoter::CREATE;
-        }
-
-        $entity = $requestParser->extractEntityFromPutRequest($request, $entity, $this->endpoint);
-
-        $errors = $validator->validate($entity);
-        if (count($errors) > 0) {
-            $errorsString = (string) $errors;
-
-            throw new HttpException(Response::HTTP_BAD_REQUEST, $errorsString);
-        }
-        if (! $authorizationChecker->isGranted($permission, $entity)) {
-            throw new AccessDeniedException('Unauthorized access!');
-        }
-
-        $this->manager->update($entity, true, false);
-
-        return $builder->buildResponseForPutRequest($this->endpoint, $this->factory->create($entity), $code, $request);
-    }
-
-    /**
-     * Modifies a single object in the API.  Can also create and
-     * object if it does not yet exist.
-     * @Route("/{id}", methods={"PATCH"})
-     */
-    public function patch(
-        string $version,
-        string $id,
-        Request $request,
-        ApiRequestParser $requestParser,
-        ValidatorInterface $validator,
-        AuthorizationCheckerInterface $authorizationChecker,
-        ApiResponseBuilder $builder
-    ): Response {
-        $type = $request->getAcceptableContentTypes();
-        if (!in_array("application/vnd.api+json", $type)) {
-            throw new BadRequestHttpException("PATCH is only allowed for JSON:API requests, use PUT instead");
-        }
-
-        $entity = $this->manager->findOneBy(['id' => $id]);
-
-        if (!$entity) {
-            throw new NotFoundHttpException(sprintf("%s/%s was not found.", $this->endpoint, $id));
-        }
-
-        $entity = $requestParser->extractEntityFromPutRequest($request, $entity, $this->endpoint);
-
-        $errors = $validator->validate($entity);
-        if (count($errors) > 0) {
-            $errorsString = (string) $errors;
-
-            throw new HttpException(Response::HTTP_BAD_REQUEST, $errorsString);
-        }
-        if (! $authorizationChecker->isGranted(AbstractVoter::EDIT, $entity)) {
-            throw new AccessDeniedException('Unauthorized access!');
-        }
-
-        $this->manager->update($entity, true, false);
-
-        $dto = $this->factory->create($entity);
-
-        return $builder->buildResponseForPatchRequest($this->endpoint, $dto, Response::HTTP_OK, $request);
-    }
-
-
-    /**
-     * Handles DELETE requests to remove an element from the API
-     * @Route("/{id}", methods={"DELETE"})
-     */
-    public function delete(
-        string $version,
-        int $id,
-        AuthorizationCheckerInterface $authorizationChecker
-    ): Response {
-        $entity = $this->manager->findOneBy(['id' => $id]);
-
-        if (! $entity) {
-            throw new NotFoundHttpException(sprintf('The resource \'%s\' was not found.', $id));
-        }
-
-        if (! $authorizationChecker->isGranted(AbstractVoter::DELETE, $entity)) {
-            throw new AccessDeniedException('Unauthorized access!');
-        }
-
-        try {
-            $this->manager->delete($entity);
-
-            return new Response('', Response::HTTP_NO_CONTENT);
-        } catch (Exception $exception) {
-            throw new RuntimeException("Failed to delete entity: " . $exception->getMessage());
-        }
+        return $builder->buildResponseForPostRequest($this->endpoint, $dtos, Response::HTTP_CREATED, $request);
     }
 
     /**
@@ -336,10 +144,11 @@ class CurriculumInventoryReports
         }
 
         $newReport = $rollover->rollover($report, $name, $description, $year);
+        $dtos = $this->fetchDtosForEntities([$newReport]);
 
         return $builder->buildResponseForPostRequest(
             $this->endpoint,
-            [$this->factory->create($newReport)],
+            $dtos,
             Response::HTTP_CREATED,
             $request
         );

--- a/src/Entity/DTO/CurriculumInventoryReportDTO.php
+++ b/src/Entity/DTO/CurriculumInventoryReportDTO.php
@@ -156,35 +156,4 @@ class CurriculumInventoryReportDTO
         $this->sequenceBlocks = [];
         $this->administrators = [];
     }
-
-    public static function createFromEntity(CurriculumInventoryReportInterface $report): CurriculumInventoryReportDTO
-    {
-        $dto = new CurriculumInventoryReportDTO(
-            $report->getId(),
-            $report->getName(),
-            $report->getDescription(),
-            $report->getYear(),
-            $report->getStartDate(),
-            $report->getEndDate(),
-            $report->getToken(),
-        );
-
-        $dto->export = $report->getExport() ? (string) $report->getExport() : null;
-        $dto->sequence = $report->getSequence() ? (string) $report->getSequence() : null;
-        $dto->program = $report->getProgram() ? (string) $report->getProgram() : null;
-
-        $sequenceBlockIds = $report->getSequenceBlocks()
-            ->map(function (CurriculumInventorySequenceBlockInterface $block) {
-                return (string) $block;
-            });
-        $dto->sequenceBlocks = $sequenceBlockIds->toArray();
-
-        $academicLevelIds = $report->getAcademicLevels()
-            ->map(function (CurriculumInventoryAcademicLevelInterface $level) {
-                return (string) $level;
-            });
-        $dto->academicLevels = $academicLevelIds->toArray();
-
-        return $dto;
-    }
 }

--- a/src/Normalizer/FactoryNormalizer.php
+++ b/src/Normalizer/FactoryNormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Normalizer;
 
+use App\Entity\DTO\CurriculumInventoryReportDTO;
 use App\Entity\DTO\LearningMaterialDTO;
 use App\Entity\LearningMaterial;
 use App\Service\CurriculumInventoryReportDecoratorFactory;
@@ -40,6 +41,9 @@ class FactoryNormalizer implements ContextAwareNormalizerInterface, Normalizatio
             case LearningMaterialDTO::class:
                 $object = $this->learningMaterialDecoratorFactory->create($object);
                 break;
+            case CurriculumInventoryReportDTO::class:
+                $object = $this->curriculumInventoryReportDecoratorFactory->create($object);
+                break;
             default:
                 throw new Exception("${class} fell through switch statement, should it have been decorated?");
         }
@@ -65,6 +69,7 @@ class FactoryNormalizer implements ContextAwareNormalizerInterface, Normalizatio
         $decoratedTypes = [
             LearningMaterial::class,
             LearningMaterialDTO::class,
+            CurriculumInventoryReportDTO::class,
         ];
         $class = is_object($classNameOrObject) ? get_class($classNameOrObject) : $classNameOrObject;
         return in_array($class, $decoratedTypes);

--- a/src/Normalizer/FactoryNormalizer.php
+++ b/src/Normalizer/FactoryNormalizer.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Normalizer;
+
+use App\Entity\DTO\LearningMaterialDTO;
+use App\Entity\LearningMaterial;
+use App\Service\CurriculumInventoryReportDecoratorFactory;
+use App\Service\LearningMaterialDecoratorFactory;
+use Exception;
+use Symfony\Component\Serializer\Encoder\NormalizationAwareInterface;
+use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+
+/**
+ * Applies a factory to decorate the entity or DTO before it is sent
+ */
+class FactoryNormalizer implements ContextAwareNormalizerInterface, NormalizationAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    private const ALREADY_CALLED = 'FACTORY_NORMALIZER_ALREADY_CALLED';
+    protected LearningMaterialDecoratorFactory $learningMaterialDecoratorFactory;
+    protected CurriculumInventoryReportDecoratorFactory $curriculumInventoryReportDecoratorFactory;
+
+    public function __construct(
+        LearningMaterialDecoratorFactory $learningMaterialDecoratorFactory,
+        CurriculumInventoryReportDecoratorFactory $curriculumInventoryReportDecoratorFactory
+    ) {
+        $this->learningMaterialDecoratorFactory = $learningMaterialDecoratorFactory;
+        $this->curriculumInventoryReportDecoratorFactory = $curriculumInventoryReportDecoratorFactory;
+    }
+
+    public function normalize($object, string $format = null, array $context = [])
+    {
+        $class = get_class($object);
+        switch ($class) {
+            case LearningMaterial::class:
+            case LearningMaterialDTO::class:
+                $object = $this->learningMaterialDecoratorFactory->create($object);
+                break;
+            default:
+                throw new Exception("${class} fell through switch statement, should it have been decorated?");
+        }
+
+        $context[self::ALREADY_CALLED] = true;
+        return $this->normalizer->normalize($object, $format, $context);
+    }
+
+    /*
+     * Since we call upon the normalizer chain here we have to avoid recursion by examining
+     * the context to avoid calling ourselves again.
+     */
+    public function supportsNormalization($classNameOrObject, string $format = null, array $context = [])
+    {
+        if (isset($context[self::ALREADY_CALLED])) {
+            return false;
+        }
+
+        if (!in_array($format, ['json', 'json-api'])) {
+            return false;
+        }
+
+        $decoratedTypes = [
+            LearningMaterial::class,
+            LearningMaterialDTO::class,
+        ];
+        $class = is_object($classNameOrObject) ? get_class($classNameOrObject) : $classNameOrObject;
+        return in_array($class, $decoratedTypes);
+    }
+}

--- a/src/Service/CurriculumInventoryReportDecoratorFactory.php
+++ b/src/Service/CurriculumInventoryReportDecoratorFactory.php
@@ -11,11 +11,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 class CurriculumInventoryReportDecoratorFactory
 {
-
-    /**
-     * @var RouterInterface
-     */
-    protected $router;
+    protected RouterInterface $router;
 
     /**
      * @param RouterInterface $router
@@ -25,39 +21,14 @@ class CurriculumInventoryReportDecoratorFactory
         $this->router = $router;
     }
 
-    /**
-     * @param $report
-     * @return CurriculumInventoryReportDTO
-     * @throws \Exception
-     */
-    public function create(
-        $report
-    ) {
-        if ($report instanceof CurriculumInventoryReportInterface) {
-            $dto = CurriculumInventoryReportDTO::createFromEntity($report);
-            return $this->decorateDto($dto);
-        }
-
-        if ($report instanceof CurriculumInventoryReportDTO) {
-            return $this->decorateDto($report);
-        }
-
-        throw new \Exception(get_class($report) . " cannot be decorated");
-    }
-
-    /**
-     * @param CurriculumInventoryReportDTO $reportDTO
-     *
-     * @return CurriculumInventoryReportDTO
-     */
-    protected function decorateDto(CurriculumInventoryReportDTO $reportDTO)
+    public function create(CurriculumInventoryReportDTO $report): CurriculumInventoryReportDTO
     {
-        $reportDTO->absoluteFileUri = $this->router->generate(
+        $report->absoluteFileUri = $this->router->generate(
             'ilios_downloadcurriculuminventoryreport',
-            ['token' => $reportDTO->token],
+            ['token' => $report->token],
             UrlGenerator::ABSOLUTE_URL
         );
 
-        return $reportDTO;
+        return $report;
     }
 }

--- a/src/Service/JsonApiDataShaper.php
+++ b/src/Service/JsonApiDataShaper.php
@@ -5,28 +5,28 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Classes\JsonApiData;
-use App\Normalizer\JsonApiDTONormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 
 class JsonApiDataShaper
 {
-    /**
-     * @var EntityManagerLookup
-     */
-    protected $entityManagerLookup;
-    /**
-     * @var JsonApiDTONormalizer
-     */
-    protected $normalizer;
+    use NormalizerAwareTrait;
 
-    public function __construct(EntityManagerLookup $entityManagerLookup, JsonApiDTONormalizer $normalizer)
-    {
+    protected EntityManagerLookup $entityManagerLookup;
+
+    public function __construct(
+        EntityManagerLookup $entityManagerLookup
+    ) {
         $this->entityManagerLookup = $entityManagerLookup;
-        $this->normalizer = $normalizer;
     }
 
     public function shapeData(array $data, array $sideLoadFields): array
     {
-        $jsonApiData = new JsonApiData($this->entityManagerLookup, $this->normalizer, $data, $sideLoadFields);
+        $jsonApiData = new JsonApiData(
+            $this->entityManagerLookup,
+            $this->normalizer,
+            $data,
+            $sideLoadFields
+        );
         return $jsonApiData->toArray();
     }
 

--- a/src/Service/SerializerFactory.php
+++ b/src/Service/SerializerFactory.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Encoder\JsonApiEncoder;
 use App\Normalizer\DTONormalizer;
+use App\Normalizer\FactoryNormalizer;
 use App\Normalizer\JsonApiDTONormalizer;
 use App\Denormalizer\EntityDenormalizer;
 use App\Normalizer\EntityNormalizer;
@@ -26,6 +27,7 @@ class SerializerFactory
      * Build our own serializer just the way we like it
      */
     public static function createSerializer(
+        FactoryNormalizer $factoryNormalizer,
         DTONormalizer $dtoNormalizer,
         JsonApiDTONormalizer $jsonApiDTONormalizer,
         JsonApiEncoder $jsonApiEncoder,
@@ -35,19 +37,24 @@ class SerializerFactory
         $jsonEncoder = new JsonEncoder();
         $array = new ArrayDenormalizer();
         $dateTime = new DateTimeNormalizer();
-        return new Serializer(
+        $serializer =  new Serializer(
             [
                 $array,
                 $dateTime,
+                $factoryNormalizer,
                 $jsonApiDTONormalizer,
                 $entityNormalizer,
                 $entityDenormalizer,
-                $dtoNormalizer
+                $dtoNormalizer,
             ],
             [
                 $jsonApiEncoder,
                 $jsonEncoder
             ]
         );
+
+        $factoryNormalizer->setNormalizer($serializer);
+
+        return $serializer;
     }
 }

--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -356,6 +356,20 @@ abstract class AbstractEndpointTest extends WebTestCase
 
     protected function getJsonApiIncludes(string $endpoint, string $id, string $include): array
     {
+        $included = $this->getJsonApiIncludeContent($endpoint, $id, $include);
+        return array_reduce($included, function (array $carry, object $obj) {
+            if (!array_key_exists($obj->type, $carry)) {
+                $carry[$obj->type] = [];
+            }
+            $carry[$obj->type][] = $obj->id;
+            sort($carry[$obj->type]);
+
+            return $carry;
+        }, []);
+    }
+
+    protected function getJsonApiIncludeContent(string $endpoint, string $id, string $include): array
+    {
         $url = $this->getUrl(
             $this->kernelBrowser,
             "app_api_${endpoint}_getone",
@@ -378,15 +392,7 @@ abstract class AbstractEndpointTest extends WebTestCase
         $content = json_decode($response->getContent());
         $this->assertObjectHasAttribute('included', $content);
 
-        return array_reduce($content->included, function (array $carry, object $obj) {
-            if (!array_key_exists($obj->type, $carry)) {
-                $carry[$obj->type] = [];
-            }
-            $carry[$obj->type][] = $obj->id;
-            sort($carry[$obj->type]);
-
-            return $carry;
-        }, []);
+        return $content->included;
     }
 
     /**

--- a/tests/Fixture/LoadLearningMaterialData.php
+++ b/tests/Fixture/LoadLearningMaterialData.php
@@ -26,6 +26,8 @@ class LoadLearningMaterialData extends AbstractFixture implements
      */
     private $container;
 
+    public const TEST_FILE_PATH = __DIR__ . '/FakeTestFiles/TESTFILE.txt';
+
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
@@ -38,11 +40,10 @@ class LoadLearningMaterialData extends AbstractFixture implements
             ->getAll();
 
         $fs = new Filesystem();
-        $fakeTestFileDir = __DIR__ . '/FakeTestFiles';
-        if (!$fs->exists($fakeTestFileDir)) {
-            $fs->mkdir($fakeTestFileDir);
+        if (!$fs->exists(dirname(self::TEST_FILE_PATH))) {
+            $fs->mkdir(dirname(self::TEST_FILE_PATH));
         }
-        $fs->copy(__FILE__, $fakeTestFileDir . '/TESTFILE.txt');
+        $fs->copy(__FILE__, self::TEST_FILE_PATH);
         $config = $this->container->get(Config::class);
         $storePath = $config->get('file_system_storage_path');
 


### PR DESCRIPTION
We were doing this work in the controller, but that doesn't account for side loaded materials. In order to ensure that all materials are decorated we need to do this work in the serializer instead.

The FactoryNormalizer is built to handle any of our data which has a factory and to transform it and then pass the result back into the serializer to continue to be processed.

Then instead of relying on JsonApiDTONormalizer directly in the JsonApiData shaping process we use the full serializer chain which ensures that side loaded data also passes through the FactoryNormalizer before landing in the JsonApiDTONormalizer.

Fixes #2991 