### PR TITLE
Remove Experimental Build Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,6 @@ jobs:
         build-args: ILIOS_VERSION=test
         target: ${{ matrix.image }}
         push: false
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
         tags: ${{ matrix.image }}:testing
     - name: Upload artifact
@@ -185,8 +183,6 @@ jobs:
          build-args: ILIOS_VERSION=test
          target: ${{ matrix.image }}
          push: false
-         cache-from: type=gha
-         cache-to: type=gha,mode=max
 
   run_containers:
     name: Run and Test Containers


### PR DESCRIPTION
This github specific docker build cache is marked as experimental and
we're consistently seeing random CI failures when mysql or elasticsearch
get updated. Removing this cache for now.