### PR TITLE
Forward proxy headers from nginx

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -39,6 +39,9 @@ server {
 
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_param X-Forwarded-Proto $http_x_forwarded_proto;
+        fastcgi_param X-Forwarded-For $http_x_forwarded_for;
+        fastcgi_param X-Forwarded-Host $http_x_forwarded_host;
 
         # Prevents URIs that include the front controller. This will 404:
         # http://domain.tld/index.php/some-path


### PR DESCRIPTION
This should allow our PHP-FPM process to correctly interpret the
original request state through an SSL terminating load balancer or other
proxy.