### PR TITLE
Pull twig off the test container

### DIFF
--- a/tests/Command/SendTeachingRemindersCommandTest.php
+++ b/tests/Command/SendTeachingRemindersCommandTest.php
@@ -78,7 +78,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
         $command = new SendTeachingRemindersCommand(
             $this->fakeOfferingRepository,
             $this->fakeSchoolRepository,
-            $kernel->getContainer()->get('twig'),
+            static::getContainer()->get('twig'),
             $this->mailer,
             $config,
             $this->fs,


### PR DESCRIPTION
This is legal and the best way, we were relying on the service to be
public, but that is deprecated in future versions of Symfony.