### PR TITLE
Improve Docker Development Setup

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,29 @@
+version: '3.5'
+services:
+  nginx:
+    ports:
+      - "8000:80"
+  db:
+    image: ilios/mysql-demo
+  php:
+    environment:
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
+      - ILIOS_REQUIRE_SECURE_CONNECTION=false
+      - ILIOS_ERROR_CAPTURE_ENABLED=false
+      - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
+      - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+    depends_on:
+      - db
+  messages:
+    environment:
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
+      - ILIOS_ERROR_CAPTURE_ENABLED=false
+      - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+    depends_on:
+        - db
+  elasticsearch:
+    image: ilios/elasticsearch
+    environment:
+      - discovery.type=single-node
+    ports:
+      - "9200:9200"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,66 @@
+version: '3.5'
+services:
+  db:
+    build:
+      context: .
+      target: mysql-demo
+    ports:
+      - "13306:3306"
+  nginx:
+    build:
+      context: .
+      target: nginx
+    ports:
+      - "8000:80"
+    volumes:
+      - ./:/var/www/ilios:delegated
+    depends_on:
+      - php
+  php:
+    build:
+      context: .
+      target: fpm-dev
+    environment:
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
+      - ILIOS_REQUIRE_SECURE_CONNECTION=false
+      - ILIOS_ERROR_CAPTURE_ENABLED=false
+      - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
+      - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+    volumes:
+      - ./:/var/www/ilios:delegated
+    depends_on:
+      - db
+  messages:
+    build:
+      context: .
+      target: consume-messages
+    environment:
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
+      - ILIOS_ERROR_CAPTURE_ENABLED=false
+      - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+    depends_on:
+        - db
+    volumes:
+      - ./:/var/www/ilios:delegated
+  elasticsearch:
+    build:
+      context: .
+      target: elasticsearch
+    environment:
+      - discovery.type=single-node
+    ports:
+      - "9200:9200"
+  apache:
+    build:
+      context: .
+      target: php-apache
+    environment:
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
+      - ILIOS_REQUIRE_SECURE_CONNECTION=false
+      - ILIOS_ERROR_CAPTURE_ENABLED=false
+      - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
+      - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+    ports:
+      - "8001:80"
+    volumes:
+      - ./:/var/www/ilios:delegated

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -50,17 +50,3 @@ services:
       - discovery.type=single-node
     ports:
       - "9200:9200"
-  apache:
-    build:
-      context: .
-      target: php-apache
-    environment:
-      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
-      - ILIOS_REQUIRE_SECURE_CONNECTION=false
-      - ILIOS_ERROR_CAPTURE_ENABLED=false
-      - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
-      - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
-    ports:
-      - "8001:80"
-    volumes:
-      - ./:/var/www/ilios:delegated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 version: '3.5'
+volumes:
+  public:
 services:
   nginx:
     image: ilios/nginx:v3
@@ -6,7 +8,11 @@ services:
       - FPM_CONTAINERS=php:9000
     depends_on:
       - php
+    volumes:
+      - public:/var/www/ilios/public:ro
   php:
     image: ilios/fpm:v3
+    volumes:
+      - public:/var/www/ilios/public
   messages:
     image: ilios/consume-messages:v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,52 +1,12 @@
 version: '3.5'
 services:
-    db:
-        build:
-            context: .
-            target: mysql-demo
-        ports:
-            - "13306:3306"
-#    nginx:
-#        build:
-#            context: .
-#            target: nginx
-#        environment:
-#            - FPM_CONTAINERS=php:9000
-#        ports:
-#            - "8000:80"
-#        volumes:
-#            - ./:/var/www/ilios:delegated
-#    php:
-#        build:
-#            context: .
-#            target: fpm-dev
-#        environment:
-#            - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
-#            - ILIOS_REQUIRE_SECURE_CONNECTION=false
-#            - ILIOS_ERROR_CAPTURE_ENABLED=false
-#            - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
-#            - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
-#        volumes:
-#            - ./:/var/www/ilios:delegated
-#    apache:
-#        build:
-#            context: .
-#            target: php-apache
-#        environment:
-#            - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
-#            - ILIOS_REQUIRE_SECURE_CONNECTION=false
-#            - ILIOS_ERROR_CAPTURE_ENABLED=false
-#            - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
-#            - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
-#        ports:
-#            - "8000:80"
-#        volumes:
-#            - ./:/var/www/ilios:delegated
-    elasticsearch:
-        build:
-            context: .
-            target: elasticsearch
-        environment:
-            - discovery.type=single-node
-        ports:
-            - "9200:9200"
+  nginx:
+    image: ilios/nginx:v3
+    environment:
+      - FPM_CONTAINERS=php:9000
+    depends_on:
+      - php
+  php:
+    image: ilios/fpm:v3
+  messages:
+    image: ilios/consume-messages:v3

--- a/docs/ilios_quick_setup_for_admins.md
+++ b/docs/ilios_quick_setup_for_admins.md
@@ -32,8 +32,6 @@ You will need Docker and Docker compose:
 - [Windows](https://www.docker.com/docker-windows)
 - [Ubuntu](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/)
 
-Then install [Symfony](https://symfony.com/download)
-
 ### Running a local development server
 
 From your ILIOS_CODE directory run:
@@ -41,7 +39,6 @@ From your ILIOS_CODE directory run:
 ```bash
 $ docker-compose pull
 $ docker-compose up -d
-$ symfony server:start -d
 ```
 
 ### Accessing Ilios
@@ -54,6 +51,5 @@ by visiting [http://localhost:8000](http://localhost:8000) in your browser.
 From your ILIOS_CODE directory run:
 
 ```bash
-$ symfony server:stop
 $ docker-compose down
 ```


### PR DESCRIPTION
Using an override system as recommended by docker. This makes it easier to develop Ilios by ensuring that the expected `docker compose up` command will build a working environment and also creates a demo experience which can use `docker compose -f docker-compose.yml -f docker-compose.demo.yml up` to build a demo enivironment both as a sample for what a working Ilios might look like as well as a nice API server to use locally when making changes to the frontend.

