### PR TITLE
Add missing extensions for PHP 8 install

### DIFF
--- a/.github/workflows/future-php.yml
+++ b/.github/workflows/future-php.yml
@@ -18,10 +18,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Use PHP 8.0
-      uses: shivammathur/setup-php@v1
+      uses: shivammathur/setup-php@v2
       with:
         php-version: 8.0
         coverage: none
+        tools: pecl
+        extensions: apcu
     - name: install dependencies
       run: composer install --no-interaction --prefer-dist
     - name: Run Tests


### PR DESCRIPTION
Wip:
- [x] Remove PR run, this is only needed to test it for now
- [x] Figure out if we need to start installing these on our CI run (they may have been removed from PHP 8)