### PR TITLE
Check for token before using it

### DIFF
--- a/src/Security/JsonWebTokenAuthenticator.php
+++ b/src/Security/JsonWebTokenAuthenticator.php
@@ -64,9 +64,7 @@ class JsonWebTokenAuthenticator extends AbstractGuardAuthenticator
         }
 
         $authorizationHeader = $request->headers->get('X-JWT-Authorization');
-        $result = preg_match('/^Token (.*)$/', $authorizationHeader, $matches);
-
-        return $result && count($matches);
+        return preg_match('/^Token \S+$/', $authorizationHeader);
     }
 
     /**
@@ -75,7 +73,7 @@ class JsonWebTokenAuthenticator extends AbstractGuardAuthenticator
     public function getCredentials(Request $request)
     {
         $authorizationHeader = $request->headers->get('X-JWT-Authorization');
-        preg_match('/^Token (.*)$/', $authorizationHeader, $matches);
+        preg_match('/^Token (\S+)$/', $authorizationHeader, $matches);
         return $matches[1];
     }
 


### PR DESCRIPTION
Returning null from getCredentials isn't allowed, instead we need to
ensure that the token is fully present in the supports method first.

Also cleaned up typing and imports.

Fixes #3151