### PR TITLE
Update Flysystem to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "project",
   "description": "The \"Ilios Standard Edition\" distribution",
   "require": {
-    "php": ">= 8.0",
+    "php": ">= 8.0.2",
     "ext-apcu": "*",
     "ext-ctype": "*",
     "ext-dom": "*",
@@ -28,9 +28,8 @@
     "ilios/mesh-parser": "^2.0",
     "jaybizzle/crawler-detect": "^1.2",
     "league/csv": "^9.5",
-    "league/flysystem": "^1.0",
-    "league/flysystem-aws-s3-v3": "^1.0",
-    "league/flysystem-cached-adapter": "^1.0",
+    "league/flysystem": "^3.0",
+    "league/flysystem-aws-s3-v3": "^3.0",
     "liip/monitor-bundle": "^2.6",
     "nelmio/cors-bundle": "^2.0",
     "pear/archive_tar": "^1.4",
@@ -87,7 +86,7 @@
   },
   "config": {
     "platform": {
-      "php": "8.0.0"
+      "php": "8.0.2"
     },
     "preferred-install": {
       "*": "dist"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbffcb9703bc37b119bfa55d381bd115",
+    "content-hash": "cc0d6ebb097a9ff202f635904dae058b",
     "packages": [
         {
             "name": "async-aws/core",
@@ -182,16 +182,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.220.3",
+            "version": "3.220.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "fbb2d7349916c15758ee02dfd001a714883a9adf"
+                "reference": "6c2e36bb61741c87ed7ffd53e15d903311ad6b60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/fbb2d7349916c15758ee02dfd001a714883a9adf",
-                "reference": "fbb2d7349916c15758ee02dfd001a714883a9adf",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6c2e36bb61741c87ed7ffd53e15d903311ad6b60",
+                "reference": "6c2e36bb61741c87ed7ffd53e15d903311ad6b60",
                 "shasum": ""
             },
             "require": {
@@ -267,9 +267,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.220.3"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.220.4"
             },
-            "time": "2022-04-22T18:18:31+00:00"
+            "time": "2022-04-25T18:16:08+00:00"
         },
         {
             "name": "beberlei/assert",
@@ -3884,54 +3884,48 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.1.9",
+            "version": "3.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "094defdb4a7001845300334e7c1ee2335925ef99"
+                "reference": "c8e137e594948240b03372e012344b07c61b9193"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/094defdb4a7001845300334e7c1ee2335925ef99",
-                "reference": "094defdb4a7001845300334e7c1ee2335925ef99",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/c8e137e594948240b03372e012344b07c61b9193",
+                "reference": "c8e137e594948240b03372e012344b07c61b9193",
                 "shasum": ""
             },
             "require": {
-                "ext-fileinfo": "*",
-                "league/mime-type-detection": "^1.3",
-                "php": "^7.2.5 || ^8.0"
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
             },
             "conflict": {
-                "league/flysystem-sftp": "<1.0.6"
+                "aws/aws-sdk-php": "3.209.31 || 3.210.0",
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1",
+                "symfony/http-client": "<5.2"
             },
             "require-dev": {
-                "phpspec/prophecy": "^1.11.1",
-                "phpunit/phpunit": "^8.5.8"
-            },
-            "suggest": {
-                "ext-ftp": "Allows you to use FTP server storage",
-                "ext-openssl": "Allows you to use FTPS server storage",
-                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
-                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
-                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
-                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
-                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
-                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
-                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
-                "league/flysystem-webdav": "Allows you to use WebDAV storage",
-                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
-                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
-                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+                "async-aws/s3": "^1.5",
+                "async-aws/simple-s3": "^1.0",
+                "aws/aws-sdk-php": "^3.198.1",
+                "composer/semver": "^3.0",
+                "ext-fileinfo": "*",
+                "ext-ftp": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.5",
+                "google/cloud-storage": "^1.23",
+                "microsoft/azure-storage-blob": "^1.1",
+                "phpseclib/phpseclib": "^2.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpunit/phpunit": "^9.5.11",
+                "sabre/dav": "^4.3.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "League\\Flysystem\\": "src/"
+                    "League\\Flysystem\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3941,73 +3935,71 @@
             "authors": [
                 {
                     "name": "Frank de Jonge",
-                    "email": "info@frenky.net"
+                    "email": "info@frankdejonge.nl"
                 }
             ],
-            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "description": "File storage abstraction for PHP",
             "keywords": [
-                "Cloud Files",
                 "WebDAV",
-                "abstraction",
                 "aws",
                 "cloud",
-                "copy.com",
-                "dropbox",
-                "file systems",
+                "file",
                 "files",
                 "filesystem",
                 "filesystems",
                 "ftp",
-                "rackspace",
-                "remote",
                 "s3",
                 "sftp",
                 "storage"
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/1.1.9"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.0.18"
             },
             "funding": [
                 {
                     "url": "https://offset.earth/frankdejonge",
-                    "type": "other"
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2021-12-09T09:40:50+00:00"
+            "time": "2022-04-25T18:55:04+00:00"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
-            "version": "1.0.29",
+            "version": "3.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
-                "reference": "4e25cc0582a36a786c31115e419c6e40498f6972"
+                "reference": "0074cf016e21a6d1eb99b6db70acdd23743fc371"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/4e25cc0582a36a786c31115e419c6e40498f6972",
-                "reference": "4e25cc0582a36a786c31115e419c6e40498f6972",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/0074cf016e21a6d1eb99b6db70acdd23743fc371",
+                "reference": "0074cf016e21a6d1eb99b6db70acdd23743fc371",
                 "shasum": ""
             },
             "require": {
-                "aws/aws-sdk-php": "^3.20.0",
-                "league/flysystem": "^1.0.40",
-                "php": ">=5.5.0"
+                "aws/aws-sdk-php": "^3.132.4",
+                "league/flysystem": "^2.0.0 || ^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
             },
-            "require-dev": {
-                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
-                "phpspec/phpspec": "^2.0.0"
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "League\\Flysystem\\AwsS3v3\\": "src/"
+                    "League\\Flysystem\\AwsS3V3\\": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4017,66 +4009,24 @@
             "authors": [
                 {
                     "name": "Frank de Jonge",
-                    "email": "info@frenky.net"
+                    "email": "info@frankdejonge.nl"
                 }
             ],
-            "description": "Flysystem adapter for the AWS S3 SDK v3.x",
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem-aws-s3-v3/issues",
-                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/1.0.29"
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.0.13"
             },
-            "time": "2020-10-08T18:58:37+00:00"
-        },
-        {
-            "name": "league/flysystem-cached-adapter",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/flysystem-cached-adapter.git",
-                "reference": "d1925efb2207ac4be3ad0c40b8277175f99ffaff"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-cached-adapter/zipball/d1925efb2207ac4be3ad0c40b8277175f99ffaff",
-                "reference": "d1925efb2207ac4be3ad0c40b8277175f99ffaff",
-                "shasum": ""
-            },
-            "require": {
-                "league/flysystem": "~1.0",
-                "psr/cache": "^1.0.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "~0.9",
-                "phpspec/phpspec": "^3.4",
-                "phpunit/phpunit": "^5.7",
-                "predis/predis": "~1.0",
-                "tedivm/stash": "~0.12"
-            },
-            "suggest": {
-                "ext-phpredis": "Pure C implemented extension for PHP"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "League\\Flysystem\\Cached\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "frankdejonge",
-                    "email": "info@frenky.net"
-                }
-            ],
-            "description": "An adapter decorator to enable meta-data caching.",
-            "support": {
-                "issues": "https://github.com/thephpleague/flysystem-cached-adapter/issues",
-                "source": "https://github.com/thephpleague/flysystem-cached-adapter/tree/master"
-            },
-            "time": "2020-07-25T15:56:04+00:00"
+            "time": "2022-04-01T22:05:11+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -7011,25 +6961,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.1",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -7058,7 +7008,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.1"
             },
             "funding": [
                 {
@@ -7074,7 +7024,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/doctrine-bridge",
@@ -15018,7 +14968,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 8.0",
+        "php": ">= 8.0.2",
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-dom": "*",
@@ -15031,7 +14981,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.0"
+        "php": "8.0.2"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -176,7 +176,7 @@ services:
       tags:
         - { name: liip_monitor.check, group: default }
 
-    League\Flysystem\FilesystemInterface:
+    League\Flysystem\FilesystemOperator:
       factory: ['@App\Service\FilesystemFactory', getFilesystem]
 
     Elasticsearch\Client:

--- a/src/Classes/LocalCachingFilesystemDecorator.php
+++ b/src/Classes/LocalCachingFilesystemDecorator.php
@@ -4,35 +4,24 @@ declare(strict_types=1);
 
 namespace App\Classes;
 
-use League\Flysystem\FileNotFoundException;
-use League\Flysystem\FilesystemInterface;
-use League\Flysystem\Handler;
-use League\Flysystem\PluginInterface;
+use League\Flysystem\DirectoryListing;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToDeleteDirectory;
+use League\Flysystem\UnableToDeleteFile;
 
 /**
  * Add a local file cache on top of our remote filesystem
- * League\Flysystem\Filesystem has cache adapters, but none of
- * them cache the actual file which is needed to avoid going back
+ * to cache the file which and avoid going back
  * and forth to S3 a bunch.
  */
-class LocalCachingFilesystemDecorator implements FilesystemInterface
+class LocalCachingFilesystemDecorator implements FilesystemOperator
 {
-    /**
-     * @var FilesystemInterface
-     */
-    private $cacheFileSystem;
+    private FilesystemOperator $cacheFileSystem;
+    private FilesystemOperator $remoteFileSystem;
+    protected bool $cacheEnabled;
 
-    /**
-     * @var FilesystemInterface
-     */
-    private $remoteFileSystem;
-
-    /**
-     * @var bool
-     */
-    protected $cacheEnabled;
-
-    public function __construct(FilesystemInterface $cacheFileSystem, FilesystemInterface $remoteFileSystem)
+    public function __construct(FilesystemOperator $cacheFileSystem, FilesystemOperator $remoteFileSystem)
     {
         $this->cacheFileSystem = $cacheFileSystem;
         $this->remoteFileSystem = $remoteFileSystem;
@@ -48,7 +37,7 @@ class LocalCachingFilesystemDecorator implements FilesystemInterface
     }
 
     /**
-     * Re enable the cache
+     * Re-enable the cache
      */
     public function enableCache(): void
     {
@@ -71,7 +60,7 @@ class LocalCachingFilesystemDecorator implements FilesystemInterface
         try {
             //cleanup any existing test file
             $this->cacheFileSystem->delete($path);
-        } catch (FileNotFoundException) {
+        } catch (FilesystemException | UnableToDeleteFile) {
             //ignore this one we don't always have files in the cache
         }
     }
@@ -79,163 +68,124 @@ class LocalCachingFilesystemDecorator implements FilesystemInterface
     /**
      * Wrapped deleteFromDir for removing possibly missing files from the local cache
      */
-    protected function deleteDirFromCache(string $dirname): void
+    protected function deleteDirectoryFromCache(string $dirname): void
     {
         try {
             //cleanup any existing test file
-            $this->cacheFileSystem->deleteDir($dirname);
-        } catch (FileNotFoundException) {
+            $this->cacheFileSystem->deleteDirectory($dirname);
+        } catch (FilesystemException | UnableToDeleteDirectory) {
             //ignore this one we don't always have files in the cache
         }
     }
 
-    public function has($path): bool
+    public function fileExists(string $location): bool
     {
-        return $this->remoteFileSystem->has($path);
+        return $this->remoteFileSystem->fileExists($location);
     }
 
-    public function read($path): string|false
+    public function directoryExists(string $location): bool
     {
-        if ($this->cacheEnabled && $this->cacheFileSystem->has($path)) {
-            return $this->cacheFileSystem->read($path);
-        }
-        $result = $this->remoteFileSystem->read($path);
+        return $this->remoteFileSystem->directoryExists($location);
+    }
 
-        if ($result !== false) {
-            $this->cacheFileSystem->put($path, $result);
-        }
+    public function has(string $location): bool
+    {
+        return $this->remoteFileSystem->has($location);
+    }
 
+    public function read(string $location): string
+    {
+        if ($this->cacheEnabled && $this->cacheFileSystem->fileExists($location)) {
+            return $this->cacheFileSystem->read($location);
+        }
+        $result = $this->remoteFileSystem->read($location);
+
+        $this->cacheFileSystem->write($location, $result);
         return $result;
     }
 
-    public function readStream($path)
+    public function readStream(string $location)
     {
-        if ($this->cacheEnabled && $this->cacheFileSystem->has($path)) {
-            return $this->cacheFileSystem->readStream($path);
+        if ($this->cacheEnabled && $this->cacheFileSystem->fileExists($location)) {
+            return $this->cacheFileSystem->readStream($location);
         }
-        $resource = $this->remoteFileSystem->readStream($path);
+        $result = $this->remoteFileSystem->readStream($location);
 
-        if ($resource !== false) {
-            $this->cacheFileSystem->putStream($path, $resource);
+        $this->cacheFileSystem->writeStream($location, $result);
+        return $result;
+    }
+
+    public function listContents(string $location, bool $deep = self::LIST_SHALLOW): DirectoryListing
+    {
+        return $this->remoteFileSystem->listContents($location, $deep);
+    }
+
+    public function lastModified(string $path): int
+    {
+        return $this->remoteFileSystem->lastModified($path);
+    }
+
+    public function fileSize(string $path): int
+    {
+        return $this->remoteFileSystem->fileSize($path);
+    }
+
+    public function mimeType(string $path): string
+    {
+        return $this->remoteFileSystem->mimeType($path);
+    }
+
+    public function visibility(string $path): string
+    {
+        return $this->remoteFileSystem->visibility($path);
+    }
+
+    public function write(string $location, string $contents, array $config = []): void
+    {
+        $this->remoteFileSystem->write($location, $contents, $config);
+        if ($this->cacheEnabled) {
+            $this->cacheFileSystem->write($location, $contents, $config);
         }
-
-
-        return $resource;
     }
 
-    public function listContents($directory = '', $recursive = false): array
+    public function writeStream(string $location, $contents, array $config = []): void
     {
-        return $this->remoteFileSystem->listContents($directory, $recursive);
+        $this->remoteFileSystem->writeStream($location, $contents, $config);
+        if ($this->cacheEnabled) {
+            $this->cacheFileSystem->writeStream($location, $contents, $config);
+        }
     }
 
-    public function getMetadata($path): array|false
+    public function setVisibility(string $path, string $visibility): void
     {
-        return $this->remoteFileSystem->getMetadata($path);
+        $this->remoteFileSystem->setVisibility($path, $visibility);
     }
 
-    public function getSize($path): int|false
+    public function delete(string $location): void
     {
-        return $this->remoteFileSystem->getSize($path);
+        $this->deleteFromCache($location);
+        $this->remoteFileSystem->delete($location);
     }
 
-    public function getMimetype($path): string|false
+    public function deleteDirectory(string $location): void
     {
-        return $this->remoteFileSystem->getMimetype($path);
+        $this->deleteDirectoryFromCache($location);
+        $this->remoteFileSystem->deleteDirectory($location);
     }
 
-    public function getTimestamp($path): int|false
+    public function createDirectory(string $location, array $config = []): void
     {
-        return $this->remoteFileSystem->getTimestamp($path);
+        $this->remoteFileSystem->createDirectory($location, $config);
     }
 
-    public function getVisibility($path): string|false
+    public function move(string $source, string $destination, array $config = []): void
     {
-        return $this->remoteFileSystem->getVisibility($path);
+        $this->deleteFromCache($source);
+        $this->remoteFileSystem->move($source, $destination, $config);
     }
 
-    public function write($path, $contents, array $config = []): bool
+    public function copy(string $source, string $destination, array $config = []): void
     {
-        $this->remoteFileSystem->write($path, $contents, $config);
-        return $this->cacheFileSystem->put($path, $contents, $config);
-    }
-
-    public function writeStream($path, $resource, array $config = []): bool
-    {
-        $this->remoteFileSystem->writeStream($path, $resource, $config);
-        return $this->cacheFileSystem->putStream($path, $resource, $config);
-    }
-
-    public function update($path, $contents, array $config = []): bool
-    {
-        $this->deleteFromCache($path);
-        return $this->remoteFileSystem->update($path, $contents, $config);
-    }
-
-    public function updateStream($path, $resource, array $config = []): bool
-    {
-        $this->deleteFromCache($path);
-        return $this->remoteFileSystem->updateStream($path, $resource, $config);
-    }
-
-    public function rename($path, $newpath): bool
-    {
-        $this->deleteFromCache($path);
-        return $this->remoteFileSystem->rename($path, $newpath);
-    }
-
-    public function copy($path, $newpath): bool
-    {
-        $this->deleteFromCache($path);
-        return $this->remoteFileSystem->copy($path, $newpath);
-    }
-
-    public function delete($path): bool
-    {
-        $this->deleteFromCache($path);
-        return $this->remoteFileSystem->delete($path);
-    }
-
-    public function deleteDir($dirname): bool
-    {
-        $this->deleteDirFromCache($dirname);
-        return $this->remoteFileSystem->deleteDir($dirname);
-    }
-
-    public function createDir($dirname, array $config = []): bool
-    {
-        return $this->remoteFileSystem->createDir($dirname, $config);
-    }
-
-    public function setVisibility($path, $visibility): bool
-    {
-        return $this->remoteFileSystem->setVisibility($path, $visibility);
-    }
-
-    public function put($path, $contents, array $config = []): bool
-    {
-        $this->cacheFileSystem->put($path, $contents, $config);
-        return $this->remoteFileSystem->put($path, $contents, $config);
-    }
-
-    public function putStream($path, $resource, array $config = []): bool
-    {
-        $this->cacheFileSystem->putStream($path, $resource, $config);
-        return $this->remoteFileSystem->putStream($path, $resource, $config);
-    }
-
-    public function readAndDelete($path): string|false
-    {
-        $this->deleteFromCache($path);
-        return $this->remoteFileSystem->readAndDelete($path);
-    }
-
-    public function get($path, Handler $handler = null): Handler
-    {
-        return $this->remoteFileSystem->get($path, $handler);
-    }
-
-    public function addPlugin(PluginInterface $plugin): static
-    {
-        return $this->remoteFileSystem->addPlugin($plugin);
+        $this->remoteFileSystem->copy($source, $destination, $config);
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -209,9 +209,6 @@
     "league/flysystem-aws-s3-v3": {
         "version": "1.0.29"
     },
-    "league/flysystem-cached-adapter": {
-        "version": "1.1.0"
-    },
     "league/mime-type-detection": {
         "version": "1.5.1"
     },

--- a/tests/Service/FilesystemFactoryTest.php
+++ b/tests/Service/FilesystemFactoryTest.php
@@ -9,16 +9,13 @@ use App\Service\Config;
 use App\Service\FilesystemFactory;
 use App\Tests\TestCase;
 use Exception;
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
 use Mockery as m;
 
 class FilesystemFactoryTest extends TestCase
 {
-    /** @var m\Mock */
-    private $config;
-
-    /** @var FilesystemFactory */
-    private $filesystemFactory;
+    private m\MockInterface|Config $config;
+    private FilesystemFactory $filesystemFactory;
 
     public function setUp(): void
     {
@@ -39,7 +36,7 @@ class FilesystemFactoryTest extends TestCase
         $this->config->shouldReceive('get')->with('storage_s3_url')->andReturn(null);
         $this->config->shouldReceive('get')->with('file_system_storage_path')->andReturn('/tmp');
         $result = $this->filesystemFactory->getFilesystem();
-        $this->assertInstanceOf(FilesystemInterface::class, $result);
+        $this->assertInstanceOf(FilesystemOperator::class, $result);
         $this->assertNotInstanceOf(LocalCachingFilesystemDecorator::class, $result);
     }
 

--- a/tests/Service/IliosFileSystemTest.php
+++ b/tests/Service/IliosFileSystemTest.php
@@ -58,7 +58,7 @@ class IliosFileSystemTest extends TestCase
         $path = __FILE__;
         $file = m::mock(File::class)
             ->shouldReceive('getPathname')->andReturn($path)->getMock();
-        $this->fileSystem->shouldReceive('putStream');
+        $this->fileSystem->shouldReceive('writeStream');
         $this->iliosFileSystem->storeLearningMaterialFile($file);
     }
 
@@ -82,7 +82,7 @@ class IliosFileSystemTest extends TestCase
     {
         $filename = 'test/file/name';
         $value = 'something something word word';
-        $this->fileSystem->shouldReceive('has')->with($filename)->once()->andReturn(true);
+        $this->fileSystem->shouldReceive('fileExists')->with($filename)->once()->andReturn(true);
         $this->fileSystem->shouldReceive('read')->with($filename)->once()->andReturn($value);
         $result = $this->iliosFileSystem->getFileContents($filename);
         $this->assertEquals($value, $result);
@@ -91,7 +91,7 @@ class IliosFileSystemTest extends TestCase
     public function testMissingGetFileContents()
     {
         $filename = 'test/file/name';
-        $this->fileSystem->shouldReceive('has')->with($filename)->once()->andReturn(false);
+        $this->fileSystem->shouldReceive('fileExists')->with($filename)->once()->andReturn(false);
         $result = $this->iliosFileSystem->getFileContents($filename);
         $this->assertFalse($result);
     }
@@ -104,9 +104,9 @@ class IliosFileSystemTest extends TestCase
         $badLm = m::mock(LearningMaterialInterface::class)
             ->shouldReceive('getRelativePath')->andReturn('badfile')
             ->mock();
-        $this->fileSystem->shouldReceive('has')
+        $this->fileSystem->shouldReceive('fileExists')
             ->with('goodfile')->andReturn(true)->once();
-        $this->fileSystem->shouldReceive('has')
+        $this->fileSystem->shouldReceive('fileExists')
             ->with('badfile')->andReturn(false)->once();
         $this->assertTrue($this->iliosFileSystem->checkLearningMaterialFilePath($goodLm));
         $this->assertFalse($this->iliosFileSystem->checkLearningMaterialFilePath($badLm));
@@ -139,8 +139,8 @@ class IliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(false);
-        $this->fileSystem->shouldReceive('put')->with($lockFilePath, 'LOCK');
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(false);
+        $this->fileSystem->shouldReceive('write')->with($lockFilePath, 'LOCK');
         $this->iliosFileSystem->createLock($name);
     }
 
@@ -148,7 +148,7 @@ class IliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(true);
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(true);
         $this->fileSystem->shouldReceive('delete')->with($lockFilePath);
         $this->iliosFileSystem->releaseLock($name);
     }
@@ -157,7 +157,7 @@ class IliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(false);
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(false);
         $this->iliosFileSystem->releaseLock($name);
     }
 
@@ -165,7 +165,7 @@ class IliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(true);
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(true);
         $status = $this->iliosFileSystem->hasLock($name);
         $this->assertTrue($status);
     }
@@ -174,7 +174,7 @@ class IliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(false);
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(false);
         $status = $this->iliosFileSystem->hasLock($name);
         $this->assertFalse($status);
     }
@@ -183,8 +183,8 @@ class IliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(false);
-        $this->fileSystem->shouldReceive('put')->with($lockFilePath, 'LOCK');
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(false);
+        $this->fileSystem->shouldReceive('write')->with($lockFilePath, 'LOCK');
         $this->iliosFileSystem->waitForLock($name);
     }
 
@@ -192,8 +192,8 @@ class IliosFileSystemTest extends TestCase
     {
         $name = 'test && file .lock';
         $lockFilePath = $this->getTestFileLock('test-file-.lock');
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(true);
-        $this->fileSystem->shouldReceive('put')->with($lockFilePath, 'LOCK');
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(true);
+        $this->fileSystem->shouldReceive('write')->with($lockFilePath, 'LOCK');
         $this->iliosFileSystem->createLock($name);
     }
 
@@ -202,7 +202,7 @@ class IliosFileSystemTest extends TestCase
         $path = __FILE__;
         $file = m::mock(UploadedFile::class)
             ->shouldReceive('getPathname')->andReturn($path)->getMock();
-        $this->fileSystem->shouldReceive('putStream');
+        $this->fileSystem->shouldReceive('writeStream');
         $this->iliosFileSystem->storeUploadedTemporaryFile($file);
     }
 
@@ -210,8 +210,9 @@ class IliosFileSystemTest extends TestCase
     {
         $hash = md5_file(__FILE__);
         $testContents = file_get_contents(__FILE__);
-        $this->fileSystem->shouldReceive('has')->with("tmp/${hash}")->andReturn(true);
-        $this->fileSystem->shouldReceive('readAndDelete')->with("tmp/${hash}")->andReturn($testContents);
+        $this->fileSystem->shouldReceive('fileExists')->with("tmp/${hash}")->andReturn(true);
+        $this->fileSystem->shouldReceive('read')->with("tmp/${hash}")->andReturn($testContents);
+        $this->fileSystem->shouldReceive('delete')->with("tmp/${hash}");
         $contents = $this->iliosFileSystem->getUploadedTemporaryFileContentsAndRemoveFile($hash);
         $this->assertSame($contents, $testContents);
     }

--- a/tests/Service/NonCachingIliosFileSystemTest.php
+++ b/tests/Service/NonCachingIliosFileSystemTest.php
@@ -66,7 +66,7 @@ class NonCachingIliosFileSystemTest extends TestCase
         $path = __FILE__;
         $file = m::mock(File::class)
             ->shouldReceive('getPathname')->andReturn($path)->getMock();
-        $this->fileSystem->shouldReceive('putStream');
+        $this->fileSystem->shouldReceive('writeStream');
         $this->iliosFileSystem->storeLearningMaterialFile($file);
     }
 
