### PR TITLE
unlock command before returning.

### DIFF
--- a/src/Command/ImportDefaultDataCommand.php
+++ b/src/Command/ImportDefaultDataCommand.php
@@ -74,6 +74,7 @@ class ImportDefaultDataCommand extends Command
         $school = $this->schoolRepository->findDTOBy([]);
         if ($school) {
             $io->error('Your database already contains data. Aborting import process.');
+            $this->release();
             return Command::FAILURE;
         }
 
@@ -190,6 +191,7 @@ class ImportDefaultDataCommand extends Command
                 'An error occurred during data import:',
                 $e->getMessage()
             ]);
+            $this->release();
             return Command::FAILURE;
         }
         $io->text('Completed data import.');


### PR DESCRIPTION
Turns out that if you run PHPUnit on our test coverage in _random mode_ (like Infection does), the test run may fail with this message

```
There was 1 failure:

1) App\Tests\Command\ImportDefaultDataCommandTest::testExecute
Failed asserting that '\n
 [ERROR] The command is already running in another process.                                                             \n
\n
' contains "Completed data import".
```

This happens when the test for the error condition runs before the happy path - we weren't releasing the lock on the command under all circumstances.
This fixes the problem.