### PR TITLE
Split mysql containers off for single platform build

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -5,7 +5,7 @@ on:
       - master
 
 jobs:
-  deploy-containers:
+  deploy--multi-platform-containers:
     name: Deploy Containers
     runs-on: ubuntu-latest
     strategy:
@@ -19,9 +19,32 @@ jobs:
           - migrate-database
           - update-frontend
           - consume-messages
+          - elasticsearch
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: zorgbort
+        password: ${{ secrets.ZORGBORT_DOCKER_TOKEN }}
+    - name: Multi Platform ${{ matrix.image }} to Docker Registry
+      uses: docker/build-push-action@v2
+      with:
+        tags: |
+            ilios/${{ matrix.image }}:latest
+        build-args: ILIOS_VERSION=dev
+        target: ${{ matrix.image }}
+        platforms: linux/amd64,linux/arm64
+        push: true
+  deploy-single-platform-containers:
+    name: Deploy Containers
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
           - mysql
           - mysql-demo
-          - elasticsearch
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -37,5 +60,4 @@ jobs:
             ilios/${{ matrix.image }}:latest
         build-args: ILIOS_VERSION=dev
         target: ${{ matrix.image }}
-        platforms: linux/amd64,linux/arm64
         push: true


### PR DESCRIPTION
The official mysql image doens't have an arm64 build for us to draft off
of so we'll have to skip multi-platform building for our images which
extend it.