@@ -90,7 +90,7 @@ class NonCachingIliosFileSystemTest extends TestCase
     {
         $filename = 'test/file/name';
         $value = 'something something word word';
-        $this->fileSystem->shouldReceive('has')->with($filename)->once()->andReturn(true);
+        $this->fileSystem->shouldReceive('fileExists')->with($filename)->once()->andReturn(true);
         $this->fileSystem->shouldReceive('read')->with($filename)->once()->andReturn($value);
         $result = $this->iliosFileSystem->getFileContents($filename, false);
         $this->assertEquals($value, $result);
@@ -102,7 +102,7 @@ class NonCachingIliosFileSystemTest extends TestCase
         $iliosFileSystem = new IliosFileSystem($fileSystem);
         $filename = 'test/file/name';
         $value = 'something something word word';
-        $fileSystem->shouldReceive('has')->with($filename)->once()->andReturn(true);
+        $fileSystem->shouldReceive('fileExists')->with($filename)->once()->andReturn(true);
         $fileSystem->shouldReceive('read')->with($filename)->once()->andReturn($value);
         $result = $iliosFileSystem->getFileContents($filename, false);
         $this->assertEquals($value, $result);
@@ -111,7 +111,7 @@ class NonCachingIliosFileSystemTest extends TestCase
     public function testMissingGetFileContents()
     {
         $filename = 'test/file/name';
-        $this->fileSystem->shouldReceive('has')->with($filename)->once()->andReturn(false);
+        $this->fileSystem->shouldReceive('fileExists')->with($filename)->once()->andReturn(false);
         $result = $this->iliosFileSystem->getFileContents($filename);
         $this->assertFalse($result);
     }
@@ -124,9 +124,9 @@ class NonCachingIliosFileSystemTest extends TestCase
         $badLm = m::mock(LearningMaterialInterface::class)
             ->shouldReceive('getRelativePath')->andReturn('badfile')
             ->mock();
-        $this->fileSystem->shouldReceive('has')
+        $this->fileSystem->shouldReceive('fileExists')
             ->with('goodfile')->andReturn(true)->once();
-        $this->fileSystem->shouldReceive('has')
+        $this->fileSystem->shouldReceive('fileExists')
             ->with('badfile')->andReturn(false)->once();
         $this->assertTrue($this->iliosFileSystem->checkLearningMaterialFilePath($goodLm));
         $this->assertFalse($this->iliosFileSystem->checkLearningMaterialFilePath($badLm));
@@ -159,8 +159,8 @@ class NonCachingIliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(false);
-        $this->fileSystem->shouldReceive('put')->with($lockFilePath, 'LOCK');
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(false);
+        $this->fileSystem->shouldReceive('write')->with($lockFilePath, 'LOCK');
         $this->iliosFileSystem->createLock($name);
     }
 
