### PR TITLE
Overwrite newer files when copying assets

### DIFF
--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -302,7 +302,7 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
             if (is_dir($path)) {
                 $this->fs->mirror($path, $this->frontendAssetDirectory . $file);
             } else {
-                $this->fs->copy($path, $this->frontendAssetDirectory . $file);
+                $this->fs->copy($path, $this->frontendAssetDirectory . $file, true);
             }
         }
     }


### PR DESCRIPTION
The file created timestamp doesn't really have anything to do with the
age of the frontend files. When we download many versions at the same
time the timestamps are network load dependent. So, when copying files
into the frontend directory (particularly VERSION.txt) we want to
overwrite each time.