### PR TITLE
Change name of stringable entity interface

### DIFF
--- a/src/Entity/AamcPcrsInterface.php
+++ b/src/Entity/AamcPcrsInterface.php
@@ -10,7 +10,7 @@ use App\Traits\CompetenciesEntityInterface;
 use App\Traits\DescribableEntityInterface;
 use App\Traits\NameableEntityInterface;
 use App\Entity\CompetencyInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\IdentifiableEntityInterface;
 
 /**
@@ -18,7 +18,7 @@ use App\Traits\IdentifiableEntityInterface;
  */
 interface AamcPcrsInterface extends
     IdentifiableEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     LoggableEntityInterface,
     CompetenciesEntityInterface
 {

--- a/src/Entity/AamcResourceTypeInterface.php
+++ b/src/Entity/AamcResourceTypeInterface.php
@@ -7,7 +7,7 @@ namespace App\Entity;
 use App\Traits\CategorizableEntityInterface;
 use App\Traits\DescribableEntityInterface;
 use App\Traits\IdentifiableEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\TitledEntityInterface;
 
 /**
@@ -15,7 +15,7 @@ use App\Traits\TitledEntityInterface;
  */
 interface AamcResourceTypeInterface extends
     IdentifiableEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     TitledEntityInterface,
     CategorizableEntityInterface
 {

--- a/src/Entity/AlertChangeTypeInterface.php
+++ b/src/Entity/AlertChangeTypeInterface.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use App\Traits\AlertableEntityInterface;
 use App\Traits\IdentifiableEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\TitledEntityInterface;
 
 /**
@@ -17,7 +17,7 @@ use App\Traits\TitledEntityInterface;
 interface AlertChangeTypeInterface extends
     IdentifiableEntityInterface,
     TitledEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     LoggableEntityInterface,
     AlertableEntityInterface
 {

--- a/src/Entity/AuditLogInterface.php
+++ b/src/Entity/AuditLogInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Traits\IdentifiableEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use DateTime;
 
 /**
@@ -14,7 +14,7 @@ use DateTime;
  */
 interface AuditLogInterface extends
     IdentifiableEntityInterface,
-    StringableEntityInterface
+    StringableEntityToIdInterface
 {
     /**
      * Set action

--- a/src/Entity/CourseClerkshipTypeInterface.php
+++ b/src/Entity/CourseClerkshipTypeInterface.php
@@ -6,7 +6,7 @@ namespace App\Entity;
 
 use App\Traits\IdentifiableEntityInterface;
 use App\Traits\TitledEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\CoursesEntityInterface;
 
 /**
@@ -15,7 +15,7 @@ use App\Traits\CoursesEntityInterface;
 interface CourseClerkshipTypeInterface extends
     IdentifiableEntityInterface,
     TitledEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     CoursesEntityInterface,
     LoggableEntityInterface
 {

--- a/src/Entity/CourseInterface.php
+++ b/src/Entity/CourseInterface.php
@@ -20,7 +20,7 @@ use App\Traits\MeshDescriptorsEntityInterface;
 use App\Traits\PublishableEntityInterface;
 use App\Traits\SchoolEntityInterface;
 use App\Traits\StudentAdvisorsEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\SessionsEntityInterface;
 
 /**
@@ -29,7 +29,7 @@ use App\Traits\SessionsEntityInterface;
 interface CourseInterface extends
     IdentifiableEntityInterface,
     TitledNullableEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     LockableEntityInterface,
     ArchivableEntityInterface,
     SessionsEntityInterface,

--- a/src/Entity/CurriculumInventoryReportInterface.php
+++ b/src/Entity/CurriculumInventoryReportInterface.php
@@ -12,7 +12,7 @@ use App\Traits\DescribableEntityInterface;
 use App\Traits\IdentifiableEntityInterface;
 use App\Traits\NameableEntityInterface;
 use App\Traits\SequenceBlocksEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 
 /**
  * Interface CurriculumInventoryReportInterface
@@ -21,7 +21,7 @@ interface CurriculumInventoryReportInterface extends
     IdentifiableEntityInterface,
     NameableEntityInterface,
     DescribableEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     LoggableEntityInterface,
     SequenceBlocksEntityInterface,
     AdministratorsEntityInterface

--- a/src/Entity/LearnerGroupInterface.php
+++ b/src/Entity/LearnerGroupInterface.php
@@ -11,7 +11,7 @@ use App\Traits\IlmSessionsEntityInterface;
 use App\Traits\InstructorGroupsEntityInterface;
 use App\Traits\InstructorsEntityInterface;
 use App\Traits\TitledEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\OfferingsEntityInterface;
 use App\Traits\UsersEntityInterface;
 
@@ -21,7 +21,7 @@ use App\Traits\UsersEntityInterface;
 interface LearnerGroupInterface extends
     IdentifiableEntityInterface,
     TitledEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     OfferingsEntityInterface,
     LoggableEntityInterface,
     UsersEntityInterface,

--- a/src/Entity/LoggableEntityInterface.php
+++ b/src/Entity/LoggableEntityInterface.php
@@ -6,12 +6,11 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 
 /**
- * Interface LoggableEntityInterface
  * Loggable entities have all changes logged automatically
  */
-interface LoggableEntityInterface extends StringableEntityInterface
+interface LoggableEntityInterface extends StringableEntityToIdInterface
 {
 }

--- a/src/Entity/MeshPreviousIndexingInterface.php
+++ b/src/Entity/MeshPreviousIndexingInterface.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Traits\IdentifiableEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 
 /**
  * Interface MeshPreviousIndexingInterface
  */
 interface MeshPreviousIndexingInterface extends
     IdentifiableEntityInterface,
-    StringableEntityInterface
+    StringableEntityToIdInterface
 {
     public function setDescriptor(MeshDescriptorInterface $descriptor);
 

--- a/src/Entity/MeshTreeInterface.php
+++ b/src/Entity/MeshTreeInterface.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Traits\IdentifiableEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 
 /**
  * Class MeshTreeInterface
  */
 interface MeshTreeInterface extends
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     IdentifiableEntityInterface
 {
     /**

--- a/src/Entity/OfferingInterface.php
+++ b/src/Entity/OfferingInterface.php
@@ -11,7 +11,7 @@ use App\Traits\InstructorGroupsEntityInterface;
 use App\Traits\InstructorsEntityInterface;
 use App\Traits\LearnerGroupsEntityInterface;
 use App\Traits\LearnersEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\TimestampableEntityInterface;
 
 /**
@@ -19,7 +19,7 @@ use App\Traits\TimestampableEntityInterface;
  */
 interface OfferingInterface extends
     IdentifiableEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     TimestampableEntityInterface,
     LoggableEntityInterface,
     SessionStampableInterface,

--- a/src/Entity/ProgramInterface.php
+++ b/src/Entity/ProgramInterface.php
@@ -11,7 +11,7 @@ use App\Traits\IdentifiableEntityInterface;
 use App\Traits\PublishableEntityInterface;
 use App\Traits\SchoolEntityInterface;
 use App\Traits\TitledEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\ProgramYearsEntityInterface;
 
 /**
@@ -20,7 +20,7 @@ use App\Traits\ProgramYearsEntityInterface;
 interface ProgramInterface extends
     IdentifiableEntityInterface,
     TitledEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     ProgramYearsEntityInterface,
     SchoolEntityInterface,
     LoggableEntityInterface,

--- a/src/Entity/SchoolConfigInterface.php
+++ b/src/Entity/SchoolConfigInterface.php
@@ -7,7 +7,7 @@ namespace App\Entity;
 use App\Traits\IdentifiableEntityInterface;
 use App\Traits\NameableEntityInterface;
 use App\Traits\SchoolEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 
 /**
  * Interface SchoolConfigInterface
@@ -16,7 +16,7 @@ interface SchoolConfigInterface extends
     SchoolEntityInterface,
     NameableEntityInterface,
     IdentifiableEntityInterface,
-    StringableEntityInterface
+    StringableEntityToIdInterface
 {
     public function getValue(): string;
 

--- a/src/Entity/SchoolInterface.php
+++ b/src/Entity/SchoolInterface.php
@@ -15,7 +15,7 @@ use App\Traits\IdentifiableEntityInterface;
 use App\Traits\InstructorGroupsEntityInterface;
 use App\Traits\SessionTypesEntityInterface;
 use App\Traits\TitledEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\CoursesEntityInterface;
 use App\Traits\ProgramsEntityInterface;
 
@@ -25,7 +25,7 @@ use App\Traits\ProgramsEntityInterface;
 interface SchoolInterface extends
     IdentifiableEntityInterface,
     TitledEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     CoursesEntityInterface,
     IndexableCoursesEntityInterface,
     ProgramsEntityInterface,

--- a/src/Entity/SessionInterface.php
+++ b/src/Entity/SessionInterface.php
@@ -16,7 +16,7 @@ use App\Traits\IdentifiableEntityInterface;
 use App\Traits\MeshDescriptorsEntityInterface;
 use App\Traits\PublishableEntityInterface;
 use App\Traits\SequenceBlocksEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\TimestampableEntityInterface;
 use App\Traits\OfferingsEntityInterface;
 
@@ -26,7 +26,7 @@ use App\Traits\OfferingsEntityInterface;
 interface SessionInterface extends
     IdentifiableEntityInterface,
     TitledNullableEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     TimestampableEntityInterface,
     OfferingsEntityInterface,
     LoggableEntityInterface,

--- a/src/Entity/TermInterface.php
+++ b/src/Entity/TermInterface.php
@@ -16,7 +16,7 @@ use App\Traits\DescribableEntityInterface;
 use App\Traits\IdentifiableEntityInterface;
 use App\Traits\ProgramYearsEntityInterface;
 use App\Traits\SessionsEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\TitledEntityInterface;
 
 /**
@@ -25,7 +25,7 @@ use App\Traits\TitledEntityInterface;
 interface TermInterface extends
     DescribableEntityInterface,
     IdentifiableEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     TitledEntityInterface,
     LoggableEntityInterface,
     ProgramYearsEntityInterface,

--- a/src/Entity/UserInterface.php
+++ b/src/Entity/UserInterface.php
@@ -12,7 +12,7 @@ use App\Traits\InstructorGroupsEntityInterface;
 use App\Traits\LearnerGroupsEntityInterface;
 use App\Traits\LearningMaterialsEntityInterface;
 use App\Traits\IdentifiableEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\OfferingsEntityInterface;
 use App\Traits\ProgramYearsEntityInterface;
 use App\Traits\SchoolEntityInterface;
@@ -22,7 +22,7 @@ use App\Traits\SchoolEntityInterface;
  */
 interface UserInterface extends
     IdentifiableEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     OfferingsEntityInterface,
     ProgramYearsEntityInterface,
     LoggableEntityInterface,

--- a/src/Entity/VocabularyInterface.php
+++ b/src/Entity/VocabularyInterface.php
@@ -11,7 +11,7 @@ use App\Traits\ActivatableEntityInterface;
 use App\Traits\CategorizableEntityInterface;
 use App\Traits\IdentifiableEntityInterface;
 use App\Traits\SchoolEntityInterface;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Traits\TitledEntityInterface;
 
 /**
@@ -20,7 +20,7 @@ use App\Traits\TitledEntityInterface;
 interface VocabularyInterface extends
     IdentifiableEntityInterface,
     SchoolEntityInterface,
-    StringableEntityInterface,
+    StringableEntityToIdInterface,
     TitledEntityInterface,
     CategorizableEntityInterface,
     ActivatableEntityInterface,

--- a/src/Service/LearningMaterialDecoratorFactory.php
+++ b/src/Service/LearningMaterialDecoratorFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Entity\DTO\LearningMaterialDTO;
-use App\Traits\StringableEntityInterface;
+use App\Traits\StringableEntityToIdInterface;
 use App\Entity\LearningMaterialInterface;
 use InvalidArgumentException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
@@ -55,12 +55,12 @@ class LearningMaterialDecoratorFactory
         $dto->userRole = $learningMaterial->getUserRole()->getId();
         $dto->owningUser = $learningMaterial->getOwningUser()->getId();
         $dto->status = $learningMaterial->getStatus()->getId();
-        $dto->courseLearningMaterials = $learningMaterial->getCourseLearningMaterials()
-            ->map(fn(StringableEntityInterface $courseLearningMaterial) => (string) $courseLearningMaterial)->toArray();
-        $dto->sessionLearningMaterials = $learningMaterial->getSessionLearningMaterials()
-            ->map(
-                fn(StringableEntityInterface $sessionLearningMaterial) => (string) $sessionLearningMaterial
-            )->toArray();
+        $dto->courseLearningMaterials = $learningMaterial->getCourseLearningMaterials()->map(
+            fn(StringableEntityToIdInterface $courseLearningMaterial) => (string) $courseLearningMaterial
+        )->toArray();
+        $dto->sessionLearningMaterials = $learningMaterial->getSessionLearningMaterials()->map(
+            fn(StringableEntityToIdInterface $sessionLearningMaterial) => (string) $sessionLearningMaterial
+        )->toArray();
 
         return $dto;
     }

--- a/src/Traits/StringableEntityToIdInterface.php
+++ b/src/Traits/StringableEntityToIdInterface.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace App\Traits;
 
-/**
- * interface StringableEntityInterface
- */
-interface StringableEntityInterface
+interface StringableEntityToIdInterface
 {
     public function __toString(): string;
 }


### PR DESCRIPTION
It wasn't super clear to me that everything implementing this interface
knew to return the ID and not some other representation of the object as
a string. I've renamed it for clarity.