### PR TITLE
Change the way the apache container boots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -230,7 +230,7 @@ COPY ./src/.htaccess /var/www/ilios/src
 # configure Apache and the PHP extensions required for Ilios and delete the source files after install
 RUN set -eux; \
 	apt-get update; \
-    apt-get install sudo libldap2-dev libldap-common zlib1g-dev libicu-dev libzip-dev libzip4 unzip -y; \
+    apt-get install acl libldap2-dev libldap-common zlib1g-dev libicu-dev libzip-dev libzip4 unzip -y; \
     docker-php-ext-configure ldap; \
     docker-php-ext-install ldap; \
     docker-php-ext-install zip; \
@@ -280,7 +280,6 @@ ARG ILIOS_VERSION="v0.1.0"
 RUN echo ${ILIOS_VERSION} > VERSION
 
 USER root
-RUN chown -R www-data:www-data /var/www/ilios
 ENTRYPOINT ["php-apache-entrypoint"]
 CMD ["apache2-foreground"]
 EXPOSE 80

--- a/docker/php-apache-entrypoint
+++ b/docker/php-apache-entrypoint
@@ -2,8 +2,18 @@
 # started with https://github.com/docker-library/php/blob/d97098c8c6af46ae1211e65ff052278ab39ba45c/7.2/stretch/apache/docker-php-entrypoint
 set -e
 
-# We need to warmup the cache in addition to starting apache
-sudo -E -u www-data /var/www/ilios/bin/console cache:warmup
+mkdir -p var/cache var/log
+if [ "$ILIOS_DATABASE_URL" ]; then
+	echo "Waiting for db to be ready..."
+	bin/console ilios:wait-for-database
+	echo "The db is now ready and reachable"
+
+	bin/console cache:warmup
+	bin/console doctrine:migrations:migrate --no-interaction
+fi
+
+setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
+setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then


### PR DESCRIPTION
Instead of chmoding in the build step I'm stealing this from the FPM
container and doing the setacl and cache clear in the entrypoint.