### PR TITLE
Modify nginx to be more tolerant of missing PHP container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,12 @@ FROM nginx:1.19-alpine as nginx
 LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
 COPY --from=src /src/app /srv/app/
 COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template
+
+# Setup PHP servers in ENV so we can round robin easily
 ENV FPM_CONTAINERS=fpm:9000
+# Docker builtin nameserver
+ENV NGINX_NAMESERVERS=127.0.0.11
+
 ARG ILIOS_VERSION="v0.1.0"
 RUN echo ${ILIOS_VERSION} > /srv/app/VERSION
 

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -4,6 +4,7 @@ server {
     root   /srv/app/public;
     server_tokens off;
     client_max_body_size 105M;
+    resolver ${NGINX_NAMESERVERS} valid=10s;
 
     location / {
         gzip_static on;
@@ -31,7 +32,13 @@ server {
     #Symfony Docs on nginx: https://symfony.com/doc/current/setup/web_server_configuration.html#nginx
     # pass the PHP scripts to FastCGI server listening on :9000
     location ~ ^/index\.php(/|$) {
-        fastcgi_pass ${FPM_CONTAINERS};
+        # Use a local variable here to prevent nginx from attempting
+        # to do a DNS lookup when it first boots. By Disguising the
+        # hostname in this way we get a more resilient NGINX setup
+        set $fpmContainers ${FPM_CONTAINERS};
+
+        # nginx will now start if host is not reachable
+        fastcgi_pass $fpmContainers;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
 


### PR DESCRIPTION
When nginx boots it was imemdiatly searching for the php-fpm host which,
if it wasn't present, would then kill nginx. This doesn't work very well
in our docker setup and can intorduce mysterious failures.

This change stores the php-fpm host as an in-nginx-config variable that
isn't read until it is needed so startup isn't blocked. Because nginx
has it's own internal dns resolution that doesn't fall back to the host
we also need to override the resolve of the server. Docker provides DNS
that works well for this, but I've added it as an environmental variable
as well so it can be overridden at boot time if fargate or some other
task runner doesn't something different.