### PR TITLE
Exclude Migrations from Code Coverage Stats

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,9 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>
+            <exclude>
+                <directory>src/Migrations</directory>
+            </exclude>
         </whitelist>
     </filter>
 


### PR DESCRIPTION
These can't really be covered by unit tests, we have specific
integrations tests specifically for migrating the DB.