### PR TITLE
Use zorgbort token to deploy github packages

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -27,10 +27,10 @@ jobs:
     - name: ${{ matrix.image }} to Github Registry
       uses: docker/build-push-action@v1
       with:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        username: zorgbort
+        password: ${{ secrets.ZORGBORT_TOKEN }}
         registry: ghcr.io
-        repository: ${{github.repository}}/${{ matrix.image }}
+        repository: ilios/${{ matrix.image }}
         tags: latest
         target: ${{ matrix.image }}
   deploy-docker-containers:

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -48,10 +48,10 @@ jobs:
     - name: ${{ matrix.image }} to Github Registry
       uses: docker/build-push-action@v1
       with:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        username: zorgbort
+        password: ${{ secrets.ZORGBORT_TOKEN }}
         registry: ghcr.io
-        repository: ${{github.repository}}/${{ matrix.image }}
+        repository: ilios/${{ matrix.image }}
         tags: ${{needs.tags.outputs.major}},${{needs.tags.outputs.minor}},${{needs.tags.outputs.patch}}
         target: ${{ matrix.image }}
   deploy-docker-containers:


### PR DESCRIPTION
The GITHUB_TOKEN for the github user doesn't work with the new packages
repository.