### PR TITLE
Add userId to sentry errors

### DIFF
--- a/src/EventListener/SentryCaptureListener.php
+++ b/src/EventListener/SentryCaptureListener.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
+use App\Classes\SessionUserInterface;
 use App\Service\Config;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Sentry\State\Scope;
 
 use function Sentry\init as sentryInit;
 use function Sentry\captureException as sentryCaptureException;
+use function Sentry\configureScope as sentryConfigureScope;
 
 /**
  * Sends errors to symfony
@@ -21,14 +25,21 @@ class SentryCaptureListener
      */
     protected $errorCaptureEnabled;
 
+    /**
+     * @var TokenStorageInterface
+     */
+    protected TokenStorageInterface $tokenStorage;
+
     public function __construct(
         Config $config,
+        TokenStorageInterface $tokenStorage,
         string $sentryDSN
     ) {
         $this->errorCaptureEnabled = $config->get('errorCaptureEnabled');
         if ($this->errorCaptureEnabled) {
             sentryInit(['dsn' => $sentryDSN]);
         }
+        $this->tokenStorage = $tokenStorage;
     }
 
     public function onKernelException(ExceptionEvent $event)
@@ -39,6 +50,17 @@ class SentryCaptureListener
             if ($exception instanceof NotFoundHttpException) {
                 return;
             }
+            $token = $this->tokenStorage->getToken();
+            if ($token) {
+                /** @var SessionUserInterface $sessionUser */
+                $sessionUser = $token->getUser();
+                sentryConfigureScope(function (Scope $scope) use ($sessionUser): void {
+                    $scope->setUser([
+                        'id' => $sessionUser->getId(),
+                    ]);
+                });
+            }
+
             sentryCaptureException($exception);
         }
     }


### PR DESCRIPTION
If a user is authenticated we can add their ID to our logs and possibly
determine the source of some errors more clearly.