### PR TITLE
Initialize LDAP before use

### DIFF
--- a/src/Service/LdapManager.php
+++ b/src/Service/LdapManager.php
@@ -10,7 +10,7 @@ use Symfony\Component\Ldap\Ldap;
 class LdapManager
 {
     protected Config $config;
-    protected Ldap $ldap;
+    protected ?Ldap $ldap = null;
 
     /**
      * Constructor


### PR DESCRIPTION
Without this we can't check if the property is falsey later.

Fixes #3350