### PR TITLE
Replace password encoder with hasher

### DIFF
--- a/src/Classes/SessionUser.php
+++ b/src/Classes/SessionUser.php
@@ -134,7 +134,7 @@ class SessionUser implements SessionUserInterface
         );
     }
 
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }

--- a/src/Classes/SessionUserInterface.php
+++ b/src/Classes/SessionUserInterface.php
@@ -6,11 +6,12 @@ namespace App\Classes;
 
 use App\Entity\SchoolInterface;
 use App\Entity\UserInterface as IliosUserInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use DateTime;
 
-interface SessionUserInterface extends UserInterface, EquatableInterface
+interface SessionUserInterface extends PasswordAuthenticatedUserInterface, UserInterface, EquatableInterface
 {
     /**
      * Is this user a root user

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -10,7 +10,6 @@ use App\Repository\UserRepository;
 use App\Service\SessionUserProvider;
 use App\Entity\AuthenticationInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,7 +17,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * Add a user by looking them up in the directory
@@ -31,7 +30,7 @@ class AddUserCommand extends Command
         protected UserRepository $userRepository,
         protected AuthenticationRepository $authenticationRepository,
         protected SchoolRepository $schoolRepository,
-        protected UserPasswordEncoderInterface $encoder,
+        protected UserPasswordHasherInterface $hasher,
         protected SessionUserProvider $sessionUserProvider
     ) {
         parent::__construct();
@@ -176,8 +175,8 @@ class AddUserCommand extends Command
             $user->setAuthentication($authentication);
             $sessionUser = $this->sessionUserProvider->createSessionUserFromUser($user);
 
-            $encodedPassword = $this->encoder->encodePassword($sessionUser, $userRecord['password']);
-            $authentication->setPasswordHash($encodedPassword);
+            $hashedPassword = $this->hasher->hashPassword($sessionUser, $userRecord['password']);
+            $authentication->setPasswordHash($hashedPassword);
 
             $this->authenticationRepository->update($authentication);
 

--- a/src/Command/ChangePasswordCommand.php
+++ b/src/Command/ChangePasswordCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * Change a users's password
@@ -26,7 +26,7 @@ class ChangePasswordCommand extends Command
     public function __construct(
         protected UserRepository $userRepository,
         protected AuthenticationRepository $authenticationRepository,
-        protected UserPasswordEncoderInterface $encoder,
+        protected UserPasswordHasherInterface $hasher,
         protected SessionUserProvider $sessionUserProvider
     ) {
         parent::__construct();
@@ -84,8 +84,8 @@ class ChangePasswordCommand extends Command
 
         $sessionUser = $this->sessionUserProvider->createSessionUserFromUser($user);
 
-        $encodedPassword = $this->encoder->encodePassword($sessionUser, $password);
-        $authentication->setPasswordHash($encodedPassword);
+        $hashedPassword = $this->hasher->hashPassword($sessionUser, $password);
+        $authentication->setPasswordHash($hashedPassword);
 
         $this->authenticationRepository->update($authentication);
 

--- a/src/Command/InstallFirstUserCommand.php
+++ b/src/Command/InstallFirstUserCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * Creates a first user account with Course Director privileges.
@@ -53,7 +53,7 @@ class InstallFirstUserCommand extends Command
         protected UserRepository $userRepository,
         protected SchoolRepository $schoolRepository,
         protected AuthenticationRepository $authenticationRepository,
-        protected UserPasswordEncoderInterface $passwordEncoder,
+        protected UserPasswordHasherInterface $passwordHasher,
         protected SessionUserProvider $sessionUserProvider
     ) {
         parent::__construct();
@@ -163,10 +163,10 @@ class InstallFirstUserCommand extends Command
         $user->setAuthentication($authentication);
         $sessionUser = $this->sessionUserProvider->createSessionUserFromUser($user);
 
-        $encodedPassword = $this->passwordEncoder->encodePassword($sessionUser, self::PASSWORD);
+        $hashedPassword = $this->passwordHasher->hashPassword($sessionUser, self::PASSWORD);
 
         $authentication->setUsername(self::USERNAME);
-        $authentication->setPasswordHash($encodedPassword);
+        $authentication->setPasswordHash($hashedPassword);
         $this->authenticationRepository->update($authentication);
 
         $output->writeln('Success!');

--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * Class AddUserCommandTest
@@ -32,7 +32,7 @@ class AddUserCommandTest extends KernelTestCase
     protected $userRepository;
     protected $authenticationRepository;
     protected $schoolRepository;
-    protected $encoder;
+    protected $hasher;
     protected $commandTester;
     protected $questionHelper;
     protected $sessionUserProvider;
@@ -43,7 +43,7 @@ class AddUserCommandTest extends KernelTestCase
         $this->userRepository = m::mock(UserRepository::class);
         $this->authenticationRepository = m::mock(AuthenticationRepository::class);
         $this->schoolRepository = m::mock(SchoolRepository::class);
-        $this->encoder = m::mock(UserPasswordEncoderInterface::class);
+        $this->hasher = m::mock(UserPasswordHasherInterface::class);
         $this->sessionUserProvider = m::mock(SessionUserProvider::class);
 
 
@@ -51,7 +51,7 @@ class AddUserCommandTest extends KernelTestCase
             $this->userRepository,
             $this->authenticationRepository,
             $this->schoolRepository,
-            $this->encoder,
+            $this->hasher,
             $this->sessionUserProvider
         );
 
@@ -332,7 +332,7 @@ class AddUserCommandTest extends KernelTestCase
         $user->shouldReceive('setAuthentication')->with($authentication);
 
 
-        $this->encoder->shouldReceive('encodePassword')->with($sessionUser, 'abc123pass')->andReturn('hashBlurb');
+        $this->hasher->shouldReceive('hashPassword')->with($sessionUser, 'abc123pass')->andReturn('hashBlurb');
 
         $this->userRepository->shouldReceive('findOneBy')->with(['campusId' => 'abc'])->andReturn(false);
         $this->userRepository->shouldReceive('findOneBy')->with(['email' => 'email@example.com'])->andReturn(false);

--- a/tests/Command/ChangePasswordCommandTest.php
+++ b/tests/Command/ChangePasswordCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * Class ChangePasswordCommandTest
@@ -38,8 +38,7 @@ class ChangePasswordCommandTest extends KernelTestCase
     protected $userRepository;
     /** @var AuthenticationRepository */
     protected $authenticationRepository;
-    /** @var UserPasswordEncoderInterface */
-    protected $encoder;
+    protected m\MockInterface|UserPasswordHasherInterface $hasher;
     /** @var SessionUserProvider */
     protected $sessionUserProvider;
 
@@ -48,13 +47,13 @@ class ChangePasswordCommandTest extends KernelTestCase
         parent::setUp();
         $this->userRepository = m::mock(UserRepository::class);
         $this->authenticationRepository = m::mock(AuthenticationRepository::class);
-        $this->encoder = m::mock(UserPasswordEncoderInterface::class);
+        $this->hasher = m::mock(UserPasswordHasherInterface::class);
         $this->sessionUserProvider = m::mock(SessionUserProvider::class);
 
         $command = new ChangePasswordCommand(
             $this->userRepository,
             $this->authenticationRepository,
-            $this->encoder,
+            $this->hasher,
             $this->sessionUserProvider
         );
         $kernel = self::bootKernel();
@@ -76,7 +75,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         parent::tearDown();
         unset($this->userRepository);
         unset($this->authenticationRepository);
-        unset($this->encoder);
+        unset($this->hasher);
         unset($this->sessionUserProvider);
         unset($this->commandTester);
     }
