### PR TITLE
Add client_max_body_size to nginx docker config

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -3,6 +3,7 @@ server {
     server_name  localhost;
     root   /srv/app/public;
     server_tokens off;
+    client_max_body_size: 105M;
 
     location / {
         gzip_static on;


### PR DESCRIPTION
105M mirrors what we have for PHP and allows files greater than the 1mb
nginx default to be uploaded.