### PR TITLE
Extract base entity class from proxy when logging

### DIFF
--- a/src/EventListener/LogEntityChanges.php
+++ b/src/EventListener/LogEntityChanges.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\PersistentCollection;
 use App\Entity\LoggableEntityInterface;
 use App\Service\LoggerQueue;
+use ReflectionClass;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
@@ -64,7 +65,7 @@ class LogEntityChanges
                         'changes' => []
                     ];
                 }
-                $ref = new \ReflectionClass($change);
+                $ref = new ReflectionClass($change);
                 $updates[$entityClass]['changes'][] = 'Ref:' . $ref->getShortName();
             }
         }
@@ -82,14 +83,15 @@ class LogEntityChanges
                         'changes' => []
                     ];
                 }
-                $ref = new \ReflectionClass($change);
+                $ref = new ReflectionClass($change);
                 $updates[$entityClass]['changes'][] = 'Ref:' . $ref->getShortName();
             }
         }
         $loggerQueue = $this->container->get(LoggerQueue::class);
         foreach ($updates as $arr) {
             $valuesChanged = implode(',', $arr['changes']);
-            $loggerQueue->add($arr['action'], $arr['entity'], $valuesChanged);
+            $entityName = $entityManager->getMetadataFactory()->getMetadataFor(get_class($arr['entity']))->getName();
+            $loggerQueue->add($arr['action'], $arr['entity'], $entityName, $valuesChanged);
         }
     }
 }

--- a/tests/Service/LoggerQueueTest.php
+++ b/tests/Service/LoggerQueueTest.php
@@ -24,10 +24,10 @@ class LoggerQueueTest extends TestCase
         $logger = m::mock(Logger::class)
             ->shouldReceive('log')
             ->times(1)
-            ->with($action, '12', get_class($school), $changes, false)
+            ->with($action, '12', 'IliosTestSchoolEntity', $changes, false)
             ->getMock();
         $queue = new LoggerQueue($logger);
-        $queue->add($action, $school, $changes);
+        $queue->add($action, $school, 'IliosTestSchoolEntity', $changes);
         $queue->flush();
     }
 


### PR DESCRIPTION
Some of our log entries in production are showing the doctrine proxy
class instead of the original entity name. By using the entity manager
we can get the original entity class name and pass it to the logger
instead of using get_class.

Fixes #3172 