### PR TITLE
Check permissions on side loaded data

### DIFF
--- a/src/Service/JsonApiDataShaper.php
+++ b/src/Service/JsonApiDataShaper.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Classes\JsonApiData;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 
 class JsonApiDataShaper
 {
     use NormalizerAwareTrait;
 
-    public function __construct(protected EntityRepositoryLookup $entityRepositoryLookup)
-    {
+    public function __construct(
+        protected EntityRepositoryLookup $entityRepositoryLookup,
+        protected AuthorizationCheckerInterface $authorizationChecker,
+    ) {
     }
 
     public function shapeData(array $data, array $sideLoadFields): array
@@ -20,6 +23,7 @@ class JsonApiDataShaper
         $jsonApiData = new JsonApiData(
             $this->entityRepositoryLookup,
             $this->normalizer,
+            $this->authorizationChecker,
             $data,
             $sideLoadFields
         );


### PR DESCRIPTION
When we access other data from JSON:API we were loading it even if the
user didn't have permission to access it. Instead we need to filter all
side loaded data through the permissions system.