@@ -168,7 +168,7 @@ class NonCachingIliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(true);
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(true);
         $this->fileSystem->shouldReceive('delete')->with($lockFilePath);
         $this->iliosFileSystem->releaseLock($name);
     }
@@ -177,7 +177,7 @@ class NonCachingIliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(false);
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(false);
         $this->iliosFileSystem->releaseLock($name);
     }
 
@@ -185,7 +185,7 @@ class NonCachingIliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(true);
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(true);
         $status = $this->iliosFileSystem->hasLock($name);
         $this->assertTrue($status);
     }
@@ -194,7 +194,7 @@ class NonCachingIliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(false);
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(false);
         $status = $this->iliosFileSystem->hasLock($name);
         $this->assertFalse($status);
     }
@@ -203,8 +203,8 @@ class NonCachingIliosFileSystemTest extends TestCase
     {
         $name = 'test.lock';
         $lockFilePath = $this->getTestFileLock($name);
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(false);
-        $this->fileSystem->shouldReceive('put')->with($lockFilePath, 'LOCK');
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(false);
+        $this->fileSystem->shouldReceive('write')->with($lockFilePath, 'LOCK');
         $this->iliosFileSystem->waitForLock($name);
     }
 
@@ -212,8 +212,8 @@ class NonCachingIliosFileSystemTest extends TestCase
     {
         $name = 'test && file .lock';
         $lockFilePath = $this->getTestFileLock('test-file-.lock');
-        $this->fileSystem->shouldReceive('has')->with($lockFilePath)->andReturn(true);
-        $this->fileSystem->shouldReceive('put')->with($lockFilePath, 'LOCK');
+        $this->fileSystem->shouldReceive('fileExists')->with($lockFilePath)->andReturn(true);
+        $this->fileSystem->shouldReceive('write')->with($lockFilePath, 'LOCK');
         $this->iliosFileSystem->createLock($name);
     }
 }


### PR DESCRIPTION
Updating to v3 requires a minimum PHP version of 8.0.2 and dropping the
caching adapter. Some API changes that are mostly cosmetic for us.

| Production Changes              | From    | To      | Compare                                                                            |
|---------------------------------|---------|---------|------------------------------------------------------------------------------------|
| aws/aws-sdk-php                 | 3.220.3 | 3.220.4 | [...](https://github.com/aws/aws-sdk-php/compare/3.220.3...3.220.4)                |
| league/flysystem                | 1.1.9   | 3.0.18  | [...](https://github.com/thephpleague/flysystem/compare/1.1.9...3.0.18)            |
| league/flysystem-aws-s3-v3      | 1.0.29  | 3.0.13  | [...](https://github.com/thephpleague/flysystem-aws-s3-v3/compare/1.0.29...3.0.13) |
| league/flysystem-cached-adapter | 1.1.0   | REMOVED |                                                                                    |
| symfony/deprecation-contracts   | v2.5.1  | v3.0.1  | [...](https://github.com/symfony/deprecation-contracts/compare/v2.5.1...v3.0.1)    |

I tested this with our S3 setup manually and also ran the `bin/console ilios:check-s3-permissions` and both worked.