### PR TITLE
Disable tracing in test env

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -4,3 +4,8 @@ sentry:
     dsn: '%env(SENTRY_DSN)%'
     options:
         before_send: 'App\Service\SentryBeforeSend'
+
+when@test:
+    sentry:
+        dsn: ~
+        tracing: false


### PR DESCRIPTION
This conflicts with out fixtures loader and causes other weird issues,
we don't need it here so disable it.