### PR TITLE
Deprecate Google Analytics

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -50,6 +50,16 @@ sudo -u apache bin/console doctrine:migrations:migrate --env=prod --no-interacti
 
 ## Version-specific steps
 
+### Upgrading to Ilios 3.99.0
+
+1. The `enable_tracking` and `tracking_code` parameters have been removed as google analytics is no longer supported.
+You should remove these parameters from your configuration by running:
+```bash
+cd YOUR_ILIOS_APPLICATION_ROOT
+bin/console ilios:set-config-value --remove enable_tracking
+bin/console ilios:set-config-value --remove tracking_code
+```
+
 ### Upgrading to Ilios 3.71.0
 
 1. The `ILIOS_DATABASE_MYSQL_VERSION` parameter has been removed, instead the MySQL version should be specified in the `ILIOS_DATABASE_URL`

--- a/src/Command/SetConfigValueCommand.php
+++ b/src/Command/SetConfigValueCommand.php
@@ -6,8 +6,10 @@ namespace App\Command;
 
 use App\Entity\ApplicationConfig;
 use App\Repository\ApplicationConfigRepository;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -39,9 +41,15 @@ class SetConfigValueCommand extends Command
                 InputArgument::REQUIRED,
                 'The name of the configuration we are setting'
             )
+            ->addOption(
+                'remove',
+                'r',
+                InputOption::VALUE_NONE,
+                'Remove the value instead of setting it'
+            )
             ->addArgument(
                 'value',
-                InputArgument::REQUIRED,
+                InputArgument::OPTIONAL,
                 'The value of the configuration we are setting'
             );
     }
@@ -50,19 +58,34 @@ class SetConfigValueCommand extends Command
     {
         $name = $input->getArgument('name');
         $value = $input->getArgument('value');
+        $isRemoving = $input->getOption('remove');
+        if (!$isRemoving && !$value) {
+            throw new RuntimeException("'value' is required");
+        }
 
         /** @var ApplicationConfig $config */
         $config = $this->applicationConfigRepository->findOneBy(['name' => $name]);
+
+        if ($isRemoving) {
+            if ($config) {
+                $this->applicationConfigRepository->delete($config);
+                $output->writeln("${name} removed.");
+                return Command::SUCCESS;
+            } else {
+                $output->writeln("<error>There was no value in the databse for ${name}</error>");
+                return Command::FAILURE;
+            }
+        }
+
         if (!$config) {
             $config = $this->applicationConfigRepository->create();
             $config->setName($name);
         }
         $config->setValue($value);
-
         $this->applicationConfigRepository->update($config, true);
 
         $output->writeln('<info>Done.</info>');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Monitor/DeprecatedConfigurationOption.php
+++ b/src/Monitor/DeprecatedConfigurationOption.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Monitor;
+
+use App\Service\Config;
+use Laminas\Diagnostics\Check\CheckInterface;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\ResultInterface;
+use Laminas\Diagnostics\Result\Success;
+use Laminas\Diagnostics\Result\Warning;
+
+class DeprecatedConfigurationOption implements CheckInterface
+{
+    public function __construct(protected Config $config)
+    {
+    }
+
+    // key is the option, value is whether to fail [true] or warn [false] when the value is present.
+    private const DEPRECATED_CONFIG = [
+        'enable_tracking' => false,
+        'tracking_code' => false,
+    ];
+    private const INSTRUCTIONS_URL = 'https://github.com/ilios/ilios/blob/master/docs/env_vars_and_config.md';
+    private const UPDATE_URL = 'https://github.com/ilios/ilios/blob/master/docs/update.md';
+
+    public function check(): ResultInterface
+    {
+        $deprecatedOptions = [];
+        foreach (self::DEPRECATED_CONFIG as $key => $shouldFail) {
+            $value = $this->config->get($key);
+            if (!is_null($value)) {
+                if ($shouldFail) {
+                    return new Failure(
+                        "'${key}' has been removed."
+                        . $this->getUpdateDocs()
+                    );
+                } else {
+                    $deprecatedOptions[] = $key;
+                }
+            }
+        }
+        if ($deprecatedOptions !== []) {
+            $message = "\n " .
+                implode("\n ", $deprecatedOptions) .
+                "\nhave been deprecated and will be removed soon.\n";
+
+            return new Warning($message . $this->getUpdateDocs());
+        }
+
+        return new Success('All required ENV variables are setup');
+    }
+
+    protected function getUpdateDocs(): string
+    {
+        $warnings[] = "\nFor help see: " . self::UPDATE_URL;
+        $warnings[] = "For information on supported variables see: " . self::INSTRUCTIONS_URL;
+        return implode("\n", $warnings) . "\n";
+    }
+
+    public function getLabel(): string
+    {
+        return 'Configuration Options';
+    }
+}

--- a/tests/Command/SetConfigValueCommandTest.php
+++ b/tests/Command/SetConfigValueCommandTest.php
@@ -92,12 +92,47 @@ class SetConfigValueCommandTest extends KernelTestCase
         ]);
     }
 
-    public function testValueRequired()
+    public function testValueRequiredIfNotRemoving()
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
             'command'      => self::COMMAND_NAME,
             'name'         => 'foo',
         ]);
+    }
+
+    public function testRemoveExistingConfig()
+    {
+        $mockConfig = m::mock(ApplicationConfig::class);
+        $this->applicationConfigRepository->shouldReceive('findOneBy')
+            ->with(['name' => 'foo'])
+            ->once()
+            ->andReturn($mockConfig);
+        $this->applicationConfigRepository->shouldReceive('delete')
+            ->with($mockConfig)
+            ->once();
+
+        $this->commandTester->execute(
+            [
+                'command'      => self::COMMAND_NAME,
+                'name'         => 'foo',
+                '--remove'       => true,
+            ]
+        );
+    }
+    public function testRemoveNonExistentConfig()
+    {
+        $this->applicationConfigRepository->shouldReceive('findOneBy')
+            ->with(['name' => 'foo'])
+            ->once()
+            ->andReturn(null);
+
+        $this->commandTester->execute(
+            [
+                'command'      => self::COMMAND_NAME,
+                'name'         => 'foo',
+                '--remove'       => true,
+            ]
+        );
     }
 }


### PR DESCRIPTION
Added a warning message to our health check and documented this
deprecation, we can remove these configuration options in the next major
release.

In order to make it easier to remove the old options (and anything else)
I added a --remove flag to our set-config-value command which will
delete a config options from the DB.

Fixes #3904