### PR TITLE
conditionally blank virtual links in school events.

### DIFF
--- a/src/Controller/SchooleventController.php
+++ b/src/Controller/SchooleventController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Classes\SessionUserInterface;
 use App\Entity\SessionInterface;
 use App\RelationshipVoter\AbstractCalendarEvent;
+use App\RelationshipVoter\SchoolEvent as SchoolEventVoter;
 use App\RelationshipVoter\AbstractVoter;
 use App\Classes\SchoolEvent;
 use App\Exception\InvalidInputWithSafeUserMessageException;
@@ -126,6 +127,10 @@ class SchooleventController extends AbstractController
                 } else {
                     $event->clearDataForUnprivilegedUsers();
                 }
+            }
+
+            if (! $authorizationChecker->isGranted(SchoolEventVoter::VIEW_VIRTUAL_LINK, $event)) {
+                $event->url = null;
             }
         }
 

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -557,6 +557,20 @@ class SchooleventsTest extends AbstractEndpointTest
         }
     }
 
+
+    public function testNotVirtualLinksForUnprivilegedUser()
+    {
+        /** @var DataLoaderInterface $dataLoader */
+        $userLoader = self::getContainer()->get(UserData::class);
+        $newUser = $this->postOne('users', 'user', 'users', $userLoader->createEmpty());
+
+        $events = $this->getEvents($newUser['school'], 0, 100000000000, $newUser['id']);
+
+        foreach ($events as $event) {
+            $this->assertArrayNotHasKey('url', $event);
+        }
+    }
+
     public function testMultidayEvent()
     {
         $school = self::getContainer()->get(SchoolData::class)->getOne();

--- a/tests/RelationshipVoter/SchoolEventTest.php
+++ b/tests/RelationshipVoter/SchoolEventTest.php
@@ -408,7 +408,7 @@ class SchoolEventTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
     }
 
-    public function testCanViewDraftDataIfCurrentUserIsNotAdministratorDirectorOrInstructorToEvent()
+    public function testCanNotViewDraftDataIfCurrentUserIsNotAdministratorDirectorOrInstructorToEvent()
     {
         $token = $this->createMockTokenWithNonRootSessionUser();
         /* @var SchoolEvent $entity */
@@ -429,6 +429,237 @@ class SchoolEventTest extends AbstractBase
         $sessionUser->shouldReceive('isInstructingIlm')->with($entity->ilmSession)->andReturn(false);
 
         $response = $this->voter->vote($token, $entity, [AbstractCalendarEvent::VIEW_DRAFT_CONTENTS]);
+
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserIsSchoolAdministratorInEventowningSchool()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserIsSchoolDirectorInEventowningSchool()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserisDirectingProgramLinkedToEventowningCoursel()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingProgramLinkedToCourse')->with($entity->school)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserIsCourseAdministratorInEventowningCourse()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $entity->course = 3;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingProgramLinkedToCourse')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringCourse')->with($entity->course)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserIsCourseDirectorInEventowningCourse()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $entity->course = 3;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingProgramLinkedToCourse')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingCourse')->with($entity->course)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserIsSessionAdministratorInEventowningSession()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $entity->course = 3;
+        $entity->session = 4;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingProgramLinkedToCourse')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringSession')->with($entity->session)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserIsInstructorInEventowningOffering()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $entity->course = 3;
+        $entity->session = 4;
+        $entity->offering = 5;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingProgramLinkedToCourse')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringSession')->with($entity->session)->andReturn(false);
+        $sessionUser->shouldReceive('isInstructingOffering')->with($entity->offering)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserIsInstructorInEventowningIlm()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $entity->course = 3;
+        $entity->session = 4;
+        $entity->offering = 5;
+        $entity->ilmSession = 6;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingProgramLinkedToCourse')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringSession')->with($entity->session)->andReturn(false);
+        $sessionUser->shouldReceive('isInstructingOffering')->with($entity->offering)->andReturn(false);
+        $sessionUser->shouldReceive('isInstructingIlm')->with($entity->ilmSession)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserIsIlmLearnerInEvent()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $entity->course = 3;
+        $entity->session = 4;
+        $entity->offering = 5;
+        $entity->ilmSession = 6;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingProgramLinkedToCourse')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringSession')->with($entity->session)->andReturn(false);
+        $sessionUser->shouldReceive('isInstructingOffering')->with($entity->offering)->andReturn(false);
+        $sessionUser->shouldReceive('isInstructingIlm')->with($entity->ilmSession)->andReturn(false);
+        $sessionUser->shouldReceive('isLearnerInIlm')->with($entity->ilmSession)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanViewVirtualLinkIfCurrentUserIsOfferingLearnerInEvent()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $entity->course = 3;
+        $entity->session = 4;
+        $entity->offering = 5;
+        $entity->ilmSession = 6;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingProgramLinkedToCourse')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringSession')->with($entity->session)->andReturn(false);
+        $sessionUser->shouldReceive('isInstructingOffering')->with($entity->offering)->andReturn(false);
+        $sessionUser->shouldReceive('isInstructingIlm')->with($entity->ilmSession)->andReturn(false);
+        $sessionUser->shouldReceive('isLearnerInIlm')->with($entity->ilmSession)->andReturn(false);
+        $sessionUser->shouldReceive('isLearnerInOffering')->with($entity->offering)->andReturn(true);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
+
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
+    }
+
+    public function testCanNotViewVirtualLinkIfCurrentUserIsNotAssociatedWithEvent()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        /* @var SchoolEvent $entity */
+        $entity = m::mock(SchoolEvent::class);
+        $entity->school = 2;
+        $entity->course = 3;
+        $entity->session = 4;
+        $entity->offering = 5;
+        $entity->ilmSession = 6;
+        $sessionUser = $token->getUser();
+        $sessionUser->shouldReceive('isAdministeringSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingSchool')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingProgramLinkedToCourse')->with($entity->school)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isDirectingCourse')->with($entity->course)->andReturn(false);
+        $sessionUser->shouldReceive('isAdministeringSession')->with($entity->session)->andReturn(false);
+        $sessionUser->shouldReceive('isInstructingOffering')->with($entity->offering)->andReturn(false);
+        $sessionUser->shouldReceive('isInstructingIlm')->with($entity->ilmSession)->andReturn(false);
+        $sessionUser->shouldReceive('isLearnerInIlm')->with($entity->ilmSession)->andReturn(false);
+        $sessionUser->shouldReceive('isLearnerInOffering')->with($entity->offering)->andReturn(false);
+
+        $response = $this->voter->vote($token, $entity, [Voter::VIEW_VIRTUAL_LINK]);
 
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
     }


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/3051

in order for the virtual link URLs to be included in the school events payload, the requesting user must be associated with the event's underlying offering or ILM  either as a learner or as an instructor/director/administrator.