### PR TITLE
Use Zorgbort PAT token for updates

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ZORGBORT_TOKEN }}
           title: ${{ steps.vars.outputs.pr_title }}
           body: ${{ steps.vars.outputs.pr_body }}
           commit-message: ${{ steps.vars.outputs.commit_message }}


### PR DESCRIPTION
This will cause the actions to run, using the GITHUB_TOKEN value doesn't
work anymore.