### PR TITLE
Add command to wait for index to be available

### DIFF
--- a/src/Command/WaitForIndexCommand.php
+++ b/src/Command/WaitForIndexCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Service\Index\Manager;
+use Elasticsearch\Client;
+use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+use Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function sleep;
+
+/**
+ * Wait for the search index to become available
+ * Useful for running before another command like consume messages
+ */
+class WaitForIndexCommand extends Command
+{
+    public const COMMAND_NAME = 'ilios:wait-for-index';
+
+    public function __construct(
+        protected ?Client $client,
+        protected Manager $indexManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName(self::COMMAND_NAME)
+            ->setDescription('Wait for a connection to index.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->client) {
+            throw new Exception("Elasticsearch is not configured.");
+        }
+        //start an infinite loop for checking the connection every second
+        while (true) {
+            sleep(1);
+            try {
+                // elasticsearch will throw an exception when this doesn't work so if that doesn't happen we're golden
+                $this->client->nodes()->info();
+
+                if ($this->indexManager->hasBeenCreated()) {
+                    return Command::SUCCESS;
+                }
+            } catch (NoNodesAvailableException) {
+                // try again;
+            }
+        }
+    }
+}

--- a/src/Service/Index/Manager.php
+++ b/src/Service/Index/Manager.php
@@ -14,10 +14,7 @@ class Manager extends ElasticSearchBase
             return;
         }
         $indexes = [
-            Users::INDEX,
-            Mesh::INDEX,
-            Curriculum::INDEX,
-            LearningMaterials::INDEX,
+            ...$this->listCurrentIndexes(),
             'ilios-public-curriculum',
             'ilios-public-mesh',
             'ilios-private-users',
@@ -53,5 +50,29 @@ class Manager extends ElasticSearchBase
             'index' => LearningMaterials::INDEX,
             'body' => LearningMaterials::getMapping()
         ]);
+    }
+
+    public function hasBeenCreated(): bool
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+        foreach ($this->listCurrentIndexes() as $index) {
+            if (!$this->client->indices()->exists(['index' => $index])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function listCurrentIndexes(): array
+    {
+        return [
+            Users::INDEX,
+            Mesh::INDEX,
+            Curriculum::INDEX,
+            LearningMaterials::INDEX,
+        ];
     }
 }

--- a/tests/Command/WaitForIndexCommandTest.php
+++ b/tests/Command/WaitForIndexCommandTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\WaitForIndexCommand;
+use App\Service\Index\Manager;
+use Doctrine\ORM\EntityManagerInterface;
+use Elasticsearch\Client;
+use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+use Elasticsearch\Namespaces\NodesNamespace;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * @group cli
+ *
+ */
+class WaitForIndexCommandTest extends KernelTestCase
+{
+    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    protected CommandTester $commandTester;
+    protected Client|m\MockInterface $client;
+    protected Manager|m\MockInterface $indexManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = m::mock(Client::class);
+        $this->indexManager = m::mock(Manager::class);
+        $command = new WaitForIndexCommand($this->client, $this->indexManager);
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->add($command);
+        $commandInApp = $application->find(WaitForIndexCommand::COMMAND_NAME);
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->client);
+        unset($this->indexManager);
+    }
+
+    public function testReturnsWhenIndexIsWorking()
+    {
+        $nodes = m::mock(NodesNamespace::class)->shouldReceive('info')->andReturn();
+        $this->client->shouldReceive('nodes')->andReturn($nodes->getMock());
+        $this->indexManager->shouldReceive('hasBeenCreated')->andReturn(true);
+
+        $this->commandTester->execute([
+            'command' => WaitForIndexCommand::COMMAND_NAME,
+        ]);
+
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+    }
+
+    public function testWaitsForConnection()
+    {
+        $nodes = m::mock(NodesNamespace::class)->shouldReceive('info')
+            ->times(2)->andThrow(NoNodesAvailableException::class);
+        $this->client->shouldReceive('nodes')->andReturn($nodes->getMock());
+        $this->indexManager->shouldReceive('hasBeenCreated')->andReturn(true);
+        $nodes->shouldReceive('info')->once()->andReturn();
+
+        $stopwatch = new Stopwatch();
+        $stopwatch->start('test');
+        $this->commandTester->execute([
+            'command' => WaitForIndexCommand::COMMAND_NAME,
+        ]);
+        $duration = $stopwatch->stop('test')->getDuration();
+        $this->assertGreaterThan(2000, $duration);
+
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+    }
+
+    public function testWaitsForIndexesToBeCreated()
+    {
+        $nodes = m::mock(NodesNamespace::class)->shouldReceive('info')->andReturn();
+        $this->client->shouldReceive('nodes')->andReturn($nodes->getMock());
+        $this->indexManager->shouldReceive('hasBeenCreated')->times(2)->andReturn(false);
+        $this->indexManager->shouldReceive('hasBeenCreated')->once()->andReturn(true);
+
+        $stopwatch = new Stopwatch();
+        $stopwatch->start('test');
+        $this->commandTester->execute([
+            'command' => WaitForIndexCommand::COMMAND_NAME,
+        ]);
+        $duration = $stopwatch->stop('test')->getDuration();
+        $this->assertGreaterThan(2000, $duration);
+
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+    }
+}


### PR DESCRIPTION
This is useful for a docker container which shouldn't run until there is
an index to run in.