### PR TITLE
updates test vectors for course rollover tests

### DIFF
--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Endpoints;
 
+use DateTime;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\DataLoader\IlmSessionData;
 use App\Tests\DataLoader\OfferingData;
@@ -226,7 +227,7 @@ class CourseTest extends ReadWriteEndpointTest
 
         $newCourse = $this->rolloverCourse([
             'id' => $course['id'],
-            'year' => 2019,
+            'year' => 2023,
             'newStartDate' => 'false',
             'skipOfferings' => 'false',
         ]);
@@ -234,9 +235,9 @@ class CourseTest extends ReadWriteEndpointTest
         $this->assertSame($course['title'], $newCourse['title']);
         $this->assertSame($course['level'], $newCourse['level']);
         $this->assertSame($course['externalId'], $newCourse['externalId']);
-        $this->assertSame(2019, $newCourse['year']);
-        $this->assertSame('2019-09-01T00:00:00+00:00', $newCourse['startDate']);
-        $this->assertSame('2019-12-29T00:00:00+00:00', $newCourse['endDate']);
+        $this->assertSame(2023, $newCourse['year']);
+        $this->assertSame('2023-09-03T00:00:00+00:00', $newCourse['startDate']);
+        $this->assertSame('2023-12-31T00:00:00+00:00', $newCourse['endDate']);
         $this->assertFalse($newCourse['locked']);
         $this->assertFalse($newCourse['archived']);
         $this->assertFalse($newCourse['published']);
@@ -278,13 +279,13 @@ class CourseTest extends ReadWriteEndpointTest
 
         $newCourse = $this->rolloverCourse([
             'id' => $course['id'],
-            'year' => 2022,
-            'newStartDate' => '2022-02-06'
+            'year' => 2023,
+            'newStartDate' => '2023-02-05'
         ]);
 
-        $this->assertSame(2022, $newCourse['year']);
-        $this->assertSame('2022-02-06T00:00:00+00:00', $newCourse['startDate'], 'start date is correct');
-        $this->assertSame('2022-06-05T00:00:00+00:00', $newCourse['endDate'], 'end date is correct');
+        $this->assertSame(2023, $newCourse['year']);
+        $this->assertSame('2023-02-05T00:00:00+00:00', $newCourse['startDate'], 'start date is correct');
+        $this->assertSame('2023-06-04T00:00:00+00:00', $newCourse['endDate'], 'end date is correct');
 
         $newSessions = $newCourse['sessions'];
         $this->assertEquals(count($newSessions), 2);
@@ -294,7 +295,7 @@ class CourseTest extends ReadWriteEndpointTest
         $session1Offerings = $newSessionsData[0]['offerings'];
         $session1OfferingData = $this->getFiltered('offerings', 'offerings', ['filters[id]' => $session1Offerings]);
 
-        $this->assertEquals('2022-02-10T15:00:00+00:00', $session1OfferingData[0]['startDate']);
+        $this->assertEquals('2023-02-09T15:00:00+00:00', $session1OfferingData[0]['startDate']);
     }
 
     public function testRolloverCourseWithNoOfferings()
@@ -386,7 +387,7 @@ class CourseTest extends ReadWriteEndpointTest
 
         $newCourse = $this->rolloverCourse([
             'id' => $course['id'],
-            'year' => 2019,
+            'year' => 2023,
         ]);
 
         $newSessionIds = $newCourse['sessions'];
@@ -425,7 +426,7 @@ class CourseTest extends ReadWriteEndpointTest
 
         $newCourse = $this->rolloverCourse([
             'id' => $course['id'],
-            'year' => 2019,
+            'year' => 2023,
             'newStartDate' => 'false',
             'skipOfferings' => 'true',
             'newCohorts' => [5]
@@ -566,7 +567,7 @@ class CourseTest extends ReadWriteEndpointTest
         $rolloverData = [
             'version' => $this->apiVersion,
             'id' => $id,
-            'year' => 2019,
+            'year' => 2023,
             'newStartDate' => 'false',
             'skipOfferings' => 'false',
         ];

--- a/tests/Service/CourseRolloverTest.php
+++ b/tests/Service/CourseRolloverTest.php
@@ -1176,8 +1176,23 @@ class CourseRolloverTest extends TestCase
         $course->setLevel(1);
         $now = new DateTime();
         $course->setYear((int) $now->format('Y'));
-        $course->setStartDate(new DateTime('yesterday'));
-        $course->setEndDate(new DateTime('tomorrow'));
+        // ACHTUNG!
+        // If we're on a calendar week 52 or 53, then pick a large-enough offset
+        // to force the start date into the new year.
+        // This will ensure that we don't run into "week of the year" mismatches when
+        // comparing start/end-dates between the original course and its rolled-over counterpart.
+        // [ST 2021/01/04, week fifty three of 2020]
+        if ($now->format('W') === '53') {
+            $course->setStartDate(new DateTime('+8 days'));
+            $course->setEndDate(new DateTime('+11 days'));
+        } elseif ($now->format('W') === '52') {
+            $course->setStartDate(new DateTime('+16 days'));
+            $course->setEndDate(new DateTime('+19 days'));
+        } else {
+            $course->setStartDate(new DateTime('tomorrow'));
+            $course->setEndDate(new DateTime('+3 days'));
+        }
+
         $course->setExternalId('I45');
         $course->setLocked(true);
         $course->setArchived(true);


### PR DESCRIPTION
the fix for the rollover service test should be permanent. i'm kicking the bucket down the road on the the api endpoint tests.