### PR TITLE
Replace last few attributes validators with annotations

### DIFF
--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -64,7 +64,10 @@ class Alert implements AlertInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $additionalText;
 
     /**

--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -64,10 +64,7 @@ class Alert implements AlertInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $additionalText;
 
     /**

--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -59,15 +59,12 @@ class Alert implements AlertInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'additional_text', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $additionalText;
 
     /**

--- a/src/Entity/Authentication.php
+++ b/src/Entity/Authentication.php
@@ -33,26 +33,20 @@ class Authentication implements AuthenticationInterface, Stringable
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=100)
-     * })
      */
     #[ORM\Column(name: 'username', type: 'string', length: 100, unique: true, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 100)]
     private $username;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=255)
-     * })
      */
     #[ORM\Column(name: 'password_hash', type: 'string', nullable: true)]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 255)]
     private $passwordHash;
 
     #[ORM\Column(name: 'invalidate_token_issued_before', type: 'datetime', nullable: true)]

--- a/src/Entity/Authentication.php
+++ b/src/Entity/Authentication.php
@@ -38,7 +38,10 @@ class Authentication implements AuthenticationInterface, Stringable
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 100)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 100),
+    ])]
     private $username;
 
     /**
@@ -46,7 +49,10 @@ class Authentication implements AuthenticationInterface, Stringable
      */
     #[ORM\Column(name: 'password_hash', type: 'string', nullable: true)]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 255)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 255),
+    ])]
     private $passwordHash;
 
     #[ORM\Column(name: 'invalidate_token_issued_before', type: 'datetime', nullable: true)]

--- a/src/Entity/Authentication.php
+++ b/src/Entity/Authentication.php
@@ -38,10 +38,7 @@ class Authentication implements AuthenticationInterface, Stringable
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 100),
-    ])]
+    #[Assert\Length(max: 100)]
     private $username;
 
     /**
@@ -49,10 +46,7 @@ class Authentication implements AuthenticationInterface, Stringable
      */
     #[ORM\Column(name: 'password_hash', type: 'string', nullable: true)]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 255),
-    ])]
+    #[Assert\Length(max: 255)]
     private $passwordHash;
 
     #[ORM\Column(name: 'invalidate_token_issued_before', type: 'datetime', nullable: true)]

--- a/src/Entity/Competency.php
+++ b/src/Entity/Competency.php
@@ -54,10 +54,7 @@ class Competency implements CompetencyInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 200),
-    ])]
+    #[Assert\Length(max: 200)]
     protected $title;
 
     /**

--- a/src/Entity/Competency.php
+++ b/src/Entity/Competency.php
@@ -54,7 +54,10 @@ class Competency implements CompetencyInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 200)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 200),
+    ])]
     protected $title;
 
     /**

--- a/src/Entity/Competency.php
+++ b/src/Entity/Competency.php
@@ -49,15 +49,12 @@ class Competency implements CompetencyInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=200)
-     * })
      */
     #[ORM\Column(type: 'string', length: 200, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 200)]
     protected $title;
 
     /**

--- a/src/Entity/Course.php
+++ b/src/Entity/Course.php
@@ -118,15 +118,12 @@ class Course implements CourseInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=255)
-     * })
      */
     #[ORM\Column(name: 'external_id', type: 'string', length: 255, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 255)]
     protected $externalId;
 
     /**

--- a/src/Entity/Course.php
+++ b/src/Entity/Course.php
@@ -123,7 +123,10 @@ class Course implements CourseInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 255)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 255),
+    ])]
     protected $externalId;
 
     /**

--- a/src/Entity/Course.php
+++ b/src/Entity/Course.php
@@ -123,10 +123,7 @@ class Course implements CourseInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 255),
-    ])]
+    #[Assert\Length(max: 255)]
     protected $externalId;
 
     /**

--- a/src/Entity/CourseLearningMaterial.php
+++ b/src/Entity/CourseLearningMaterial.php
@@ -50,7 +50,10 @@ class CourseLearningMaterial implements CourseLearningMaterialInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $notes;
 
     /**

--- a/src/Entity/CourseLearningMaterial.php
+++ b/src/Entity/CourseLearningMaterial.php
@@ -44,16 +44,13 @@ class CourseLearningMaterial implements CourseLearningMaterialInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'notes', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $notes;
 
     /**

--- a/src/Entity/CourseLearningMaterial.php
+++ b/src/Entity/CourseLearningMaterial.php
@@ -50,10 +50,7 @@ class CourseLearningMaterial implements CourseLearningMaterialInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $notes;
 
     /**

--- a/src/Entity/CurriculumInventoryAcademicLevel.php
+++ b/src/Entity/CurriculumInventoryAcademicLevel.php
@@ -60,7 +60,10 @@ class CurriculumInventoryAcademicLevel implements CurriculumInventoryAcademicLev
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $description;
     /**
      * @var int

--- a/src/Entity/CurriculumInventoryAcademicLevel.php
+++ b/src/Entity/CurriculumInventoryAcademicLevel.php
@@ -60,11 +60,9 @@ class CurriculumInventoryAcademicLevel implements CurriculumInventoryAcademicLev
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $description;
+
     /**
      * @var int
      */

--- a/src/Entity/CurriculumInventoryAcademicLevel.php
+++ b/src/Entity/CurriculumInventoryAcademicLevel.php
@@ -55,15 +55,12 @@ class CurriculumInventoryAcademicLevel implements CurriculumInventoryAcademicLev
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'description', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $description;
     /**
      * @var int

--- a/src/Entity/CurriculumInventoryReport.php
+++ b/src/Entity/CurriculumInventoryReport.php
@@ -54,10 +54,7 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 200),
-    ])]
+    #[Assert\Length(max: 200)]
     protected $name;
 
     /**
@@ -67,10 +64,7 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $description;
 
     /**
@@ -149,10 +143,7 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
      */
     #[ORM\Column(name: 'token', type: 'string', length: 64, nullable: true)]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 64),
