### PR TITLE
Catch missing data correctly

### DIFF
--- a/src/Controller/SchooleventController.php
+++ b/src/Controller/SchooleventController.php
@@ -60,8 +60,8 @@ class SchooleventController extends AbstractController
             }
             $events = $schoolRepository->findSessionEventsForSchool($school->getId(), $session->getId());
         } else {
-            $fromTimestamp = $request->get('from');
-            $toTimestamp = $request->get('to');
+            $fromTimestamp = $request->get('from') ?? '';
+            $toTimestamp = $request->get('to') ?? '';
             $from = DateTime::createFromFormat('U', $fromTimestamp);
             $to = DateTime::createFromFormat('U', $toTimestamp);
 

--- a/src/Controller/UsereventController.php
+++ b/src/Controller/UsereventController.php
@@ -67,8 +67,8 @@ class UsereventController extends AbstractController
             }
             $events = $repository->findSessionEventsForUser($user->getId(), $session->getId());
         } else {
-            $fromTimestamp = $request->get('from');
-            $toTimestamp = $request->get('to');
+            $fromTimestamp = $request->get('from') ?? '';
+            $toTimestamp = $request->get('to') ?? '';
             $from = DateTime::createFromFormat('U', $fromTimestamp);
             $to = DateTime::createFromFormat('U', $toTimestamp);
 

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -631,6 +631,56 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertEquals($users[3]['displayName'], $events[0]['instructors'][1]);
     }
 
+    public function testMissingFrom()
+    {
+        $school = self::getContainer()->get(SchoolData::class)->getOne();
+        $parameters = [
+            'version' => $this->apiVersion,
+            'id' => $school['id'],
+            'to' => 1000000
+        ];
+        $url = $this->getUrl(
+            $this->kernelBrowser,
+            'ilios_api_schoolevents',
+            $parameters
+        );
+        $this->createJsonRequest(
+            'GET',
+            $url,
+            null,
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
+    }
+
+    public function testMissingT0()
+    {
+        $school = self::getContainer()->get(SchoolData::class)->getOne();
+        $parameters = [
+            'version' => $this->apiVersion,
+            'id' => $school['id'],
+            'from' => 1000000
+        ];
+        $url = $this->getUrl(
+            $this->kernelBrowser,
+            'ilios_api_schoolevents',
+            $parameters
+        );
+        $this->createJsonRequest(
+            'GET',
+            $url,
+            null,
+            $this->getAuthenticatedUserToken($this->kernelBrowser)
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
+    }
+
     protected function getEvents($schoolId, $from, $to, $userId = null)
     {
         $parameters = [

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -1041,6 +1041,56 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertSame($users[3]['displayName'], $events[0]['instructors'][1]);
     }
 
+    public function testMissingFrom()
+    {
+        $userId = 5;
+        $parameters = [
+            'version' => $this->apiVersion,
+            'id' => $userId,
+            'to' => 1000,
+        ];
+        $url = $this->getUrl(
+            $this->kernelBrowser,
+            'ilios_api_userevents',
+            $parameters
+        );
+        $this->createJsonRequest(
+            'GET',
+            $url,
+            null,
+            $this->getTokenForUser($this->kernelBrowser, $userId)
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
+    }
+
+    public function testMissingTo()
+    {
+        $userId = 5;
+        $parameters = [
+            'version' => $this->apiVersion,
+            'id' => $userId,
+            'from' => 1000,
+        ];
+        $url = $this->getUrl(
+            $this->kernelBrowser,
+            'ilios_api_userevents',
+            $parameters
+        );
+        $this->createJsonRequest(
+            'GET',
+            $url,
+            null,
+            $this->getTokenForUser($this->kernelBrowser, $userId)
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
+    }
+
     /**
      * @param int $userId
      * @param int $from


### PR DESCRIPTION
In both user and school events we have a check to ensure that from/to
are sent with the request, however that was failing because of strict
type checking. Fixed and added tests.

Fixes #3678