### PR TITLE
Re-organize how the frontend is stored on disk

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -31,6 +31,8 @@ services:
       - ./:/srv/app:rw,cached
       # Remove the var/ directory from the bind-mount for better performance
       - /srv/app/var
+      # Share the frontend files
+      - ./var/frontend:/srv/app/var/frontend:rw,cached
     depends_on:
       - db
   messages:

--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -31,17 +31,14 @@ use function is_dir;
  */
 class UpdateFrontendCommand extends Command implements CacheWarmerInterface
 {
-    /**
-     * @var string
-     */
-    public const ACTIVE_FRONTEND_VERSION_DIRECTORY = '/ilios/frontend/';
-    public const ARCHIVE_FILE_NAME = 'frontend.tar.gz';
-    public const UNPACKED_DIRECTORY = '/deploy-dist/';
+    private const ACTIVE_FRONTEND_VERSION_DIRECTORY = '/active/';
+    private const UNPACKED_DIRECTORY = '/deploy-dist/';
+    private const FRONTEND_FILES = '/var/frontend/';
 
-    public const STAGING_CDN_ASSET_DOMAIN = 'https://frontend-archive-staging.iliosproject.org/';
-    public const STAGING_ASSET_LIST = 'https://frontend-archive-staging.s3.us-west-2.amazonaws.com/';
-    public const PRODUCTION_CDN_ASSET_DOMAIN = 'https://frontend-archive-production.iliosproject.org/';
-    public const PRODUCTION_ASSET_LIST = 'https://frontend-archive-production.s3.us-west-2.amazonaws.com/';
+    private const STAGING_CDN_ASSET_DOMAIN = 'https://frontend-archive-staging.iliosproject.org/';
+    private const STAGING_ASSET_LIST = 'https://frontend-archive-staging.s3.us-west-2.amazonaws.com/';
+    private const PRODUCTION_CDN_ASSET_DOMAIN = 'https://frontend-archive-production.iliosproject.org/';
+    private const PRODUCTION_ASSET_LIST = 'https://frontend-archive-production.s3.us-west-2.amazonaws.com/';
 
     private const STAGING = 'stage';
     private const PRODUCTION = 'prod';
@@ -57,12 +54,11 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
         protected Filesystem $fs,
         protected Config $config,
         private Archive $archive,
-        protected string $kernelCacheDir,
-        string $kernelProjectDir,
+        protected string $kernelProjectDir,
         protected string $apiVersion,
         protected string $environment
     ) {
-        $temporaryFileStorePath = $kernelProjectDir . '/var/tmp/frontend-update-files';
+        $temporaryFileStorePath = $this->kernelProjectDir . self::FRONTEND_FILES . "/assets";
         $this->fs->mkdir($temporaryFileStorePath);
         $this->productionTemporaryFileStore = $temporaryFileStorePath . '/prod';
         $this->fs->mkdir($this->productionTemporaryFileStore);
@@ -177,10 +173,9 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
 
     protected function activateVersion(string $distributionPath): void
     {
-        $frontendPath = $this->kernelCacheDir . self::ACTIVE_FRONTEND_VERSION_DIRECTORY;
+        $frontendPath = self::getActiveFrontendIndexPath($this->kernelProjectDir);
         $this->fs->remove($frontendPath);
-        $this->fs->mkdir($frontendPath);
-        $this->fs->copy("${distributionPath}/index.json", "${frontendPath}/index.json");
+        $this->fs->copy("${distributionPath}/index.json", $frontendPath);
     }
 
     protected function downloadAndExtractAllArchives(string $environment): ?string
@@ -320,5 +315,10 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
         if ($this->output) {
             $this->output->writeln("<${type}>${message}</${type}>");
         }
+    }
+
+    public static function getActiveFrontendIndexPath(string $kernelProjectDir): string
+    {
+        return $kernelProjectDir . self::FRONTEND_FILES  . '/index.json';
     }
 }