-    ])]
+    #[Assert\Length(max: 64)]
     protected $token;
 
     /**

--- a/src/Entity/CurriculumInventoryReport.php
+++ b/src/Entity/CurriculumInventoryReport.php
@@ -49,28 +49,22 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=200)
-     * })
      */
     #[ORM\Column(type: 'string', length: 200, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 200)]
     protected $name;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'description', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $description;
 
     /**
@@ -146,13 +140,10 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=64)
-     * })
      */
     #[ORM\Column(name: 'token', type: 'string', length: 64, nullable: true)]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 64)]
     protected $token;
 
     /**

--- a/src/Entity/CurriculumInventoryReport.php
+++ b/src/Entity/CurriculumInventoryReport.php
@@ -54,7 +54,10 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 200)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 200),
+    ])]
     protected $name;
 
     /**
@@ -64,7 +67,10 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $description;
 
     /**
@@ -143,7 +149,10 @@ class CurriculumInventoryReport implements CurriculumInventoryReportInterface
      */
     #[ORM\Column(name: 'token', type: 'string', length: 64, nullable: true)]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 64)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 64),
+    ])]
     protected $token;
 
     /**

--- a/src/Entity/CurriculumInventorySequence.php
+++ b/src/Entity/CurriculumInventorySequence.php
@@ -59,7 +59,10 @@ class CurriculumInventorySequence implements CurriculumInventorySequenceInterfac
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $description;
 
     public function setReport(CurriculumInventoryReportInterface $report)

--- a/src/Entity/CurriculumInventorySequence.php
+++ b/src/Entity/CurriculumInventorySequence.php
@@ -54,15 +54,12 @@ class CurriculumInventorySequence implements CurriculumInventorySequenceInterfac
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'description', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $description;
 
     public function setReport(CurriculumInventoryReportInterface $report)

--- a/src/Entity/CurriculumInventorySequence.php
+++ b/src/Entity/CurriculumInventorySequence.php
@@ -59,10 +59,7 @@ class CurriculumInventorySequence implements CurriculumInventorySequenceInterfac
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $description;
 
     public function setReport(CurriculumInventoryReportInterface $report)

--- a/src/Entity/CurriculumInventorySequenceBlock.php
+++ b/src/Entity/CurriculumInventorySequenceBlock.php
@@ -62,10 +62,7 @@ class CurriculumInventorySequenceBlock implements CurriculumInventorySequenceBlo
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $description;
 
     /**

--- a/src/Entity/CurriculumInventorySequenceBlock.php
+++ b/src/Entity/CurriculumInventorySequenceBlock.php
@@ -57,15 +57,12 @@ class CurriculumInventorySequenceBlock implements CurriculumInventorySequenceBlo
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'description', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $description;
 
     /**

--- a/src/Entity/CurriculumInventorySequenceBlock.php
+++ b/src/Entity/CurriculumInventorySequenceBlock.php
@@ -62,7 +62,10 @@ class CurriculumInventorySequenceBlock implements CurriculumInventorySequenceBlo
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $description;
 
     /**

--- a/src/Entity/LearnerGroup.php
+++ b/src/Entity/LearnerGroup.php
@@ -66,7 +66,10 @@ class LearnerGroup implements LearnerGroupInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 100)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 100),
+    ])]
     protected $location;
 
     #[ORM\Column(name: 'url', type: 'string', length: 2000, nullable: true)]

--- a/src/Entity/LearnerGroup.php
+++ b/src/Entity/LearnerGroup.php
@@ -61,15 +61,12 @@ class LearnerGroup implements LearnerGroupInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=100)
-     * })
      */
     #[ORM\Column(name: 'location', type: 'string', length: 100, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 100)]
     protected $location;
 
     #[ORM\Column(name: 'url', type: 'string', length: 2000, nullable: true)]

--- a/src/Entity/LearnerGroup.php
+++ b/src/Entity/LearnerGroup.php
@@ -66,10 +66,7 @@ class LearnerGroup implements LearnerGroupInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 100),
-    ])]
+    #[Assert\Length(max: 100)]
     protected $location;
 
     #[ORM\Column(name: 'url', type: 'string', length: 2000, nullable: true)]

--- a/src/Entity/LearningMaterial.php
+++ b/src/Entity/LearningMaterial.php
@@ -59,16 +59,13 @@ class LearningMaterial implements LearningMaterialInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'description', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $description;
 
     /**
@@ -84,26 +81,20 @@ class LearningMaterial implements LearningMaterialInterface
     /**
      * renamed Asset Creator
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=80)
-     * })
      */
     #[ORM\Column(name: 'asset_creator', type: 'string', length: 80, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 80)]
     protected $originalAuthor;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=64)
-     * })
      */
     #[ORM\Column(name: 'token', type: 'string', length: 64, nullable: true)]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 64)]
     protected $token;
 
     /**
@@ -195,15 +186,12 @@ class LearningMaterial implements LearningMaterialInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'copyright_rationale', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $copyrightRationale;
 
     /**

--- a/src/Entity/LearningMaterial.php
+++ b/src/Entity/LearningMaterial.php
@@ -65,7 +65,10 @@ class LearningMaterial implements LearningMaterialInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $description;
 
     /**
@@ -86,7 +89,10 @@ class LearningMaterial implements LearningMaterialInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 80)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 80),
+    ])]
     protected $originalAuthor;
 
     /**
@@ -94,7 +100,10 @@ class LearningMaterial implements LearningMaterialInterface
      */
     #[ORM\Column(name: 'token', type: 'string', length: 64, nullable: true)]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 64)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 64),
