### PR TITLE
Add default learning material storage

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -7,7 +7,7 @@ ILIOS_SECRET=NotSecretChangeMe
 ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=8.0
 
 # Where on the file system to store upload learning materials
-ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+#ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
 
 # These options will override the data in the application_config database table
 # They aren't required, but can make it easier to develop locally against a production database

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ FakeTestFiles
 !/public/index.php
 !/public/.htaccess
 !/public/theme-overrides
+files
 
 # Created by docker build, shouldn't leak into app
 VERSION

--- a/src/Monitor/IliosFileSystem.php
+++ b/src/Monitor/IliosFileSystem.php
@@ -22,6 +22,9 @@ class IliosFileSystem implements CheckInterface
     public function check(): ResultInterface
     {
         $path = $this->config->get('file_system_storage_path');
+        if (!$path) {
+            return new Failure("No storage path on the filesystem. You need to configure this value.");
+        }
         if (!is_writable($path)) {
             return new Failure("${path} is not writable");
         }

--- a/tests/Service/FilesystemFactoryTest.php
+++ b/tests/Service/FilesystemFactoryTest.php
@@ -21,7 +21,7 @@ class FilesystemFactoryTest extends TestCase
     {
         parent::setUp();
         $this->config = m::mock(Config::class);
-        $this->filesystemFactory = new FilesystemFactory($this->config, '/tmp');
+        $this->filesystemFactory = new FilesystemFactory($this->config, '/tmp', '/tmp');
     }
 
     public function tearDown(): void


### PR DESCRIPTION
Installing Ilios can be difficult and deciding where to store learning
materials makes it more difficult still. In developer environments we
were already defaulting this to /tmp which is way more risky then
storing things in the application root. The health check still ensures
that a proper production setup has set this value, but for initial
installs I think this may be sufficient and much easier.