### PR TITLE
Correctly normalize calendar event session

### DIFF
--- a/src/Classes/CalendarEvent.php
+++ b/src/Classes/CalendarEvent.php
@@ -145,7 +145,7 @@ class CalendarEvent
     /**
      * @var int
      * @IS\Expose
-     * @IS\Type("boolean")
+     * @IS\Type("integer")
      */
     public $session;
 

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -48,60 +48,60 @@ class UsereventTest extends AbstractEndpointTest
         );
         $lms = $events[0]['learningMaterials'];
 
-        $this->assertEquals(9, count($lms));
-        $this->assertEquals(15, count($lms[0]));
-        $this->assertEquals('1', $lms[0]['id']);
-        $this->assertEquals('1', $lms[0]['sessionLearningMaterial']);
-        $this->assertEquals('1', $lms[0]['session']);
-        $this->assertEquals('1', $lms[0]['course']);
-        $this->assertEquals('1', $lms[0]['position']);
+        $this->assertSame(9, count($lms));
+        $this->assertSame(15, count($lms[0]));
+        $this->assertSame('1', $lms[0]['id']);
+        $this->assertSame('1', $lms[0]['sessionLearningMaterial']);
+        $this->assertSame('1', $lms[0]['session']);
+        $this->assertSame('1', $lms[0]['course']);
+        $this->assertSame('1', $lms[0]['position']);
         $this->assertTrue($lms[0]['required']);
         $this->assertStringStartsWith('firstlm', $lms[0]['title']);
-        $this->assertEquals('desc1', $lms[0]['description']);
-        $this->assertEquals('author1', $lms[0]['originalAuthor']);
-        $this->assertEquals('citation1', $lms[0]['citation']);
-        $this->assertEquals('citation', $lms[0]['mimetype']);
-        $this->assertEquals('session1Title', $lms[0]['sessionTitle']);
-        $this->assertEquals('firstCourse', $lms[0]['courseTitle']);
-        $this->assertEquals('2016-09-04T00:00:00+00:00', $lms[5]['firstOfferingDate']);
-        $this->assertEquals(0, count($lms[0]['instructors']));
+        $this->assertSame('desc1', $lms[0]['description']);
+        $this->assertSame('author1', $lms[0]['originalAuthor']);
+        $this->assertSame('citation1', $lms[0]['citation']);
+        $this->assertSame('citation', $lms[0]['mimetype']);
+        $this->assertSame('session1Title', $lms[0]['sessionTitle']);
+        $this->assertSame('firstCourse', $lms[0]['courseTitle']);
+        $this->assertSame('2016-09-04T00:00:00+00:00', $lms[5]['firstOfferingDate']);
+        $this->assertSame(0, count($lms[0]['instructors']));
         $this->assertFalse($lms[0]['isBlanked']);
 
-        $this->assertEquals(15, count($lms[1]));
+        $this->assertSame(15, count($lms[1]));
         $this->assertFalse($lms[1]['isBlanked']);
 
-        $this->assertEquals(17, count($lms[2]));
+        $this->assertSame(17, count($lms[2]));
         $this->assertFalse($lms[2]['isBlanked']);
 
-        $this->assertEquals(18, count($lms[3]));
+        $this->assertSame(18, count($lms[3]));
         $this->assertFalse($lms[3]['isBlanked']);
 
-        $this->assertEquals(10, count($lms[4]));
-        $this->assertEquals('6', $lms[4]['id']);
-        $this->assertEquals('6', $lms[4]['courseLearningMaterial']);
-        $this->assertEquals('1', $lms[4]['course']);
-        $this->assertEquals('4', $lms[4]['position']);
-        $this->assertEquals('sixthlm', $lms[4]['title']);
-        $this->assertEquals('firstCourse', $lms[4]['courseTitle']);
-        $this->assertEquals('2016-09-04T00:00:00+00:00', $lms[4]['firstOfferingDate']);
+        $this->assertSame(10, count($lms[4]));
+        $this->assertSame('6', $lms[4]['id']);
+        $this->assertSame('6', $lms[4]['courseLearningMaterial']);
+        $this->assertSame('1', $lms[4]['course']);
+        $this->assertSame('4', $lms[4]['position']);
+        $this->assertSame('sixthlm', $lms[4]['title']);
+        $this->assertSame('firstCourse', $lms[4]['courseTitle']);
+        $this->assertSame('2016-09-04T00:00:00+00:00', $lms[4]['firstOfferingDate']);
         $this->assertEmpty($lms[4]['instructors']);
         $this->assertNotEmpty($lms[4]['startDate']);
         $this->assertTrue($lms[4]['isBlanked']);
 
-        $this->assertEquals(18, count($lms[5]));
+        $this->assertSame(18, count($lms[5]));
         $this->assertNotEmpty($lms[5]['endDate']);
         $this->assertFalse($lms[5]['isBlanked']);
 
