### PR TITLE
Restore configuration for trusted proxies

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -17,6 +17,9 @@ framework:
     php_errors:
         log: true
 
+    #required to ensure load balancer terminated SSL can still generate SSL errors.
+    trusted_proxies: '%env(TRUSTED_PROXIES)%'
+
 when@test:
     framework:
         test: true


### PR DESCRIPTION
This was removed in a config update and it is critically needed so that
https URLs are still generated when SSL is terminated on the load
balancer.