### PR TITLE
Don't require frontend divs to have a class

### DIFF
--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -152,7 +152,7 @@ class IndexController extends AbstractController
 
         $divs = array_map(fn($obj) => [
             'id' => $obj->id,
-            'class' => $obj->class,
+            'class' => $obj->class ?? '',
             'htmlContent' => $obj->htmlContent,
         ], $json->div);
 


### PR DESCRIPTION
This isn't always present. Fixes #3890