### PR TITLE
Validate empty strings correctly

### DIFF
--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -76,11 +76,10 @@ class Alert implements AlertInterface
      * @ORM\Column(name="additional_text", type="text", nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/Authentication.php
+++ b/src/Entity/Authentication.php
@@ -42,11 +42,10 @@ class Authentication implements AuthenticationInterface
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 100,
-     *     allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=100)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -58,11 +57,10 @@ class Authentication implements AuthenticationInterface
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 255,
-     *     allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=255)
+     * })
      *
      */
     private $passwordHash;

--- a/src/Entity/Competency.php
+++ b/src/Entity/Competency.php
@@ -57,11 +57,10 @@ class Competency implements CompetencyInterface
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 200,
-     *     allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=200)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/Course.php
+++ b/src/Entity/Course.php
@@ -147,11 +147,10 @@ class Course implements CourseInterface
      * @ORM\Column(type="string", length=255, name="external_id", nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *     min = 1,
-     *     max = 255,
-     *     allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=255)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/CourseLearningMaterial.php
+++ b/src/Entity/CourseLearningMaterial.php
@@ -52,11 +52,10 @@ class CourseLearningMaterial implements CourseLearningMaterialInterface
      *
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *     min = 1,
-     *     max = 65000,
-     *     allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/CurriculumInventoryAcademicLevel.php
+++ b/src/Entity/CurriculumInventoryAcademicLevel.php
@@ -78,11 +78,10 @@ class CurriculumInventoryAcademicLevel implements CurriculumInventoryAcademicLev
      * @ORM\Column(name="description", type="text", nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *     min = 1,
-     *     max = 65000,
-     *     allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/CurriculumInventoryReport.php
+++ b/src/Entity/CurriculumInventoryReport.php
@@ -62,14 +62,13 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
     * @ORM\Column(type="string", length=200, nullable=true)
     *
     * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 200,
-     *      allowEmptyString = true
-     * )
-     *
-     * @IS\Expose
-     * @IS\Type("string")
+    * @Assert\AtLeastOneOf({
+    *     @Assert\Blank,
+    *     @Assert\Length(min=1,max=200)
+    * })
+    *
+    * @IS\Expose
+    * @IS\Type("string")
     */
     protected $name;
 
@@ -79,14 +78,13 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
     * @ORM\Column(name="description", type="text", nullable=true)
     *
     * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
-     *
-     * @IS\Expose
-     * @IS\Type("string")
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
+    *
+    * @IS\Expose
+    * @IS\Type("string")
     */
     protected $description;
 
@@ -188,11 +186,10 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
      * @ORM\Column(name="token", type="string", length=64, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 64,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=64)
+     * })
      */
     protected $token;
 

--- a/src/Entity/CurriculumInventorySequence.php
+++ b/src/Entity/CurriculumInventorySequence.php
@@ -65,11 +65,10 @@ class CurriculumInventorySequence implements CurriculumInventorySequenceInterfac
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/CurriculumInventorySequenceBlock.php
+++ b/src/Entity/CurriculumInventorySequenceBlock.php
@@ -67,11 +67,10 @@ class CurriculumInventorySequenceBlock implements CurriculumInventorySequenceBlo
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/LearnerGroup.php
+++ b/src/Entity/LearnerGroup.php
@@ -75,11 +75,10 @@ class LearnerGroup implements LearnerGroupInterface
      * @ORM\Column(name="location", type="string", length=100, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 100,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=100)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/LearningMaterial.php
+++ b/src/Entity/LearningMaterial.php
@@ -206,8 +206,7 @@ class LearningMaterial implements LearningMaterialInterface
      * @Assert\Length(
      *      min = 1,
      *      max = 512,
-     *      groups={"citation"},
-     *      allowEmptyString = true
+     *      groups={"citation"}
      * )
      *
      * @IS\Expose

--- a/src/Entity/LearningMaterial.php
+++ b/src/Entity/LearningMaterial.php
@@ -73,12 +73,10 @@ class LearningMaterial implements LearningMaterialInterface
      * @ORM\Column(name="description", type="text", nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
-     *
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      * @IS\Expose
      * @IS\Type("string")
      * @IS\RemoveMarkup
@@ -105,11 +103,10 @@ class LearningMaterial implements LearningMaterialInterface
      * @ORM\Column(name="asset_creator", type="string", length=80, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 80,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=80)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -122,11 +119,10 @@ class LearningMaterial implements LearningMaterialInterface
      * @ORM\Column(name="token", type="string", length=64, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 64,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=64)
+     * })
      */
     protected $token;
 
