### PR TITLE
Restore symfony auto-scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -279,6 +279,7 @@ COMPOSER_HOME=/tmp \
 APP_ENV=prod \
 APP_DEBUG=false \
 MAILER_DSN=null://null \
+ILIOS_DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db" \
 ILIOS_LOCALE=en \
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt \
 ILIOS_REQUIRE_SECURE_CONNECTION=false \

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,6 +136,7 @@ RUN ln -sf "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 RUN set -eux; \
 	composer install --prefer-dist --no-progress --no-interaction; \
     rm -f .env.local.php; \
+    composer run-script --no-dev post-install-cmd; \
     bin/console cache:warmup; \
     sync
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -296,7 +296,7 @@ RUN /usr/bin/composer install \
     --classmap-authoritative \
     #creates an empty env.php file, real ENV values will control the app
     && /usr/bin/composer dump-env prod \
-    && /usr/bin/composer clear-cache
+    && composer run-script --no-dev post-install-cmd
 
 ARG ILIOS_VERSION="v0.1.0"
 RUN echo ${ILIOS_VERSION} > VERSION

--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,8 @@
   },
   "scripts": {
     "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
     },
     "ilios-scripts": [
       "App\\Composer\\MigrateParameters::migrate",


### PR DESCRIPTION
These were removed when the bin/setup command was introduced to work
around a cache clearing issue with our docker container that wasn't
fully noted. As far as I can tell we don't have that issue anymore and
containers are able to build with these scripts in place. This is
important because the asset install is expected by many bundles so we
need to make sure it happens.

edit: The original issue was missing the `ILIOS_DATABSE_URL` config value, but I've copied our approach from the `php-fpm` containers to the `php-apache` containers and created an empty `sqlite` DB URL which will, of course, be overridden in any real app.