### PR TITLE
Require authentication to access by default

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -2,6 +2,7 @@ security:
   enable_authenticator_manager: true
   access_control:
     - { path: ^/api/doc, roles: PUBLIC_ACCESS }
+    - { path: ^/api, roles: PUBLIC_ACCESS }
     - { path: ^/(auth|application)/(login|config|logout), roles: PUBLIC_ACCESS }
     - { path: '^/', roles: IS_AUTHENTICATED_FULLY }
   access_decision_manager:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -3,12 +3,14 @@ security:
   access_control:
     - { path: '^/api/doc', roles: PUBLIC_ACCESS }
     - { path: '^/api$', roles: PUBLIC_ACCESS }
-    - { path: '^/lm/[a-zA-Z0-9]{64}$', roles: PUBLIC_ACCESS }
-    - { path: '^/ci-report-dl/[a-zA-Z0-9]{64}$', roles: PUBLIC_ACCESS }
     - { path: '^/application/config', roles: PUBLIC_ACCESS }
     - { path: '^/auth/(login|logout)', roles: PUBLIC_ACCESS }
-    - { path: '^/ilios/health', roles: PUBLIC_ACCESS }
-    - { path: '^/', roles: IS_AUTHENTICATED_FULLY }
+    - { path: '^/auth', roles: IS_AUTHENTICATED_FULLY }
+    - { path: '^/api', roles: IS_AUTHENTICATED_FULLY }
+    - { path: '^/application', roles: IS_AUTHENTICATED_FULLY }
+    - { path: '^/upload', roles: IS_AUTHENTICATED_FULLY }
+    - { path: '^/error', roles: IS_AUTHENTICATED_FULLY }
+    - { path: '^/', roles: PUBLIC_ACCESS }
   access_decision_manager:
     allow_if_all_abstain: false
     strategy: unanimous

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -3,7 +3,7 @@ security:
   access_control:
     - { path: '^/api/doc', roles: PUBLIC_ACCESS }
     - { path: '^/api$', roles: PUBLIC_ACCESS }
-    - { path: '^/lm/\s+', roles: PUBLIC_ACCESS }
+    - { path: '^/lm/[a-zA-Z0-9]{64}$', roles: PUBLIC_ACCESS }
     - { path: '^/application/config', roles: PUBLIC_ACCESS }
     - { path: '^/auth/(login|logout)', roles: PUBLIC_ACCESS }
     - { path: '^/', roles: IS_AUTHENTICATED_FULLY }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,9 +1,11 @@
 security:
   enable_authenticator_manager: true
   access_control:
-    - { path: ^/api/doc, roles: PUBLIC_ACCESS }
-    - { path: ^/api, roles: PUBLIC_ACCESS }
-    - { path: ^/(auth|application)/(login|config|logout), roles: PUBLIC_ACCESS }
+    - { path: '^/api/doc', roles: PUBLIC_ACCESS }
+    - { path: '^/api$', roles: PUBLIC_ACCESS }
+    - { path: '^/lm/\s+', roles: PUBLIC_ACCESS }
+    - { path: '^/application/config', roles: PUBLIC_ACCESS }
+    - { path: '^/auth/(login|logout)', roles: PUBLIC_ACCESS }
     - { path: '^/', roles: IS_AUTHENTICATED_FULLY }
   access_decision_manager:
     allow_if_all_abstain: false
@@ -20,32 +22,7 @@ security:
     dev:
       pattern: ^/(_(profiler|wdt)|css|images|js)/
       security: false
-    authenticated_auth:
-      pattern:    ^/auth
-      stateless: true
-      custom_authenticators:
-        - App\Security\JsonWebTokenAuthenticator
-      provider: session_user
-    authenticated_application:
-      pattern:    ^/application
-      stateless: true
-      custom_authenticators:
-        - App\Security\JsonWebTokenAuthenticator
-      provider: session_user
-    upload:
-      pattern:    ^/upload
-      stateless: true
-      custom_authenticators:
-        - App\Security\JsonWebTokenAuthenticator
-      provider: session_user
-    errors:
-      pattern:    ^/errors
-      stateless: true
-      custom_authenticators:
-        - App\Security\JsonWebTokenAuthenticator
-      provider: session_user
-    default:
-      pattern:    ^/api
+    main:
       stateless: true
       custom_authenticators:
         - App\Security\JsonWebTokenAuthenticator

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,6 +4,7 @@ security:
     - { path: '^/api/doc', roles: PUBLIC_ACCESS }
     - { path: '^/api$', roles: PUBLIC_ACCESS }
     - { path: '^/lm/[a-zA-Z0-9]{64}$', roles: PUBLIC_ACCESS }
