### PR TITLE
Re-enable nightly deploy of tagged redis container

### DIFF
--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -50,7 +50,7 @@ jobs:
           - mysql
           - mysql-demo
           - elasticsearch
-          # - redis
+           - redis
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Now that there is a live v3.100.0 version of this container we can
re-enable the nightly builds as well.