### PR TITLE
Use internal method to search

### DIFF
--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -162,7 +162,7 @@ class Curriculum extends ElasticSearchBase
                     ]
                 ]
             ];
-            $results = $this->client->search($params);
+            $results = $this->doSearch($params);
 
             $materialsById = array_reduce($results['hits']['hits'], function (array $carry, array $hit) {
                 $result = $hit['_source'];


### PR DESCRIPTION
We need to use doSearch here because searching directly on the client
bypasses our protections for there not being a client configured.