### PR TITLE
Add query option to session endpoint

### DIFF
--- a/src/Controller/API/Sessions.php
+++ b/src/Controller/API/Sessions.php
@@ -4,16 +4,58 @@ declare(strict_types=1);
 
 namespace App\Controller\API;
 
+use App\RelationshipVoter\AbstractVoter;
 use App\Repository\SessionRepository;
+use App\Service\ApiRequestParser;
+use App\Service\ApiResponseBuilder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * @Route("/api/{version<v3>}/sessions")
  */
 class Sessions extends ReadWriteController
 {
-    public function __construct(SessionRepository $repository)
+    public function __construct(protected SessionRepository $sessionRepository)
     {
-        parent::__construct($repository, 'sessions');
+        parent::__construct($sessionRepository, 'sessions');
+    }
+
+    /**
+     * Handle the special 'q' parameter for sessions
+     * @Route("", methods={"GET"})
+     */
+    public function getAll(
+        string $version,
+        Request $request,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ApiResponseBuilder $builder
+    ): Response {
+        $q = $request->get('q');
+        $parameters = ApiRequestParser::extractParameters($request);
+
+        if (null !== $q && '' !== $q) {
+            $dtos = $this->sessionRepository->findDTOsByQ(
+                $q,
+                $parameters['orderBy'],
+                $parameters['limit'],
+                $parameters['offset'],
+                $parameters['criteria'],
+            );
+
+            $filteredResults = array_filter(
+                $dtos,
+                fn($object) => $authorizationChecker->isGranted(AbstractVoter::VIEW, $object)
+            );
+
+            //Re-index numerically index the array
+            $values = array_values($filteredResults);
+
+            return $builder->buildResponseForGetAllRequest($this->endpoint, $values, Response::HTTP_OK, $request);
+        }
+
+        return parent::getAll($version, $request, $authorizationChecker, $builder);
     }
 }

--- a/tests/DataLoader/SessionData.php
+++ b/tests/DataLoader/SessionData.php
@@ -22,7 +22,7 @@ class SessionData extends AbstractDataLoader
             'instructionalNotes' => $this->faker->text(100),
             'sessionType' => 1,
             'course' => 1,
-            'description' => $this->faker->text(),
+            'description' => $this->faker->text() . 'description',
             'terms' => ['2', '5'],
             'sessionObjectives' => ['1'],
             'meshDescriptors' => ['abc1'],
@@ -69,6 +69,7 @@ class SessionData extends AbstractDataLoader
             'instructionalNotes' => $this->faker->text(100),
             'sessionType' => 2,
             'course' => 2,
+            'description' => $this->faker->text() . 'description',
             'terms' => ['3', '6'],
             'sessionObjectives' => [],
             'meshDescriptors' => ["abc2"],
@@ -81,7 +82,7 @@ class SessionData extends AbstractDataLoader
 
         $arr[] = [
             'id' => 4,
-            'title' => $this->faker->text(10),
+            'title' => $this->faker->text(10) . 'fourth',
             'equipmentRequired' => false,
             'supplemental' => false,
             'attendanceRequired' => false,

--- a/tests/Endpoints/SessionTest.php
+++ b/tests/Endpoints/SessionTest.php
@@ -148,6 +148,91 @@ class SessionTest extends ReadWriteEndpointTest
         ];
     }
 
+    public function qsToTest()
+    {
+        return [
+            ['session1Title', [0]],
+            ['1', [0]],
+            ['title', [0]],
+            ['fourth', [3]],
+            ['xyznothing', []],
+            ['description', [0, 1, 2]],
+            ['second', [1]],
+            ['', [0, 1, 2, 3, 4, 5, 6, 7]],
+        ];
+    }
+
+    /**
+     * @dataProvider qsToTest
+     */
+    public function testFindByQ(string $q, array $dataKeys)
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $expectedData = array_map(fn($i) => $all[$i], $dataKeys);
+        $filters = ['q' => $q];
+        $this->filterTest($filters, $expectedData);
+    }
+
+    /**
+     * @dataProvider qsToTest
+     */
+    public function testFindByQJsonApi(string $q, array $dataKeys)
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $expectedData = array_map(fn($i) => $all[$i], $dataKeys);
+        $filters = ['q' => $q];
+        $this->jsonApiFilterTest($filters, $expectedData);
+    }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithLimit()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['description'], 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'description', 'limit' => 2];
+        $this->filterTest($filters, [$all[0], $all[1]]);
+    }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithOffset()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['description'], 'offset' => 0];
+        $this->filterTest($filters, [$all[0]]);
+    }
+
+    /**
+     * Ensure offset and limit work
+     */
+    public function testFindByQWithOffsetAndLimit()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['description'], 'offset' => 0, 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'description', 'offset' => 2, 'limit' => 2];
+        $this->filterTest($filters, [$all[2]]);
+    }
+
+    public function testFindByQWithOffsetAndLimitJsonApi()
+    {
+        $dataLoader = $this->getDataLoader();
+        $all = $dataLoader->getAll();
+        $filters = ['q' => $all[0]['description'], 'offset' => 0, 'limit' => 1];
+        $this->filterTest($filters, [$all[0]]);
+        $filters = ['q' => 'description', 'offset' => 2, 'limit' => 2];
+        $this->jsonApiFilterTest($filters, [$all[2]]);
+    }
+
     protected function getTimeStampFields()
     {
         return ['updatedAt'];


### PR DESCRIPTION
This adds support for the `q` parameter in sessions allowing them to be
searched for by name or description. This will make them easier to find
in the report builder.