### PR TITLE
rm obsolete metadata_cache_driver config item.

### DIFF
--- a/config/packages/prod/doctrine.yaml
+++ b/config/packages/prod/doctrine.yaml
@@ -4,9 +4,6 @@ doctrine:
         driver: pdo_mysql
     orm:
         auto_generate_proxy_classes: false
-        metadata_cache_driver:
-            type: pool
-            pool: doctrine.system_cache_pool
         query_cache_driver:
             type: pool
             pool: doctrine.system_cache_pool


### PR DESCRIPTION
this can be removed without substitute.

refs #3616 