### PR TITLE
Remove hardwired list of valid API endpoints

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,15 +5,6 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     ilios_api_version: v3.0
-    ilios_api_valid_endpoints: >-
-      aamcmethods,aamcpcrses,aamcresourcetypes,academicyears,applicationconfigs,assessmentoptions,authentications,
-      cohorts,competencies,courses,courseclerkshiptypes,courselearningmaterials,courseobjectives,curriculuminventoryacademiclevels,curriculuminventoryexports,
-      curriculuminventoryinstitutions,curriculuminventorysequenceblocks,curriculuminventorysequences,curriculuminventoryreports,
-      departments,ilmsessions,ingestionexceptions,instructorgroups,learnergroups,learningmaterials,learningmaterialstatuses,learningmaterialuserroles,
-      meshconcepts,meshdescriptors,meshterms,meshpreviousindexings,meshqualifiers,meshterms,meshtrees,
-      objectives,offerings,pendinguserupdates,permissions,programs,programyears,programyearobjectives,programyearstewards,reports,
-      sessionlearningmaterials,sessiondescriptions,sessionlearningmaterials,sessions,sessionobjectives,sessiontypes,schoolconfigs,schools,
-      terms,usermadereminders,userroles,users,vocabularies
     ilios_api_valid_api_versions: 'v1|v3'
     sentry_dsn: https://c70286fb157048be9ebc6e918e8c2b79@sentry.io/1323198
 


### PR DESCRIPTION
We no longer use this to route requests, they all go to their own
controller now.