+    ])]
     protected $token;
 
     /**

--- a/src/Entity/LearningMaterial.php
+++ b/src/Entity/LearningMaterial.php
@@ -65,10 +65,7 @@ class LearningMaterial implements LearningMaterialInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $description;
 
     /**
@@ -89,10 +86,7 @@ class LearningMaterial implements LearningMaterialInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 80),
-    ])]
+    #[Assert\Length(max: 80)]
     protected $originalAuthor;
 
     /**
@@ -100,10 +94,7 @@ class LearningMaterial implements LearningMaterialInterface
      */
     #[ORM\Column(name: 'token', type: 'string', length: 64, nullable: true)]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 64),
-    ])]
+    #[Assert\Length(max: 64)]
     protected $token;
 
     /**

--- a/src/Entity/MeshConcept.php
+++ b/src/Entity/MeshConcept.php
@@ -65,41 +65,32 @@ class MeshConcept implements MeshConceptInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'scope_note', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $scopeNote;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=512)
-     * })
      */
     #[ORM\Column(name: 'casn_1_name', type: 'string', length: 512, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 512)]
     protected $casn1Name;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=30)
-     * })
      */
     #[ORM\Column(name: 'registry_number', type: 'string', length: 30, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 30)]
     protected $registryNumber;
 
     /**

--- a/src/Entity/MeshConcept.php
+++ b/src/Entity/MeshConcept.php
@@ -70,7 +70,10 @@ class MeshConcept implements MeshConceptInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $scopeNote;
 
     /**
@@ -80,7 +83,10 @@ class MeshConcept implements MeshConceptInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 512)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 512),
+    ])]
     protected $casn1Name;
 
     /**
@@ -90,7 +96,10 @@ class MeshConcept implements MeshConceptInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 30)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 30),
+    ])]
     protected $registryNumber;
 
     /**

--- a/src/Entity/MeshConcept.php
+++ b/src/Entity/MeshConcept.php
@@ -70,10 +70,7 @@ class MeshConcept implements MeshConceptInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $scopeNote;
 
     /**
@@ -83,10 +80,7 @@ class MeshConcept implements MeshConceptInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 512),
-    ])]
+    #[Assert\Length(max: 512)]
     protected $casn1Name;
 
     /**
@@ -96,10 +90,7 @@ class MeshConcept implements MeshConceptInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 30),
-    ])]
+    #[Assert\Length(max: 30)]
     protected $registryNumber;
 
     /**

--- a/src/Entity/MeshDescriptor.php
+++ b/src/Entity/MeshDescriptor.php
@@ -45,10 +45,6 @@ class MeshDescriptor implements MeshDescriptorInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=12)
-     * })
      */
     #[ORM\Column(name: 'mesh_descriptor_uid', type: 'string', length: 12)]
     #[ORM\Id]
@@ -56,33 +52,28 @@ class MeshDescriptor implements MeshDescriptorInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 12)]
     protected $id;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=192)
-     * })
      */
     #[ORM\Column(type: 'string', length: 192)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\NotBlank]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 192)]
     protected $name;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'annotation', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $annotation;
 
     /**

--- a/src/Entity/MeshDescriptor.php
+++ b/src/Entity/MeshDescriptor.php
@@ -52,7 +52,10 @@ class MeshDescriptor implements MeshDescriptorInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 12)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 12),
+    ])]
     protected $id;
 
     /**
@@ -73,7 +76,10 @@ class MeshDescriptor implements MeshDescriptorInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $annotation;
 
     /**

--- a/src/Entity/MeshDescriptor.php
+++ b/src/Entity/MeshDescriptor.php
@@ -52,10 +52,7 @@ class MeshDescriptor implements MeshDescriptorInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 12),
-    ])]
+    #[Assert\Length(max: 12)]
     protected $id;
 
     /**
@@ -76,10 +73,7 @@ class MeshDescriptor implements MeshDescriptorInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $annotation;
 
     /**

--- a/src/Entity/MeshTerm.php
+++ b/src/Entity/MeshTerm.php
@@ -70,15 +70,12 @@ class MeshTerm implements MeshTermInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=12)
-     * })
      */
     #[ORM\Column(name: 'lexical_tag', type: 'string', length: 12, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 12)]
     protected $lexicalTag;
 
     /**

--- a/src/Entity/MeshTerm.php
+++ b/src/Entity/MeshTerm.php
@@ -75,7 +75,10 @@ class MeshTerm implements MeshTermInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 12)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 12),
+    ])]
     protected $lexicalTag;
 
     /**

--- a/src/Entity/MeshTerm.php
+++ b/src/Entity/MeshTerm.php
@@ -75,10 +75,7 @@ class MeshTerm implements MeshTermInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 12),
-    ])]
+    #[Assert\Length(max: 12)]
     protected $lexicalTag;
 
     /**

--- a/src/Entity/Offering.php
+++ b/src/Entity/Offering.php
@@ -58,10 +58,7 @@ class Offering implements OfferingInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 255),
-    ])]
+    #[Assert\Length(max: 255)]
     protected $room;
 
     /**
@@ -71,10 +68,7 @@ class Offering implements OfferingInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 255),
-    ])]
+    #[Assert\Length(max: 255)]
     protected $site;
 
     /**

--- a/src/Entity/Offering.php
+++ b/src/Entity/Offering.php
@@ -58,7 +58,10 @@ class Offering implements OfferingInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 255)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 255),
+    ])]
     protected $room;
 
     /**
@@ -68,7 +71,10 @@ class Offering implements OfferingInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 255)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 255),
+    ])]
     protected $site;
 
     /**

--- a/src/Entity/Offering.php
+++ b/src/Entity/Offering.php
@@ -53,28 +53,22 @@ class Offering implements OfferingInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=255)
-     * })
      */
     #[ORM\Column(name: 'room', type: 'string', length: 255, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 255)]
     protected $room;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=255)
