### PR TITLE
Grant student advisors access to learning materials

### DIFF
--- a/src/Classes/SchoolEvent.php
+++ b/src/Classes/SchoolEvent.php
@@ -30,24 +30,28 @@ class SchoolEvent extends CalendarEvent
     }
 
     /**
-     * This information is not available to un-privileged users
+     * Clear out all draft and schedule events as well as all materials
      */
     public function clearDataForUnprivilegedUsers()
     {
         $this->instructionalNotes = null;
         $this->clearDataForDraftOrScheduledEvent();
         $this->removeMaterialsInDraft();
-        $this->clearMaterials();
+        array_walk($this->learningMaterials, function (UserMaterial $lm) {
+            $lm->clearMaterial();
+        });
     }
 
     /**
-     * Blanks this event's learning materials.
+     * Clear out all draft and schedule events as well as LMs based on time
      */
-    protected function clearMaterials(): void
+    public function clearDataForStudentAssociatedWithEvent(DateTime $dateTime)
     {
-        /** @var UserMaterial $lm */
-        foreach ($this->learningMaterials as $lm) {
-            $lm->clearMaterial();
-        }
+        $this->instructionalNotes = null;
+        $this->clearDataForDraftOrScheduledEvent();
+        $this->removeMaterialsInDraft();
+        array_walk($this->learningMaterials, function (UserMaterial $lm) use ($dateTime) {
+            $lm->clearTimedMaterial($dateTime);
+        });
     }
 }

