### PR TITLE
Adds cascading deletes to alert recipients relationship.

### DIFF
--- a/migrations/Version20210201224131.php
+++ b/migrations/Version20210201224131.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilios\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds cascading deletes to alert recipients relationship.
+ */
+final class Version20210201224131 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Adds cascading deletes to alert recipients relationship.';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE alert_recipient DROP FOREIGN KEY FK_D97AE69D93035F72');
+        $this->addSql('ALTER TABLE alert_recipient DROP FOREIGN KEY FK_D97AE69DC32A47EE');
+        $this->addSql('ALTER TABLE alert_recipient ADD CONSTRAINT FK_D97AE69D93035F72 FOREIGN KEY (alert_id) REFERENCES alert (alert_id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE alert_recipient ADD CONSTRAINT FK_D97AE69DC32A47EE FOREIGN KEY (school_id) REFERENCES school (school_id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE alert_recipient DROP FOREIGN KEY FK_D97AE69D93035F72');
+        $this->addSql('ALTER TABLE alert_recipient DROP FOREIGN KEY FK_D97AE69DC32A47EE');
+        $this->addSql('ALTER TABLE alert_recipient ADD CONSTRAINT FK_D97AE69D93035F72 FOREIGN KEY (alert_id) REFERENCES alert (alert_id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+        $this->addSql('ALTER TABLE alert_recipient ADD CONSTRAINT FK_D97AE69DC32A47EE FOREIGN KEY (school_id) REFERENCES school (school_id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+    }
+}

--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -144,10 +144,10 @@ class Alert implements AlertInterface
      * @ORM\ManyToMany(targetEntity="School", inversedBy="alerts")
      * @ORM\JoinTable(name="alert_recipient",
      *   joinColumns={
-     *     @ORM\JoinColumn(name="alert_id", referencedColumnName="alert_id")
+     *     @ORM\JoinColumn(name="alert_id", referencedColumnName="alert_id", onDelete="CASCADE")
      *   },
      *   inverseJoinColumns={
-     *     @ORM\JoinColumn(name="school_id", referencedColumnName="school_id")
+     *     @ORM\JoinColumn(name="school_id", referencedColumnName="school_id", onDelete="CASCADE")
      *   }
      * )
      * @ORM\OrderBy({"id" = "ASC"})


### PR DESCRIPTION
currently, alerts cannot be deleted wholesale due to a blocking foreign-key constraint on alert instigators. this removes this constraint by declaring cascading deletes on this relationship instead.

refs #3286 