### PR TITLE
Ensure we have a SessionUser before accessing ID

### DIFF
--- a/src/EventListener/SentryCaptureListener.php
+++ b/src/EventListener/SentryCaptureListener.php
@@ -52,13 +52,14 @@ class SentryCaptureListener
             }
             $token = $this->tokenStorage->getToken();
             if ($token) {
-                /** @var SessionUserInterface $sessionUser */
                 $sessionUser = $token->getUser();
-                sentryConfigureScope(function (Scope $scope) use ($sessionUser): void {
-                    $scope->setUser([
-                        'id' => $sessionUser->getId(),
-                    ]);
-                });
+                if ($sessionUser instanceof SessionUserInterface) {
+                    sentryConfigureScope(function (Scope $scope) use ($sessionUser): void {
+                        $scope->setUser([
+                            'id' => $sessionUser->getId(),
+                        ]);
+                    });
+                }
             }
 
             sentryCaptureException($exception);


### PR DESCRIPTION
There are some cases where the user from $token->getUser() is actually a
string and not a SessionUserInterface, we need to check for that before
attempting to access it.

Fixes #3149 