### PR TITLE
initialize xdebug mode to coverage instead of using command line params.

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Use PHP ${{ env.latest_php }}
         uses: shivammathur/setup-php@v2
         with:
-          coverage: none
           php-version: ${{ env.latest_php }}
           extensions: apcu
           ini-values: xdebug.mode=coverage

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -25,14 +25,13 @@ jobs:
           coverage: none
           php-version: ${{ env.latest_php }}
           extensions: apcu
+          ini-values: xdebug.mode=coverage
       - name: install dependencies
         run: composer install --no-interaction --prefer-dist
       - name: create coverage
-        run:
-          php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-xml=build/coverage --log-junit=build/coverage/phpunit.junit.xml
+        run: vendor/bin/phpunit --coverage-xml=build/coverage --log-junit=build/coverage/phpunit.junit.xml
       - name: infection
-        run:
-          vendor/bin/infection --coverage=build/coverage
+        run: vendor/bin/infection --coverage=build/coverage
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
trying to shake the `The file "index.xml" could not be found: Could not find any "index.xml"  file in "/home/runner/work/ilios/ilios/build/coverage"` warning emitted by this action. 

It appears that command line options are being dropped, so using init values as a (hopefully working) alternative. 