### PR TITLE
Add messenger transport to php-apache container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,7 +240,8 @@ APP_DEBUG=false \
 MAILER_DSN=null://null \
 ILIOS_LOCALE=en \
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt \
-ILIOS_REQUIRE_SECURE_CONNECTION=false
+ILIOS_REQUIRE_SECURE_CONNECTION=false \
+MESSENGER_TRANSPORT_DSN=doctrine://default
 
 WORKDIR /var/www/ilios
 RUN /usr/bin/touch .env


### PR DESCRIPTION
This is required here as well as in the PHP base as this container is
standalone.