### PR TITLE
expose the value of the academic-year flag via the config API endpoint.

### DIFF
--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -41,6 +41,9 @@ class ConfigController extends AbstractController
         }
         $configuration['searchEnabled'] = $curriculumSearch->isEnabled();
 
+        $configuration['academicYearCrossesCalendarYearBoundaries']
+            = $config->get('academic_year_crosses_calendar_year_boundaries');
+
         return new JsonResponse(['config' => $configuration]);
     }
 }

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -62,6 +62,7 @@ class ConfigControllerTest extends WebTestCase
                 'apiVersion' => $container->getParameter('ilios_api_version'),
                 'trackingEnabled' => false,
                 'searchEnabled' => false,
+                'academicYearCrossesCalendarYearBoundaries' => false,
             ],
             $data
         );
@@ -94,6 +95,7 @@ class ConfigControllerTest extends WebTestCase
                 'trackingEnabled' => true,
                 'trackingCode' => '123-code!',
                 'searchEnabled' => false,
+                'academicYearCrossesCalendarYearBoundaries' => false,
             ],
             $data
         );


### PR DESCRIPTION
we need this in the frontend to determine labeling of the year dropdown values in the "new course" component, possibly in other places as well.