### PR TITLE
Fix setup command and add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,3 +241,29 @@ jobs:
         docker build --target elasticsearch -t ilios-elasticsearch .
         docker run -d --name elasticsearch ilios-elasticsearch
         docker ps | grep -q ilios-elasticsearch
+
+  check_setup_command:
+    name: Setup Command
+    needs: code_style_security
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [7.4]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v1
+        with:
+          coverage: none
+          php-version: ${{ matrix.php-version }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Run Setup Command
+        run: bin/setup

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,8 @@
 #!/usr/bin/env php
 <?php
-
-//Parse .env files and load them into the environment
-require dirname(__DIR__).'/config/bootstrap.php';
+require dirname(__DIR__).'/vendor/autoload.php';
+use Symfony\Component\Dotenv\Dotenv;
+(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 
 Commands::checkForAppENV();
 Commands::isComposerInstalled();
@@ -36,7 +36,6 @@ class Commands
             case 127:
                 self::writeError("Unable to find `composer` command. See https://getcomposer.org/ for help installing it.");
                 exit(1);
-                break;
         }
     }
 
@@ -66,7 +65,6 @@ class Commands
                     self::output($message);
                 }
                 exit(1);
-                break;
         }
     }
 
@@ -95,7 +93,6 @@ class Commands
                 self::writeError($errorMessage);
                 self::output("Run\n `${path}`\nto see what went wrong");
                 exit(1);
-                break;
         }
     }
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,12 +1,14 @@
 #!/usr/bin/env php
 <?php
+
+Commands::isComposerInstalled();
+Commands::install();
+
 require dirname(__DIR__).'/vendor/autoload.php';
 use Symfony\Component\Dotenv\Dotenv;
 (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 
 Commands::checkForAppENV();
-Commands::isComposerInstalled();
-Commands::install();
 Commands::clearAndWarmUpCache();
 Commands::assetsInstall();
 Commands::checkRequirements();

--- a/bin/setup
+++ b/bin/setup
@@ -108,11 +108,6 @@ class Commands
             self::output("Run\n${path}\nto see why");
             exit(1);
         }
-        self::runSymfonyCommand(
-            'monitor:health  --group=default --group=production',
-            'Health Check Passed',
-            'Health Check Failed.'
-        );
     }
 
     private static function output($message)

--- a/docs/install.md
+++ b/docs/install.md
@@ -89,6 +89,11 @@ bin/console doctrine:fixtures:load --env=prod
 
 This will create your database schema, with all tables and constraints, and will also load in all the default lookup table data, like competencies and topics --- which you can modify once you're done with setup --- but it won't have any course data or any other unique data about your specific school or curriculum until you log in and add some.
 
+## Check your setup
+There are a number of automated health checks which will ensure that your system is configured optimally and point to any issues. Run them as:
+```bash
+bin/console monitor:health  --group=default --group=production
+```
 
 * Finally, you should clear all cached items from the system, including the Symfony Cache (and its store on the filesystem) and the APC cache:
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -85,7 +85,6 @@ If you are NOT upgrading from a previous version of Ilios, you can create a new,
 bin/console doctrine:database:create --env=prod
 bin/console doctrine:migrations:migrate --env=prod
 bin/console doctrine:fixtures:load --env=prod
-bin/console messenger:setup-transports
 ```
 
 This will create your database schema, with all tables and constraints, and will also load in all the default lookup table data, like competencies and topics --- which you can modify once you're done with setup --- but it won't have any course data or any other unique data about your specific school or curriculum until you log in and add some.


### PR DESCRIPTION
The autoloder had diverged from the symfony standard because it wasn't
updated during the last major version sweep.