### PR TITLE
Enable automerge for development dependencies

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+on: pull_request_target
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Output Checks
+        run: |
+          echo ${{steps.metadata.outputs.dependency-names}}
+          echo ${{steps.metadata.outputs.update-type}}
+          echo ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+          echo ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+          echo ${{steps.metadata.outputs.dependency-type}}
+          echo ${{steps.metadata.outputs.dependency-type == 'direct:development'}}
+      - name: Enable auto-merge for develpment dependencies
+        if: ${{ steps.metadata.outputs.dependency-type == 'direct:development' && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
For patch and minor updates of things in require-dev we can go ahead and
automerge them when tests pass.