### PR TITLE
Remove deprecated eventClass from CalendarEvent

### DIFF
--- a/config/swagger/definitions/CalendarEvent.yml
+++ b/config/swagger/definitions/CalendarEvent.yml
@@ -27,11 +27,6 @@ CalendarEvent:
    description: The ID of the ILM Session this event belongs to
    type: integer
    readOnly: true
-  eventClass:
-   description: CSS class to apply to an event
-   type: string
-   readOnly: true
-   deprecated: true
   color:
    description: Color to apply to an event
    type: string

--- a/src/Classes/CalendarEvent.php
+++ b/src/Classes/CalendarEvent.php
@@ -60,16 +60,6 @@ class CalendarEvent
 
     /**
      * @var string
-     *
-     * @deprecated use color instead
-     *
-     * @IS\Expose
-     * @IS\Type("string")
-     **/
-    public $eventClass;
-
-    /**
-     * @var string
      * @IS\Expose
      * @IS\Type("string")
      **/


### PR DESCRIPTION
This hasn't been populated in a long time and has been marked as
deprecated.