### PR TITLE
Remove HTML spacing elements

### DIFF
--- a/config/packages/exercise_html_purifier.yaml
+++ b/config/packages/exercise_html_purifier.yaml
@@ -5,9 +5,11 @@ exercise_html_purifier:
       config:
         # the charset used by the original contents
         Core.Encoding: 'UTF-8'
-        HTML.Allowed: 'a[href|target],br,div,dd,dl,dt,em,li,ol,p,strong,sub,sup,ul'
+        HTML.Allowed: 'a[href|target],div,dd,dl,dt,em,li,ol,p,strong,sub,sup,ul'
         Attr.AllowedFrameTargets:
           - '_blank'
+        AutoFormat.RemoveEmpty: true
+        AutoFormat.RemoveEmpty.RemoveNbsp: true
         # full configuration reference: http://htmlpurifier.org/live/configdoc/plain.html
 
 # Read the https://github.com/Exercise/HTMLPurifierBundle/blob/master/README.md file

--- a/src/Repository/CourseLearningMaterialRepository.php
+++ b/src/Repository/CourseLearningMaterialRepository.php
@@ -106,12 +106,9 @@ class CourseLearningMaterialRepository extends ServiceEntityRepository implement
         $this->attachClosingCriteriaToQueryBuilder($qb, $criteria, $orderBy, $limit, $offset);
     }
 
-    /**
-     * @return int
-     */
-    public function getTotalCourseLearningMaterialCount()
+    public function getTotalCourseLearningMaterialCount(): int
     {
-        return $this->_em->createQuery('SELECT COUNT(l.id) FROM App\Entity\CourseLearningMaterial l')
+        return (int) $this->_em->createQuery('SELECT COUNT(l.id) FROM App\Entity\CourseLearningMaterial l')
             ->getSingleScalarResult();
     }
 }

--- a/src/Repository/SessionLearningMaterialRepository.php
+++ b/src/Repository/SessionLearningMaterialRepository.php
@@ -118,12 +118,9 @@ class SessionLearningMaterialRepository extends ServiceEntityRepository implemen
         $this->attachClosingCriteriaToQueryBuilder($qb, $criteria, $orderBy, $limit, $offset);
     }
 
-    /**
-     * @return int
-     */
-    public function getTotalSessionLearningMaterialCount()
+    public function getTotalSessionLearningMaterialCount(): int
     {
-        return $this->_em->createQuery('SELECT COUNT(l.id) FROM App\Entity\SessionLearningMaterial l')
+        return (int) $this->_em->createQuery('SELECT COUNT(l.id) FROM App\Entity\SessionLearningMaterial l')
             ->getSingleScalarResult();
     }
 }

--- a/tests/Command/CleanupStringsCommandTest.php
+++ b/tests/Command/CleanupStringsCommandTest.php
@@ -53,7 +53,7 @@ class CleanupStringsCommandTest extends KernelTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->purifier = m::mock(HTMLPurifier::class);
+        $this->purifier = static::getContainer()->get(HTMLPurifier::class);
         $this->sessionObjectiveRepository = m::mock(SessionObjectiveRepository::class);
         $this->courseObjectiveRepository = m::mock(CourseObjectiveRepository::class);
         $this->programYearObjectiveRepository = m::mock(ProgramYearObjectiveRepository::class);
@@ -109,7 +109,7 @@ class CleanupStringsCommandTest extends KernelTestCase
             ->mock();
         $dirtySessionObjective = m::mock(SessionObjectiveInterface::class)
             ->shouldReceive('getTitle')->andReturn('<script>alert();</script><h1>html title</h1>')
-            ->shouldReceive('setTitle')->with('<h1>html title</h1>')
+            ->shouldReceive('setTitle')->with('html title')
             ->mock();
         $this->sessionObjectiveRepository->shouldReceive('findBy')->with([], ['id' => 'ASC'], 500, 0)
             ->andReturn([$cleanSessionObjective, $dirtySessionObjective]);
@@ -121,7 +121,7 @@ class CleanupStringsCommandTest extends KernelTestCase
             ->mock();
         $dirtyCourseObjective = m::mock(CourseObjectiveInterface::class)
             ->shouldReceive('getTitle')->andReturn('<script>alert();</script><h1>html title</h1>')
-            ->shouldReceive('setTitle')->with('<h1>html title</h1>')
+            ->shouldReceive('setTitle')->with('html title')
             ->mock();
         $this->courseObjectiveRepository->shouldReceive('findBy')->with([], ['id' => 'ASC'], 500, 0)
             ->andReturn([$cleanCourseObjective, $dirtyCourseObjective]);
@@ -133,21 +133,13 @@ class CleanupStringsCommandTest extends KernelTestCase
             ->mock();
         $dirtyProgramYearObjective = m::mock(ProgramYearObjectiveInterface::class)
             ->shouldReceive('getTitle')->andReturn('<script>alert();</script><h1>html title</h1>')
-            ->shouldReceive('setTitle')->with('<h1>html title</h1>')
+            ->shouldReceive('setTitle')->with('html title')
             ->mock();
         $this->programYearObjectiveRepository->shouldReceive('findBy')->with([], ['id' => 'ASC'], 500, 0)
             ->andReturn([$cleanPyObjective, $dirtyProgramYearObjective]);
         $this->programYearObjectiveRepository->shouldReceive('update')->with($dirtyProgramYearObjective, false);
         $this->programYearObjectiveRepository->shouldReceive('getTotalObjectiveCount')->andReturn(2);
 
