### PR TITLE
Add manual dispatch to updating dependencies

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,6 +1,7 @@
 name: Update Dependencies
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '15 14 * * 1' # weekly, on Monday morning (UTC)
 


### PR DESCRIPTION
This allows the task to be run on demand when needed to get newer
updates.