@@ -93,7 +92,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         $sessionUser = m::mock(SessionUserInterface::class);
         $this->sessionUserProvider->shouldReceive('createSessionUserFromUser')->with($user)->andReturn($sessionUser);
 
-        $this->encoder->shouldReceive('encodePassword')->with($sessionUser, '123456789')->andReturn('abc');
+        $this->hasher->shouldReceive('hashPassword')->with($sessionUser, '123456789')->andReturn('abc');
         $authentication->shouldReceive('setPasswordHash')->with('abc')->once();
 
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
@@ -122,7 +121,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         $sessionUser = m::mock(SessionUserInterface::class);
         $this->sessionUserProvider->shouldReceive('createSessionUserFromUser')->with($user)->andReturn($sessionUser);
 
-        $this->encoder->shouldReceive('encodePassword')->with($sessionUser, '123456789')->andReturn('abc');
+        $this->hasher->shouldReceive('hashPassword')->with($sessionUser, '123456789')->andReturn('abc');
         $authentication->shouldReceive('setPasswordHash')->with('abc')->once();
 
         $this->authenticationRepository->shouldReceive('update')->with($authentication);

--- a/tests/Command/InstallFirstUserCommandTest.php
+++ b/tests/Command/InstallFirstUserCommandTest.php
@@ -15,7 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * Class InstallFirstUserCommandTest
@@ -30,7 +30,7 @@ class InstallFirstUserCommandTest extends KernelTestCase
     protected $userRepository;
     protected $authenticationRepository;
     protected $schoolRepository;
-    protected $encoder;
+    protected $hasher;
     protected $questionHelper;
     protected $sessionUserProvider;
 
@@ -48,14 +48,14 @@ class InstallFirstUserCommandTest extends KernelTestCase
         $this->userRepository = m::mock(UserRepository::class);
         $this->authenticationRepository = m::mock(AuthenticationRepository::class);
         $this->schoolRepository = m::mock(SchoolRepository::class);
-        $this->encoder = m::mock(UserPasswordEncoderInterface::class);
+        $this->hasher = m::mock(UserPasswordHasherInterface::class);
         $this->sessionUserProvider = m::mock(SessionUserProvider::class);
 
         $command = new InstallFirstUserCommand(
             $this->userRepository,
             $this->schoolRepository,
             $this->authenticationRepository,
-            $this->encoder,
+            $this->hasher,
             $this->sessionUserProvider
         );
         $kernel = self::bootKernel();
@@ -170,7 +170,7 @@ class InstallFirstUserCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('update')->with($user);
         $this->authenticationRepository->shouldReceive('create')->andReturn($authentication);
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
-        $this->encoder->shouldReceive('encodePassword')->with($sessionUser, 'Ch4nge_m3')->andReturn('hashBlurb');
+        $this->hasher->shouldReceive('hashPassword')->with($sessionUser, 'Ch4nge_m3')->andReturn('hashBlurb');
         $this->userRepository->shouldReceive('update');
         $this->sessionUserProvider->shouldReceive('createSessionUserFromUser')->with($user)->andReturn($sessionUser);
     }


### PR DESCRIPTION
This is essentially a semantic change to clear up what the service does.
The only iffy part is that the order of interfaces in SessionUser has to
be correct in order for the more specific getPassword with a return type
to be read.