-        $this->purifier->shouldReceive('purify')
-            ->with('clean title')
-            ->andReturn('clean title')
-            ->times(3);
-        $this->purifier->shouldReceive('purify')
-            ->with('<script>alert();</script><h1>html title</h1>')
-            ->andReturn('<h1>html title</h1>')
-            ->times(3);
         $this->em->shouldReceive('flush')->times(3);
         $this->em->shouldReceive('clear')->times(3);
         $this->commandTester->execute([
@@ -170,7 +162,7 @@ class CleanupStringsCommandTest extends KernelTestCase
             ->mock();
         $dirty = m::mock('App\Entity\LearningMaterialInterface')
             ->shouldReceive('getDescription')->andReturn('<script>alert();</script><h1>html title</h1>')
-            ->shouldReceive('setDescription')->with('<h1>html title</h1>')
+            ->shouldReceive('setDescription')->with('html title')
             ->mock();
         $this->learningMaterialRepository->shouldReceive('findBy')
             ->with([], ['id' => 'ASC'], 500, 0)
@@ -178,10 +170,6 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->learningMaterialRepository->shouldReceive('update')->with($dirty, false);
         $this->learningMaterialRepository->shouldReceive('getTotalLearningMaterialCount')->andReturn(2);
 
-        $this->purifier->shouldReceive('purify')->with('clean title')->andReturn('clean title');
-        $this->purifier->shouldReceive('purify')
-            ->with('<script>alert();</script><h1>html title</h1>')
-            ->andReturn('<h1>html title</h1>');
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute([
@@ -204,7 +192,7 @@ class CleanupStringsCommandTest extends KernelTestCase
             ->mock();
         $dirtyCourse = m::mock('App\Entity\CourseLearningMaterialInterface')
             ->shouldReceive('getNotes')->andReturn('<script>alert();</script><h1>html course note</h1>')
-            ->shouldReceive('setNotes')->with('<h1>html course note</h1>')
+            ->shouldReceive('setNotes')->with('html course note')
             ->mock();
         $this->courseLearningMaterialRepository->shouldReceive('findBy')
             ->with([], ['id' => 'ASC'], 500, 0)
@@ -212,18 +200,12 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->courseLearningMaterialRepository->shouldReceive('update')->with($dirtyCourse, false);
         $this->courseLearningMaterialRepository->shouldReceive('getTotalCourseLearningMaterialCount')->andReturn(2);
 
-        $this->purifier->shouldReceive('purify')->with('clean course note')->andReturn('clean course note');
-        $this->purifier->shouldReceive('purify')
-            ->with('<script>alert();</script><h1>html course note</h1>')
-            ->andReturn('<h1>html course note</h1>');
-
-
         $cleanSession = m::mock('App\Entity\SessionLearningMaterialInterface')
             ->shouldReceive('getNotes')->andReturn('clean session note')
             ->mock();
         $dirtySession = m::mock('App\Entity\SessionLearningMaterialInterface')
             ->shouldReceive('getNotes')->andReturn('<script>alert();</script><h1>html session note</h1>')
-            ->shouldReceive('setNotes')->with('<h1>html session note</h1>')
+            ->shouldReceive('setNotes')->with('html session note')
             ->mock();
         $this->sessionLearningMaterialRepository->shouldReceive('findBy')
             ->with([], ['id' => 'ASC'], 500, 0)
@@ -231,11 +213,6 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->sessionLearningMaterialRepository->shouldReceive('update')
             ->with($dirtySession, false);
         $this->sessionLearningMaterialRepository->shouldReceive('getTotalSessionLearningMaterialCount')->andReturn(2);
-
-        $this->purifier->shouldReceive('purify')->with('clean session note')->andReturn('clean session note');
-        $this->purifier->shouldReceive('purify')
-            ->with('<script>alert();</script><h1>html session note</h1>')
-            ->andReturn('<h1>html session note</h1>');
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->twice();
@@ -266,7 +243,7 @@ class CleanupStringsCommandTest extends KernelTestCase
             ->mock();
         $dirty = m::mock(SessionInterface::class)
             ->shouldReceive('getDescription')->andReturn('<script>alert();</script><h1>html title</h1>')
-            ->shouldReceive('setDescription')->with('<h1>html title</h1>')
+            ->shouldReceive('setDescription')->with('html title')
             ->mock();
         $this->sessionRepository->shouldReceive('findBy')
             ->with([], ['id' => 'ASC'], 500, 0)
@@ -274,10 +251,6 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->sessionRepository->shouldReceive('update')->with($dirty, false);
         $this->sessionRepository->shouldReceive('getTotalSessionCount')->andReturn(2);
 
-        $this->purifier->shouldReceive('purify')->with('clean title')->andReturn('clean title');
-        $this->purifier->shouldReceive('purify')
-            ->with('<script>alert();</script><h1>html title</h1>')
-            ->andReturn('<h1>html title</h1>');
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute([


### PR DESCRIPTION
These blank constructs like `<p><br /></p>` are often inserted by Froala, but they don't play nice with styling on the frontend. After this change I ran our `CleanupStrings` command against demo data and see:

```
$ bin/console ilios:cleanup-strings --session-description --objective-title --learningmaterial-description --learningmaterial-note --learningmaterial-links
Starting cleanup of objective titles...
 159840/159840 [============================] 100%
9999 Objective Titles updated.
Starting cleanup of learning material description...
 78350/78350 [============================] 100%
1292 Learning Material Descriptions updated.
Starting cleanup of course learning material notes...
 2141/2141 [============================] 100%
0 Course Learning Material Notes updated.

Starting cleanup of session learning material notes...
 83910/83910 [============================] 100%
134 Session Learning Material Notes updated.
Starting cleanup of session descriptions...
 50427/50427 [============================] 100%
7991 Session Descriptions updated.
Starting cleanup of learning material links...
 78350/78350 [============================] 100%
307 learning material links updated, 86 failures.
```