### PR TITLE
Allow LM description to be null

### DIFF
--- a/src/Entity/LearningMaterial.php
+++ b/src/Entity/LearningMaterial.php
@@ -70,7 +70,7 @@ class LearningMaterial implements LearningMaterialInterface
     /**
      * @var string
      *
-     * @ORM\Column(name="description", type="text")
+     * @ORM\Column(name="description", type="text", nullable=true)
      *
      * @Assert\Type(type="string")
      * @Assert\Length(

--- a/src/Migrations/Version20200728222336.php
+++ b/src/Migrations/Version20200728222336.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200728222336 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Make learning material description nullable';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE learning_material CHANGE description description LONGTEXT DEFAULT NULL');
+        $this->addSql('UPDATE learning_material SET description=NULL WHERE description=""');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('UPDATE learning_material SET description="" WHERE description=NULL');
+        $this->addSql('ALTER TABLE learning_material CHANGE description description LONGTEXT CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`');
+    }
+}

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -61,6 +61,7 @@ class LearningMaterialTest extends ReadWriteEndpointTest
         return [
             'title' => ['title', $this->getFaker()->text(60)],
             'description' => ['description', $this->getFaker()->text],
+            'nullDescription' => ['description', null],
             'originalAuthor' => ['originalAuthor', $this->getFaker()->text(80)],
             'userRole' => ['userRole', 2],
             'status' => ['status', LearningMaterialStatusInterface::IN_DRAFT],


### PR DESCRIPTION
We've been allowing an empty string here which was auto created when we
ran NULL through our HTML purifier. Since we're not running null through
the purifier anymore we should allow it as a value for description.

Fixes #3003