### PR TITLE
Deploy to new github registry

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        registry: docker.pkg.github.com
+        registry: ghcr.io
         repository: ${{github.repository}}/${{ matrix.image }}
         tags: latest
         target: ${{ matrix.image }}

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        registry: docker.pkg.github.com
+        registry: ghcr.io
         repository: ${{github.repository}}/${{ matrix.image }}
         tags: ${{needs.tags.outputs.major}},${{needs.tags.outputs.minor}},${{needs.tags.outputs.patch}}
         target: ${{ matrix.image }}


### PR DESCRIPTION
This is an improvement over the github packages as they can be made
publicly available. We still recommend and document the docker
registry, but this is out backup and may be our default in the future.