### PR TITLE
Add command to sync student status

### DIFF
--- a/src/Command/SyncStudentStatusCommand.php
+++ b/src/Command/SyncStudentStatusCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\UserRoleInterface;
+use App\Repository\UserRepository;
+use App\Repository\UserRoleRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use App\Entity\UserInterface;
+use App\Service\Directory;
+
+/**
+ * Syncs students from the directory.
+ */
+class SyncStudentStatusCommand extends Command
+{
+    public function __construct(
+        protected UserRepository $userRepository,
+        protected UserRoleRepository $userRoleRepository,
+        protected Directory $directory
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('ilios:sync-students')
+            ->setDescription('Sync students from the directory.')
+            ->addArgument(
+                'filter',
+                InputArgument::REQUIRED,
+                'An LDAP filter to use in finding students in the directory.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Starting student synchronization process.</info>');
+        $filter = $input->getArgument('filter');
+
+        $students = $this->directory->findByLdapFilter($filter);
+
+        if (!$students) {
+            $output->writeln("<error>{$filter} returned no results.</error>");
+            return 0;
+        }
+        $output->writeln('<info>Found ' . count($students) . ' students in the directory.</info>');
+
+        $studentsCampusIds = array_map(fn(array $arr) => $arr['campusId'], $students);
+
+        $notStudents = $this->userRepository->findUsersWhoAreNotStudents($studentsCampusIds);
+        $usersToUpdate = array_filter(
+            $notStudents,
+            fn(UserInterface $user) => !$user->isUserSyncIgnore() && $user->isEnabled()
+        );
+        if ($usersToUpdate === []) {
+            $output->writeln("<info>There are no students to update.</info>");
+            return 0;
+        }
+        $output->writeln(
+            '<info>There are ' .
+            count($usersToUpdate) .
+            ' students in Ilios who will be marked as a Student.</info>'
+        );
+        $rows = array_map(fn(UserInterface $user) => [
+            $user->getCampusId(),
+            $user->getFirstName(),
+            $user->getLastName(),
+            $user->getEmail(),
+        ], $usersToUpdate);
+        $table = new Table($output);
+        $table->setHeaders(['Campus ID', 'First', 'Last', 'Email'])->setRows($rows);
+        $table->render();
+
+        $helper = $this->getHelper('question');
+        $output->writeln('');
+        $question = new ConfirmationQuestion(
+            '<question>Do you wish to mark these users as Students? </question>' . "\n",
+            true
+        );
+
+        if ($helper->ask($input, $output, $question)) {
+            $studentRole = $this->userRoleRepository->findOneBy(['title' => 'Student']);
+            foreach ($usersToUpdate as $user) {
+                $user->addRole($studentRole);
+                $this->userRepository->update($user, false);
+            }
+            $this->userRepository->flush();
+
+            $output->writeln('<info>Students updated successfully!</info>');
+
+            return 0;
+        } else {
+            $output->writeln('<comment>Update canceled,</comment>');
+
+            return 1;
+        }
+    }
+}

--- a/tests/Command/SyncStudentStatusCommandTest.php
+++ b/tests/Command/SyncStudentStatusCommandTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\SyncStudentStatusCommand;
+use App\Entity\UserInterface;
+use App\Entity\UserRoleInterface;
+use App\Repository\UserRepository;
+use App\Repository\UserRoleRepository;
+use App\Service\Directory;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+class SyncStudentStatusCommandTest extends KernelTestCase
+{
+    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    private const COMMAND_NAME = 'ilios:sync-students';
+
+    protected UserRepository|m\MockInterface $userRepository;
+    protected UserRoleRepository|m\MockInterface $userRoleRepository;
+    protected CommandTester $commandTester;
+    protected QuestionHelper $questionHelper;
+    protected Directory|m\MockInterface $directory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->userRepository = m::mock(UserRepository::class);
+        $this->userRoleRepository = m::mock(UserRoleRepository::class);
+        $this->directory = m::mock(Directory::class);
+
+        $command = new SyncStudentStatusCommand($this->userRepository, $this->userRoleRepository, $this->directory);
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->add($command);
+        $commandInApp = $application->find(self::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+        $this->questionHelper = $command->getHelper('question');
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->userRepository);
+        unset($this->userRoleRepository);
+        unset($this->directory);
+        unset($this->commandTester);
+    }
+
+    public function testExecute()
+    {
+        $fakeDirectoryUser1 = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+        ];
+        $fakeDirectoryUser2 = [
+            'firstName' => 'first2',
+            'lastName' => 'last2',
+            'email' => 'email2',
+            'telephoneNumber' => 'phone2',
+            'campusId' => 'abc2',
+        ];
+        $role = m::mock(UserRoleInterface::class);
+        $user = m::mock(UserInterface::class)
+            ->shouldReceive('getId')->andReturn(42)
+            ->shouldReceive('getFirstName')->andReturn('first')
+            ->shouldReceive('getLastName')->andReturn('last')
+            ->shouldReceive('getEmail')->andReturn('email')
+            ->shouldReceive('getCampusId')->andReturn('abc')
+            ->shouldReceive('isUserSyncIgnore')->andReturn(false)
+            ->shouldReceive('isEnabled')->andReturn(true)
+            ->shouldReceive('addRole')->with($role)->once()
+            ->mock();
+        $this->directory->shouldReceive('findByLdapFilter')
+            ->with('FILTER')
+            ->andReturn([$fakeDirectoryUser1, $fakeDirectoryUser2]);
+        $this->userRepository->shouldReceive('findUsersWhoAreNotStudents')
+            ->with(['abc', 'abc2'])
+            ->andReturn([$user]);
+        $this->userRepository->shouldReceive('update')
+            ->with($user, false)->once();
+        $this->userRepository->shouldReceive('flush')->once();
+        $this->userRoleRepository
+            ->shouldReceive('findOneBy')
+            ->with(['title' => 'Student'])
+            ->andReturn($role);
+
+        $this->commandTester->setInputs(['Yes']);
+        $this->commandTester->execute([
+            'command'   => self::COMMAND_NAME,
+            'filter'    => 'FILTER'
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/Found 2 students in the directory./',
+            $output
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/There are 1 students in Ilios who will be marked as a Student./',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/Do you wish to mark these users as Students?/',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/abc\s+\| first\s+\| last\s+\| email /',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/Students updated successfully!/',
+            $output
+        );
+    }
+
+    public function testFilterRequired()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+    }
+}


### PR DESCRIPTION
New users are sometimes added without the correct student status or else
their status changes after they are added. This command can be run with
an LDAP filter to discover all students in the directory and then mark
them as students in Ilios.

Fixes #3564