### PR TITLE
Improve handling of missing data in JSON:API

### DIFF
--- a/src/Encoder/JsonApiEncoder.php
+++ b/src/Encoder/JsonApiEncoder.php
@@ -44,9 +44,7 @@ class JsonApiEncoder implements EncoderInterface, DecoderInterface
         $shaped = $this->dataShaper->shapeData($data, $context['sideLoadFields']);
 
         if (array_key_exists('singleItem', $context) && $context['singleItem']) {
-            $data = $shaped['data'];
-            $item = $data[0];
-            $shaped['data'] = $item;
+            $shaped['data'] = $shaped['data'][0] ?? null;
         }
 
         return json_encode($shaped);


### PR DESCRIPTION
When data was not present or the user didn't have permission to access
it we were throwing a PHP warning here since the array didn't have an
index at 0. By using null coalescing here we can avoid the warning and
still return the same data.

Fixes #3640