### PR TITLE
Add MySQL as a build stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,3 +226,13 @@ jobs:
         docker build --target admin -t ilios-admin .
         docker run -d --name ilios-admin ilios-admin
         docker ps | grep -q ilios-admin
+    - name: MySQL
+      run: |
+        docker build --target ilios-mysql -t ilios-mysql .
+        docker run -d --name ilios-mysql ilios-mysql
+        docker ps | grep -q ilios-mysql
+    - name: MySQL Demo
+      run: |
+        docker build --target ilios-mysql-demo -t ilios-mysql-demo .
+        docker run -d --name ilios-mysql-demo ilios-mysql-demo
+        docker ps | grep -q ilios-mysql-demo

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -10,7 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [php-apache, nginx, fpm, fpm-dev, admin, migrate-database, update-frontend, consume-messages]
+        image:
+          - php-apache
+          - nginx
+          - fpm
+          - fpm-dev
+          - admin
+          - migrate-database
+          - update-frontend
+          - consume-messages
+          - ilios-mysql
+          - ilios-mysql-demo
     steps:
     - uses: actions/checkout@v2
     - name: ${{ matrix.image }} to Github Registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,20 @@ ENV MYSQL_RANDOM_ROOT_PASSWORD yes
 COPY docker/ilios-mysql.cnf /etc/mysql/conf.d/ilios.cnf
 
 ###############################################################################
+# Setup a mysql server running the demo database for use in development
+###############################################################################
+FROM ilios-mysql as ilios-mysql-demo
+LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
+ENV MYSQL_USER ilios
+ENV MYSQL_PASSWORD ilios
+ENV MYSQL_DATABASE ilios
+ENV DEMO_DATABASE_LOCATION https://s3-us-west-2.amazonaws.com/ilios-demo-db.iliosproject.org/latest_db/ilios3_demosite_db.sql.gz
+RUN apt-get update && apt-get install -y wget
+
+COPY docker/fetch-demo-database.sh /fetch-demo-database.sh
+RUN /bin/bash /fetch-demo-database.sh
+
+###############################################################################
 # Our original and still relevant apache based runtime, includes everything in
 # a single container
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,14 @@ ENTRYPOINT ["/var/www/ilios/bin/console"]
 CMD ["messenger:consume", "async"]
 
 ###############################################################################
+# MySQL configured as needed for Ilios
+###############################################################################
+FROM mysql:5.6 as ilios-mysql
+LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
+ENV MYSQL_RANDOM_ROOT_PASSWORD yes
+COPY docker/ilios-mysql.cnf /etc/mysql/conf.d/ilios.cnf
+
+###############################################################################
 # Our original and still relevant apache based runtime, includes everything in
 # a single container
 ###############################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3.5'
 services:
     db:
-        image: ilios/mysql-demo
+        build:
+            context: .
+            target: ilios-mysql-demo
         ports:
             - "13306:3306"
 #    nginx:

--- a/docker/fetch-demo-database.sh
+++ b/docker/fetch-demo-database.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euf -o pipefail
+
+ENTRYPOINT_PATH="/docker-entrypoint-initdb.d/ilios.sql"
+DOWNLOAD_PATH="/tmp/demo.sql.gz"
+DATA_PATH="/tmp/demo.sql"
+
+if [ ! -f $ENTRYPOINT_PATH ]; then
+	echo 'Retrieving Ilios Demo Database...'
+	/usr/bin/wget --no-verbose -O $DOWNLOAD_PATH $DEMO_DATABASE_LOCATION
+	echo 'done... unpacking demo database'
+	gunzip $DOWNLOAD_PATH
+	echo 'done.... copying ilios demo database to by read automatically by docker'
+	echo "USE ilios;" > $ENTRYPOINT_PATH
+	cat $DATA_PATH >> $ENTRYPOINT_PATH
+	rm $DATA_PATH
+	echo 'done'
+fi

--- a/docker/ilios-mysql.cnf
+++ b/docker/ilios-mysql.cnf
@@ -1,0 +1,5 @@
+[mysqld]
+  max_allowed_packet     = 64M
+  innodb_log_buffer_size = 32M
+  innodb_log_file_size   = 768M
+  skip-name-resolve


### PR DESCRIPTION
Moves both the ilios-mysql and ilios-mysql-demo servers from https://github.com/ilios/docker to this repo so their are built and tagged with the app.