### PR TITLE
Drop PHP 7.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   ILIOS_SECRET: ThisTokenIsNotSoSecretChangeIt
   ILIOS_FILE_SYSTEM_STORAGE_PATH: /tmp
   SYMFONY_DEPRECATIONS_HELPER: disabled=1
-  latest_php: 7.4
+  latest_php: 8.0
 
 jobs:
   code_style:
@@ -51,7 +51,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.4,8.0]
+        php-version: [8.0]
 
     steps:
     - uses: actions/checkout@v2
@@ -97,7 +97,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.4,8.0]
+        php-version: [8.0]
 
     steps:
     - uses: actions/checkout@v2
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [7.4,8.0]
+        php-version: [8.0]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV FPM_CONTAINERS=fpm:9000
 # Dependencies we need in all PHP containers
 # Production ready composer pacakges installed
 ###############################################################################
-FROM php:7.4-fpm as php-base
+FROM php:8.0-fpm as php-base
 LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 COPY --from=src /src /var/www/ilios
@@ -190,7 +190,7 @@ RUN /bin/bash /fetch-demo-database.sh
 ###############################################################################
 # Setup elasticsearch with the plugins we needed
 ###############################################################################
-FROM elasticsearch:7.8.1 as elasticsearch
+FROM elasticsearch:7.13.1 as elasticsearch
 LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
 RUN bin/elasticsearch-plugin install -b ingest-attachment
 
@@ -198,7 +198,7 @@ RUN bin/elasticsearch-plugin install -b ingest-attachment
 # Our original and still relevant apache based runtime, includes everything in
 # a single container
 ###############################################################################
-FROM php:7.4-apache as php-apache
+FROM php:8.0-apache as php-apache
 LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 COPY --from=src /src /var/www/ilios

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "project",
   "description": "The \"Ilios Standard Edition\" distribution",
   "require": {
-    "php": ">= 7.4",
+    "php": ">= 8.0",
     "ext-apcu": "*",
     "ext-ctype": "*",
     "ext-dom": "*",
@@ -75,7 +75,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.4.0"
+      "php": "8.0.0"
     },
     "preferred-install": {
       "*": "dist"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e395aaecda50f2efeec76cc47f5024e9",
+    "content-hash": "3cda4dfb935464d5cc6cb92afcd6113c",
     "packages": [
         {
             "name": "async-aws/core",
@@ -132,16 +132,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.183.13",
+            "version": "3.184.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "0e0be404854482b7cae61ef9f707c7a876b43cdf"
+                "reference": "78fe691ab466fecf195209672f6c00c5d4ed219a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0e0be404854482b7cae61ef9f707c7a876b43cdf",
-                "reference": "0e0be404854482b7cae61ef9f707c7a876b43cdf",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/78fe691ab466fecf195209672f6c00c5d4ed219a",
+                "reference": "78fe691ab466fecf195209672f6c00c5d4ed219a",
                 "shasum": ""
             },
             "require": {
@@ -216,9 +216,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.183.13"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.184.2"
             },
-            "time": "2021-06-04T18:12:54+00:00"
+            "time": "2021-06-11T18:20:15+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -1593,16 +1593,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "1c2780df6b58998f411e64973cfa464ba0a06e00"
+                "reference": "8d0c58655cf9d76462d00ec5dd099737e513e86d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/1c2780df6b58998f411e64973cfa464ba0a06e00",
-                "reference": "1c2780df6b58998f411e64973cfa464ba0a06e00",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/8d0c58655cf9d76462d00ec5dd099737e513e86d",
+                "reference": "8d0c58655cf9d76462d00ec5dd099737e513e86d",
                 "shasum": ""
             },
             "require": {
@@ -1677,7 +1677,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.1.2"
+                "source": "https://github.com/doctrine/migrations/tree/3.1.3"
             },
             "funding": [
                 {
@@ -1693,7 +1693,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-24T12:54:34+00:00"
+            "time": "2021-06-10T19:24:33+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -2768,25 +2768,25 @@
         },
         {
             "name": "ilios/mesh-parser",
-            "version": "v2.0.1",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ilios/mesh-parser.git",
-                "reference": "387df63c6d4c6703e5dbcf28099f74a1d9c73c3c"
+                "reference": "b72149c11b050a7d77d5f62f8ffd90cac76cdc88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ilios/mesh-parser/zipball/387df63c6d4c6703e5dbcf28099f74a1d9c73c3c",
-                "reference": "387df63c6d4c6703e5dbcf28099f74a1d9c73c3c",
+                "url": "https://api.github.com/repos/ilios/mesh-parser/zipball/b72149c11b050a7d77d5f62f8ffd90cac76cdc88",
+                "reference": "b72149c11b050a7d77d5f62f8ffd90cac76cdc88",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.1|~7.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "fzaninotto/faker": "^1.5",
+                "fakerphp/faker": "@stable",
                 "mockery/mockery": "@stable",
-                "phpunit/phpunit": "6.*",
+                "phpunit/phpunit": "@stable",
                 "squizlabs/php_codesniffer": "@stable"
             },
             "type": "library",
@@ -2814,9 +2814,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ilios/mesh-parser/issues",
-                "source": "https://github.com/ilios/mesh-parser/tree/master"
+                "source": "https://github.com/ilios/mesh-parser/tree/v2.0.2"
             },
-            "time": "2019-02-05T19:18:47+00:00"
+            "time": "2021-02-25T19:33:04+00:00"
         },
         {
             "name": "jaybizzle/crawler-detect",
@@ -4715,20 +4715,20 @@
         },
         {
             "name": "psr/link",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/link.git",
-                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562"
+                "reference": "846c25f58a1f02b93a00f2404e3626b6bf9b7807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/link/zipball/eea8e8662d5cd3ae4517c9b864493f59fca95562",
-                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562",
+                "url": "https://api.github.com/repos/php-fig/link/zipball/846c25f58a1f02b93a00f2404e3626b6bf9b7807",
+                "reference": "846c25f58a1f02b93a00f2404e3626b6bf9b7807",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
@@ -4752,6 +4752,7 @@
                 }
             ],
             "description": "Common interfaces for HTTP links",
