### PR TITLE
Allow PHP Attributes to mark DTOs

### DIFF
--- a/src/Attribute/DTO.php
+++ b/src/Attribute/DTO.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class DTO
+{
+    public const VALUE = 'value';
+
+    public function __construct(public string $value)
+    {
+    }
+}

--- a/src/Attribute/Expose.php
+++ b/src/Attribute/Expose.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Expose
+{
+}

--- a/src/Attribute/Id.php
+++ b/src/Attribute/Id.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Id
+{
+}

--- a/src/Attribute/ReadOnly.php
+++ b/src/Attribute/ReadOnly.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Attribute;
+
+use Attribute;
+
+/**
+ * Properties which can be read in the API, but
+ * cannot be written to.  Any attempt to write to
+ * them will be silently ignored in the API.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ReadOnly
+{
+}

--- a/src/Attribute/Related.php
+++ b/src/Attribute/Related.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Related
+{
+    public function __construct(public ?string $value = null)
+    {
+    }
+}

--- a/src/Attribute/RemoveMarkup.php
+++ b/src/Attribute/RemoveMarkup.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Attribute;
+
+use Attribute;
+
+/**
+ * Apply this to a property in order to purify
+ * the submitted content and remove any non-standard
+ * or harmful markup.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class RemoveMarkup
+{
+}

--- a/src/Attribute/Type.php
+++ b/src/Attribute/Type.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Attribute;
+
+use Attribute;
+
+/**
+ * Indicates the type of data contained in the property
+ * some amount of type casting takes place to convert to
+ * and from the designated type.
+ *
+ * Entity: The value will be converted to the related objects
+ * id in JSON and converted back into the entity it represents
+ *
+ * entityCollection: presented as an array of ids and converted
+ * into and array of entities when it is PUT
+ *
+ * array<string> generally the DTO representation of an entity collection
+ * we just have the IDs in an array and each of them is a string
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Type
+{
+    public const VALUE = 'value';
+    private const ALLOWED_VALUES = [
+     'integer',
+     'float',
+     'string',
+     'boolean',
+     'dateTime',
+     'entity',
+     'entityCollection',
+     'array',
+     'array<string>',
+     'array<dto>',
+    ];
+
+    public string $value;
+
+    public function __construct(string $value)
+    {
+        if (!in_array($value, self::ALLOWED_VALUES)) {
+            throw new \InvalidArgumentException("${value} is not a valid type");
+        }
+        $this->value = $value;
+    }
+}

--- a/src/Entity/DTO/AamcMethodDTO.php
+++ b/src/Entity/DTO/AamcMethodDTO.php
@@ -4,51 +4,27 @@ declare(strict_types=1);
 
 namespace App\Entity\DTO;
 
-use App\Annotation as IS;
+use App\Attribute as IA;
 
-/**
- * Class AamcMethodDTO
- * Data transfer object for a aamcMethod
- *
- * @IS\DTO("aamcMethods")
- */
+#[IA\DTO("aamcMethods")]
 class AamcMethodDTO
 {
-    /**
-     * @IS\Id
-     * @IS\Expose
-     * @IS\Type("string")
-     */
-    public string $id;
-
-    /**
-     * @IS\Expose
-     * @IS\Type("string")
-     *
-     */
-    public string $description;
-
-    /**
-     * @IS\Expose
-     * @IS\Related
-     * @IS\Type("array<string>")
-     */
+    #[IA\Expose]
+    #[IA\Related]
+    #[IA\Type("array<string>")]
     public array $sessionTypes = [];
 
-    /**
-     * @IS\Expose
-     * @IS\Type("boolean")
-     */
-    public bool $active;
-
-
     public function __construct(
-        string $id,
-        string $description,
-        bool $active
+        #[IA\Expose]
+        #[IA\Id]
+        #[IA\Type("string")]
+        public string $id,
+        #[IA\Expose]
+        #[IA\Type("string")]
+        public string $description,
+        #[IA\Expose]
+        #[IA\Type("boolean")]
+        public bool $active
     ) {
-        $this->id = $id;
-        $this->description = $description;
-        $this->active = $active;
     }
 }


### PR DESCRIPTION
This is the first step in removing our need for dockblock annotations
and the userland libraries needed to read those tags. Initial benchmarks
put this at about 5% faster for the trivial usecase in our tests, it may
be a bigger performance improvement with complicated multi-object
JSON:API requests.

This is POC at this point with only AamcMethodDTO actually making the
transition, but I've modified out lookup to account first for attributes
and then to fallback to the annotations. This should allow a multi-step
transition of all DTOs to this over time.