### PR TITLE
Replace strftime usage

### DIFF
--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -345,7 +345,7 @@ class CourseTest extends ReadWriteEndpointTest
          * with YYYY being last year.
          * [ST 2018/01/02].
          */
-        $course['year'] = intval(strftime('%Y'), 10) - 1;
+        $course['year'] = intval(date('Y'), 10) - 1;
         $newCourseTitle = 'New (very cool) course title';
 
         $newCourse = $this->rolloverCourse([


### PR DESCRIPTION
This method is deprecated by PHP in v8.1. Drop in replacement here,
didn't touch the kludge.