### PR TITLE
Drop Support for PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   ILIOS_FILE_SYSTEM_STORAGE_PATH: /tmp
   SYMFONY_DEPRECATIONS_HELPER: disabled=1
   MESSENGER_TRANSPORT_DSN: doctrine://default
-  latest_php: 8.0
+  latest_php: 8.1
   DOCKER_BUILDKIT: 1
 
 jobs:
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.0, 8.1]
+        php-version: [8.1]
 
     steps:
     - uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.0, 8.1]
+        php-version: [8.1]
 
     steps:
     - uses: actions/checkout@v3
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.0, 8.1]
+        php-version: [8.1]
 
     steps:
       - uses: actions/checkout@v3
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.0, 8.1]
+        php-version: [8.1]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use PHP 8.0
+    - name: Use PHP 8.1
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.0
+        php-version: 8.1
         coverage: pcov
         extensions: apcu
     - name: install dependencies

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use PHP 8.0
+    - name: Use PHP 8.1
       uses: shivammathur/setup-php@v2
       with:
         coverage: none
-        php-version: 8.0
+        php-version: 8.1
         extensions: apcu
     - name: install composer-lock-diff
       run: composer global require davidrjonas/composer-lock-diff

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "project",
   "description": "The \"Ilios Standard Edition\" distribution",
   "require": {
-    "php": ">= 8.0.2",
+    "php": ">= 8.1",
     "ext-apcu": "*",
     "ext-ctype": "*",
     "ext-dom": "*",
@@ -87,7 +87,7 @@
   },
   "config": {
     "platform": {
-      "php": "8.0.2"
+      "php": "8.1"
     },
     "preferred-install": {
       "*": "dist"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6adc69de7d6410507a0a20383a0826c",
+    "content-hash": "d04bc3c65b643eb1a0a654cfde414057",
     "packages": [
         {
             "name": "async-aws/core",
@@ -15412,7 +15412,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 8.0.2",
+        "php": ">= 8.1",
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-dom": "*",
@@ -15425,7 +15425,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.2"
+        "php": "8.1"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/config/packages/monitor.yaml
+++ b/config/packages/monitor.yaml
@@ -6,7 +6,7 @@ liip_monitor:
       default:
         php_extensions: [apcu, mbstring, ldap, xml, dom, mysqlnd, pdo, zip, json, zlib, ctype, iconv]
         php_version:
-            "8.0": ">="
+            "8.1": ">="
         readable_directory: ["%kernel.cache_dir%"]
         writable_directory: ["%kernel.cache_dir%"]
       production:

--- a/docs/ilios_php_version_policy.md
+++ b/docs/ilios_php_version_policy.md
@@ -1,20 +1,20 @@
 # Ilios and PHP
 
-In an effort to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP 7 for running Ilios.
+In an effort to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios.
   
 ### The Ilios PHP Version Policy
 
-At any given time, the Ilios application will only be supported on the very latest minor version of PHP 7 and, for the first 3 months of that version's release, we will also ensure support for the previous minor version.  After 3 months, only Ilios instances running on the newest version of PHP 7 will continue to be supported.
+At any given time, the Ilios application will only be supported on the very latest minor version of PHP and, for the first 3 months of that version's release, we will also ensure support for the previous minor version.  After 3 months, only Ilios instances running on the newest version of PHP will continue to be supported.
  
 #### Policy Example
 
-For example, the current version of PHP is v8.0.  When PHP v8.1 is released, we will continue to ensure the Ilios code will work on PHP 8.0 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 8.1 going forward.
+For example, the current version of PHP is v8.1.  When PHP v8.2 is released, we will continue to ensure the Ilios code will work on PHP 8.1 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 8.2 going forward.
 
 ### Currently Supported Versions of PHP
 
 Based on the policy above, Ilios is currently compatible with the following versions of PHP:
 
-* PHP 8.0
+* PHP 8.1
  
 ### Up-To-Date PHP Repositories for CentOS and RHEL
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ Ilios 3 uses a Symfony (PHP/SQL) backend to serve its API, so these tools and th
 
 * CentOS 7 - Any modern Linux should work, but we recommend Redhat (RHEL, CentOS, or Fedora) or Ubuntu
 * MySQL using the InnoDB database engine (v5.7 or later required, 8+ recommended)
-* PHP v8.0+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
+* PHP v8.1+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
 
 NOTE: Several institutions have successfully deployed Ilios using Microsoft IIS on Windows as their webserver, but we do not recommend it as we do not have alot of experience with it ourselves and we've only ever support Ilios on Linux systems.  That being said, if you MUST use IIS for Windows and are having trouble getting Ilios running properly, please contact the [Ilios Project Support Team](https://iliosproject.org) at support@iliosproject.org if you have any problems and we might be able to help you out!
 
@@ -64,7 +64,7 @@ You should now be in the '/web/ilios3/ilios' directory
 # errors related to git files in your own user's `.config` directory:
 sudo -u apache git checkout tags/$(git fetch --tags; git describe --tags `git rev-list --tags --max-count=1`)
 ```
-5. Run the following command to build the packages and its dependencies.  This step assumes you have PHP 8.0+ and Composer installed on your system:
+5. Run the following command to build the packages and its dependencies.  This step assumes you have PHP 8.1+ and Composer installed on your system:
 ```bash
 sudo -u apache bin/setup
 ```


### PR DESCRIPTION
In accordance with our PHP version support policy we're no ready to drop
PHP 8.0 and require PHP 8.1 for Ilios.