### PR TITLE
Changes collation on join table to realign it with rest of schema.

### DIFF
--- a/migrations/Version20220202010454.php
+++ b/migrations/Version20220202010454.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilios\Migrations;
+
+use App\Classes\MysqlMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Changes collation on join table to realign it with rest of schema.
+ */
+final class Version20220202010454 extends MysqlMigration
+{
+    public function getDescription(): string
+    {
+        return 'Changes collation on join table to realign it with rest of schema.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE mesh_concept_x_term COLLATE 'utf8_unicode_ci'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE mesh_concept_x_term COLLATE 'utf8_general_ci'");
+    }
+}


### PR DESCRIPTION
"one of these things is not like the others"

```sql
SELECT table_name, table_collation
FROM information_schema.`TABLES`
WHERE table_schema = 'ilios'
AND table_name LIKE 'mesh%';
```

| TABLE\_NAME | TABLE\_COLLATION |
| :--- | :--- |
| mesh\_concept | utf8\_unicode\_ci |
| mesh\_concept\_x\_term | utf8\_general\_ci |
| mesh\_descriptor | utf8\_unicode\_ci |
| mesh\_descriptor\_x\_concept | utf8\_unicode\_ci |
| mesh\_descriptor\_x\_qualifier | utf8\_unicode\_ci |
| mesh\_previous\_indexing | utf8\_unicode\_ci |
| mesh\_qualifier | utf8\_unicode\_ci |
| mesh\_term | utf8\_unicode\_ci |
| mesh\_tree | utf8\_unicode\_ci |

this PR adds a migration that realigns the collation on the `mesh_concept_x_term` table, since the new version of Doctrine ORM is choking on this mismatch during schema validation.
