### PR TITLE
Add default user based permissions to all tokens

### DIFF
--- a/src/Service/JsonWebTokenManager.php
+++ b/src/Service/JsonWebTokenManager.php
@@ -83,6 +83,12 @@ class JsonWebTokenManager
         return $arr['refreshCount'] ?? 0;
     }
 
+    public function getPermissionsFromToken($jwt): string
+    {
+        $arr = $this->decode($jwt);
+        return $arr['permissions'] ?? 'user';
+    }
+
     protected function decode($jwt): array
     {
         $decoded = JWT::decode($jwt, new Key($this->jwtKey, self::SIGNING_ALGORITHM));
@@ -149,6 +155,7 @@ class JsonWebTokenManager
             'can_create_or_update_user_in_any_school' => $canCreateOrUpdateUserInAnySchool,
             'firstCreatedAt' => $firstCreatedAt->format('U'),
             'refreshCount' => $refreshCount,
+            'permissions' => 'user', //all tokens are user tokens right now and get permissions from the user
         ];
     }
 

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -200,6 +200,7 @@ class AuthControllerTest extends WebTestCase
 
         // test for sameness
         $this->assertSame($token['user_id'], $token2['user_id']);
+        $this->assertSame($token['permissions'], $token2['permissions']);
         $this->assertSame($token['iss'], $token2['iss']);
         $this->assertSame($token['aud'], $token2['aud']);
         $this->assertSame($token['firstCreatedAt'], $token2['firstCreatedAt']);
@@ -209,6 +210,10 @@ class AuthControllerTest extends WebTestCase
         //refresh should increment counter
         $this->assertEquals(0, $token['refreshCount']);
         $this->assertEquals(1, $token2['refreshCount']);
+
+        //both tokens have user level permissions
+        $this->assertEquals('user', $token['permissions']);
+        $this->assertEquals('user', $token2['permissions']);
     }
 
     public function testGetTokenWithNonDefaultTtl()

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -76,6 +76,12 @@ class JsonWebTokenManagerTest extends TestCase
         $this->assertSame($stamp, $this->obj->getExpiresAtFromToken($jwt)->format('U'));
     }
 
+    public function testUserTokensGetUserPermissions()
+    {
+        $jwt = $this->buildToken();
+        $this->assertSame('user', $this->obj->getPermissionsFromToken($jwt));
+    }
+
     public function testCreateJwtFromSessionUser()
     {
         $sessionUser = m::mock(SessionUserInterface::class)


### PR DESCRIPTION
Currently all of the tokens we generate get their permissions from the
user that generates them. Let's explicitly indicate that so we can
enhance it later by adding specific permissions to the token itself.

Refs #4039