--- a/src/Classes/SessionUser.php
+++ b/src/Classes/SessionUser.php
@@ -20,110 +20,29 @@ use DateTime;
  */
 class SessionUser implements SessionUserInterface
 {
-    /**
-     * @var int
-     */
-    protected $userId;
-
-    /**
-     * @var bool
-     */
-    protected $isRoot;
-
-    /**
-     * @var bool
-     */
-    protected $isEnabled;
-
-    /**
-     * @var DateTime
-     */
-    protected $tokenNotValidBefore;
-
-    /**
-     * @var int
-     */
-    protected $schoolId;
-
-    /**
-     * @var bool
-     */
-    protected $isLegacyAccount;
-
-    /**
-     * @var string
-     */
-    protected $password;
-
-    /**
-     * @var array
-     */
-    protected $directedCourseAndSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $administeredCourseAndSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $directedSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $administeredSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $administeredSessionCourseAndSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $instructedOfferingIlmSessionCourseAndSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $instructedLearnerGroupSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $instructorGroupSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $directedProgramAndSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $directedProgramYearProgramAndSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $administeredCurriculumInventoryReportAndSchoolIds;
-
-    /**
-     * @var array
-     */
-    protected $learnerGroupIds;
-
-    /**
-     * @var array
-     */
-    protected $instructorGroupIds;
-
-    /**
-     * @var array
-     */
-    protected $coursesCohortsProgramYearAndProgramIdsLinkedToProgramsDirectedByUser;
+    protected int $userId;
+    protected bool $isRoot;
+    protected bool $isEnabled;
+    protected int $schoolId;
+    protected ?DateTime $tokenNotValidBefore = null;
+    protected ?string $password;
+    protected bool $isLegacyAccount = false;
+    protected array $directedCourseAndSchoolIds;
+    protected array $administeredCourseAndSchoolIds;
+    protected array $directedSchoolIds;
+    protected array $administeredSchoolIds;
+    protected array $administeredSessionCourseAndSchoolIds;
+    protected array $studentAdvisedSessionAndCourseIds;
+    protected array $instructedOfferingIlmSessionCourseAndSchoolIds;
+    protected array $instructedLearnerGroupSchoolIds;
+    protected array $instructorGroupSchoolIds;
+    protected array $directedProgramAndSchoolIds;
+    protected array $directedProgramYearProgramAndSchoolIds;
+    protected array $administeredCurriculumInventoryReportAndSchoolIds;
+    protected array $learnerGroupIds;
+    protected array $instructorGroupIds;
+    protected array $coursesCohortsProgramYearAndProgramIdsLinkedToProgramsDirectedByUser;
+    protected array $learnerIlmAndOfferingIds;
 
     /**
      * @var UserManager
@@ -490,6 +409,26 @@ class SessionUser implements SessionUserInterface
         return in_array($ilmId, $this->getInstructedIlmIds());
     }
 
+    public function isStudentAdvisorInSession(int $sessionId): bool
+    {
+        return in_array($sessionId, $this->getStudentAdvisedSessionIds());
+    }
+
+    public function isStudentAdvisorInCourse(int $courseId): bool
+    {
+        return in_array($courseId, $this->getStudentAdvisedCourseIds());
+    }
+
+    public function isLearnerInOffering(int $offeringId): bool
+    {
+        return in_array($offeringId, $this->getLearnerOfferingsIds());
+    }
+
+    public function isLearnerInIlm(int $ilmId): bool
+    {
+        return in_array($ilmId, $this->getLearnerIlmIds());
+    }
+
     /**
      * @inheritdoc
      * @throws Exception
@@ -772,6 +711,11 @@ class SessionUser implements SessionUserInterface
         return $this->getInstructedOfferingIlmSessionCourseAndSchoolIds()['courseIds'];
     }
 
+    protected function getStudentAdvisedCourseIds(): array
+    {
+        return $this->getStudentAdvisedSessionAndCourseIds()['courseIds'];
+    }
+
     /**
      * @inheritdoc
      * @throws Exception
@@ -797,6 +741,11 @@ class SessionUser implements SessionUserInterface
     public function getInstructedIlmIds(): array
     {
         return $this->getInstructedOfferingIlmSessionCourseAndSchoolIds()['ilmIds'];
+    }
+
+    protected function getStudentAdvisedSessionIds(): array
+    {
+        return $this->getStudentAdvisedSessionAndCourseIds()['sessionIds'];
     }
 
     /**
@@ -890,6 +839,16 @@ class SessionUser implements SessionUserInterface
         return $this->getCoursesCohortsProgramYearAndProgramIdsLinkedToProgramsDirectedByUser()['courseIds'];
     }
 
+    protected function getLearnerOfferingsIds(): array
+    {
+        return $this->getLearnerIlmAndOfferingIds()['offeringIds'];
+    }
+
+    protected function getLearnerIlmIds(): array
+    {
+        return $this->getLearnerIlmAndOfferingIds()['ilmIds'];
+    }
+
     /**
      * @inheritdoc
      * @throws Exception
@@ -977,6 +936,32 @@ class SessionUser implements SessionUserInterface
                 $this->userManager->getAdministeredSessionCourseAndSchoolIds($this->getId());
         }
         return $this->administeredSessionCourseAndSchoolIds;
+    }
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    protected function getStudentAdvisedSessionAndCourseIds(): array
+    {
+        if (!isset($this->studentAdvisedSessionAndCourseIds)) {
+            $this->studentAdvisedSessionAndCourseIds =
+                $this->userManager->getStudentAdvisedSessionAndCourseIds($this->getId());
+        }
+        return $this->studentAdvisedSessionAndCourseIds;
+    }
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    protected function getLearnerIlmAndOfferingIds(): array
+    {
+        if (!isset($this->learnerIlmAndOfferingIds)) {
+            $this->learnerIlmAndOfferingIds =
+                $this->userManager->getLearnerIlmAndOfferingIds($this->getId());
+        }
+        return $this->learnerIlmAndOfferingIds;
     }
 
     /**

--- a/src/Classes/SessionUserInterface.php
+++ b/src/Classes/SessionUserInterface.php
@@ -116,6 +116,10 @@ interface SessionUserInterface extends UserInterface, EquatableInterface, Encode
     public function isTeachingSession(int $sessionId): bool;
     public function isInstructingOffering(int $sessionId): bool;
     public function isInstructingIlm(int $sessionId): bool;
+    public function isStudentAdvisorInSession(int $sessionId): bool;
+    public function isStudentAdvisorInCourse(int $courseId): bool;
+    public function isLearnerInOffering(int $offeringId): bool;
+    public function isLearnerInIlm(int $ilmId): bool;
 
     public function rolesInSession(
         int $sessionId,
@@ -183,6 +187,7 @@ interface SessionUserInterface extends UserInterface, EquatableInterface, Encode
      * @return array
      */
     public function getAdministeredSessionCourseIds(): array;
+
 
     /**
      * @return array

--- a/src/Controller/SchooleventController.php
+++ b/src/Controller/SchooleventController.php
@@ -129,10 +129,20 @@ class SchooleventController extends AbstractController
         $allEvents = $schoolManager->addMaterialsToEvents($allEvents);
         $allEvents = $schoolManager->addSessionDataToEvents($allEvents);
 
+        $now = new DateTime();
         /* @var SchoolEvent $event */
         foreach ($allEvents as $event) {
             if (! $authorizationChecker->isGranted(AbstractCalendarEvent::VIEW_DRAFT_CONTENTS, $event)) {
-                $event->clearDataForUnprivilegedUsers();
+                if (
+                    $sessionUser->isStudentAdvisorInCourse($event->course) ||
+                    $sessionUser->isStudentAdvisorInSession($event->session) ||
+                    ($event->offering && $sessionUser->isLearnerInOffering($event->offering)) ||
+                    ($event->ilmSession && $sessionUser->isLearnerInIlm($event->ilmSession))
+                ) {
+                    $event->clearDataForStudentAssociatedWithEvent($now);
+                } else {
+                    $event->clearDataForUnprivilegedUsers();
+                }
             }
         }
 

--- a/src/Entity/Manager/UserManager.php
+++ b/src/Entity/Manager/UserManager.php
@@ -293,6 +293,20 @@ class UserManager extends BaseManager
         return $repository->getAdministeredSessionCourseAndSchoolIds($userId);
     }
 
