### PR TITLE
Don't encode passwords in tests

### DIFF
--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -1,0 +1,4 @@
+security:
+  encoders:
+    App\Classes\SessionUserInterface:
+      algorithm: plaintext

--- a/tests/DataLoader/AuthenticationData.php
+++ b/tests/DataLoader/AuthenticationData.php
@@ -15,13 +15,13 @@ class AuthenticationData extends AbstractDataLoader
         $arr[] = [
             'user' => '1',
             'username' => 'legacyuser',
-            'passwordHash' => '$2a$10$CY96FLwV3dAA3hOLBHc/TeFZoaqH5/qlwNoFioj7dtKkKlVBTquve',
+            'passwordHash' => 'legacyuserpass',
         ];
 
         $arr[] = [
             'user' => '2',
             'username' => 'newuser',
-            'passwordHash' => '$2a$10$CY96FLwV3dAA3hOLBHc/TeFZoaqH5/qlwNoFioj7dtKkKlVBTquve'
+            'passwordHash' => 'newuserpass'
         ];
         return $arr;
     }


### PR DESCRIPTION
This cuts a few minutes off our total test run time as it doesn't waste
CPU cycles encoding fake passwords. Thanks Twitter!