### PR TITLE
Replace Stringy lib with a utility method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "ext-zlib": "*",
     "composer/composer": "^2.1",
     "composer/package-versions-deprecated": "1.11.99.4",
-    "danielstjules/stringy": "^3.1",
     "doctrine/annotations": "^1.0",
     "doctrine/doctrine-bundle": "^2.4",
     "doctrine/doctrine-fixtures-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff913f0507b9a59b465c7e446ddd70aa",
+    "content-hash": "c99bfaf715cdd99dc56e2f21a03eab2a",
     "packages": [
         {
             "name": "async-aws/core",
@@ -1018,66 +1018,6 @@
                 }
             ],
             "time": "2021-12-08T13:07:32+00:00"
-        },
-        {
-            "name": "danielstjules/stringy",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/danielstjules/Stringy.git",
-                "reference": "df24ab62d2d8213bbbe88cc36fc35a4503b4bd7e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/danielstjules/Stringy/zipball/df24ab62d2d8213bbbe88cc36fc35a4503b4bd7e",
-                "reference": "df24ab62d2d8213bbbe88cc36fc35a4503b4bd7e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "symfony/polyfill-mbstring": "~1.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Stringy\\": "src/"
-                },
-                "files": [
-                    "src/Create.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel St. Jules",
-                    "email": "danielst.jules@gmail.com",
-                    "homepage": "http://www.danielstjules.com"
-                }
-            ],
-            "description": "A string manipulation library with multibyte support",
-            "homepage": "https://github.com/danielstjules/Stringy",
-            "keywords": [
-                "UTF",
-                "helpers",
-                "manipulation",
-                "methods",
-                "multibyte",
-                "string",
-                "utf-8",
-                "utility",
-                "utils"
-            ],
-            "support": {
-                "issues": "https://github.com/danielstjules/Stringy/issues",
-                "source": "https://github.com/danielstjules/Stringy"
-            },
-            "time": "2017-06-12T01:10:27+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -15310,5 +15250,5 @@
     "platform-overrides": {
         "php": "8.0.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -9,7 +9,8 @@ use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\ServerException;
 use Exception;
 
-use function Stringy\create as s;
+use function preg_replace;
+use function strtoupper;
 
 class Config
 {
@@ -55,7 +56,8 @@ class Config
      */
     protected function getValueFromEnv($name): string|bool|null
     {
-        $envName = 'ILIOS_' .  s($name)->underscored()->toUpperCase();
+        $snakeName = $this->camelToSnake($name);
+        $envName = 'ILIOS_' .  strtoupper($snakeName);
         $result = null;
         if (isset($_ENV[$envName])) {
             $result = $_ENV[$envName];
@@ -108,5 +110,15 @@ class Config
         }
 
         return $result;
+    }
+
+    /**
+     * Convert camelCaseString to camel_case_string
+     */
+    protected function camelToSnake(string $str): string
+    {
+        $rhett = preg_replace('/[A-Z]/', '_$0', $str);
+        $rhett = preg_replace('/[-\s]/', '_', $rhett);
+        return strtolower($rhett);
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -41,9 +41,6 @@
     "composer/xdebug-handler": {
         "version": "2.0.2"
     },
-    "danielstjules/stringy": {
-        "version": "3.1.0"
-    },
     "dealerdirect/phpcodesniffer-composer-installer": {
         "version": "v0.7.1"
     },

--- a/tests/Service/ConfigTest.php
+++ b/tests/Service/ConfigTest.php
@@ -9,8 +9,6 @@ use App\Service\Config;
 use Mockery as m;
 use App\Tests\TestCase;
 
-use function Stringy\create as s;
-
 /**
  * Class LoggerQueueTest
  * @package App\Tests\Classes
@@ -23,7 +21,7 @@ class ConfigTest extends TestCase
         $config = new Config($repository);
         $value = '123Test';
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertEquals($value, $result);
@@ -47,7 +45,7 @@ class ConfigTest extends TestCase
         $config = new Config($repository);
         $value = 'false';
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertTrue($result === false);
@@ -60,7 +58,7 @@ class ConfigTest extends TestCase
         $config = new Config($repository);
         $value = 'true';
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertTrue($result === true);
@@ -72,7 +70,7 @@ class ConfigTest extends TestCase
         $repository = m::mock(ApplicationConfigRepository::class);
         $config = new Config($repository);
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_ENV[$envKey] = 'null';
         $repository->shouldReceive('getValue')->with($key)->once();
         $config->get($key);
@@ -85,7 +83,7 @@ class ConfigTest extends TestCase
         $config = new Config($repository);
         $value = 'FALSE';
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertTrue($result === false);
@@ -98,7 +96,7 @@ class ConfigTest extends TestCase
         $config = new Config($repository);
         $value = 'TRUE';
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_ENV[$envKey] = $value;
         $result = $config->get($key);
         $this->assertTrue($result === true);
@@ -110,7 +108,7 @@ class ConfigTest extends TestCase
         $repository = m::mock(ApplicationConfigRepository::class);
         $config = new Config($repository);
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_ENV[$envKey] = 'NULL';
         $repository->shouldReceive('getValue')->with($key)->once();
         $config->get($key);
@@ -123,7 +121,7 @@ class ConfigTest extends TestCase
         $config = new Config($repository);
         $value = '123Test';
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_ENV[$envKey] = $value;
         $_SERVER[$envKey] = 'bad';
         $result = $config->get($key);
@@ -138,7 +136,7 @@ class ConfigTest extends TestCase
         $config = new Config($repository);
         $value = '123Test';
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_ENV[$envKey] = null;
         $_SERVER[$envKey] = $value;
         $result = $config->get($key);
@@ -153,7 +151,7 @@ class ConfigTest extends TestCase
         $config = new Config($repository);
         $value = '123Test';
         $key = 'random-key-99';
-        $envKey = 'ILIOS_' . s($key)->underscored()->toUpperCase();
+        $envKey = 'ILIOS_RANDOM_KEY_99';
         $_SERVER[$envKey] = $value;
         $result = $config->get($key);
         $this->assertEquals($value, $result);


### PR DESCRIPTION
We're only using this in a single place to transform fairly regular
input so I ditched the dependency which hasn't been updated in a while
and replaced it with this method.