+    public function getStudentAdvisedSessionAndCourseIds(int $userId): array
+    {
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->getStudentAdvisedSessionAndCourseIds($userId);
+    }
+
+    public function getLearnerIlmAndOfferingIds(int $userId): array
+    {
+        /** @var UserRepository $repository */
+        $repository = $this->getRepository();
+        return $repository->getLearnerIlmAndOfferingIds($userId);
+    }
+
     /**
      * @param $userId
      * @return array

--- a/tests/DataLoader/UserData.php
+++ b/tests/DataLoader/UserData.php
@@ -259,6 +259,16 @@ class UserData extends AbstractDataLoader
         ];
     }
 
+    public function createEmpty()
+    {
+        return [
+            'lastName' => $this->faker->lastName,
+            'firstName' => $this->faker->firstName,
+            'email' => $this->faker->email,
+            'school' => "1",
+        ];
+    }
+
     public function createInvalid()
     {
         return [];

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -5,6 +5,16 @@ declare(strict_types=1);
 namespace App\Tests\Endpoints;
 
 use App\Entity\OfferingInterface;
+use App\Tests\DataLoader\DataLoaderInterface;
+use App\Tests\Fixture\LoadCourseLearningMaterialData;
+use App\Tests\Fixture\LoadCourseObjectiveData;
+use App\Tests\Fixture\LoadIlmSessionData;
+use App\Tests\Fixture\LoadLearningMaterialData;
+use App\Tests\Fixture\LoadOfferingData;
+use App\Tests\Fixture\LoadProgramYearObjectiveData;
+use App\Tests\Fixture\LoadSchoolData;
+use App\Tests\Fixture\LoadSessionLearningMaterialData;
+use App\Tests\Fixture\LoadSessionObjectiveData;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\DataLoader\CourseData;
 use App\Tests\DataLoader\IlmSessionData;
@@ -27,28 +37,92 @@ class SchooleventsTest extends AbstractEndpointTest
     protected function getFixtures()
     {
         return [
-            'App\Tests\Fixture\LoadOfferingData',
-            'App\Tests\Fixture\LoadIlmSessionData',
-            'App\Tests\Fixture\LoadSchoolData',
-            'App\Tests\Fixture\LoadLearningMaterialData',
-            'App\Tests\Fixture\LoadCourseLearningMaterialData',
-            'App\Tests\Fixture\LoadSessionLearningMaterialData',
-            'App\Tests\Fixture\LoadSessionObjectiveData',
-            'App\Tests\Fixture\LoadCourseObjectiveData',
-            'App\Tests\Fixture\LoadProgramYearObjectiveData',
+            LoadOfferingData::class,
+            LoadIlmSessionData::class,
+            LoadSchoolData::class,
+            LoadLearningMaterialData::class,
+            LoadCourseLearningMaterialData::class,
+            LoadSessionLearningMaterialData::class,
+            LoadSessionObjectiveData::class,
+            LoadCourseObjectiveData::class,
+            LoadProgramYearObjectiveData::class,
         ];
     }
 
-    public function testAttachedUserMaterialsAreBlankedForStudents()
+    public function testAttachedUserMaterialsAreBlankedByTimedRelease()
     {
         $school = $this->getContainer()->get(SchoolData::class)->getOne();
         $userId = 5;
         $events = $this->getEvents($school['id'], 0, 100000000000, $userId);
         $lms = $events[3]['learningMaterials'];
         $this->assertEquals(9, count($lms));
+        $this->assertFalse($lms[0]['isBlanked']);
+        $this->assertFalse($lms[1]['isBlanked']);
+        $this->assertFalse($lms[2]['isBlanked']);
+        $this->assertFalse($lms[3]['isBlanked']);
+        $this->assertTrue($lms[4]['isBlanked'], 'start date is in the future');
+        $this->assertFalse($lms[5]['isBlanked']);
+        $this->assertTrue($lms[6]['isBlanked'], 'end date is in the past');
+        $this->assertFalse($lms[7]['isBlanked']);
+        $this->assertTrue($lms[8]['isBlanked'], 'start and end dates are in the past');
+    }
+
+    public function testAttachedUserMaterialsAreBlankedForUsersWhenTheyLackPermissionToAccessThem()
+    {
+        /** @var DataLoaderInterface $dataLoader */
+        $userLoader = $this->getContainer()->get(UserData::class);
+        $newUser = $this->postOne('users', 'user', 'users', $userLoader->createEmpty());
+
+        $events = $this->getEvents($newUser['school'], 0, 100000000000, $newUser['id']);
+        $lms = $events[3]['learningMaterials'];
+        $this->assertEquals(9, count($lms));
         foreach ($lms as $lm) {
             $this->assertTrue($lm['isBlanked']);
         }
