### PR TITLE
Remove redis container from nightly build

### DIFF
--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -50,7 +50,7 @@ jobs:
           - mysql
           - mysql-demo
           - elasticsearch
-          - redis
+          # - redis
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This hasn't been published yet and we shouldn't attempt to tag it every
night.