+    - { path: '^/ci-report-dl/[a-zA-Z0-9]{64}$', roles: PUBLIC_ACCESS }
     - { path: '^/application/config', roles: PUBLIC_ACCESS }
     - { path: '^/auth/(login|logout)', roles: PUBLIC_ACCESS }
     - { path: '^/', roles: IS_AUTHENTICATED_FULLY }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -7,6 +7,7 @@ security:
     - { path: '^/ci-report-dl/[a-zA-Z0-9]{64}$', roles: PUBLIC_ACCESS }
     - { path: '^/application/config', roles: PUBLIC_ACCESS }
     - { path: '^/auth/(login|logout)', roles: PUBLIC_ACCESS }
+    - { path: '^/ilios/health', roles: PUBLIC_ACCESS }
     - { path: '^/', roles: IS_AUTHENTICATED_FULLY }
   access_decision_manager:
     allow_if_all_abstain: false

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -3,6 +3,7 @@ security:
   access_control:
     - { path: ^/api/doc, roles: PUBLIC_ACCESS }
     - { path: ^/(auth|application)/(login|config|logout), roles: PUBLIC_ACCESS }
+    - { path: '^/', roles: IS_AUTHENTICATED_FULLY }
   access_decision_manager:
     allow_if_all_abstain: false
     strategy: unanimous

