### PR TITLE
Remove unused variable in catch

### DIFF
--- a/src/Classes/ElasticSearchBase.php
+++ b/src/Classes/ElasticSearchBase.php
@@ -81,7 +81,7 @@ class ElasticSearchBase
         }
         try {
             return $this->client->delete($params);
-        } catch (Missing404Exception $e) {
+        } catch (Missing404Exception) {
             return ['result' => 'deleted'];
         }
     }
@@ -93,7 +93,7 @@ class ElasticSearchBase
         }
         try {
             return $this->client->deleteByQuery($params);
-        } catch (Missing404Exception $e) {
+        } catch (Missing404Exception) {
             return ['failures' => []];
         }
     }

--- a/src/Classes/LocalCachingFilesystemDecorator.php
+++ b/src/Classes/LocalCachingFilesystemDecorator.php
@@ -72,7 +72,7 @@ class LocalCachingFilesystemDecorator implements FilesystemInterface
         try {
             //cleanup any existing test file
             $this->cacheFileSystem->delete($path);
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException) {
             //ignore this one we don't always have files in the cache
         }
     }
@@ -86,7 +86,7 @@ class LocalCachingFilesystemDecorator implements FilesystemInterface
         try {
             //cleanup any existing test file
             $this->cacheFileSystem->deleteDir($dirname);
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException) {
             //ignore this one we don't always have files in the cache
         }
     }

--- a/src/Command/CleanupStringsCommand.php
+++ b/src/Command/CleanupStringsCommand.php
@@ -415,7 +415,7 @@ class CleanupStringsCommand extends Command
         $url = 'https://' . $fixed;
         try {
             $this->httpClient->request('HEAD', $url);
-        } catch (Exception $e) {
+        } catch (Exception) {
             // fallback - try getting a response over plain HTTP.
             $url = 'http://' . $fixed;
             $this->httpClient->request('HEAD', $url);

--- a/src/Command/FixLearningMaterialMimeTypesCommand.php
+++ b/src/Command/FixLearningMaterialMimeTypesCommand.php
@@ -96,7 +96,7 @@ class FixLearningMaterialMimeTypesCommand extends Command
                             } else {
                                 try {
                                     $newMimeType = $file->getMimeType();
-                                } catch (\ErrorException $e) {
+                                } catch (\ErrorException) {
                                     $fileName = $lm->getFilename();
                                     $newMimeType = $this->getMimetypeForFileName($fileName);
                                 }

--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -163,7 +163,7 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
             $output->writeln("<info>Frontend updated successfully${message}!</info>");
 
             return 0;
-        } catch (Exception $e) {
+        } catch (Exception) {
             $output->writeln("<error>No matching frontend found${message}!</error>");
 
             return 1;
@@ -184,7 +184,7 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
             }
             $this->downloadAndExtractArchive(self::PRODUCTION, $version);
             $this->copyStaticFilesIntoPublicDirectory();
-        } catch (Exception $e) {
+        } catch (Exception) {
             print "\n\n**Warning: Unable to load frontend. Please run ilios:maintenance:update-frontend again.**\n\n\n";
         }
 

--- a/src/Repository/AuthenticationRepository.php
+++ b/src/Repository/AuthenticationRepository.php
@@ -44,7 +44,7 @@ class AuthenticationRepository extends ServiceEntityRepository implements DTORep
             $result = $qb->getQuery()->getSingleResult();
         } catch (NoResultException $e) {
             // do nothing.
-        } catch (NonUniqueResultException $e) {
+        } catch (NonUniqueResultException) {
             // do nothing.
         }
         return $result;

--- a/src/Repository/SchoolConfigRepository.php
+++ b/src/Repository/SchoolConfigRepository.php
@@ -86,7 +86,7 @@ class SchoolConfigRepository extends ServiceEntityRepository implements DTORepos
 
         try {
             $result = $qb->getQuery()->getSingleScalarResult();
-        } catch (NoResultException $e) {
+        } catch (NoResultException) {
             $result = null;
         }
 

--- a/src/Security/JsonWebTokenAuthenticator.php
+++ b/src/Security/JsonWebTokenAuthenticator.php
@@ -97,7 +97,7 @@ class JsonWebTokenAuthenticator extends AbstractGuardAuthenticator
             $username = $this->jwtManager->getUserIdFromToken($jwt);
         } catch (UnexpectedValueException $e) {
             throw new CustomUserMessageAuthenticationException('Invalid JSON Web Token: ' . $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             throw new CustomUserMessageAuthenticationException('Invalid JSON Web Token');
         }
 

--- a/src/Service/CasAuthentication.php
+++ b/src/Service/CasAuthentication.php
@@ -96,7 +96,7 @@ class CasAuthentication implements AuthenticationInterface
             try {
                 $this->jwtManager->getUserIdFromToken($jwt);
                 return $this->createSuccessResponseFromJWT($jwt);
-            } catch (UnexpectedValueException $e) {
+            } catch (UnexpectedValueException) {
                 //JWT could not be validated, move on
             }
         }

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -97,7 +97,7 @@ class Config
             return $this->applicationConfigRepository->getValue($name);
         } catch (ServerException $e) {
             return null;
-        } catch (ConnectionException $e) {
+        } catch (ConnectionException) {
             return null;
         }
     }

--- a/src/Service/LoggerQueue.php
+++ b/src/Service/LoggerQueue.php
@@ -54,7 +54,7 @@ class LoggerQueue
                 $this->logger->log($action, $objectId, $item['className'], $changes, false);
             }
             $this->logger->flush(); // explicitly flush the logger.
-        } catch (Exception $e) {
+        } catch (Exception) {
             // eat this exception.
         }
     }


### PR DESCRIPTION
This is now allowed in PHP so we no longer need to specify an unused
variable in each catch statement.