### PR TITLE
Force int types on user input

### DIFF
--- a/src/Controller/DirectoryController.php
+++ b/src/Controller/DirectoryController.php
@@ -76,8 +76,8 @@ class DirectoryController extends AbstractController
                 $results = $searchResults;
             }
         }
-        $offset = $request->query->has('offset') ? $request->query->all()['offset'] : 0;
-        $limit = $request->query->has('limit') ? $request->query->all()['limit'] : count($results);
+        $offset = $request->query->has('offset') ? (int) $request->query->all()['offset'] : 0;
+        $limit = $request->query->has('limit') ? (int) $request->query->all()['limit'] : count($results);
         $results = array_slice($results, $offset, $limit);
 
         $campusIds = array_map(function ($arr) {


### PR DESCRIPTION
These query params come through as strings, but array_slice requires int
so I've coerced them into the correct type.