### PR TITLE
Remove unused sessionDescription field

### DIFF
--- a/src/Entity/DTO/SessionDTO.php
+++ b/src/Entity/DTO/SessionDTO.php
@@ -128,12 +128,6 @@ class SessionDTO
     public array $meshDescriptors = [];
 
     /**
-     * @IS\Related("sessionDescriptions")
-     * @IS\Type("integer")
-     */
-    public $sessionDescription;
-
-    /**
      * @var int[]
      * @IS\Expose
      * @IS\Related("sessionLearningMaterials")


### PR DESCRIPTION
This relationship was removed in API v3 and is no longer needed here.