### PR TITLE
Add our VERSION to the cache prefix seed

### DIFF
--- a/src/DependencyInjection/PrefixSeedCompilerPass.php
+++ b/src/DependencyInjection/PrefixSeedCompilerPass.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Add the contents of our VERSION file to the cache prefix seed
+ * this ensures that we won't have collisions in a production environment
+ * when doing a blue/green deploy.
+ */
+class PrefixSeedCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasParameter('cache.prefix.seed')) {
+            $seed = $container->getParameterBag()->resolveValue($container->getParameter('cache.prefix.seed'));
+        } else {
+            $seed = '_' . $container->getParameter('kernel.project_dir');
+            $seed .= '.' . $container->getParameter('kernel.container_class');
+        }
+        $pathToVersionFile = __DIR__ . '/../../VERSION';
+        if (is_readable($pathToVersionFile)) {
+            $seed .= file_get_contents($pathToVersionFile);
+        }
+        $container->setParameter('cache.prefix.seed', $seed);
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App;
 
+use App\DependencyInjection\PrefixSeedCompilerPass;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
 use function date_default_timezone_set;
@@ -22,5 +25,10 @@ class Kernel extends BaseKernel
         // Force a UTC timezone on everyone
         date_default_timezone_set('UTC');
         parent::__construct($environment, $debug);
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new PrefixSeedCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 64);
     }
 }


### PR DESCRIPTION
This ensures that we won't have collisions in a production environment
when doing a deploy. Instead the different versions of the app will
write to different caches.