### PR TITLE
Clear container deprecation

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -314,6 +314,10 @@ services:
     App\Service\DataimportFileLocator:
       public: true
 
+    App\Service\EntityManagerLookup:
+      arguments:
+        $container: '@service_container'
+
     App\Service\Filesystem:
       public: true
 


### PR DESCRIPTION
This service is becoming private in symfony 5.2 so we can't rely on
auto-injection anymore and have to manually tag this.