### PR TITLE
whitelist which plugins are allowed to execute code during a composer run.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,13 @@
     "preferred-install": {
       "*": "dist"
     },
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true,
+      "symfony/flex": true,
+      "phpstan/extension-installer": true,
+      "symfony/runtime": true
+    }
   },
   "minimum-stability": "stable",
   "autoload": {


### PR DESCRIPTION
was prompted with this during `composer install` after upgrading to latest version of composer (v2.2.3).

```
$ composer install
composer/package-versions-deprecated contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "composer/package-versions-deprecated" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
phpstan/extension-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "phpstan/extension-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
symfony/flex contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "symfony/flex" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
symfony/runtime contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "symfony/runtime" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
```

see https://getcomposer.org/doc/06-config.md#allow-plugins