### PR TITLE
Comment out DB config in dev env file

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -4,7 +4,7 @@
 ILIOS_SECRET=NotSecretChangeMe
 
 # Configure your db driver and server_version in config/packages/doctrine.yaml
-ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=8.0
+# ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=8.0
 
 # Where on the file system to store upload learning materials
 ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp


### PR DESCRIPTION
Having this in both .env and .env.dev makes is annoying on first setup
to change it in the right place. Let's comment out the one in .env.dev
so creating a .env.local is enough to get started.