-        $this->assertEquals(10, count($lms[6]));
+        $this->assertSame(10, count($lms[6]));
         $this->assertNotEmpty($lms[6]['endDate']);
         $this->assertTrue($lms[6]['isBlanked']);
 
-        $this->assertEquals(19, count($lms[7]));
+        $this->assertSame(19, count($lms[7]));
         $this->assertNotEmpty($lms[7]['startDate']);
         $this->assertNotEmpty($lms[7]['endDate']);
         $this->assertFalse($lms[7]['isBlanked']);
 
-        $this->assertEquals(11, count($lms[8]));
+        $this->assertSame(11, count($lms[8]));
         $this->assertNotEmpty($lms[8]['startDate']);
         $this->assertNotEmpty($lms[8]['endDate']);
         $this->assertTrue($lms[8]['isBlanked']);
@@ -124,31 +124,36 @@ class UsereventTest extends AbstractEndpointTest
             $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
 
-        $this->assertEquals(12, count($events), 'Expected events returned');
-        $this->assertEquals(
+        $this->assertSame(12, count($events), 'Expected events returned');
+        $this->assertSame(
             $events[0]['offering'],
             3,
             'offering is correct for event 0'
         );
-        $this->assertEquals(
+        $this->assertSame(
+            $events[0]['session'],
+            2,
+            'session is correct for event 0'
+        );
+        $this->assertSame(
             $events[0]['startDate'],
             $offerings[2]['startDate'],
             'startDate is correct for event 0'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[0]['endDate'],
             $offerings[2]['endDate'],
             'endDate is correct for event 0'
         );
         $this->assertArrayNotHasKey('url', $events[0]);
-        $this->assertEquals($events[0]['courseTitle'], $courses[0]['title'], 'title is correct for event 0');
-        $this->assertEquals($events[0]['course'], $courses[0]['id'], 'id is correct for event 0');
-        $this->assertEquals(
+        $this->assertSame($events[0]['courseTitle'], $courses[0]['title'], 'title is correct for event 0');
+        $this->assertSame($events[0]['course'], $courses[0]['id'], 'id is correct for event 0');
+        $this->assertSame(
             $events[0]['courseExternalId'],
             $courses[0]['externalId'],
             'course external id correct for event 0'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[0]['courseLevel'],
             $courses[0]['level'],
             'course level correct for event 0'
@@ -164,22 +169,22 @@ class UsereventTest extends AbstractEndpointTest
             'course terms correct for event 0'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             $events[0]['sessionTypeTitle'],
             $sessionTypes[1]['title'],
             'session type title is correct for event 0'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[0]['sessionTypeId'],
             $sessionTypes[1]['id'],
             'session type id is correct for event 0'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[0]['sessionDescription'],
             $sessions[1]['description'],
             'session description is correct for event 0'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[0]['instructionalNotes'],
             $sessions[1]['instructionalNotes'],
             'instructional notes is correct for event 0'
@@ -189,7 +194,7 @@ class UsereventTest extends AbstractEndpointTest
             $sessions[1]['terms'],
             'session terms is correct for event (d)'
         );
-        $this->assertEquals(
+        $this->assertSame(
             count($events[0]['learningMaterials']),
             9,
             'Event 0 has the correct number of learning materials'
@@ -211,27 +216,27 @@ class UsereventTest extends AbstractEndpointTest
             'attendanceRequired is correct for event 0'
         );
 
-        $this->assertEquals(1, count($events[0]['postrequisites']));
-        $this->assertEquals(6, $events[0]['postrequisites'][0]['offering']);
-        $this->assertEquals(3, $events[0]['postrequisites'][0]['session']);
+        $this->assertSame(1, count($events[0]['postrequisites']));
+        $this->assertSame(6, $events[0]['postrequisites'][0]['offering']);
+        $this->assertSame(3, $events[0]['postrequisites'][0]['session']);
         $this->assertEmpty($events[0]['prerequisites']);
 
-        $this->assertEquals($events[1]['offering'], 4, 'offering is correct for event 1');
-        $this->assertEquals(
+        $this->assertSame($events[1]['offering'], 4, 'offering is correct for event 1');
+        $this->assertSame(
             $events[1]['startDate'],
             $offerings[3]['startDate'],
             'startDate is correct for event 1'
         );
-        $this->assertEquals($events[1]['endDate'], $offerings[3]['endDate'], 'endDate is correct for event 1');
+        $this->assertSame($events[1]['endDate'], $offerings[3]['endDate'], 'endDate is correct for event 1');
         $this->assertArrayNotHasKey('url', $events[1]);
-        $this->assertEquals($events[1]['courseTitle'], $courses[0]['title'], 'title is correct for event 1');
-        $this->assertEquals($events[1]['course'], $courses[0]['id'], 'id is correct for event 1');
-        $this->assertEquals(
+        $this->assertSame($events[1]['courseTitle'], $courses[0]['title'], 'title is correct for event 1');
+        $this->assertSame($events[1]['course'], $courses[0]['id'], 'id is correct for event 1');
+        $this->assertSame(
             $events[1]['courseExternalId'],
             $courses[0]['externalId'],
             'course external id correct for event 1'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[1]['courseLevel'],
             $courses[0]['level'],
             'course level correct for event 1'
@@ -246,22 +251,22 @@ class UsereventTest extends AbstractEndpointTest
             $courses[0]['terms'],
             'course terms correct for event 1'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[1]['sessionTypeTitle'],
             $sessionTypes[1]['title'],
             'session type title is correct for event 1'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[1]['sessionTypeId'],
             $sessionTypes[1]['id'],
             'session type id is correct for event 1'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[1]['sessionDescription'],
             $sessions[1]['description'],
             'session description is correct for event 1'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[1]['instructionalNotes'],
             $sessions[1]['instructionalNotes'],
             'instructional notes is correct for event 1'
@@ -271,7 +276,7 @@ class UsereventTest extends AbstractEndpointTest
             $sessions[1]['terms'],
             'session terms is correct for event (d)'
         );
-        $this->assertEquals(
+        $this->assertSame(
             count($events[1]['learningMaterials']),
             9,
             'Event 1 has the correct number of learning materials'
@@ -292,31 +297,31 @@ class UsereventTest extends AbstractEndpointTest
             $events[1]['attendanceRequired'],
             'attendanceRequired is correct for event 1'
         );
-        $this->assertEquals(1, count($events[1]['postrequisites']));
-        $this->assertEquals(6, $events[1]['postrequisites'][0]['offering']);
-        $this->assertEquals(3, $events[1]['postrequisites'][0]['session']);
+        $this->assertSame(1, count($events[1]['postrequisites']));
+        $this->assertSame(6, $events[1]['postrequisites'][0]['offering']);
+        $this->assertSame(3, $events[1]['postrequisites'][0]['session']);
         $this->assertEmpty($events[1]['prerequisites']);
 
-        $this->assertEquals($events[2]['offering'], 5, 'offering is correct for event 2');
-        $this->assertEquals(
+        $this->assertSame($events[2]['offering'], 5, 'offering is correct for event 2');
+        $this->assertSame(
             $events[2]['startDate'],
             $offerings[4]['startDate'],
             'startDate is correct for event 2'
         );
-        $this->assertEquals($events[2]['endDate'], $offerings[4]['endDate'], 'endDate is correct for event 2');
-        $this->assertEquals(
+        $this->assertSame($events[2]['endDate'], $offerings[4]['endDate'], 'endDate is correct for event 2');
+        $this->assertSame(
             $events[2]['url'],
             $offerings[4]['url'],
             'url is correct for event 2'
         );
-        $this->assertEquals($events[2]['courseTitle'], $courses[0]['title'], 'title is correct for event 2');
-        $this->assertEquals($events[2]['course'], $courses[0]['id'], 'id is correct for event 2');
-        $this->assertEquals(
+        $this->assertSame($events[2]['courseTitle'], $courses[0]['title'], 'title is correct for event 2');
+        $this->assertSame($events[2]['course'], $courses[0]['id'], 'id is correct for event 2');
+        $this->assertSame(
             $events[2]['courseExternalId'],
             $courses[0]['externalId'],
             'course external id correct for event 2'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[2]['courseLevel'],
             $courses[0]['level'],
             'course level correct for event 2'
@@ -331,22 +336,22 @@ class UsereventTest extends AbstractEndpointTest
             $courses[0]['terms'],
             'course terms correct for event 2'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[2]['sessionTypeTitle'],
             $sessionTypes[1]['title'],
             'session type title is correct for event 2'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[2]['sessionTypeId'],
             $sessionTypes[1]['id'],
             'session type id is correct for event 2'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[2]['sessionDescription'],
             $sessions[1]['description'],
             'session description is correct for event 2'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[2]['instructionalNotes'],
             $sessions[1]['instructionalNotes'],
             'instructional notes is correct for event 2'
@@ -356,7 +361,7 @@ class UsereventTest extends AbstractEndpointTest
             $sessions[1]['terms'],
             'session terms is correct for event (d)'
         );
-        $this->assertEquals(
+        $this->assertSame(
             count($events[2]['learningMaterials']),
             9,
             'Event 2 has the correct number of learning materials'
@@ -377,23 +382,23 @@ class UsereventTest extends AbstractEndpointTest
             $events[2]['attendanceRequired'],
             'attendanceRequired is correct for event 2'
         );
-        $this->assertEquals(1, count($events[2]['postrequisites']));
-        $this->assertEquals(6, $events[2]['postrequisites'][0]['offering']);
-        $this->assertEquals(3, $events[2]['postrequisites'][0]['session']);
+        $this->assertSame(1, count($events[2]['postrequisites']));
+        $this->assertSame(6, $events[2]['postrequisites'][0]['offering']);
+        $this->assertSame(3, $events[2]['postrequisites'][0]['session']);
         $this->assertEmpty($events[2]['prerequisites']);
 
-        $this->assertEquals($events[3]['offering'], 6, 'offering is correct for event 3');
-        $this->assertEquals($events[3]['startDate'], $offerings[5]['startDate'], 'startDate is correct for event 3');
-        $this->assertEquals($events[3]['endDate'], $offerings[5]['endDate'], 'endDate is correct for event 3');
+        $this->assertSame($events[3]['offering'], 6, 'offering is correct for event 3');
+        $this->assertSame($events[3]['startDate'], $offerings[5]['startDate'], 'startDate is correct for event 3');
+        $this->assertSame($events[3]['endDate'], $offerings[5]['endDate'], 'endDate is correct for event 3');
         $this->assertArrayNotHasKey('url', $events[3]);
-        $this->assertEquals($events[3]['courseTitle'], $courses[1]['title'], 'title is correct for event 3');
-        $this->assertEquals($events[3]['course'], $courses[1]['id'], 'id is correct for event 3');
-        $this->assertEquals(
+        $this->assertSame($events[3]['courseTitle'], $courses[1]['title'], 'title is correct for event 3');
+        $this->assertSame($events[3]['course'], $courses[1]['id'], 'id is correct for event 3');
+        $this->assertSame(
             $events[3]['courseExternalId'],
             $courses[1]['externalId'],
             'course external id correct for event 3'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[3]['courseLevel'],
             $courses[1]['level'],
             'course level correct for event 3'
@@ -408,17 +413,17 @@ class UsereventTest extends AbstractEndpointTest
             $courses[1]['terms'],
             'course terms correct for event 3'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[3]['sessionTypeTitle'],
             $sessionTypes[1]['title'],
             'session type title is correct for event 3'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[3]['sessionTypeId'],
             $sessionTypes[1]['id'],
             'session type id is correct for event 3'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[3]['instructionalNotes'],
             $sessions[2]['instructionalNotes'],
             'instructional notes is correct for event 3'
@@ -428,7 +433,7 @@ class UsereventTest extends AbstractEndpointTest
             $sessions[2]['terms'],
             'session terms is correct for event (d)'
         );
-        $this->assertEquals(
+        $this->assertSame(
             7,
             count($events[3]['learningMaterials']),
             'Event 3 has the correct number of learning materials'
@@ -452,23 +457,23 @@ class UsereventTest extends AbstractEndpointTest
             'attendanceRequired is correct for event 3'
         );
         $this->assertEmpty($events[3]['postrequisites']);
-        $this->assertEquals(3, count($events[3]['prerequisites']));
+        $this->assertSame(3, count($events[3]['prerequisites']));
         $sessionIds = array_unique(array_column($events[3]['prerequisites'], 'session'));
         sort($sessionIds);
-        $this->assertEquals([2], $sessionIds);
+        $this->assertSame([2], $sessionIds);
 
-        $this->assertEquals($events[4]['offering'], 7, 'offering is correct for event 4');
-        $this->assertEquals($events[4]['startDate'], $offerings[6]['startDate'], 'startDate is correct for event 4');
-        $this->assertEquals($events[4]['endDate'], $offerings[6]['endDate'], 'endDate is correct for event 4');
+        $this->assertSame($events[4]['offering'], 7, 'offering is correct for event 4');
+        $this->assertSame($events[4]['startDate'], $offerings[6]['startDate'], 'startDate is correct for event 4');
+        $this->assertSame($events[4]['endDate'], $offerings[6]['endDate'], 'endDate is correct for event 4');
         $this->assertArrayNotHasKey('url', $events[4]);
-        $this->assertEquals($events[4]['courseTitle'], $courses[1]['title'], 'title is correct for event 4');
-        $this->assertEquals($events[4]['course'], $courses[1]['id'], 'id is correct for event 4');
-        $this->assertEquals(
+        $this->assertSame($events[4]['courseTitle'], $courses[1]['title'], 'title is correct for event 4');
+        $this->assertSame($events[4]['course'], $courses[1]['id'], 'id is correct for event 4');
+        $this->assertSame(
             $events[4]['courseExternalId'],
             $courses[1]['externalId'],
             'course external id correct for event 4'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[4]['courseLevel'],
             $courses[1]['level'],
             'course level correct for event 4'
@@ -483,17 +488,17 @@ class UsereventTest extends AbstractEndpointTest
             $courses[1]['terms'],
             'course terms correct for event 4'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[4]['sessionTypeTitle'],
             $sessionTypes[1]['title'],
             'session type title is correct for event 4'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[4]['sessionTypeId'],
             $sessionTypes[1]['id'],
             'session type id is correct for event 4'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[4]['instructionalNotes'],
             $sessions[2]['instructionalNotes'],
             'instructional notes is correct for event 4'
@@ -503,7 +508,7 @@ class UsereventTest extends AbstractEndpointTest
             $sessions[2]['terms'],
             'session terms is correct for event (d)'
         );
-        $this->assertEquals(
+        $this->assertSame(
             7,
             count($events[4]['learningMaterials']),
             'Event 4 has the correct number of learning materials'
@@ -527,22 +532,22 @@ class UsereventTest extends AbstractEndpointTest
             'attendanceRequired is correct for event 4'
         );
         $this->assertEmpty($events[4]['postrequisites']);
-        $this->assertEquals(3, count($events[4]['prerequisites']));
+        $this->assertSame(3, count($events[4]['prerequisites']));
         $sessionIds = array_unique(array_column($events[4]['prerequisites'], 'session'));
         sort($sessionIds);
-        $this->assertEquals([2], $sessionIds);
+        $this->assertSame([2], $sessionIds);
 
-        $this->assertEquals($events[5]['ilmSession'], 1, 'ilmSession is correct for 5');
-        $this->assertEquals($events[5]['startDate'], $ilmSessions[0]['dueDate'], 'dueDate is correct for 5');
-        $this->assertEquals($events[5]['courseTitle'], $courses[1]['title'], 'title is correct for 5');
+        $this->assertSame($events[5]['ilmSession'], 1, 'ilmSession is correct for 5');
+        $this->assertSame($events[5]['startDate'], $ilmSessions[0]['dueDate'], 'dueDate is correct for 5');
+        $this->assertSame($events[5]['courseTitle'], $courses[1]['title'], 'title is correct for 5');
         $this->assertArrayNotHasKey('url', $events[5]);
-        $this->assertEquals($events[5]['course'], $courses[1]['id'], 'id is correct for 5');
-        $this->assertEquals(
+        $this->assertSame($events[5]['course'], $courses[1]['id'], 'id is correct for 5');
+        $this->assertSame(
             $events[5]['courseExternalId'],
             $courses[1]['externalId'],
             'course external id correct for event 5'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[5]['courseLevel'],
             $courses[1]['level'],
             'course level correct for event 5'
@@ -557,12 +562,12 @@ class UsereventTest extends AbstractEndpointTest
             $courses[1]['terms'],
             'course terms correct for event 5'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[5]['sessionTypeTitle'],
             $sessionTypes[0]['title'],
             'session type title is correct for event 5'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[5]['sessionTypeId'],
             $sessionTypes[0]['id'],
             'session type id is correct for event 5'
@@ -572,7 +577,7 @@ class UsereventTest extends AbstractEndpointTest
             $events[5],
             'instructional notes is correct for event 5'
         );
-        $this->assertEquals(count($events[5]['learningMaterials']), 0, 'Event 5 has no learning materials');
+        $this->assertSame(count($events[5]['learningMaterials']), 0, 'Event 5 has no learning materials');
 
         $this->assertFalse(
             $events[5]['attireRequired'],
@@ -594,17 +599,17 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEmpty($events[5]['postrequisites']);
         $this->assertEmpty($events[5]['prerequisites']);
 
-        $this->assertEquals($events[6]['ilmSession'], 2, 'ilmSession is correct for event 6');
-        $this->assertEquals($events[6]['startDate'], $ilmSessions[1]['dueDate'], 'dueDate is correct for event 6');
+        $this->assertSame($events[6]['ilmSession'], 2, 'ilmSession is correct for event 6');
+        $this->assertSame($events[6]['startDate'], $ilmSessions[1]['dueDate'], 'dueDate is correct for event 6');
         $this->assertArrayNotHasKey('url', $events[6]);
-        $this->assertEquals($events[6]['courseTitle'], $courses[1]['title'], 'title is correct for event 6');
-        $this->assertEquals($events[6]['course'], $courses[1]['id'], 'id is correct for event 6');
-        $this->assertEquals(
+        $this->assertSame($events[6]['courseTitle'], $courses[1]['title'], 'title is correct for event 6');
+        $this->assertSame($events[6]['course'], $courses[1]['id'], 'id is correct for event 6');
+        $this->assertSame(
             $events[6]['courseExternalId'],
             $courses[1]['externalId'],
             'course external id correct for event 6'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[6]['courseLevel'],
             $courses[1]['level'],
             'course level correct for event 6'
@@ -619,12 +624,12 @@ class UsereventTest extends AbstractEndpointTest
             $courses[1]['terms'],
             'course terms correct for event 6'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[6]['sessionTypeTitle'],
             $sessionTypes[0]['title'],
             'session type title is correct for event 6'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[6]['sessionTypeId'],
             $sessionTypes[0]['id'],
             'session type id is correct for event 6'
@@ -634,7 +639,7 @@ class UsereventTest extends AbstractEndpointTest
             $events[6],
             'instructional notes is correct for event 6'
         );
-        $this->assertEquals(count($events[6]['learningMaterials']), 0, 'Event 6 has no learning materials');
+        $this->assertSame(count($events[6]['learningMaterials']), 0, 'Event 6 has no learning materials');
         $this->assertFalse(
             $events[6]['attireRequired'],
             'attire is correct for event 6'
@@ -655,17 +660,17 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEmpty($events[6]['postrequisites']);
         $this->assertEmpty($events[6]['prerequisites']);
 
-        $this->assertEquals($events[7]['ilmSession'], 3, 'ilmSession is correct for event 7');
-        $this->assertEquals($events[7]['startDate'], $ilmSessions[2]['dueDate'], 'dueDate is correct for event 7');
-        $this->assertEquals($events[7]['courseTitle'], $courses[1]['title'], 'title is correct for event 7');
+        $this->assertSame($events[7]['ilmSession'], 3, 'ilmSession is correct for event 7');
+        $this->assertSame($events[7]['startDate'], $ilmSessions[2]['dueDate'], 'dueDate is correct for event 7');
+        $this->assertSame($events[7]['courseTitle'], $courses[1]['title'], 'title is correct for event 7');
         $this->assertArrayNotHasKey('url', $events[7]);
-        $this->assertEquals($events[7]['course'], $courses[1]['id'], 'id is correct for event 7');
-        $this->assertEquals(
+        $this->assertSame($events[7]['course'], $courses[1]['id'], 'id is correct for event 7');
+        $this->assertSame(
             $events[7]['courseExternalId'],
             $courses[1]['externalId'],
             'course external id correct for event 7'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[7]['courseLevel'],
             $courses[1]['level'],
             'course level correct for event 7'
@@ -680,12 +685,12 @@ class UsereventTest extends AbstractEndpointTest
             $courses[1]['terms'],
             'course terms correct for event 7'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[7]['sessionTypeTitle'],
             $sessionTypes[0]['title'],
             'session type title is correct for event 7'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[7]['sessionTypeId'],
             $sessionTypes[0]['id'],
             'session type id is correct for event 7'
@@ -695,7 +700,7 @@ class UsereventTest extends AbstractEndpointTest
             $events[7],
             'instructional notes is correct for event 7'
         );
-        $this->assertEquals(count($events[7]['learningMaterials']), 0, 'Event 7 has no learning materials');
+        $this->assertSame(count($events[7]['learningMaterials']), 0, 'Event 7 has no learning materials');
         $this->assertFalse(
             $events[7]['attireRequired'],
             'attire is correct for event 7'
@@ -716,17 +721,17 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEmpty($events[7]['postrequisites']);
         $this->assertEmpty($events[7]['prerequisites']);
 
-        $this->assertEquals($events[8]['ilmSession'], 4, 'ilmSession is correct for event 8');
-        $this->assertEquals($events[8]['startDate'], $ilmSessions[3]['dueDate'], 'dueDate is correct for event 8');
+        $this->assertSame($events[8]['ilmSession'], 4, 'ilmSession is correct for event 8');
+        $this->assertSame($events[8]['startDate'], $ilmSessions[3]['dueDate'], 'dueDate is correct for event 8');
         $this->assertArrayNotHasKey('url', $events[8]);
-        $this->assertEquals($events[8]['courseTitle'], $courses[1]['title'], 'title is correct for event 8');
-        $this->assertEquals($events[8]['course'], $courses[1]['id'], 'id is correct for event 8');
-        $this->assertEquals(
+        $this->assertSame($events[8]['courseTitle'], $courses[1]['title'], 'title is correct for event 8');
+        $this->assertSame($events[8]['course'], $courses[1]['id'], 'id is correct for event 8');
+        $this->assertSame(
             $events[8]['courseExternalId'],
             $courses[1]['externalId'],
             'course external id correct for event 8'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[8]['courseLevel'],
             $courses[1]['level'],
             'course level correct for event 8'
@@ -741,12 +746,12 @@ class UsereventTest extends AbstractEndpointTest
             $courses[1]['terms'],
             'course terms correct for event 8'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[8]['sessionTypeTitle'],
             $sessionTypes[0]['title'],
             'session type title is correct for event 8'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[8]['sessionTypeId'],
             $sessionTypes[0]['id'],
             'session type id is correct for event 8'
@@ -756,7 +761,7 @@ class UsereventTest extends AbstractEndpointTest
             $events[8],
             'instructional notes is correct for event 8'
         );
-        $this->assertEquals(count($events[8]['learningMaterials']), 0, 'Event 8 has no learning materials');
+        $this->assertSame(count($events[8]['learningMaterials']), 0, 'Event 8 has no learning materials');
         $this->assertFalse(
             $events[8]['attireRequired'],
             'attire is correct for event 8'
@@ -777,34 +782,34 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertEmpty($events[8]['postrequisites']);
         $this->assertEmpty($events[8]['prerequisites']);
 
-        $this->assertEquals(
+        $this->assertSame(
             $events[9]['url'],
             $offerings[0]['url'],
             'url is correct for event 9'
         );
-        $this->assertEquals($events[9]['startDate'], $offerings[0]['startDate'], 'startDate is correct for event 9');
-        $this->assertEquals($events[9]['endDate'], $offerings[0]['endDate'], 'endDate is correct for event 9');
-        $this->assertEquals(
+        $this->assertSame($events[9]['startDate'], $offerings[0]['startDate'], 'startDate is correct for event 9');
+        $this->assertSame($events[9]['endDate'], $offerings[0]['endDate'], 'endDate is correct for event 9');
+        $this->assertSame(
             $events[9]['sessionTypeTitle'],
             $sessionTypes[0]['title'],
             'session type title is correct for event 9'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[9]['sessionTypeId'],
             $sessionTypes[0]['id'],
             'session type id is correct for event 9'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[9]['course'],
             $courses[0]['id'],
             'course id correct for event 9'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[9]['courseExternalId'],
             $courses[0]['externalId'],
             'course external id correct for event 9'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[9]['courseLevel'],
             $courses[0]['level'],
             'course level correct for event 9'
@@ -819,12 +824,12 @@ class UsereventTest extends AbstractEndpointTest
             $courses[0]['terms'],
             'course terms correct for event 9'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[9]['sessionDescription'],
             $sessions[0]['description'],
             'session description is correct for event 9'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[9]['instructionalNotes'],
             $sessions[0]['instructionalNotes'],
             'instructional notes is correct for event 9'
@@ -834,7 +839,7 @@ class UsereventTest extends AbstractEndpointTest
             $sessions[0]['terms'],
             'session terms is correct for event (d)'
         );
-        $this->assertEquals(
+        $this->assertSame(
             count($events[9]['learningMaterials']),
             10,
             'Event 6 has the correct number of learning materials'
@@ -857,39 +862,39 @@ class UsereventTest extends AbstractEndpointTest
             $events[9],
             'attendanceRequired is correct for event 9'
         );
-        $this->assertEquals(0, count($events[9]['postrequisites']));
+        $this->assertSame(0, count($events[9]['postrequisites']));
         $this->assertEmpty($events[9]['prerequisites']);
 
         /** @var OfferingInterface $offering */
         $offering = $this->fixtures->getReference('offerings8');
-        $this->assertEquals(8, $events[10]['offering'], 'offering is correct for event 10');
-        $this->assertEquals(
+        $this->assertSame(8, $events[10]['offering'], 'offering is correct for event 10');
+        $this->assertSame(
             $events[10]['startDate'],
             $offering->getStartDate()->format('c'),
             'startDate is correct for event 10'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[10]['endDate'],
             $offering->getEndDate()->format('c'),
             'endDate is correct for event 10'
         );
         $this->assertArrayNotHasKey('url', $events[10]);
-        $this->assertEquals(
+        $this->assertSame(
             $events[10]['sessionTypeTitle'],
             $sessionTypes[1]['title'],
             'session type title is correct for event 10'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[10]['instructionalNotes'],
             $sessions[2]['instructionalNotes'],
             'instructional notes is correct for event 10'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[10]['course'],
             $courses[1]['id'],
             'course id correct for event 10'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $events[10]['courseExternalId'],
             $courses[1]['externalId'],
             'course external id correct for event 10'
@@ -912,12 +917,12 @@ class UsereventTest extends AbstractEndpointTest
             'attendanceRequired is correct for event 10'
         );
         $this->assertEmpty($events[10]['postrequisites']);
-        $this->assertEquals(3, count($events[10]['prerequisites']));
+        $this->assertSame(3, count($events[10]['prerequisites']));
         $sessionIds = array_unique(array_column($events[10]['prerequisites'], 'session'));
         sort($sessionIds);
-        $this->assertEquals([2], $sessionIds);
+        $this->assertSame([2], $sessionIds);
         foreach ($events as $event) {
-            $this->assertEquals($userId, $event['user']);
+            $this->assertSame($userId, $event['user']);
         }
     }
 
@@ -934,11 +939,11 @@ class UsereventTest extends AbstractEndpointTest
             $to->getTimestamp(),
             $this->getAuthenticatedUserToken($this->kernelBrowser)
         );
-        $this->assertEquals(1, count($events), 'Expected events returned');
+        $this->assertSame(1, count($events), 'Expected events returned');
 
-        $this->assertEquals($events[0]['startDate'], $offerings[5]['startDate']);
-        $this->assertEquals($events[0]['endDate'], $offerings[5]['endDate']);
-        $this->assertEquals($events[0]['offering'], $offerings[5]['id']);
+        $this->assertSame($events[0]['startDate'], $offerings[5]['startDate']);
+        $this->assertSame($events[0]['endDate'], $offerings[5]['endDate']);
+        $this->assertSame($events[0]['offering'], $offerings[5]['id']);
     }
 
     public function testPrivilegedUsersGetsEventsForUnpublishedSessions()
@@ -955,14 +960,14 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertFalse($event['isScheduled']);
         $lms = $event['learningMaterials'];
 
-        $this->assertEquals(7, count($lms));
-        $this->assertEquals('2', $lms[0]['sessionLearningMaterial']);
-        $this->assertEquals('3', $lms[1]['sessionLearningMaterial']);
-        $this->assertEquals('4', $lms[2]['sessionLearningMaterial']);
-        $this->assertEquals('5', $lms[3]['sessionLearningMaterial']);
-        $this->assertEquals('6', $lms[4]['sessionLearningMaterial']);
-        $this->assertEquals('7', $lms[5]['sessionLearningMaterial']);
-        $this->assertEquals('8', $lms[6]['sessionLearningMaterial']);
+        $this->assertSame(7, count($lms));
+        $this->assertSame('2', $lms[0]['sessionLearningMaterial']);
+        $this->assertSame('3', $lms[1]['sessionLearningMaterial']);
+        $this->assertSame('4', $lms[2]['sessionLearningMaterial']);
+        $this->assertSame('5', $lms[3]['sessionLearningMaterial']);
+        $this->assertSame('6', $lms[4]['sessionLearningMaterial']);
+        $this->assertSame('7', $lms[5]['sessionLearningMaterial']);
+        $this->assertSame('8', $lms[6]['sessionLearningMaterial']);
     }
 
     public function testGetEventsBySessionForCourseDirector()
@@ -976,17 +981,17 @@ class UsereventTest extends AbstractEndpointTest
             $this->getTokenForUser($this->kernelBrowser, $userId)
         );
 
-        $this->assertEquals(3, count($events), 'Expected events returned');
-        $this->assertEquals(
+        $this->assertSame(3, count($events), 'Expected events returned');
+        $this->assertSame(
             $sessionId,
             $events[0]['session']
         );
-        $this->assertEquals(6, $events[0]['offering']);
-        $this->assertEquals($sessionId, $events[0]['session']);
-        $this->assertEquals(7, $events[1]['offering']);
-        $this->assertEquals($sessionId, $events[1]['session']);
-        $this->assertEquals(8, $events[2]['offering']);
-        $this->assertEquals($sessionId, $events[2]['session']);
+        $this->assertSame(6, $events[0]['offering']);
+        $this->assertSame($sessionId, $events[0]['session']);
+        $this->assertSame(7, $events[1]['offering']);
+        $this->assertSame($sessionId, $events[1]['session']);
+        $this->assertSame(8, $events[2]['offering']);
+        $this->assertSame($sessionId, $events[2]['session']);
     }
 
     public function testGetEventsBySessionForLearner()
@@ -1000,15 +1005,15 @@ class UsereventTest extends AbstractEndpointTest
             $this->getTokenForUser($this->kernelBrowser, $userId)
         );
 
-        $this->assertEquals(2, count($events), 'Expected events returned');
-        $this->assertEquals(
+        $this->assertSame(2, count($events), 'Expected events returned');
+        $this->assertSame(
             $sessionId,
             $events[0]['session']
         );
-        $this->assertEquals(1, $events[0]['offering']);
-        $this->assertEquals($sessionId, $events[0]['session']);
-        $this->assertEquals(2, $events[1]['offering']);
-        $this->assertEquals($sessionId, $events[1]['session']);
+        $this->assertSame(1, $events[0]['offering']);
+        $this->assertSame($sessionId, $events[0]['session']);
+        $this->assertSame(2, $events[1]['offering']);
+        $this->assertSame($sessionId, $events[1]['session']);
     }
 
     public function testAttachedInstructorsUseDisplayName()
@@ -1022,11 +1027,11 @@ class UsereventTest extends AbstractEndpointTest
         );
         $users = $this->getContainer()->get(UserData::class)->getAll();
 
-        $this->assertEquals($events[0]['offering'], 3);
+        $this->assertSame($events[0]['offering'], 3);
 
-        $this->assertEquals(2, count($events[0]['instructors']));
-        $this->assertEquals($users[1]['displayName'], $events[0]['instructors'][0]);
-        $this->assertEquals($users[3]['displayName'], $events[0]['instructors'][1]);
+        $this->assertSame(2, count($events[0]['instructors']));
+        $this->assertSame($users[1]['displayName'], $events[0]['instructors'][0]);
+        $this->assertSame($users[3]['displayName'], $events[0]['instructors'][1]);
     }
 
     /**


### PR DESCRIPTION
This isn't a bool, the only reason tests were passing is because
apparently assertEquals in PHPUnit thinks 2 and true are the same... PHP ¯\\_(ツ)_/¯

Fixes #3104