### PR TITLE
Docker docs fixup

### DIFF
--- a/docs/ilios_quick_setup_for_admins.md
+++ b/docs/ilios_quick_setup_for_admins.md
@@ -37,8 +37,9 @@ You will need Docker and Docker compose:
 From your ILIOS_CODE directory run:
 
 ```bash
-$ docker-compose pull
-$ docker-compose up -d
+$ compose install
+$ bin/console cache:warmup
+$ docker compose up -d
 ```
 
 ### Accessing Ilios
@@ -51,5 +52,5 @@ by visiting [http://localhost:8000](http://localhost:8000) in your browser.
 From your ILIOS_CODE directory run:
 
 ```bash
-$ docker-compose down
+$ docker compose down
 ```


### PR DESCRIPTION
Because we share the working directory in our development docker setup
using the override file we need to do a bit of pre-setup before starting
the default containers.