-     * })
      */
     #[ORM\Column(name: 'site', type: 'string', length: 255, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 255)]
     protected $site;
 
     /**

--- a/src/Entity/Program.php
+++ b/src/Entity/Program.php
@@ -58,15 +58,12 @@ class Program implements ProgramInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=10)
-     * })
      */
     #[ORM\Column(name: 'short_title', type: 'string', length: 10, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 10)]
     protected $shortTitle;
 
     /**

--- a/src/Entity/Program.php
+++ b/src/Entity/Program.php
@@ -63,10 +63,7 @@ class Program implements ProgramInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 10),
-    ])]
+    #[Assert\Length(max: 10)]
     protected $shortTitle;
 
     /**

--- a/src/Entity/Program.php
+++ b/src/Entity/Program.php
@@ -63,7 +63,10 @@ class Program implements ProgramInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 10)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 10),
+    ])]
     protected $shortTitle;
 
     /**

--- a/src/Entity/Report.php
+++ b/src/Entity/Report.php
@@ -44,10 +44,7 @@ class Report implements ReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 240),
-    ])]
+    #[Assert\Length(max: 240)]
     protected $title;
 
     /**
@@ -87,10 +84,7 @@ class Report implements ReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 32),
-    ])]
+    #[Assert\Length(max: 32)]
     protected $prepositionalObject;
 
     /**
@@ -100,10 +94,7 @@ class Report implements ReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 14),
-    ])]
+    #[Assert\Length(max: 14)]
     protected $prepositionalObjectTableRowId;
 
     /**

--- a/src/Entity/Report.php
+++ b/src/Entity/Report.php
@@ -44,7 +44,10 @@ class Report implements ReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 240)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 240),
+    ])]
     protected $title;
 
     /**
@@ -84,7 +87,10 @@ class Report implements ReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 32)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 32),
+    ])]
     protected $prepositionalObject;
 
     /**
@@ -94,7 +100,10 @@ class Report implements ReportInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 14)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 14),
+    ])]
     protected $prepositionalObjectTableRowId;
 
     /**

--- a/src/Entity/Report.php
+++ b/src/Entity/Report.php
@@ -39,15 +39,12 @@ class Report implements ReportInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=240)
-     * })
      */
     #[ORM\Column(type: 'string', length: 240, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 240)]
     protected $title;
 
     /**
@@ -82,28 +79,22 @@ class Report implements ReportInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=32)
-     * })
      */
     #[ORM\Column(name: 'prepositional_object', type: 'string', length: 32, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 32)]
     protected $prepositionalObject;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=14)
-     * })
      */
     #[ORM\Column(name: 'prepositional_object_table_row_id', type: 'string', length: 14, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 14)]
     protected $prepositionalObjectTableRowId;
 
     /**

--- a/src/Entity/School.php
+++ b/src/Entity/School.php
@@ -73,7 +73,10 @@ class School implements SchoolInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 8)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 8),
+    ])]
     protected $templatePrefix;
 
     /**

--- a/src/Entity/School.php
+++ b/src/Entity/School.php
@@ -68,15 +68,12 @@ class School implements SchoolInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=8)
-     * })
      */
     #[ORM\Column(name: 'template_prefix', type: 'string', length: 8, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 8)]
     protected $templatePrefix;
 
     /**

--- a/src/Entity/School.php
+++ b/src/Entity/School.php
@@ -73,10 +73,7 @@ class School implements SchoolInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 8),
-    ])]
+    #[Assert\Length(max: 8)]
     protected $templatePrefix;
 
     /**

--- a/src/Entity/Session.php
+++ b/src/Entity/Session.php
@@ -140,30 +140,24 @@ class Session implements SessionInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'instructionalNotes', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $instructionalNotes;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'description', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $description;
 
     /**

--- a/src/Entity/Session.php
+++ b/src/Entity/Session.php
@@ -146,7 +146,10 @@ class Session implements SessionInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $instructionalNotes;
 
     /**
@@ -157,7 +160,10 @@ class Session implements SessionInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $description;
 
     /**

--- a/src/Entity/Session.php
+++ b/src/Entity/Session.php
@@ -146,10 +146,7 @@ class Session implements SessionInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $instructionalNotes;
 
     /**
@@ -160,10 +157,7 @@ class Session implements SessionInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $description;
 
     /**

--- a/src/Entity/SessionLearningMaterial.php
+++ b/src/Entity/SessionLearningMaterial.php
@@ -49,16 +49,13 @@ class SessionLearningMaterial implements SessionLearningMaterialInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'notes', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $notes;
 
     /**

--- a/src/Entity/SessionLearningMaterial.php
+++ b/src/Entity/SessionLearningMaterial.php
@@ -55,7 +55,10 @@ class SessionLearningMaterial implements SessionLearningMaterialInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $notes;
 
     /**

--- a/src/Entity/SessionLearningMaterial.php
+++ b/src/Entity/SessionLearningMaterial.php
@@ -55,10 +55,7 @@ class SessionLearningMaterial implements SessionLearningMaterialInterface
     #[IA\Type('string')]
     #[IA\RemoveMarkup]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $notes;
 
     /**

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -71,7 +71,10 @@ class Term implements TermInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 65000)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 65000),
+    ])]
     protected $description;
 
     /**

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -66,15 +66,12 @@ class Term implements TermInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=65000)
-     * })
      */
     #[ORM\Column(name: 'description', type: 'text', nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 65000)]
     protected $description;
 
     /**

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -71,10 +71,7 @@ class Term implements TermInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 65000),
-    ])]
+    #[Assert\Length(max: 65000)]
     protected $description;
 
     /**

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -82,7 +82,10 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 20)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 20),
+    ])]
     protected $middleName;
 
     /**
@@ -92,7 +95,10 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 200)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 200),
+    ])]
     protected $displayName;
 
     /**
@@ -102,7 +108,10 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 30)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 30),
+    ])]
     protected $phone;
 
     /**
@@ -123,7 +132,10 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Email]
-    #[Assert\Length(min: 1, max: 100)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 100),
+    ])]
     protected $preferredEmail;
 
     /**
@@ -153,7 +165,10 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 16)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 16),
+    ])]
     protected $campusId;
 
     /**
@@ -163,7 +178,10 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\Length(min: 1, max: 16)]
+    #[Assert\AtLeastOneOf([
+        new Assert\Blank(),
+        new Assert\Length(min: 1, max: 16),
+    ])]
     protected $otherId;
 
     /**

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -77,41 +77,32 @@ class User implements UserInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=20)
-     * })
      */
     #[ORM\Column(name: 'middle_name', type: 'string', length: 20, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 20)]
     protected $middleName;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=200)
