### PR TITLE
Capitalize API doc tag

### DIFF
--- a/config/swagger/paths/courseobjective.yml
+++ b/config/swagger/paths/courseobjective.yml
@@ -33,7 +33,7 @@
         items:
           type: string
     tags:
-      - courseobjective
+      - Courseobjective
     responses:
       '200':
         description: An array of course objectives.
@@ -64,7 +64,7 @@
               items:
                 $ref: '#/definitions/CourseObjective'
     tags:
-      - courseobjective
+      - Courseobjective
     responses:
       '201':
         description: An array of newly created course objectives.
@@ -95,7 +95,7 @@
         description: id
         type: integer
     tags:
-      - courseobjective
+      - Courseobjective
     responses:
       '200':
         description: A single course objective.
@@ -131,7 +131,7 @@
             courseObjective:
               $ref: '#/definitions/CourseObjective'
     tags:
-      - courseobjective
+      - Courseobjective
     responses:
       '200':
         description: The updated course objective.
@@ -161,7 +161,7 @@
         description: id
         type: integer
     tags:
-      - courseobjective
+      - Courseobjective
     responses:
       '204':
         description: Course objective successfully deleted.

--- a/config/swagger/paths/sessionobjective.yml
+++ b/config/swagger/paths/sessionobjective.yml
@@ -33,7 +33,7 @@
         items:
           type: string
     tags:
-      - sessionobjective
+      - Sessionobjective
     responses:
       '200':
         description: An array of session objectives.
@@ -64,7 +64,7 @@
               items:
                 $ref: '#/definitions/SessionObjective'
     tags:
-      - sessionobjective
+      - Sessionobjective
     responses:
       '201':
         description: An array of newly created session objectives.
@@ -95,7 +95,7 @@
         description: id
         type: integer
     tags:
-      - sessionobjective
+      - Sessionobjective
     responses:
       '200':
         description: A single session objective.
@@ -131,7 +131,7 @@
             sessionObjective:
               $ref: '#/definitions/SessionObjective'
     tags:
-      - sessionobjective
+      - Sessionobjective
     responses:
       '200':
         description: The updated session objective.
@@ -161,7 +161,7 @@
         description: id
         type: integer
     tags:
-      - sessionobjective
+      - Sessionobjective
     responses:
       '204':
         description: Session objective successfully deleted.


### PR DESCRIPTION
This matches the other endpoints in the docs by capitalizing the name of
the route.