### PR TITLE
Remove indirect dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "ext-xmlwriter": "*",
     "ext-zlib": "*",
     "composer/composer": "^2.1",
-    "composer/package-versions-deprecated": "1.11.99.4",
     "doctrine/annotations": "^1.0",
     "doctrine/doctrine-bundle": "^2.4",
     "doctrine/doctrine-fixtures-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c99bfaf715cdd99dc56e2f21a03eab2a",
+    "content-hash": "a34c98e51fd18714cb205087d06bcadc",
     "packages": [
         {
             "name": "async-aws/core",


### PR DESCRIPTION
This was expanded into our dependencies by symfony flex, but we don't
need it directly and don't need to keep it here.