### PR TITLE
Build and deploy an elasticsearch container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,3 +236,8 @@ jobs:
         docker build --target mysql-demo -t ilios-mysql-demo .
         docker run -d --name mysql-demo ilios-mysql-demo
         docker ps | grep -q ilios-mysql-demo
+    - name: Elasticsearch
+      run: |
+        docker build --target elasticsearch -t ilios-elasticsearch .
+        docker run -d --name elasticsearch ilios-elasticsearch
+        docker ps | grep -q ilios-elasticsearch

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -21,6 +21,7 @@ jobs:
           - consume-messages
           - mysql
           - mysql-demo
+          - elasticsearch
     steps:
     - uses: actions/checkout@v2
     - name: ${{ matrix.image }} to Github Registry
@@ -48,6 +49,7 @@ jobs:
           - consume-messages
           - mysql
           - mysql-demo
+          - elasticsearch
     steps:
     - uses: actions/checkout@v2
     - name: ${{ matrix.image }} to Docker Registry

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -42,6 +42,7 @@ jobs:
           - consume-messages
           - mysql
           - mysql-demo
+          - elasticsearch
     steps:
     - uses: actions/checkout@v2
     - name: ${{ matrix.image }} to Github Registry
@@ -70,6 +71,7 @@ jobs:
           - consume-messages
           - mysql
           - mysql-demo
+          - elasticsearch
     steps:
     - uses: actions/checkout@v2
     - name: ${{ matrix.image }} to Docker Registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,6 +185,13 @@ COPY docker/fetch-demo-database.sh /fetch-demo-database.sh
 RUN /bin/bash /fetch-demo-database.sh
 
 ###############################################################################
+# Setup elasticsearch with the plugins we needed
+###############################################################################
+FROM elasticsearch:7.8.1 as elasticsearch
+LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
+RUN bin/elasticsearch-plugin install -b ingest-attachment
+
+###############################################################################
 # Our original and still relevant apache based runtime, includes everything in
 # a single container
 ###############################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,13 +43,10 @@ services:
 #        volumes:
 #            - ./:/var/www/ilios:delegated
     elasticsearch:
-        build: ./docker/elasticsearch-dev
+        build:
+            context: .
+            target: elasticsearch
         environment:
             - discovery.type=single-node
-            - http.cors.enabled=true
-            - http.cors.allow-origin=http://localhost:1358
-            - http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
-            - http.cors.allow-credentials=true
-            - http.max_content_length=10mb #matches the AWS ElasticSearch limit
         ports:
             - "9200:9200"

--- a/docker/docker-compose-everything.yml
+++ b/docker/docker-compose-everything.yml
@@ -77,14 +77,11 @@ services:
             - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
             - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
     elasticsearch:
-        build: ./elasticsearch-dev
+        build:
+            context: ../
+            target: elasticsearch
         environment:
             - discovery.type=single-node
-            - http.cors.enabled=true
-            - http.cors.allow-origin=http://localhost:1358
-            - http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
-            - http.cors.allow-credentials=true
-            - http.max_content_length=10mb #matches the AWS ElasticSearch limit
         ports:
             - "9200:9200"
 volumes:

--- a/docker/elasticsearch-dev/Dockerfile
+++ b/docker/elasticsearch-dev/Dockerfile
@@ -1,3 +1,0 @@
-FROM elasticsearch:7.6.2
-MAINTAINER Ilios Project Team <support@iliosproject.org>
-RUN bin/elasticsearch-plugin install -b ingest-attachment


### PR DESCRIPTION
We primarily need this for development, but it is a useful indication of
the required plugins that are required in an elasticsearch service
offering.