### PR TITLE
Add a healthcheck to nginx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,8 @@ jobs:
     - name: Nginx
       run: |
         docker run -d --name ilios-nginx nginx:testing
-        docker ps | grep -q ilios-nginx
+        sleep 15
+        docker ps --filter "health=healthy" | grep -q ilios-nginx
     - name: FPM
       run: |
         docker run -d --name ilios-fpm -e ILIOS_SECRET -e ILIOS_DATABASE_URL -e ILIOS_FILE_SYSTEM_STORAGE_PATH fpm:testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV NGINX_NAMESERVERS=127.0.0.11
 
 ARG ILIOS_VERSION="v0.1.0"
 RUN echo ${ILIOS_VERSION} > /srv/app/VERSION
+HEALTHCHECK --interval=5s CMD /usr/bin/nc -vz -w1 localhost 80
 
 ###############################################################################
 # Dependencies we need in all PHP containers


### PR DESCRIPTION
This will check to ensure port 80 is open and listening every 5 seconds,
we can use it in CI to ensure the container actually started.