### PR TITLE
Add ARM builds to our docker builds

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -37,4 +37,5 @@ jobs:
             ilios/${{ matrix.image }}:latest
         build-args: ILIOS_VERSION=dev
         target: ${{ matrix.image }}
+        platforms: linux/amd64,linux/arm64
         push: true


### PR DESCRIPTION
This will allow our containers to run natively on Apple Silicon.

I'm not sure if Github can build this architecture without an emulation layer, but we'll have to merge this to find out. I can't think of any other way to test it.