### PR TITLE
Disable Sentry entirely in tests and dev environments

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -15,5 +15,5 @@ return [
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Liip\TestFixturesBundle\LiipTestFixturesBundle::class => ['dev' => true, 'test' => true],
     Shivas\VersioningBundle\ShivasVersioningBundle::class => ['all' => true],
-    Sentry\SentryBundle\SentryBundle::class => ['all' => true],
+    Sentry\SentryBundle\SentryBundle::class => ['prod' => true],
 ];

--- a/config/packages/prod/sentry.yaml
+++ b/config/packages/prod/sentry.yaml
@@ -6,7 +6,3 @@ sentry:
         before_send: 'App\Service\SentryBeforeSend'
         send_default_pii: true
 
-when@test:
-    sentry:
-        dsn: ~
-        tracing: false


### PR DESCRIPTION
We only need this in production and when it's loaded in tests it throws
an annoying error about the error_handler being removed even though it
is disabled. Ditch it entirely from where we don't need it.