### PR TITLE
Re-add missing method to LM repository

### DIFF
--- a/src/Repository/LearningMaterialRepository.php
+++ b/src/Repository/LearningMaterialRepository.php
@@ -365,6 +365,14 @@ class LearningMaterialRepository extends ServiceEntityRepository implements DTOR
     /**
      * @return int
      */
+    public function getTotalLearningMaterialCount(): int
+    {
+        return $this->count([]);
+    }
+
+    /**
+     * @return int
+     */
     public function getTotalFileLearningMaterialCount()
     {
         $dql = 'SELECT COUNT(l.id) FROM App\Entity\LearningMaterial l WHERE l.relativePath IS NOT NULL';


### PR DESCRIPTION
This was dropped when moving from Manager to Repository and is needed in
the cleanup strings command.