### PR TITLE
Add Version to Docker Build

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -35,5 +35,6 @@ jobs:
       with:
         tags: |
             ilios/${{ matrix.image }}:latest
+        build-args: ILIOS_VERSION=dev
         target: ${{ matrix.image }}
         push: true

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -57,6 +57,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         tags: ilios/ilios/${{ matrix.image }}:${{needs.tags.outputs.major}},ilios/ilios/${{ matrix.image }}:${{needs.tags.outputs.minor}},ilios/ilios/${{ matrix.image }}:${{needs.tags.outputs.patch}}
+        build-args: ILIOS_VERSION=${{needs.tags.outputs.patch}}
         target: ${{ matrix.image }}
         push: true
   deploy-docker-containers:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ FakeTestFiles
 !/public/.htaccess
 !/public/theme-overrides
 
+# Created by docker build, shouldn't leak into app
+VERSION
+
 ###> squizlabs/php_codesniffer ###
 /.phpcs-cache
 /phpcs.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
 COPY --from=src /src /var/www/ilios
 COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template
 ENV FPM_CONTAINERS=fpm:9000
+ARG ILIOS_VERSION="v0.1.0"
+RUN echo ${ILIOS_VERSION} > VERSION
 
 ###############################################################################
 # Dependencies we need in all PHP containers
@@ -79,6 +81,8 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY ./docker/php.ini $PHP_INI_DIR/conf.d/ilios.ini
 #Override the default entrypoint script with our own
 COPY docker/php-fpm-entrypoint /usr/local/bin/docker-php-entrypoint
+ARG ILIOS_VERSION="v0.1.0"
+RUN echo ${ILIOS_VERSION} > VERSION
 
 ###############################################################################
 # FPM configured to run ilios
@@ -255,6 +259,9 @@ RUN /usr/bin/composer install \
     #creates an empty env.php file, real ENV values will control the app
     && /usr/bin/composer dump-env prod \
     && /usr/bin/composer clear-cache
+
+ARG ILIOS_VERSION="v0.1.0"
+RUN echo ${ILIOS_VERSION} > VERSION
 
 USER root
 RUN chown -R www-data:www-data /var/www/ilios


### PR DESCRIPTION
We were relying on the git tag for the version, however it doesn't
actually end up in the image so we need to pass the version in through
the build.