### PR TITLE
Send User IDs with Sentry Errors

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -4,6 +4,7 @@ sentry:
     dsn: '%env(SENTRY_DSN)%'
     options:
         before_send: 'App\Service\SentryBeforeSend'
+        send_default_pii: true
 
 when@test:
     sentry:


### PR DESCRIPTION
This extracts user data from the symfony token and sends it along for
the logs.