### PR TITLE
Enable required apache modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,13 +206,15 @@ RUN \
     && pecl install apcu \
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable opcache \
+    # enable modules
+    && a2enmod rewrite mpm_prefork deflate headers \
     && rm -rf /var/lib/apt/lists/* \
     # remove the apt source files to save space
     && apt-get purge libldap2-dev zlib1g-dev libicu-dev -y \
     && apt-get autoremove -y
 
 COPY ./docker/php.ini $PHP_INI_DIR
-COPY ./docker/apache.conf /etc/apache2/sites-enabled/000-default.conf
+COPY ./docker/apache.conf /etc/apache2/sites-available/000-default.conf
 
 # add our own entrypoint scripts
 COPY docker/php-apache-entrypoint /usr/local/bin/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,20 @@ services:
 #            - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
 #        volumes:
 #            - ./:/var/www/ilios:delegated
+#    apache:
+#        build:
+#            context: .
+#            target: php-apache
+#        environment:
+#            - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.6
+#            - ILIOS_REQUIRE_SECURE_CONNECTION=false
+#            - ILIOS_ERROR_CAPTURE_ENABLED=false
+#            - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
+#            - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+#        ports:
+#            - "8000:80"
+#        volumes:
+#            - ./:/var/www/ilios:delegated
     elasticsearch:
         build: ./docker/elasticsearch-dev
         environment:


### PR DESCRIPTION
Our php-apache container was missing some crucial modules. I also added
a commented out section to our docker compose config to use this
container.