--- a/src/Monitor/Frontend.php
+++ b/src/Monitor/Frontend.php
@@ -12,15 +12,13 @@ use Laminas\Diagnostics\Result\Success;
 
 class Frontend implements CheckInterface
 {
-    public function __construct(private string $kernelCacheDir)
+    public function __construct(private string $kernelProjectDir)
     {
     }
 
     public function check(): ResultInterface
     {
-        $assetsPath = $this->kernelCacheDir . UpdateFrontendCommand::ACTIVE_FRONTEND_VERSION_DIRECTORY;
-        $path = $assetsPath . 'index.json';
-
+        $path = UpdateFrontendCommand::getActiveFrontendIndexPath($this->kernelProjectDir);
         if (!file_exists($path)) {
             return new Failure("has not been loaded. Run bin/console ilios:maintenance:update-frontend");
         }

--- a/tests/Controller/IndexControllerTest.php
+++ b/tests/Controller/IndexControllerTest.php
@@ -19,20 +19,9 @@ class IndexControllerTest extends WebTestCase
     private const COMMAND_NAME = 'ilios:maintenance:update-frontend';
     private const TEST_API_VERSION = '33.14-test';
 
-    /**
-     * @var m\Mock
-     */
-    protected $assetsPath;
-
-    /**
-     * @var Filesystem
-     */
-    protected $fileSystem;
-
-    /**
-     * @var KernelBrowser
-     */
-    protected $kernelBrowser;
+    protected string $jsonPath;
+    protected Filesystem $fileSystem;
+    protected KernelBrowser $kernelBrowser;
 
     /**
      * @var array
@@ -44,8 +33,8 @@ class IndexControllerTest extends WebTestCase
         parent::setUp();
         $this->kernelBrowser = static::createClient();
         $container = $this->kernelBrowser->getContainer();
-        $cacheDir = $container->getParameter('kernel.cache_dir');
-        $this->assetsPath =  $cacheDir . UpdateFrontendCommand::ACTIVE_FRONTEND_VERSION_DIRECTORY;
+        $projectDir = $container->getParameter('kernel.project_dir');
+        $this->jsonPath = UpdateFrontendCommand::getActiveFrontendIndexPath($projectDir);
         $this->fileSystem = new Filesystem();
         $this->testFiles = [];
     }
@@ -66,7 +55,6 @@ class IndexControllerTest extends WebTestCase
 
     public function testIndex()
     {
-        $jsonPath = $this->assetsPath . 'index.json';
         $json = json_encode([
             'meta' => [],
             'link' => [],
@@ -75,7 +63,7 @@ class IndexControllerTest extends WebTestCase
             'noScript' => [],
             'div' => [],
         ]);
-        $this->setupTestFile($jsonPath, $json, false);
+        $this->setupTestFile($this->jsonPath, $json, false);
         $this->kernelBrowser->request('GET', '/');
         $response = $this->kernelBrowser->getResponse();
 
@@ -98,7 +86,6 @@ class IndexControllerTest extends WebTestCase
 
     public function testGzippedWhenRequested()
     {
-        $jsonPath = $this->assetsPath . 'index.json';
         $json = json_encode([
             'meta' => [],
             'link' => [],
@@ -107,7 +94,7 @@ class IndexControllerTest extends WebTestCase
             'noScript' => [],
             'div' => [],
         ]);
-        $this->setupTestFile($jsonPath, $json, false);
+        $this->setupTestFile($this->jsonPath, $json, false);
         $this->kernelBrowser->request(
             'GET',
             '/',
@@ -134,7 +121,6 @@ class IndexControllerTest extends WebTestCase
 
     public function testIndexFromCacheIsTheSameInGzippedAndUnCompressed()
     {
-        $jsonPath = $this->assetsPath . 'index.json';
         $json = json_encode([
             'meta' => [],
             'link' => [],
@@ -143,7 +129,7 @@ class IndexControllerTest extends WebTestCase
             'noScript' => [],
             'div' => [],
         ]);
-        $this->setupTestFile($jsonPath, $json, false);
+        $this->setupTestFile($this->jsonPath, $json, false);
 
         $this->kernelBrowser->request(
             'GET',
@@ -190,7 +176,6 @@ class IndexControllerTest extends WebTestCase
 
     public function testErrorCaptureConfiguration()
     {
-        $jsonPath = $this->assetsPath . 'index.json';
         $json = json_encode([
             'meta' => [],
             'link' => [],
@@ -201,7 +186,7 @@ class IndexControllerTest extends WebTestCase
         ]);
         $orig = $_ENV['ILIOS_ERROR_CAPTURE_ENABLED'];
         $_ENV['ILIOS_ERROR_CAPTURE_ENABLED'] = true;
-        $this->setupTestFile($jsonPath, $json, false);
+        $this->setupTestFile($this->jsonPath, $json, false);
         $this->kernelBrowser->request('GET', '/');
         $response = $this->kernelBrowser->getResponse();
 


### PR DESCRIPTION
Instead of splitting this up into various cache and tmp directories I've
consolidated everything into var/frontend. This is makes it possible to
share this directory with containers making it easier to develop and
test ilios.

I also realized that we were still thinking about the active version as
a path to many assets, but it's really just a single JSON file so I
changed the way we share that path with other areas of the application
and was able to drop some constants and make others private.