### PR TITLE
Restrict webserver info in headers

### DIFF
--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -1,3 +1,6 @@
+ServerSignature Off
+ServerTokens Prod
+
 <VirtualHost *:80>
     ServerAdmin support@iliosproject.org
     DocumentRoot /var/www/ilios/public

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -2,6 +2,7 @@ server {
     listen       80;
     server_name  localhost;
     root   /var/www/ilios/public;
+    server_tokens off;
 
     location / {
         gzip_static on;


### PR DESCRIPTION
Adding configuration settings to both our apache and nginx containers to
limit what info we expose in headers.