### PR TITLE
Deal with bad file hashes correctly

### DIFF
--- a/src/Controller/API/LearningMaterials.php
+++ b/src/Controller/API/LearningMaterials.php
@@ -164,11 +164,11 @@ class LearningMaterials
             if (property_exists($obj, 'fileHash')) {
                 $fileHash = $obj->fileHash;
                 $contents = $fs->getUploadedTemporaryFileContentsAndRemoveFile($fileHash);
-                $tmpFile = $temporaryFileSystem->createFile($contents);
+                $tmpFile = $contents ? $temporaryFileSystem->createFile($contents) : null;
                 if (!$tmpFile || !$tmpFile->isReadable()) {
                     throw new HttpException(
                         Response::HTTP_BAD_REQUEST,
-                        'This "fileHash" is not valid'
+                        'This "fileHash" is not valid or the file may have already been used in a previous upload'
                     );
                 }
                 unset($obj->fileHash);

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -377,6 +377,19 @@ class LearningMaterialTest extends ReadWriteEndpointTest
         $this->badPostTest($data);
     }
 
+    public function testPostLearningMaterialFileWithoutFile()
+    {
+        /** @var LearningMaterialData $dataLoader */
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->createFile();
+        $data['fileHash'] = 'iamnotreal';
+        $data['filename'] = 'We can only understand what we can perceive.gif';
+
+        $data['mimetype'] = 'text/x-php';
+        $data['filesize'] = '33M';
+        $this->badPostTest($data);
+    }
+
     /**
      * Ensure when LMs are sideloaded they have a correct URL path
      */


### PR DESCRIPTION
We already had error checking in place for this, unfortuantly after
moving to strict mode the createFile method was throwing an exception
before we could get to it. Sometimes LMs are uploaded twice and the
second time the file doesn't exist anymore.

Fixes #3055