### PR TITLE
Remove invalid comparison check

### DIFF
--- a/src/Controller/API/CurriculumInventorySequenceBlocks.php
+++ b/src/Controller/API/CurriculumInventorySequenceBlocks.php
@@ -257,7 +257,7 @@ class CurriculumInventorySequenceBlocks extends ReadWriteController
             /* @var CurriculumInventorySequenceBlockInterface $current */
             $current = $blocks[$i];
             $j = $i + 1;
-            if ($current->getId() !== $block && $current->getOrderInSequence() !== $j) {
+            if ($current->getOrderInSequence() !== $j) {
                 $current->setOrderInSequence($j);
                 $this->repository->update($current, false, false);
             }


### PR DESCRIPTION
This could never be true as comparing any value for ID to an object
doesn't make sense. We do allow the CIBlock class to cast itself to a
string by its ID, however since getId() is going to return and int and
we're doing a strict comparison I don't believe even PHP magic would
ever evaluate this to true.