### PR TITLE
Drop unused exception variable

### DIFF
--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -163,7 +163,7 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
                 $this->copyAssetsIntoPublicDirectory($currentDistributionPath);
                 $this->activateVersion($currentDistributionPath);
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             print "\n\n**Warning: Unable to load frontend. Please run ilios:maintenance:update-frontend again.**\n\n\n";
         }
 

--- a/src/Repository/AuthenticationRepository.php
+++ b/src/Repository/AuthenticationRepository.php
@@ -43,7 +43,7 @@ class AuthenticationRepository extends ServiceEntityRepository implements DTORep
         $result = null;
         try {
             $result = $qb->getQuery()->getSingleResult();
-        } catch (NoResultException $e) {
+        } catch (NoResultException) {
             // do nothing.
         } catch (NonUniqueResultException) {
             // do nothing.

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -89,7 +89,7 @@ class Config
     {
         try {
             return $this->applicationConfigRepository->getValue($name);
-        } catch (ServerException $e) {
+        } catch (ServerException) {
             return null;
         } catch (ConnectionException) {
             return null;


### PR DESCRIPTION
In PHP8 this isn't required anymore so if we don't use it we can drop
it.