+            "homepage": "https://github.com/php-fig/link",
             "keywords": [
                 "http",
                 "http-link",
@@ -4761,9 +4762,9 @@
                 "rest"
             ],
             "support": {
-                "source": "https://github.com/php-fig/link/tree/master"
+                "source": "https://github.com/php-fig/link/tree/1.1.1"
             },
-            "time": "2016-10-28T16:06:13+00:00"
+            "time": "2021-03-11T22:59:13+00:00"
         },
         {
             "name": "psr/log",
@@ -12607,16 +12608,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -12659,7 +12660,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -12667,7 +12668,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -13788,7 +13789,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 7.4",
+        "php": ">= 8.0",
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-dom": "*",
@@ -13801,7 +13802,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4.0"
+        "php": "8.0.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/packages/monitor.yaml
+++ b/config/packages/monitor.yaml
@@ -6,7 +6,7 @@ liip_monitor:
       default:
         php_extensions: [apcu, mbstring, ldap, xml, dom, mysqlnd, pdo, zip, json, zlib, ctype, iconv]
         php_version:
-            "7.4": ">="
+            "8.0": ">="
         readable_directory: ["%kernel.cache_dir%"]
         writable_directory: ["%kernel.cache_dir%"]
       production:

--- a/docker/php-fpm-entrypoint
+++ b/docker/php-fpm-entrypoint
@@ -4,7 +4,7 @@ set -e
 /var/www/ilios/bin/console cache:warmup
 /bin/chown -R www-data:www-data /var/www/ilios
 
-# From https://github.com/docker-library/php/blob/b6fd2f70018163227f0f18f3ba1fa4d70e6d929e/7.4/alpine3.12/fpm/docker-php-entrypoint
+# From https://github.com/docker-library/php/blob/cf8840d0d56ef92e899dac67ebdf8112e9d2f492/8.0/alpine3.13/fpm/docker-php-entrypoint
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
 	set -- php-fpm "$@"

--- a/docs/ilios_php_version_policy.md
+++ b/docs/ilios_php_version_policy.md
@@ -8,13 +8,13 @@ At any given time, the Ilios application will only be supported on the very late
  
 #### Policy Example
 
-For example, the current version of PHP is v7.4.  When PHP v8.0 is released, we will continue to ensure the Ilios code will work on PHP 7.4 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 8.0 going forward.
+For example, the current version of PHP is v8.0.  When PHP v8.1 is released, we will continue to ensure the Ilios code will work on PHP 8.0 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 8.1 going forward.
 
 ### Currently Supported Versions of PHP
 
 Based on the policy above, Ilios is currently compatible with the following versions of PHP:
 
-* PHP 7.4
+* PHP 8.0
  
 ### Up-To-Date PHP Repositories for CentOS and RHEL
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ Ilios 3 uses a Symfony (PHP/SQL) backend to serve its API, so these tools and th
 
 * CentOS 7 - Any modern Linux should work, but we recommend Redhat (RHEL, CentOS, or Fedora) or Ubuntu
 * MySQL using the InnoDB database engine (v5.5 or later required, 5.7+ recommended)
-* PHP v7.4+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
+* PHP v8.0+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
 
 NOTE: Several institutions have successfully deployed Ilios using Microsoft IIS on Windows as their webserver, but we do not recommend it as we do not have alot of experience with it ourselves and we've only ever support Ilios on Linux systems.  That being said, if you MUST use IIS for Windows and are having trouble getting Ilios running properly, please contact the [Ilios Project Support Team](https://iliosproject.org) at support@iliosproject.org if you have any problems and we might be able to help you out!
 
@@ -64,7 +64,7 @@ You should now be in the '/web/ilios3/ilios' directory
 # errors related to git files in your own user's `.config` directory:
 sudo -u apache git checkout tags/$(git fetch --tags; git describe --tags `git rev-list --tags --max-count=1`)
 ```
-5. Run the following command to build the packages and its dependencies.  This step assumes you have PHP 7.4+ and Composer installed on your system:
+5. Run the following command to build the packages and its dependencies.  This step assumes you have PHP 8.0+ and Composer installed on your system:
 ```bash
 sudo -u apache bin/setup
 ```


### PR DESCRIPTION
inline with out official policy it is time to drop support for PHP 7.4
and move onto PHP 8 full time.