### PR TITLE
Fix missing temporary directory

### DIFF
--- a/docker/fpm/docker-entrypoint.sh
+++ b/docker/fpm/docker-entrypoint.sh
@@ -6,7 +6,7 @@ if [ "${1#-}" != "$1" ]; then
 	set -- php-fpm "$@"
 fi
 
-mkdir -p var/cache var/log
+mkdir -p var/cache var/log var/tmp
 if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 	
 	if [ "$ILIOS_DATABASE_URL" ]; then

--- a/docker/php-apache-entrypoint
+++ b/docker/php-apache-entrypoint
@@ -2,7 +2,7 @@
 # started with https://github.com/docker-library/php/blob/d97098c8c6af46ae1211e65ff052278ab39ba45c/7.2/stretch/apache/docker-php-entrypoint
 set -e
 
-mkdir -p var/cache var/log
+mkdir -p var/cache var/log var/tmp
 if [ "$ILIOS_DATABASE_URL" ]; then
 	echo "Waiting for db to be ready..."
 	bin/console ilios:wait-for-database

--- a/src/Service/TemporaryFileSystem.php
+++ b/src/Service/TemporaryFileSystem.php
@@ -17,7 +17,11 @@ class TemporaryFileSystem
 
     public function __construct(protected SymfonyFileSystem $fileSystem, string $kernelProjectDir)
     {
-        $tmpPath = realpath($kernelProjectDir . '/var/tmp');
+        $varPath = realpath($kernelProjectDir . '/var');
+        $tmpPath = $varPath . '/tmp';
+        if (!$fileSystem->exists($tmpPath)) {
+            $fileSystem->mkdir($tmpPath);
+        }
         $this->temporaryFileStorePath = $tmpPath . '/uploads';
         if (!$fileSystem->exists($this->temporaryFileStorePath)) {
             $fileSystem->mkdir($this->temporaryFileStorePath);

--- a/tests/Service/TemporaryFileSystemTest.php
+++ b/tests/Service/TemporaryFileSystemTest.php
@@ -46,7 +46,10 @@ class TemporaryFileSystemTest extends TestCase
         $fs->mkdir($this->uploadDirectory);
 
         $this->mockFileSystem = m::mock(SymfonyFileSystem::class);
-        $this->mockFileSystem->shouldReceive('exists')->with($this->uploadDirectory)->andReturn(true);
+        $this->mockFileSystem->shouldReceive('exists')
+            ->with($this->fakeTestFileDir .  '/var/tmp')->andReturn(true);
+        $this->mockFileSystem->shouldReceive('exists')
+            ->with($this->uploadDirectory)->andReturn(true);
 
         $this->tempFileSystem = new TemporaryFileSystem($this->mockFileSystem, $this->fakeTestFileDir);
     }


### PR DESCRIPTION
When var/tmp doesn't exist realpath returns false which then attempts to
write ilios files to /uploads instead of /var/tmp/uploads. We need to
create var/tmp in containers, but also be more resilient and create it
if necessary when storing files.

Fixes #4072