-     * })
      */
     #[ORM\Column(name: 'display_name', type: 'string', length: 200, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 200)]
     protected $displayName;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=30)
-     * })
      */
     #[ORM\Column(name: 'phone', type: 'string', length: 30, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 30)]
     protected $phone;
 
     /**
@@ -127,15 +118,12 @@ class User implements UserInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=100)
-     * })
      */
     #[ORM\Column(name: 'preferred_email', type: 'string', length: 100, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Email]
+    #[Assert\Length(min: 1, max: 100)]
     protected $preferredEmail;
 
     /**
@@ -160,28 +148,22 @@ class User implements UserInterface
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=16)
-     * })
      */
     #[ORM\Column(name: 'uc_uid', type: 'string', length: 16, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 16)]
     protected $campusId;
 
     /**
      * @var string
-     * @Assert\AtLeastOneOf({
-     *     @Assert\Blank,
-     *     @Assert\Length(min=1,max=16)
-     * })
      */
     #[ORM\Column(name: 'other_id', type: 'string', length: 16, nullable: true)]
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
+    #[Assert\Length(min: 1, max: 16)]
     protected $otherId;
 
     /**

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -82,10 +82,7 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 20),
-    ])]
+    #[Assert\Length(max: 20)]
     protected $middleName;
 
     /**
@@ -95,10 +92,7 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 200),
-    ])]
+    #[Assert\Length(max: 200)]
     protected $displayName;
 
     /**
@@ -108,10 +102,7 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 30),
-    ])]
+    #[Assert\Length(max: 30)]
     protected $phone;
 
     /**
@@ -132,10 +123,7 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Email]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 100),
-    ])]
+    #[Assert\Length(max: 100)]
     protected $preferredEmail;
 
     /**
@@ -165,10 +153,7 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 16),
-    ])]
+    #[Assert\Length(max: 16)]
     protected $campusId;
 
     /**
@@ -178,10 +163,7 @@ class User implements UserInterface
     #[IA\Expose]
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
-    #[Assert\AtLeastOneOf([
-        new Assert\Blank(),
-        new Assert\Length(min: 1, max: 16),
-    ])]
+    #[Assert\Length(max: 16)]
     protected $otherId;
 
     /**

--- a/tests/Entity/AlertTest.php
+++ b/tests/Entity/AlertTest.php
@@ -36,6 +36,9 @@ class AlertTest extends EntityBase
 
         $this->object->setTableRowId(3215);
         $this->object->setTableName('zippeedee doo dah');
+        $this->object->setAdditionalText('');
+        $this->validate(0);
+        $this->object->setAdditionalText('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/AuthenticationTest.php
+++ b/tests/Entity/AuthenticationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\Authentication;
+use App\Entity\UserInterface;
 use Mockery as m;
 
 /**
@@ -24,6 +25,17 @@ class AuthenticationTest extends EntityBase
     protected function setUp(): void
     {
         $this->object = new Authentication();
+    }
+
+    public function testNotBlankValidation()
+    {
+        $notBlank = [
+            'user',
+        ];
+        $this->validateNotBlanks($notBlank);
+
+        $this->object->setUser(m::mock(UserInterface::class));
+        $this->validate(0);
     }
 
     /**

--- a/tests/Entity/AuthenticationTest.php
+++ b/tests/Entity/AuthenticationTest.php
@@ -35,6 +35,11 @@ class AuthenticationTest extends EntityBase
         $this->validateNotBlanks($notBlank);
 
         $this->object->setUser(m::mock(UserInterface::class));
+        $this->object->setUsername('');
+        $this->object->setPasswordHash('');
+        $this->validate(0);
+        $this->object->setUsername('test');
+        $this->object->setPasswordHash('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/CompetencyTest.php
+++ b/tests/Entity/CompetencyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\Competency;
+use App\Entity\SchoolInterface;
 use Mockery as m;
 
 /**
@@ -24,6 +25,17 @@ class CompetencyTest extends EntityBase
     protected function setUp(): void
     {
         $this->object = new Competency();
+    }
+
+    public function testNotBlankValidation()
+    {
+        $notNull = [
+            'school',
+        ];
+        $this->validateNotNulls($notNull);
+
+        $this->object->setSchool(m::mock(SchoolInterface::class));
+        $this->validate(0);
     }
 
     /**

--- a/tests/Entity/CompetencyTest.php
+++ b/tests/Entity/CompetencyTest.php
@@ -35,6 +35,9 @@ class CompetencyTest extends EntityBase
         $this->validateNotNulls($notNull);
 
         $this->object->setSchool(m::mock(SchoolInterface::class));
+        $this->object->setTitle('');
+        $this->validate(0);
+        $this->object->setTitle('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/CourseLearningMaterialTest.php
+++ b/tests/Entity/CourseLearningMaterialTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\CourseInterface;
 use App\Entity\CourseLearningMaterial;
+use App\Entity\LearningMaterialInterface;
 use Mockery as m;
 
 /**
@@ -24,6 +26,19 @@ class CourseLearningMaterialTest extends EntityBase
     protected function setUp(): void
     {
         $this->object = new CourseLearningMaterial();
+    }
+
+    public function testNotBlankValidation()
+    {
+        $notNull = [
+            'course',
+            'learningMaterial',
+        ];
+        $this->validateNotNulls($notNull);
+
+        $this->object->setCourse(m::mock(CourseInterface::class));
+        $this->object->setLearningMaterial(m::mock(LearningMaterialInterface::class));
+        $this->validate(0);
     }
 
     /**

--- a/tests/Entity/CourseLearningMaterialTest.php
+++ b/tests/Entity/CourseLearningMaterialTest.php
@@ -39,6 +39,8 @@ class CourseLearningMaterialTest extends EntityBase
         $this->object->setCourse(m::mock(CourseInterface::class));
         $this->object->setLearningMaterial(m::mock(LearningMaterialInterface::class));
         $this->validate(0);
+        $this->object->setNotes('');
+        $this->validate(0);
     }
 
     /**

--- a/tests/Entity/CourseTest.php
+++ b/tests/Entity/CourseTest.php
@@ -50,6 +50,9 @@ class CourseTest extends EntityBase
         $this->object->setYear(2004);
         $this->object->setStartDate(new DateTime());
         $this->object->setEndDate(new DateTime());
+        $this->object->setExternalId('');
+        $this->validate(0);
+        $this->object->setExternalId('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/Entity/CurriculumInventoryAcademicLevelTest.php
@@ -35,6 +35,9 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
 
         $this->object->setName('50 char max name test');
         $this->object->setLevel(4);
+        $this->object->setDescription('');
+        $this->validate(0);
+        $this->object->setDescription('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/CurriculumInventoryInstitutionTest.php
+++ b/tests/Entity/CurriculumInventoryInstitutionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\CurriculumInventoryInstitution;
+use App\Entity\SchoolInterface;
 use Mockery as m;
 
 /**
@@ -37,7 +38,7 @@ class CurriculumInventoryInstitutionTest extends EntityBase
             'addressZipCode',
             'addressCountryCode'
         ];
-        $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
+        $this->object->setSchool(m::mock(SchoolInterface::class));
         $this->validateNotBlanks($notBlank);
 
         $this->object->setName('10lenMAX');

--- a/tests/Entity/CurriculumInventoryReportTest.php
+++ b/tests/Entity/CurriculumInventoryReportTest.php
@@ -41,6 +41,11 @@ class CurriculumInventoryReportTest extends EntityBase
         $this->object->setYear(2001);
         $this->object->setStartDate(new DateTime());
         $this->object->setEndDate(new DateTime());
+        $this->object->setName('');
+        $this->object->setDescription('');
+        $this->validate(0);
+        $this->object->setName('test');
+        $this->object->setDescription('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Entity/CurriculumInventorySequenceBlockTest.php
@@ -49,6 +49,9 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
         $this->object->setMaximum(521);
         $this->object->setStartDate(new DateTime());
         $this->object->setEndDate(new DateTime());
+        $this->object->setDescription('');
+        $this->validate(0);
+        $this->object->setDescription('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/CurriculumInventorySequenceTest.php
+++ b/tests/Entity/CurriculumInventorySequenceTest.php
@@ -35,6 +35,9 @@ class CurriculumInventorySequenceTest extends EntityBase
         $this->validateNotNulls($notNull);
 
         $this->object->setReport(m::mock(CurriculumInventoryReportInterface::class));
+        $this->object->setDescription('');
+        $this->validate(0);
+        $this->object->setDescription('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/CurriculumInventorySequenceTest.php
+++ b/tests/Entity/CurriculumInventorySequenceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\CurriculumInventoryReportInterface;
 use App\Entity\CurriculumInventorySequence;
 use Mockery as m;
 
@@ -24,6 +25,17 @@ class CurriculumInventorySequenceTest extends EntityBase
     protected function setUp(): void
     {
         $this->object = new CurriculumInventorySequence();
+    }
+
+    public function testNotBlankValidation()
+    {
+        $notNull = [
+            'report',
+        ];
+        $this->validateNotNulls($notNull);
+
+        $this->object->setReport(m::mock(CurriculumInventoryReportInterface::class));
+        $this->validate(0);
     }
 
     /**

--- a/tests/Entity/IngestionExceptionTest.php
+++ b/tests/Entity/IngestionExceptionTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\IngestionException;
-use Mockery as m;
 
 /**
  * Tests for Entity IngestionException
@@ -24,6 +23,17 @@ class IngestionExceptionTest extends EntityBase
     protected function setUp(): void
     {
         $this->object = new IngestionException();
+    }
+
+    public function testNotBlankValidation()
+    {
+        $notBlank = [
+            'uid',
+        ];
+        $this->validateNotBlanks($notBlank);
+
+        $this->object->setUid('jayden_rules');
+        $this->validate(0);
     }
 
     // not sure about this one -- there is the ID field which is NotBlank() but I recall this failing

--- a/tests/Entity/LearnerGroupTest.php
+++ b/tests/Entity/LearnerGroupTest.php
@@ -40,6 +40,9 @@ class LearnerGroupTest extends EntityBase
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('test');
+        $this->object->setLocation('');
+        $this->validate(0);
+        $this->object->setLocation('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/LearningMaterialTest.php
+++ b/tests/Entity/LearningMaterialTest.php
@@ -44,6 +44,11 @@ class LearningMaterialTest extends EntityBase
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('test');
+        $this->object->setDescription('');
+        $this->object->setOriginalAuthor('');
+        $this->validate(0);
+        $this->object->setDescription('test');
+        $this->object->setOriginalAuthor('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/MeshConceptTest.php
+++ b/tests/Entity/MeshConceptTest.php
@@ -34,6 +34,13 @@ class MeshConceptTest extends EntityBase
         $this->validateNotBlanks($notBlank);
 
         $this->object->setName('test_name');
+        $this->object->setScopeNote('');
+        $this->object->setCasn1Name('');
+        $this->object->setRegistryNumber('');
+        $this->validate(0);
+        $this->object->setScopeNote('test');
+        $this->object->setCasn1Name('test');
+        $this->object->setRegistryNumber('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/MeshDescriptorTest.php
+++ b/tests/Entity/MeshDescriptorTest.php
@@ -39,7 +39,12 @@ class MeshDescriptorTest extends EntityBase
         ];
         $this->validateNotBlanks($notBlank);
 
+        $this->object->setId('');
         $this->object->setName('test name');
+        $this->object->setAnnotation('');
+        $this->validate(0);
+        $this->object->setId('test');
+        $this->object->setAnnotation('test');
         $this->validate(0);
     }
     /**

--- a/tests/Entity/MeshTermTest.php
+++ b/tests/Entity/MeshTermTest.php
@@ -36,6 +36,9 @@ class MeshTermTest extends EntityBase
 
         $this->object->setName('test up to 192 in length search string');
         $this->object->setMeshTermUid('boots!');
+        $this->object->setLexicalTag('');
+        $this->validate(0);
+        $this->object->setLexicalTag('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/OfferingTest.php
+++ b/tests/Entity/OfferingTest.php
@@ -43,6 +43,11 @@ class OfferingTest extends EntityBase
 
         $this->object->setStartDate(new DateTime());
         $this->object->setEndDate(new DateTime());
+        $this->object->setRoom('');
+        $this->object->setSite('');
+        $this->validate(0);
+        $this->object->setRoom('test');
+        $this->object->setSite('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/OfferingTest.php
+++ b/tests/Entity/OfferingTest.php
@@ -8,6 +8,7 @@ use App\Entity\Course;
 use App\Entity\Offering;
 use App\Entity\School;
 use App\Entity\Session;
+use App\Entity\SessionInterface;
 use DateTime;
 use Mockery as m;
 
@@ -36,7 +37,7 @@ class OfferingTest extends EntityBase
             'startDate',
             'endDate'
         ];
-        $this->object->setSession(m::mock('App\Entity\SessionInterface'));
+        $this->object->setSession(m::mock(SessionInterface::class));
 
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/ProgramTest.php
+++ b/tests/Entity/ProgramTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\Program;
+use App\Entity\SchoolInterface;
 use Mockery as m;
 
 /**
@@ -32,7 +33,7 @@ class ProgramTest extends EntityBase
             'title',
             'duration'
         ];
-        $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
+        $this->object->setSchool(m::mock(SchoolInterface::class));
 
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/ProgramTest.php
+++ b/tests/Entity/ProgramTest.php
@@ -39,6 +39,9 @@ class ProgramTest extends EntityBase
 
         $this->object->setTitle('DVc');
         $this->object->setDuration(30);
+        $this->object->setShortTitle('');
+        $this->validate(0);
+        $this->object->setShortTitle('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/ProgramYearTest.php
+++ b/tests/Entity/ProgramYearTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\Program;
+use App\Entity\ProgramInterface;
 use App\Entity\ProgramYear;
 use App\Entity\ProgramYearObjective;
 use App\Entity\School;
@@ -34,7 +35,7 @@ class ProgramYearTest extends EntityBase
         $notBlank = [
             'startYear',
         ];
-        $this->object->setProgram(m::mock('App\Entity\ProgramInterface'));
+        $this->object->setProgram(m::mock(ProgramInterface::class));
 
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/ReportTest.php
+++ b/tests/Entity/ReportTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\Report;
+use App\Entity\UserInterface;
 use Mockery as m;
 
 /**
@@ -32,6 +33,19 @@ class ReportTest extends EntityBase
     public function testConstructor()
     {
         $this->assertNotEmpty($this->object->getCreatedAt());
+    }
+
+    public function testNotBlankValidation()
+    {
+        $errors = $this->validate(2);
+        $this->assertEquals([
+            "subject" => "NotBlank",
+            "user" => "NotNull",
+        ], $errors);
+
+        $this->object->setUser(m::mock(UserInterface::class));
+        $this->object->setSubject('test');
+        $this->validate(0);
     }
 
     /**

--- a/tests/Entity/ReportTest.php
+++ b/tests/Entity/ReportTest.php
@@ -45,6 +45,13 @@ class ReportTest extends EntityBase
 
         $this->object->setUser(m::mock(UserInterface::class));
         $this->object->setSubject('test');
+        $this->object->setTitle('');
+        $this->object->setPrepositionalObject('');
+        $this->object->setPrepositionalObjectTableRowId('');
+        $this->validate(0);
+        $this->object->setTitle('test');
+        $this->object->setPrepositionalObject('test');
+        $this->object->setPrepositionalObjectTableRowId('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/SchoolTest.php
+++ b/tests/Entity/SchoolTest.php
@@ -37,6 +37,9 @@ class SchoolTest extends EntityBase
 
         $this->object->setTitle('test');
         $this->object->setIliosAdministratorEmail('dartajax@winner.net');
+        $this->object->setTemplatePrefix('');
+        $this->validate(0);
+        $this->object->setTemplatePrefix('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/SessionLearningMaterialTest.php
+++ b/tests/Entity/SessionLearningMaterialTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\LearningMaterialInterface;
+use App\Entity\SessionInterface;
 use App\Entity\SessionLearningMaterial;
 use Mockery as m;
 
@@ -32,6 +34,21 @@ class SessionLearningMaterialTest extends EntityBase
     public function testConstructor()
     {
         $this->assertEmpty($this->object->getMeshDescriptors());
+    }
+
+    public function testNotBlankValidation()
+    {
+        $notNull = [
+            'required',
+            'session',
+            'learningMaterial',
+        ];
+        $this->validateNotNulls($notNull);
+
+        $this->object->setRequired(false);
+        $this->object->setSession(m::mock(SessionInterface::class));
+        $this->object->setLearningMaterial(m::mock(LearningMaterialInterface::class));
+        $this->validate(0);
     }
 
     /**

--- a/tests/Entity/SessionLearningMaterialTest.php
+++ b/tests/Entity/SessionLearningMaterialTest.php
@@ -48,6 +48,9 @@ class SessionLearningMaterialTest extends EntityBase
         $this->object->setRequired(false);
         $this->object->setSession(m::mock(SessionInterface::class));
         $this->object->setLearningMaterial(m::mock(LearningMaterialInterface::class));
+        $this->object->setNotes('');
+        $this->validate(0);
+        $this->object->setNotes('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/SessionTest.php
+++ b/tests/Entity/SessionTest.php
@@ -32,13 +32,13 @@ class SessionTest extends EntityBase
 
     public function testNotBlankValidation()
     {
-        $notBlank = [
-
-        ];
         $this->object->setSessionType(m::mock(SessionTypeInterface::class));
         $this->object->setCourse(m::mock(CourseInterface::class));
-
-        $this->validateNotBlanks($notBlank);
+        $this->object->setInstructionalNotes('');
+        $this->object->setDescription('');
+        $this->validate(0);
+        $this->object->setInstructionalNotes('test');
+        $this->object->setDescription('test');
         $this->validate(0);
     }
 
@@ -50,8 +50,8 @@ class SessionTest extends EntityBase
         ];
         $this->validateNotNulls($notNull);
 
-        $this->object->setSessionType(m::mock('App\Entity\SessionTypeInterface'));
-        $this->object->setCourse(m::mock('App\Entity\CourseInterface'));
+        $this->object->setSessionType(m::mock(SessionTypeInterface::class));
+        $this->object->setCourse(m::mock(CourseInterface::class));
 
         $this->validate(0);
     }

--- a/tests/Entity/SessionTest.php
+++ b/tests/Entity/SessionTest.php
@@ -8,6 +8,7 @@ use App\Entity\Course;
 use App\Entity\CourseInterface;
 use App\Entity\School;
 use App\Entity\Session;
+use App\Entity\SessionTypeInterface;
 use Mockery as m;
 
 /**
@@ -34,8 +35,8 @@ class SessionTest extends EntityBase
         $notBlank = [
 
         ];
-        $this->object->setSessionType(m::mock('App\Entity\SessionTypeInterface'));
-        $this->object->setCourse(m::mock('App\Entity\CourseInterface'));
+        $this->object->setSessionType(m::mock(SessionTypeInterface::class));
+        $this->object->setCourse(m::mock(CourseInterface::class));
 
         $this->validateNotBlanks($notBlank);
         $this->validate(0);

--- a/tests/Entity/SessionTypeTest.php
+++ b/tests/Entity/SessionTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\SchoolInterface;
 use App\Entity\SessionType;
 use Exception;
 use Mockery as m;
@@ -32,7 +33,7 @@ class SessionTypeTest extends EntityBase
         $notBlank = [
             'title'
         ];
-        $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
+        $this->object->setSchool(m::mock(SchoolInterface::class));
 
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/TermTest.php
+++ b/tests/Entity/TermTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Entity;
 use App\Entity\CourseInterface;
 use App\Entity\SessionInterface;
 use App\Entity\Term;
+use App\Entity\VocabularyInterface;
 use Mockery as m;
 
 /**
@@ -38,6 +39,19 @@ class TermTest extends EntityBase
         $this->assertEmpty($this->object->getSessions());
         $this->assertEmpty($this->object->getChildren());
         $this->assertEmpty($this->object->getAamcResourceTypes());
+    }
+
+    public function testNotBlankValidation()
+    {
+        $errors = $this->validate(2);
+        $this->assertEquals([
+            "title" => "NotBlank",
+            "vocabulary" => "NotNull",
+        ], $errors);
+
+        $this->object->setVocabulary(m::mock(VocabularyInterface::class));
+        $this->object->setTitle('test');
+        $this->validate(0);
     }
 
     /**

--- a/tests/Entity/TermTest.php
+++ b/tests/Entity/TermTest.php
@@ -51,6 +51,9 @@ class TermTest extends EntityBase
 
         $this->object->setVocabulary(m::mock(VocabularyInterface::class));
         $this->object->setTitle('test');
+        $this->object->setDescription('');
+        $this->validate(0);
+        $this->object->setDescription('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -39,6 +39,19 @@ class UserTest extends EntityBase
         $this->object->setLastName('Andrews');
         $this->object->setFirstName('Julia');
         $this->object->setEmail('sanders@ucsf.edu');
+        $this->object->setMiddleName('');
+        $this->object->setDisplayName('');
+        $this->object->setPhone('');
+        $this->object->setPreferredEmail('');
+        $this->object->setCampusId('');
+        $this->object->setOtherId('');
+        $this->validate(0);
+        $this->object->setMiddleName('test');
+        $this->object->setDisplayName('test');
+        $this->object->setPhone('test');
+        $this->object->setPreferredEmail('test@example.com');
+        $this->object->setCampusId('test');
+        $this->object->setOtherId('test');
         $this->validate(0);
     }
 

--- a/tests/Entity/VocabularyTest.php
+++ b/tests/Entity/VocabularyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\SchoolInterface;
 use App\Entity\Vocabulary;
 use Mockery as m;
 
@@ -32,6 +33,19 @@ class VocabularyTest extends EntityBase
     public function testConstructor()
     {
         $this->assertEmpty($this->object->getTerms());
+    }
+
+    public function testNotEmptyValidation()
+    {
+        $errors = $this->validate(2);
+        $this->assertEquals([
+            "title" => "NotBlank",
+            "school" => "NotNull",
+        ], $errors);
+
+        $this->object->setSchool(m::mock(SchoolInterface::class));
+        $this->object->setTitle('Jackson is the best dog!');
+        $this->validate(0);
     }
 
     /**


### PR DESCRIPTION
These weren't able to be code modded in #4006 because of the nesting, however it
turns out we didn't need the nesting because the Length validator allows
null and empty strings to pass through as valid now.