### PR TITLE
Only compare sequence blocks if necessary

### DIFF
--- a/src/Controller/API/CurriculumInventorySequenceBlocks.php
+++ b/src/Controller/API/CurriculumInventorySequenceBlocks.php
@@ -234,10 +234,13 @@ class CurriculumInventorySequenceBlocks extends ReadWriteController
 
         $blocks = $parent->getChildrenAsSortedList();
 
-        $blocks = array_filter(
-            $blocks,
-            fn(CurriculumInventorySequenceBlockInterface $sibling) => $sibling->getId() !== $block->getId()
-        );
+        if ($this->repository->isEntityPersisted($block)) {
+            $blocks = array_filter(
+                $blocks,
+                fn(CurriculumInventorySequenceBlockInterface $sibling) => $sibling->getId() !== $block->getId()
+            );
+        }
+
         $blocks = array_values($blocks);
 
         $minRange = 1;

--- a/src/Repository/RepositoryInterface.php
+++ b/src/Repository/RepositoryInterface.php
@@ -76,7 +76,13 @@ interface RepositoryInterface
 
     /**
      * Get the ID field for this type of entity
-     * Usualy it is "id", but sometimes it isn't
+     * Usually it is "id", but sometimes it isn't
      */
     public function getIdField(): string;
+
+    /**
+     * Check if an entity has been persisted to the DB
+     * Useful when we don't know if something may have an ID or not
+     */
+    public function isEntityPersisted(object $entity): bool;
 }

--- a/src/Traits/ManagerRepository.php
+++ b/src/Traits/ManagerRepository.php
@@ -81,6 +81,11 @@ trait ManagerRepository
         return $meta->getSingleIdentifierFieldName();
     }
 
+    public function isEntityPersisted(object $entity): bool
+    {
+        return $this->getEntityManager()->contains($entity);
+    }
+
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null): array
     {
         $qb = $this->getEntityManager()->createQueryBuilder();


### PR DESCRIPTION
When a new block hasn't get been persisted we don't need to compare it
by id to all the other blocks (it's id is null).

This prevents us checking the id value before it has been set once the
id is typed.