+    }
+
+    public function testAttachedUserMaterialsAreAvailableToCourseStudentAdvisors()
+    {
+        /** @var DataLoaderInterface $dataLoader */
+        $userLoader = $this->getContainer()->get(UserData::class);
+        $postData = $userLoader->createEmpty();
+        $postData['studentAdvisedCourses'] = ['1'];
+        $newUser = $this->postOne('users', 'user', 'users', $postData);
+
+        $events = $this->getEvents($newUser['school'], 0, 100000000000, $newUser['id']);
+        $lms = $events[3]['learningMaterials'];
+        $this->assertEquals(9, count($lms));
+        $this->assertFalse($lms[0]['isBlanked']);
+        $this->assertFalse($lms[1]['isBlanked']);
+        $this->assertFalse($lms[2]['isBlanked']);
+        $this->assertFalse($lms[3]['isBlanked']);
+        $this->assertTrue($lms[4]['isBlanked'], 'start date is in the future');
+        $this->assertFalse($lms[5]['isBlanked']);
+        $this->assertTrue($lms[6]['isBlanked'], 'end date is in the past');
+        $this->assertFalse($lms[7]['isBlanked']);
+        $this->assertTrue($lms[8]['isBlanked'], 'start and end dates are in the past');
+    }
+
+    public function testAttachedUserMaterialsAreAvailableToSessionStudentAdvisors()
+    {
+        /** @var DataLoaderInterface $dataLoader */
+        $userLoader = $this->getContainer()->get(UserData::class);
+        $postData = $userLoader->createEmpty();
+        $postData['studentAdvisedSessions'] = ['1'];
+        $newUser = $this->postOne('users', 'user', 'users', $postData);
+
+        $events = $this->getEvents($newUser['school'], 0, 100000000000, $newUser['id']);
+        $lms = $events[3]['learningMaterials'];
+        $this->assertEquals(9, count($lms));
+        $this->assertFalse($lms[0]['isBlanked']);
+        $this->assertFalse($lms[1]['isBlanked']);
+        $this->assertFalse($lms[2]['isBlanked']);
+        $this->assertFalse($lms[3]['isBlanked']);
+        $this->assertTrue($lms[4]['isBlanked'], 'start date is in the future');
+        $this->assertFalse($lms[5]['isBlanked']);
+        $this->assertTrue($lms[6]['isBlanked'], 'end date is in the past');
+        $this->assertFalse($lms[7]['isBlanked']);
+        $this->assertTrue($lms[8]['isBlanked'], 'start and end dates are in the past');
     }
 
     public function testGetEvents()


### PR DESCRIPTION
Instead of blanking all materials for everyone this checks the
permissions of a user first. Students who are in the session as well as
student advisors attached to the session or course will now be able to
access all non-draft time released materials when viewing an event
through the school calendar.

Refs ilios/frontend#5102