### PR TITLE
Wait for database command and docker improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,8 +148,7 @@ HEALTHCHECK CMD nc -vz 127.0.0.1 22 || exit 1
 # Should be run once on a new deployment
 ###############################################################################
 FROM php-base as migrate-database
-ENTRYPOINT ["/var/www/ilios/bin/console"]
-CMD ["doctrine:migrations:migrate", "-n"]
+ENTRYPOINT bin/console ilios:wait-for-database; bin/console doctrine:migrations:migrate -n
 
 ###############################################################################
 # Single purpose container to updates the frontend
@@ -167,8 +166,7 @@ CMD ["ilios:update-frontend"]
 # do every hour
 ###############################################################################
 FROM php-base as consume-messages
-ENTRYPOINT ["/var/www/ilios/bin/console"]
-CMD ["messenger:consume", "async"]
+ENTRYPOINT bin/console ilios:wait-for-database; bin/console messenger:consume async
 
 ###############################################################################
 # MySQL configured as needed for Ilios

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -40,6 +40,19 @@ services:
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
     depends_on:
         - db
+        - elasticsearch
+    volumes:
+      - ./:/var/www/ilios:delegated
+  migrate:
+    build:
+      context: .
+      target: migrate-database
+    environment:
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=5.7
+      - ILIOS_ERROR_CAPTURE_ENABLED=false
+      - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+    depends_on:
+        - db
     volumes:
       - ./:/var/www/ilios:delegated
   elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,5 @@ services:
       - public:/var/www/ilios/public
   messages:
     image: ilios/consume-messages:v3
+  migrate:
+    image: ilios/migrate-database:v3

--- a/src/Command/WaitForDatabaseCommand.php
+++ b/src/Command/WaitForDatabaseCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function sleep;
+
+/**
+ * Wait for the database to become available
+ * Useful for running before another command like migrate
+ */
+class WaitForDatabaseCommand extends Command
+{
+    public const COMMAND_NAME = 'ilios:wait-for-database';
+
+    public function __construct(
+        protected EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName(self::COMMAND_NAME)
+            ->setDescription('Wait for a database connection.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        //start an infinite loop for checking the connection every second
+        while (true) {
+            sleep(1);
+            try {
+                // doctrine will throw an exception when this doesn't work so if that doesn't happen we're golden
+                $this->entityManager->getConnection()->executeQuery('Select 1');
+
+                return Command::SUCCESS;
+            } catch (ConnectionException) {
+                // try again;
+            }
+        }
+    }
+}

--- a/tests/Command/WaitForDatabaseCommandTest.php
+++ b/tests/Command/WaitForDatabaseCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\WaitForDatabaseCommand;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * @group cli
+ *
+ */
+class WaitForDatabaseCommandTest extends KernelTestCase
+{
+    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    protected CommandTester $commandTester;
+    private EntityManagerInterface|m\MockInterface $entityManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->entityManager = m::mock(EntityManagerInterface::class);
+        $command = new WaitForDatabaseCommand($this->entityManager);
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->add($command);
+        $commandInApp = $application->find(WaitForDatabaseCommand::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->entityManager);
+    }
+
+    public function testReturnsWhenDbIsWorking()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('executeQuery')->with('Select 1');
+        $this->entityManager->shouldReceive('getConnection')->once()->andReturn($connection);
+
+        $this->commandTester->execute([
+            'command' => WaitForDatabaseCommand::COMMAND_NAME,
+        ]);
+
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+    }
+
+    public function testWaitsForConnection()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('executeQuery')->with('Select 1')
+            ->times(2)->andThrow(m::mock(ConnectionException::class));
+        $connection->shouldReceive('executeQuery')->once()->with('Select 1');
+        $this->entityManager->shouldReceive('getConnection')->andReturn($connection);
+
+        $stopwatch = new Stopwatch();
+        $stopwatch->start('test');
+        $this->commandTester->execute([
+            'command' => WaitForDatabaseCommand::COMMAND_NAME,
+        ]);
+        $duration = $stopwatch->stop('test')->getDuration();
+        $this->assertGreaterThan(2000, $duration);
+
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+    }
+}


### PR DESCRIPTION
Adding a command `Ilios:wait-for-database` which loops indefinitely until the DB is available allows us to unlock the messages and migration docker commands.