### PR TITLE
Filter GraphQL results by ID

### DIFF
--- a/src/Service/GraphQL/TypeRegistry.php
+++ b/src/Service/GraphQL/TypeRegistry.php
@@ -19,7 +19,6 @@ class TypeRegistry
 {
     private const CACHE_KEY = 'ilios-graphql-type-registry';
     protected array $types = [];
-    protected Inflector $inflector;
 
     public function __construct(
         protected EntityMetadata $entityMetadata,
@@ -28,7 +27,6 @@ class TypeRegistry
         protected TypeResolver $typeResolver,
         protected FieldResolver $fieldResolver,
     ) {
-        $this->inflector = InflectorFactory::create();
     }
 
     public function getTypes(): array
@@ -132,17 +130,12 @@ class TypeRegistry
         $idProperty = array_values($idProperties)[0];
         $type = $this->entityMetadata->getTypeOfProperty($idProperty);
         $name = $idProperty->getName();
-        $pluralName = $this->inflector->pluralize($name);
-        $type = match ($type) {
-            'string' => Type::string(),
-            'integer' => Type::int(),
-        };
         return [
             $name => [
-                'type' => $type
-            ],
-            $pluralName => [
-                'type' => Type::listOf($type)
+                'type' => Type::listOf(match ($type) {
+                    'string' => Type::string(),
+                    'integer' => Type::int(),
+                })
             ]
         ];
     }

--- a/src/Service/GraphQL/TypeRegistry.php
+++ b/src/Service/GraphQL/TypeRegistry.php
@@ -9,12 +9,16 @@ use App\Service\EntityMetadata;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use ReflectionProperty;
+use Symfony\Component\String\Inflector\EnglishInflector;
 use Symfony\Contracts\Cache\CacheInterface;
+
+use function array_key_exists;
 
 class TypeRegistry
 {
     private const CACHE_KEY = 'ilios-graphql-type-registry';
     protected array $types = [];
+    protected EnglishInflector $inflector;
 
     public function __construct(
         protected EntityMetadata $entityMetadata,
@@ -23,6 +27,7 @@ class TypeRegistry
         protected TypeResolver $typeResolver,
         protected FieldResolver $fieldResolver,
     ) {
+        $this->inflector = new EnglishInflector();
     }
 
     public function getTypes(): array
@@ -69,8 +74,12 @@ class TypeRegistry
 
     protected function getType(string $name): ObjectType
     {
-        $def = $this->getTypeDefinition($name);
-        return new ObjectType($def);
+        if (!array_key_exists($name, $this->types)) {
+            $def = $this->getTypeDefinition($name);
+            $this->types[$name] = new ObjectType($def);
+        }
+
+        return $this->types[$name];
     }
 
     protected function buildPropertyField(ReflectionProperty $property): array

--- a/src/Service/GraphQL/TypeResolver.php
+++ b/src/Service/GraphQL/TypeResolver.php
@@ -19,8 +19,6 @@ use function call_user_func;
 
 class TypeResolver
 {
-    protected Inflector $inflector;
-
     public function __construct(
         protected DTOInfo $dtoInfo,
         protected EntityMetadata $entityMetadata,
@@ -28,7 +26,6 @@ class TypeResolver
         protected DeferredBuffer $buffer,
         protected AuthorizationCheckerInterface $authorizationChecker,
     ) {
-        $this->inflector = InflectorFactory::create();
     }
 
     public function __invoke($source, $args, $context, ResolveInfo $info)
@@ -50,16 +47,9 @@ class TypeResolver
             });
         }
 
-        // $args can be id or ids, but in both cases we have to pass id to the repository
-        $criteria = [];
-        foreach ($args as $key => $value) {
-            if (is_array($value)) {
-                $key = $this->inflector->singularize($key);
-            }
-            $criteria[$key] = $value;
-        }
-
-        return $this->filterValues($repository->findDTOsBy($criteria));
+        //we can pass $ars directly because our GraphQL library will reject
+        //any args that aren't part of our schema
+        return $this->filterValues($repository->findDTOsBy($args));
     }
 
     protected function getRef(string $fieldName, ?object $source): ReflectionClass

--- a/src/Service/GraphQL/TypeResolver.php
+++ b/src/Service/GraphQL/TypeResolver.php
@@ -45,7 +45,7 @@ class TypeResolver
             });
         }
 
-        return $this->filterValues($repository->findDTOsBy([]));
+        return $this->filterValues($repository->findDTOsBy($args));
     }
 
     protected function getRef(string $fieldName, ?object $source): ReflectionClass

--- a/tests/DataLoader/AbstractDataLoader.php
+++ b/tests/DataLoader/AbstractDataLoader.php
@@ -9,10 +9,13 @@ use App\Attribute\Related;
 use App\Service\EntityRepositoryLookup;
 use App\Service\EntityMetadata;
 use DateTime;
-use Exception;
 use Faker\Factory as FakerFactory;
 use ReflectionClass;
 use ReflectionProperty;
+
+use function array_filter;
+use function array_map;
+use function array_values;
 
 /**
  * Abstract utilities for loading data
@@ -172,5 +175,23 @@ abstract class AbstractDataLoader implements DataLoaderInterface
         $names = array_map(fn(ReflectionProperty $p) => $p->name, $scalarProperties);
 
         return array_values($names);
+    }
+
+    /**
+     * Get all the scalar fields (not relationships) of a DTO
+     */
+    public function getIdField(): string
+    {
+        $class = $this->getDtoClass();
+        $reflection = new ReflectionClass($class);
+        $properties = $this->entityMetadata->extractExposedProperties($reflection);
+        $scalarProperties = array_filter(
+            $properties,
+            fn(ReflectionProperty $p) => $p->getAttributes(Id::class)
+        );
+
+        $names = array_map(fn(ReflectionProperty $p) => $p->name, $scalarProperties);
+
+        return array_values($names)[0];
     }
 }

--- a/tests/DataLoader/DataLoaderInterface.php
+++ b/tests/DataLoader/DataLoaderInterface.php
@@ -56,4 +56,9 @@ interface DataLoaderInterface
      * Get all scalar fields for a data type
      */
     public function getScalarFields(): array;
+
+    /**
+     * Get all scalar fields for a data type
+     */
+    public function getIdField(): string;
 }

--- a/tests/GetEndpointTestable.php
+++ b/tests/GetEndpointTestable.php
@@ -32,6 +32,7 @@ trait GetEndpointTestable
         $this->getAllWithLimitAndOffsetJsonApiTest();
         if (property_exists($this, 'isGraphQLTestable') && $this->isGraphQLTestable) {
             $this->getAllGraphQLTest();
+            $this->getSomeGraphQLTest();
         }
     }
 


### PR DESCRIPTION
Big performance improvement in not loading a bunch of data we don't need. This enabled a query like `"query { schools(id: [1, 3]) { id } }"` which will only load the schools with id 1,3. I made a judgement call to simplify this API and just call it `id` even though it takes an array of IDs. We could also have an `id` and `ids`, but that seems unnecessary at this point.