### PR TITLE
Refactor API Controllers to use composition

### DIFF
--- a/src/Controller/API/MeshConcepts.php
+++ b/src/Controller/API/MeshConcepts.php
@@ -5,15 +5,32 @@ declare(strict_types=1);
 namespace App\Controller\API;
 
 use App\Repository\MeshConceptRepository;
+use App\Traits\APIController\GetAll;
+use App\Traits\APIController\GetOne;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @Route("/api/{version<v3>}/meshconcepts")
  */
-class MeshConcepts extends ReadOnlyController
+class MeshConcepts
 {
+    use GetOne;
+    use GetAll;
+
+    protected MeshConceptRepository $repository;
+
     public function __construct(MeshConceptRepository $repository)
     {
-        parent::__construct($repository, 'meshconcepts');
+        $this->repository = $repository;
+    }
+
+    protected function getRepository(): MeshConceptRepository
+    {
+        return $this->repository;
+    }
+
+    protected function getEndpoint(): string
+    {
+        return 'meshconcepts';
     }
 }

--- a/src/Traits/APIController/GetAll.php
+++ b/src/Traits/APIController/GetAll.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits\APIController;
+
+use App\RelationshipVoter\AbstractVoter;
+use App\Repository\RepositoryInterface;
+use App\Service\ApiRequestParser;
+use App\Service\ApiResponseBuilder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+trait GetAll
+{
+    /**
+     * Handles GET request for multiple entities
+     * @Route("", methods={"GET"})
+     */
+    public function getAll(
+        string $version,
+        Request $request,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ApiResponseBuilder $builder
+    ): Response {
+        $parameters = ApiRequestParser::extractParameters($request);
+
+        $dtos = $this->getRepository()->findDTOsBy(
+            $parameters['criteria'],
+            $parameters['orderBy'],
+            $parameters['limit'],
+            $parameters['offset']
+        );
+
+        $filteredResults = array_filter($dtos, function ($object) use ($authorizationChecker) {
+            return $authorizationChecker->isGranted(AbstractVoter::VIEW, $object);
+        });
+
+        //Re-index numerically index the array
+        $values = array_values($filteredResults);
+
+        return $builder->buildResponseForGetAllRequest($this->endpoint, $values, Response::HTTP_OK, $request);
+    }
+
+    abstract protected function getRepository(): RepositoryInterface;
+    abstract protected function getEndpoint(): string;
+}

--- a/src/Traits/APIController/GetOne.php
+++ b/src/Traits/APIController/GetOne.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits\APIController;
+
+use App\RelationshipVoter\AbstractVoter;
+use App\Repository\RepositoryInterface;
+use App\Service\ApiResponseBuilder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+trait GetOne
+{
+    /**
+     * Handles GET request for a single entity
+     * @Route("/{id}", methods={"GET"})
+     */
+    public function getOne(
+        string $version,
+        string $id,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ApiResponseBuilder $builder,
+        Request $request
+    ): Response {
+        $repository = $this->getRepository();
+        $dto = $repository->findDTOBy(['id' => $id]);
+
+        if (! $dto) {
+            throw new NotFoundHttpException(sprintf("%s/%s was not found.", $this->endpoint, $id));
+        }
+
+        $values = $authorizationChecker->isGranted(AbstractVoter::VIEW, $dto) ? [$dto] : [];
+
+        return $builder->buildResponseForGetOneRequest($this->getEndpoint(), $values, Response::HTTP_OK, $request);
+    }
+
+    abstract protected function getRepository(): RepositoryInterface;
+    abstract protected function getEndpoint(): string;
+}


### PR DESCRIPTION
By composing these out of traits it is easier to declare and use the
correct types. Since PHP types aren't allowed to extend and interface on
class members I've moved the repository and endpoint info into strings.