### PR TITLE
Fix error with authentication username

### DIFF
--- a/src/Entity/Repository/AuthenticationRepository.php
+++ b/src/Entity/Repository/AuthenticationRepository.php
@@ -23,9 +23,12 @@ class AuthenticationRepository extends EntityRepository implements DTORepository
     public function findOneByUsername($username)
     {
         $qb = $this->_em->createQueryBuilder();
-        $qb->add('select', 'a')->from('App\Entity\Authentication', 'a');
-        $qb->where($qb->expr()->like('a.username', "?1"));
-        $qb->setParameter(1, '%' . $username . '%');
+        $qb->select('a')->from(Authentication::class, 'a');
+        $qb->where($qb->expr()->eq(
+            $qb->expr()->lower('a.username'),
+            ":username"
+        ));
+        $qb->setParameter('username', trim(strtolower($username)));
         $result = null;
         try {
             $result = $qb->getQuery()->getSingleResult();


### PR DESCRIPTION
We were incorrectly rejecting users from logging in when their
username partially matched another user. Example demo123 could log in,
but demo1 could not. The same case insensitivity can be had through a
query expression and avoid this issue.