### PR TITLE
Remove unnecessary cache

### DIFF
--- a/src/Service/GraphQL/TypeRegistry.php
+++ b/src/Service/GraphQL/TypeRegistry.php
@@ -17,7 +17,6 @@ use function array_key_exists;
 
 class TypeRegistry
 {
-    private const CACHE_KEY = 'ilios-graphql-type-registry';
     protected array $types = [];
 
     public function __construct(
@@ -30,14 +29,6 @@ class TypeRegistry
     }
 
     public function getTypes(): array
-    {
-        return $this->appCache->get(
-            self::CACHE_KEY,
-            fn () => $this->createTypeRegistry()
-        );
-    }
-
-    protected function createTypeRegistry(): array
     {
         $types = [];
         foreach ($this->dtoInfo->getGraphQLTypeList() as $name) {


### PR DESCRIPTION
Profiled this change and there is no difference between the cached and
uncached versions. This is probably because we use callbacks to build
portions of the schema only when they're needed. This use of callbacks
makes this cache unworkable with Symfony 5.4 so removing the cache makes
us ready to upgrade.

Profile of a fairly large request https://blackfire.io/profiles/compare/237f09e9-dc4a-47b7-97d4-55e61bb54bd9/graph