### PR TITLE
Return HTTP_UNAUTHORIZED when user isn't authenticated

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -39,11 +39,11 @@ class AuthController extends AbstractController
             /** @var SessionUserInterface $sessionUser */
             $sessionUser = $token->getUser();
             if ($sessionUser instanceof SessionUserInterface) {
-                return new JsonResponse(['userId' => $sessionUser->getId()], JsonResponse::HTTP_OK);
+                return new JsonResponse(['userId' => $sessionUser->getId()], Response::HTTP_OK);
             }
         }
 
-        return new JsonResponse(['userId' => null], Response::HTTP_OK);
+        return new JsonResponse(['userId' => null], Response::HTTP_UNAUTHORIZED);
     }
 
     /**
@@ -65,7 +65,7 @@ class AuthController extends AbstractController
             }
         }
 
-        return new JsonResponse(['jwt' => null], JsonResponse::HTTP_OK);
+        return new JsonResponse(['jwt' => null], Response::HTTP_UNAUTHORIZED);
     }
 
     /**


### PR DESCRIPTION
Return a 401 is correct, the 200 wasn't.

Fixes #3657 