### PR TITLE
Ask the messenger container to wait for the index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,8 @@ HEALTHCHECK CMD nc -vz 127.0.0.1 22 || exit 1
 # Should be run once on a new deployment
 ###############################################################################
 FROM php-base as migrate-database
-ENTRYPOINT bin/console ilios:wait-for-database; bin/console doctrine:migrations:migrate -n
+ENTRYPOINT bin/console ilios:wait-for-database; \
+           bin/console doctrine:migrations:migrate -n
 
 ###############################################################################
 # Single purpose container to updates the frontend
@@ -166,7 +167,9 @@ CMD ["ilios:update-frontend"]
 # do every hour
 ###############################################################################
 FROM php-base as consume-messages
-ENTRYPOINT bin/console ilios:wait-for-database; bin/console messenger:consume async
+ENTRYPOINT bin/console ilios:wait-for-database; \
+           bin/console ilios:wait-for-index; \
+           bin/console messenger:consume async
 
 ###############################################################################
 # MySQL configured as needed for Ilios


### PR DESCRIPTION
This ensures we don't fill the log with garbage while everything is
starting or getting setup.