--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -961,6 +961,28 @@ abstract class AbstractEndpointTest extends WebTestCase
     }
 
     /**
+     * Test POSTing without authentication to the API
+     */
+    protected function anonymousDeniedPostTest(array $data)
+    {
+        $endpoint = $this->getPluralName();
+        $responseKey = $this->getCamelCasedPluralName();
+        $this->createJsonRequest(
+            'POST',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_${endpoint}_post",
+                ['version' => $this->apiVersion]
+            ),
+            json_encode([$responseKey => [$data]]),
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
      * Test POSTing bad data to the API
      * @param array $data
      * @param int $code
@@ -983,6 +1005,28 @@ abstract class AbstractEndpointTest extends WebTestCase
         $response = $this->kernelBrowser->getResponse();
 
         $this->assertJsonResponse($response, $code);
+    }
+
+    /**
+     * Test PUTing as anonymous to the API
+     */
+    protected function anonymousDeniedPutTest(array $data)
+    {
+        $endpoint = $this->getPluralName();
+        $responseKey = $this->getCamelCasedPluralName();
+        $this->createJsonRequest(
+            'PUT',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_${endpoint}_put",
+                ['version' => $this->apiVersion, 'id' => $data['id']]
+            ),
+            json_encode([$responseKey => [$data]]),
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
     }
 
     /**
@@ -1127,6 +1171,28 @@ abstract class AbstractEndpointTest extends WebTestCase
     }
 
     /**
+     * Test PATCHing as anonymous to the API
+     */
+    protected function anonymousDeniedPatchTest(array $data)
+    {
+        $endpoint = $this->getPluralName();
+        $responseKey = $this->getCamelCasedPluralName();
+        $this->createJsonRequest(
+            'PATCH',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_${endpoint}_patch",
+                ['version' => $this->apiVersion, 'id' => $data['id']]
+            ),
+            json_encode([$responseKey => [$data]]),
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
      * Test deleting an object from the API
      *
      * @param $id
@@ -1189,6 +1255,49 @@ abstract class AbstractEndpointTest extends WebTestCase
         $response = $this->kernelBrowser->getResponse();
 
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Ensure that anonymous users cannot access the resource
+     */
+    protected function anonymousAccessDeniedOneTest()
+    {
+        $endpoint = $this->getPluralName();
+        $loader = $this->getDataLoader();
+        $data = $loader->getOne();
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_${endpoint}_getone",
+                ['version' => $this->apiVersion, 'id' => $data['id']]
+            ),
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * Ensure that anonymous users cannot access the resource
+     */
+    protected function anonymousAccessDeniedAllTest()
+    {
+        $endpoint = $this->getPluralName();
+        $loader = $this->getDataLoader();
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_${endpoint}_getall",
+                ['version' => $this->apiVersion]
+            ),
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
     }
 
     /**

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -72,4 +72,31 @@ class ApiControllerTest extends WebTestCase
         $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }
+
+    public function testApiInfoAuthenticated()
+    {
+        $this->kernelBrowser->request(
+            'GET',
+            '/api',
+            [],
+            [],
+            ['HTTP_X-JWT-Authorization' => 'Token ' . $this->getTokenForUser($this->kernelBrowser, 1)],
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertStringContainsString('<h1>API Info</h1>', $response->getContent());
+    }
+
+    public function testApiInfoNotAuthenticated()
+    {
+        $this->kernelBrowser->request(
+            'GET',
+            '/api',
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertStringContainsString('<h1>API Info</h1>', $response->getContent());
+    }
 }

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -158,9 +158,6 @@ class AuthControllerTest extends WebTestCase
 
         $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
-        $response = json_decode($response->getContent(), true);
-        $this->assertArrayHasKey('userId', $response);
-        $this->assertSame($response['userId'], null);
     }
 
     public function testWhoAmIExpiredToken()
@@ -242,9 +239,6 @@ class AuthControllerTest extends WebTestCase
         );
         $response = $this->kernelBrowser->getResponse();
         $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
-        $response = json_decode($response->getContent(), true);
-        $this->assertArrayHasKey('jwt', $response);
-        $this->assertSame($response['jwt'], null);
     }
 
     public function testGetTokenForExpiredToken()
@@ -301,7 +295,7 @@ class AuthControllerTest extends WebTestCase
         );
 
         $response = $this->kernelBrowser->getResponse();
-        $this->assertJsonResponse($response, Response::HTTP_INTERNAL_SERVER_ERROR);
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
     }
 
     protected function getExpiredToken(int $userId): string

--- a/tests/Controller/ErrorControllerTest.php
+++ b/tests/Controller/ErrorControllerTest.php
@@ -53,4 +53,23 @@ class ErrorControllerTest extends WebTestCase
         $response = $this->kernelBrowser->getResponse();
         $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode(), $response->getContent());
     }
+
+    public function testAnonymousAccessDenied()
+    {
+        $faker = FakerFactory::create();
+
+        $data = [
+            'mainMessage' => $faker->text(100),
+            'stack' => $faker->text(1000)
+        ];
+        $this->makeJsonRequest(
+            $this->kernelBrowser,
+            'POST',
+            '/errors',
+            json_encode(['data' => json_encode($data)])
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+    }
 }

--- a/tests/Controller/UploadControllerTest.php
+++ b/tests/Controller/UploadControllerTest.php
@@ -65,6 +65,22 @@ class UploadControllerTest extends WebTestCase
         $this->assertSame($data['filename'], 'TESTFILE.txt');
         $this->assertSame($data['fileHash'], md5_file(__FILE__));
     }
+    public function testAnonymousUploadFileDenied()
+    {
+        $client = static::createClient();
+
+        $this->makeJsonRequest(
+            $client,
+            'POST',
+            '/upload',
+            null,
+            [],
+            ['file' => $this->fakeTestFile]
+        );
+
+        $response = $client->getResponse();
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
 
     public function testBadUpload()
     {

--- a/tests/Endpoints/AcademicYearTest.php
+++ b/tests/Endpoints/AcademicYearTest.php
@@ -137,4 +137,37 @@ class AcademicYearTest extends ReadEndpointTest
 
         return $academicYears;
     }
+
+    public function anonymousAccessDeniedOneTest()
+    {
+        $academicYears = $this->getYears();
+        $id = $academicYears[0]['id'];
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_academicyears_getone",
+                ['version' => $this->apiVersion, 'id' => $id]
+            ),
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
+    public function anonymousAccessDeniedAllTest()
+    {
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_academicyears_getall",
+                ['version' => $this->apiVersion]
+            ),
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
 }

--- a/tests/Endpoints/AuthenticationTest.php
+++ b/tests/Endpoints/AuthenticationTest.php
@@ -552,4 +552,49 @@ class AuthenticationTest extends ReadWriteEndpointTest
             $this->putTest($data, $postData, $id);
         }
     }
+
+    public function anonymousAccessDeniedOneTest()
+    {
+        $loader = $this->getDataLoader();
+        $data = $loader->getOne();
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_authentications_getone",
+                ['version' => $this->apiVersion, 'id' => $data['user']]
+            ),
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
+    public function anonymousAccessDeniedAllTest()
+    {
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_authentications_getall",
+                ['version' => $this->apiVersion]
+            ),
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
+
+    protected function anonymousDeniedPutTest(array $data)
+    {
+        $data['id'] = $data['user'];
+        parent::anonymousDeniedPutTest($data);
+    }
+
+    protected function anonymousDeniedPatchTest(array $data)
+    {
+        $data['id'] = $data['user'];
+        parent::anonymousDeniedPatchTest($data);
+    }
 }

--- a/tests/Endpoints/CurrentSessionTest.php
+++ b/tests/Endpoints/CurrentSessionTest.php
@@ -42,7 +42,7 @@ class CurrentSessionTest extends WebTestCase
         unset($this->fixtures);
     }
 
-    public function testGetGetCurrentSession()
+    public function testGetCurrentSession()
     {
         $url = $this->getUrl(
             $this->kernelBrowser,
@@ -68,5 +68,21 @@ class CurrentSessionTest extends WebTestCase
         $data = json_decode($response->getContent(), true);
 
         $this->assertEquals(2, $data['userId']);
+    }
+    public function testAccessDeniedForAnonymousUser()
+    {
+        $url = $this->getUrl(
+            $this->kernelBrowser,
+            'ilios_api_currentsession',
+            ['version' => $this->apiVersion]
+        );
+        $this->makeJsonRequest(
+            $this->kernelBrowser,
+            'GET',
+            $url,
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
     }
 }

--- a/tests/Endpoints/CurriculumInventoryExportTest.php
+++ b/tests/Endpoints/CurriculumInventoryExportTest.php
@@ -132,4 +132,16 @@ class CurriculumInventoryExportTest extends AbstractEndpointTest
 
         $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND);
     }
+    public function testAnonymousPostDenied()
+    {
+        $url = '/api/' . $this->apiVersion . '/curriculuminventoryexports/';
+        $this->createJsonRequest(
+            'POST',
+            $url,
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
 }

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -681,6 +681,29 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
     }
 
+    public function testAccessDenied()
+    {
+        $parameters = [
+            'version' => $this->apiVersion,
+            'id' => 1,
+            'from' => 1000000,
+            'to' => 1000000,
+        ];
+        $url = $this->getUrl(
+            $this->kernelBrowser,
+            'ilios_api_schoolevents',
+            $parameters
+        );
+        $this->createJsonRequest(
+            'GET',
+            $url,
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
+
     protected function getEvents($schoolId, $from, $to, $userId = null)
     {
         $parameters = [

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -1091,6 +1091,29 @@ class UsereventTest extends AbstractEndpointTest
         $this->assertJsonResponse($response, Response::HTTP_BAD_REQUEST);
     }
 
+    public function testAccessDenied()
+    {
+        $parameters = [
+            'version' => $this->apiVersion,
+            'from' => 1000000,
+            'to' => 1000000,
+            'id' => 99,
+        ];
+        $url = $this->getUrl(
+            $this->kernelBrowser,
+            'ilios_api_userevents',
+            $parameters
+        );
+        $this->createJsonRequest(
+            'GET',
+            $url,
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
+
     /**
      * @param int $userId
      * @param int $from

--- a/tests/Endpoints/UsermaterialsTest.php
+++ b/tests/Endpoints/UsermaterialsTest.php
@@ -156,6 +156,28 @@ class UsermaterialsTest extends AbstractEndpointTest
         $this->assertCount(9, $materials, 'All materials returned');
     }
 
+    public function testAccessDenied()
+    {
+        $parameters = [
+            'version' => $this->apiVersion,
+            'id' => 99
+        ];
+        $url = $this->getUrl(
+            $this->kernelBrowser,
+            'ilios_api_usermaterials',
+            $parameters
+        );
+
+        $this->createJsonRequest(
+            'GET',
+            $url
+        );
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_UNAUTHORIZED);
+    }
+
     protected function getMaterials($userId, $before = null, $after = null, $authUser = null)
     {
         $parameters = [

--- a/tests/GetEndpointTestable.php
+++ b/tests/GetEndpointTestable.php
@@ -66,4 +66,10 @@ trait GetEndpointTestable
         }
         $this->filterTest($filters, $expectedData);
     }
+
+    public function testAccessDenied()
+    {
+        $this->anonymousAccessDeniedOneTest();
+        $this->anonymousAccessDeniedAllTest();
+    }
 }

--- a/tests/ReadWriteEndpointTest.php
+++ b/tests/ReadWriteEndpointTest.php
@@ -67,6 +67,16 @@ abstract class ReadWriteEndpointTest extends ReadEndpointTest
     }
 
     /**
+     * Test a failure when posting an object
+     */
+    public function testPostAnonymousAccessDenied()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->create();
+        $this->anonymousDeniedPostTest($data);
+    }
+
+    /**
      * Test POST several of this type of object
      */
     public function testPostMany()
@@ -225,5 +235,21 @@ abstract class ReadWriteEndpointTest extends ReadEndpointTest
         $dataLoader = $this->getDataLoader();
         $data = $dataLoader->getOne();
         $this->deleteTest($data['id']);
+    }
+
+    public function testPutAnonymousAccessDenied()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->getOne();
+
+        $this->anonymousDeniedPutTest($data);
+    }
+
+    public function testPatchAnonymousAccessDenied()
+    {
+        $dataLoader = $this->getDataLoader();
+        $data = $dataLoader->getOne();
+
+        $this->anonymousDeniedPatchTest($data);
     }
 }


### PR DESCRIPTION
When we updated our security config a change was needed to default
protect resources as it appears symfony moved to default allow with this
change. I've added a configuration option to protect everything by
default and added some tests to ensure this stays true.