### PR TITLE
Reset the container between messages

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,7 +1,7 @@
 framework:
   messenger:
     failure_transport: failed
-
+    reset_on_message: true
     transports:
       # https://symfony.com/doc/current/messenger.html#transport-configuration
        async: '%env(MESSENGER_TRANSPORT_DSN)%'


### PR DESCRIPTION
This prevents leaky services like the logger from holding onto memory.