@@ -254,11 +250,10 @@ class LearningMaterial implements LearningMaterialInterface
      * @ORM\Column(name="copyright_rationale", type="text", nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/MeshConcept.php
+++ b/src/Entity/MeshConcept.php
@@ -82,11 +82,10 @@ class MeshConcept implements MeshConceptInterface
      * @ORM\Column(name="scope_note", type="text", nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -99,11 +98,10 @@ class MeshConcept implements MeshConceptInterface
      * @ORM\Column(name="casn_1_name", type="string", length=512, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 512,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=512)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -116,11 +114,10 @@ class MeshConcept implements MeshConceptInterface
      * @ORM\Column(name="registry_number", type="string", length=30, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 30,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=30)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/MeshDescriptor.php
+++ b/src/Entity/MeshDescriptor.php
@@ -54,11 +54,10 @@ class MeshDescriptor implements MeshDescriptorInterface
      * @ORM\GeneratedValue(strategy="NONE")
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 12,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=12)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -72,11 +71,10 @@ class MeshDescriptor implements MeshDescriptorInterface
      *
      * @Assert\NotBlank()
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 192,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=192)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -89,11 +87,10 @@ class MeshDescriptor implements MeshDescriptorInterface
      * @ORM\Column(name="annotation", type="text", nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/MeshTerm.php
+++ b/src/Entity/MeshTerm.php
@@ -93,11 +93,10 @@ class MeshTerm implements MeshTermInterface
      * @ORM\Column(name="lexical_tag", type="string", length=12, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 12,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=12)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/Offering.php
+++ b/src/Entity/Offering.php
@@ -63,11 +63,10 @@ class Offering implements OfferingInterface
      * @ORM\Column(name="room", type="string", length=255, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 255,
-     *      allowEmptyString=true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=255)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -80,11 +79,10 @@ class Offering implements OfferingInterface
      * @ORM\Column(name="site", type="string", length=255, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 255,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=255)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/Program.php
+++ b/src/Entity/Program.php
@@ -72,11 +72,10 @@ class Program implements ProgramInterface
      * @ORM\Column(name="short_title", type="string", length=10, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 10,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=10)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/Report.php
+++ b/src/Entity/Report.php
@@ -45,11 +45,10 @@ class Report implements ReportInterface
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 240,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=240)
+     * })
      *
      *
      * @IS\Expose
@@ -106,11 +105,10 @@ class Report implements ReportInterface
      * @ORM\Column(name="prepositional_object", type="string", length=32, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 32,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=32)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -123,11 +121,10 @@ class Report implements ReportInterface
      * @ORM\Column(name="prepositional_object_table_row_id", type="string", length=14, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 14,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=14)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/School.php
+++ b/src/Entity/School.php
@@ -87,11 +87,10 @@ class School implements SchoolInterface
      * @ORM\Column(name="template_prefix", type="string", length=8, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 8,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=8)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/Session.php
+++ b/src/Entity/Session.php
@@ -177,11 +177,10 @@ class Session implements SessionInterface
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -196,11 +195,10 @@ class Session implements SessionInterface
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/SessionDescription.php
+++ b/src/Entity/SessionDescription.php
@@ -70,11 +70,10 @@ class SessionDescription implements SessionDescriptionInterface
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/SessionLearningMaterial.php
+++ b/src/Entity/SessionLearningMaterial.php
@@ -57,11 +57,10 @@ class SessionLearningMaterial implements SessionLearningMaterialInterface
      * @ORM\Column(name="notes", type="text", nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -79,11 +79,10 @@ class Term implements TermInterface
      * @var string
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 65000,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=65000)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -96,11 +96,10 @@ class User implements UserInterface
      * @ORM\Column(name="middle_name", type="string", length=20, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 20,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=20)
+     * })
      * @IS\Expose
      * @IS\Type("string")
      */
@@ -112,11 +111,10 @@ class User implements UserInterface
      * @ORM\Column(name="display_name", type="string", length=200, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 200,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=200)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -129,11 +127,10 @@ class User implements UserInterface
      * @ORM\Column(name="phone", type="string", length=30, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 30,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=30)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -163,12 +160,10 @@ class User implements UserInterface
      * @ORM\Column(name="preferred_email", type="string", length=100, nullable=true)
      *
      * @Assert\Email
-     *
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 100,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=100)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -207,11 +202,10 @@ class User implements UserInterface
      * @ORM\Column(name="uc_uid", type="string", length=16, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 16,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=16)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")
@@ -224,11 +218,10 @@ class User implements UserInterface
      * @ORM\Column(name="other_id", type="string", length=16, nullable=true)
      *
      * @Assert\Type(type="string")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 16,
-     *      allowEmptyString = true
-     * )
+     * @Assert\AtLeastOneOf({
+     *     @Assert\Blank,
+     *     @Assert\Length(min=1,max=16)
+     * })
      *
      * @IS\Expose
      * @IS\Type("string")


### PR DESCRIPTION
This is the new pattern as allowEmptyString is deprecated in Symfony
5.2.