### PR TITLE
Disable serializer data collection

### DIFF
--- a/config/packages/web_profiler.yaml
+++ b/config/packages/web_profiler.yaml
@@ -6,7 +6,8 @@ when@dev:
     framework:
         profiler:
             only_exceptions: false
-            collect_serializer_data: true
+            # disabled, see https://github.com/symfony/symfony/issues/46471 breaks our SerializerFactory service
+            collect_serializer_data: false
 
 when@test:
     web_profiler:


### PR DESCRIPTION
In symfony 6.1 when this is enabled instead of getting the service we
asked for we get a TraceableNormalizer instead which isn't valid.
Easiest way to resume development is to remove this data collection and
the problem it causes for us.