### PR TITLE
Add User Session Material Status

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,7 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
-    ilios_api_version: v3.6
+    ilios_api_version: v3.7
     env(TRUSTED_PROXIES):
     env(ILIOS_REDIS_URL):
     env(ILIOS_CACHE_DECRYPTION_KEY):

--- a/migrations/Version20220714000000.php
+++ b/migrations/Version20220714000000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilios\Migrations;
+
+use App\Classes\MysqlMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20220714000000 extends MysqlMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add session learning material status table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE user_session_material_status (id BIGINT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, session_learning_material_id INT NOT NULL, status INT NOT NULL, last_updated_at DATETIME NOT NULL, INDEX IDX_6CC10903A76ED395 (user_id), INDEX IDX_6CC10903E8376E0A (session_learning_material_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE user_session_material_status ADD CONSTRAINT FK_6CC10903A76ED395 FOREIGN KEY (user_id) REFERENCES user (user_id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE user_session_material_status ADD CONSTRAINT FK_6CC10903E8376E0A FOREIGN KEY (session_learning_material_id) REFERENCES session_learning_material (session_learning_material_id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE user_session_material_status');
+    }
+}

--- a/src/Classes/SessionUser.php
+++ b/src/Classes/SessionUser.php
@@ -41,6 +41,7 @@ class SessionUser implements SessionUserInterface
     protected array $instructorGroupIds;
     protected array $coursesCohortsProgramYearAndProgramIdsLinkedToProgramsDirectedByUser;
     protected array $learnerIlmAndOfferingIds;
+    protected array $learnerSessionIds;
     protected UserRepository $userRepository;
 
     public function __construct(IliosUserInterface $user, UserRepository $userRepository)
@@ -349,6 +350,11 @@ class SessionUser implements SessionUserInterface
     public function isLearnerInOffering(int $offeringId): bool
     {
         return in_array($offeringId, $this->getLearnerOfferingsIds());
+    }
+
+    public function isLearnerInSession(int $sessionId): bool
+    {
+        return in_array($sessionId, $this->getLearnerSessionIds());
     }
 
     public function isLearnerInIlm(int $ilmId): bool
@@ -881,6 +887,14 @@ class SessionUser implements SessionUserInterface
                 $this->userRepository->getLearnerIlmAndOfferingIds($this->getId());
         }
         return $this->learnerIlmAndOfferingIds;
+    }
+
+    protected function getLearnerSessionIds(): array
+    {
+        if (!isset($this->learnerSessionIds)) {
+            $this->learnerSessionIds = $this->userRepository->getLearnerSessionIds($this->getId());
+        }
+        return $this->learnerSessionIds;
     }
 
     /**

--- a/src/Classes/SessionUserInterface.php
+++ b/src/Classes/SessionUserInterface.php
@@ -98,6 +98,7 @@ interface SessionUserInterface extends PasswordAuthenticatedUserInterface, UserI
     public function isStudentAdvisorInCourse(int $courseId): bool;
     public function isLearnerInOffering(int $offeringId): bool;
     public function isLearnerInIlm(int $ilmId): bool;
+    public function isLearnerInSession(int $sessionId): bool;
 
     public function rolesInSession(
         int $sessionId,

--- a/src/Controller/API/UserSessionMaterialStatuses.php
+++ b/src/Controller/API/UserSessionMaterialStatuses.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\API;
+
+use App\Entity\DTO\UserSessionMaterialStatusDTO;
+use App\Repository\UserSessionMaterialStatusRepository;
+use App\Service\ApiRequestParser;
+use App\Service\ApiResponseBuilder;
+use Nelmio\ApiDocBundle\Annotation\Model;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[OA\Tag(name:'User Session Material Statuses')]
+#[Route('/api/{version<v3>}/usersessionmaterialstatuses')]
+class UserSessionMaterialStatuses extends AbstractApiController
+{
+    public function __construct(UserSessionMaterialStatusRepository $repository)
+    {
+        parent::__construct($repository, 'usersessionmaterialstatuses');
+    }
+
+    #[Route(
+        '/{id}',
+        methods: ['GET']
+    )]
+    #[OA\Get(
+        path: '/api/{version}/usersessionmaterialstatuses/{id}',
+        summary: 'Fetch a single user session learning material.',
+        parameters: [
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
+            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+        ],
+        responses: [
+            new OA\Response(
+                response: '200',
+                description: 'A single user session learning material.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(
+                            'userSessionMaterialStatuses',
+                            type: 'array',
+                            items: new OA\Items(
+                                ref: new Model(type: UserSessionMaterialStatusDTO::class)
+                            )
+                        )
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(response: '404', description: 'Not found.')
+        ]
+    )]
+    public function getOne(
+        string $version,
+        string $id,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ApiResponseBuilder $builder,
+        Request $request
+    ): Response {
+        return $this->handleGetOne($version, $id, $authorizationChecker, $builder, $request);
+    }
+
+    #[Route(
+        methods: ['GET']
+    )]
+    #[OA\Get(
+        path: "/api/{version}/usersessionmaterialstatuses",
+        summary: "Fetch all sessions.",
+        parameters: [
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
+            new OA\Parameter(
+                name: 'offset',
+                description: 'Offset',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'integer')
+            ),
+            new OA\Parameter(
+                name: 'limit',
+                description: 'Limit results',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'integer')
+            ),
+            new OA\Parameter(
+                name: 'order_by',
+                description: 'Order by fields. Must be an array, i.e. <code>&order_by[id]=ASC&order_by[x]=DESC</code>',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(
+                    type: 'array',
+                    items: new OA\Items(type: 'string'),
+                ),
+                style: "deepObject"
+            ),
+            new OA\Parameter(
+                name: 'filters',
+                description: 'Filter by fields. Must be an array, i.e. <code>&filters[id]=3</code>',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(
+                    type: 'array',
+                    items: new OA\Items(type: 'string'),
+                ),
+                style: "deepObject"
+            )
+        ],
+        responses: [
+            new OA\Response(
+                response: '200',
+                description: 'An array of sessions.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(
+                            'userSessionMaterialStatuses',
+                            type: 'array',
+                            items: new OA\Items(
+                                ref: new Model(type: UserSessionMaterialStatusDTO::class)
+                            )
+                        )
+                    ],
+                    type: 'object'
+                )
+            )
+        ]
+    )]
+    public function getAll(
+        string $version,
+        Request $request,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ApiResponseBuilder $builder
+    ): Response {
+        return $this->handleGetAll($version, $request, $authorizationChecker, $builder);
+    }
+
+    #[Route(methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/{version}/usersessionmaterialstatuses',
+        summary: "Create sessions.",
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(
+                        'userSessionMaterialStatuses',
+                        type: 'array',
+                        items: new OA\Items(
+                            ref: new Model(type: UserSessionMaterialStatusDTO::class)
+                        )
+                    )
+                ],
+                type: 'object',
+            )
+        ),
+        parameters: [
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+        ],
+        responses: [
+            new OA\Response(
+                response: '201',
+                description: 'An array of newly created sessions.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(
+                            'userSessionMaterialStatuses',
+                            type: 'array',
+                            items: new OA\Items(
+                                ref: new Model(type: UserSessionMaterialStatusDTO::class)
+                            )
+                        )
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(response: '400', description: 'Bad Request Data.'),
+            new OA\Response(response: '403', description: 'Access Denied.')
+        ]
+    )]
+    public function post(
+        string $version,
+        Request $request,
+        ApiRequestParser $requestParser,
+        ValidatorInterface $validator,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ApiResponseBuilder $builder
+    ): Response {
+        return $this->handlePost($version, $request, $requestParser, $validator, $authorizationChecker, $builder);
+    }
+
+    #[Route(
+        '/{id}',
+        methods: ['PUT']
+    )]
+    #[OA\Put(
+        path: '/api/{version}/usersessionmaterialstatuses/{id}',
+        summary: 'Update or create a user session learning material.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(
+                        'userSessionMaterialStatuses',
+                        ref: new Model(type: UserSessionMaterialStatusDTO::class),
+                        type: 'object'
+                    )
+                ],
+                type: 'object',
+            )
+        ),
+        parameters: [
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
+            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+        ],
+        responses: [
+            new OA\Response(
+                response: '200',
+                description: 'The updated user session learning material.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(
+                            'userSessionMaterialStatuses',
+                            ref: new Model(type: UserSessionMaterialStatusDTO::class)
+                        )
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: '201',
+                description: 'The newly created user session learning material.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(
+                            'userSessionMaterialStatuses',
+                            ref: new Model(type: UserSessionMaterialStatusDTO::class)
+                        )
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(response: '400', description: 'Bad Request Data.'),
+            new OA\Response(response: '403', description: 'Access Denied.'),
+            new OA\Response(response: '404', description: 'Not Found.')
+        ]
+    )]
+    public function put(
+        string $version,
+        string $id,
+        Request $request,
+        ApiRequestParser $requestParser,
+        ValidatorInterface $validator,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ApiResponseBuilder $builder
+    ): Response {
+        return $this->handlePut($version, $id, $request, $requestParser, $validator, $authorizationChecker, $builder);
+    }
+
+    #[Route(
+        '/{id}',
+        methods: ['PATCH']
+    )]
+    public function patch(
+        string $version,
+        string $id,
+        Request $request,
+        ApiRequestParser $requestParser,
+        ValidatorInterface $validator,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ApiResponseBuilder $builder
+    ): Response {
+        return $this->handlePatch($version, $id, $request, $requestParser, $validator, $authorizationChecker, $builder);
+    }
+
+    #[Route(
+        '/{id}',
+        methods: ['DELETE']
+    )]
+    #[OA\Delete(
+        path: '/api/{version}/usersessionmaterialstatuses/{id}',
+        summary: 'Delete a user session learning material.',
+        parameters: [
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
+            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+        ],
+        responses: [
+            new OA\Response(response: '204', description: 'Deleted.'),
+            new OA\Response(response: '403', description: 'Access Denied.'),
+            new OA\Response(response: '404', description: 'Not Found.'),
+            new OA\Response(
+                response: '500',
+                description: 'Deletion failed (usually caused by non-cascading relationships).'
+            )
+        ]
+    )]
+    public function delete(
+        string $version,
+        string $id,
+        AuthorizationCheckerInterface $authorizationChecker
+    ): Response {
+        return $this->handleDelete($version, $id, $authorizationChecker);
+    }
+}

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -45,7 +45,11 @@ class ConfigController extends AbstractController
 
         $configuration['academicYearCrossesCalendarYearBoundaries'] = $config->get(
             'academic_year_crosses_calendar_year_boundaries'
-        );
+        ) ?? false;
+
+        $configuration['materialStatusEnabled'] = $config->get(
+            'material_status_enabled'
+        ) ?? false;
 
         return new JsonResponse(['config' => $configuration]);
     }

--- a/src/Entity/DTO/UserDTO.php
+++ b/src/Entity/DTO/UserDTO.php
@@ -240,6 +240,12 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             items: new OA\Items(type: "string")
         ),
         new OA\Property(
+            "sessionMaterialStatuses",
+            description: "Session Material Statuses",
+            type: "array",
+            items: new OA\Items(type: "string")
+        ),
+        new OA\Property(
             "auditLogs",
             description: "Audit logs",
             type: "array",
@@ -502,6 +508,14 @@ class UserDTO
     #[IA\Related('curriculumInventoryReports')]
     #[IA\Type('array<string>')]
     public array $administeredCurriculumInventoryReports = [];
+
+    /**
+     * @var int[]
+     */
+    #[IA\Expose]
+    #[IA\Related('userSessionMaterialStatuses')]
+    #[IA\Type('array<string>')]
+    public array $sessionMaterialStatuses = [];
 
     /**
      * @var int[]

--- a/src/Entity/DTO/UserSessionMaterialStatusDTO.php
+++ b/src/Entity/DTO/UserSessionMaterialStatusDTO.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Entity\DTO;
 
 use App\Attribute as IA;
+use DateTime;
 use OpenApi\Attributes as OA;
 
 #[IA\DTO("userSessionMaterialStatuses")]
@@ -32,6 +33,12 @@ use OpenApi\Attributes as OA;
             description: "Status",
             type: "integer"
         ),
+        new OA\Property(
+            "updatedAt",
+            description: "Last Updated At",
+            type: "string",
+            format: "date-time"
+        ),
     ]
 )]
 class UserSessionMaterialStatusDTO
@@ -54,6 +61,9 @@ class UserSessionMaterialStatusDTO
         #[IA\Expose]
         #[IA\Type("integer")]
         public int $status,
+        #[IA\Expose]
+        #[IA\Type("dateTime")]
+        public Datetime $updatedAt,
     ) {
     }
 }

--- a/src/Entity/DTO/UserSessionMaterialStatusDTO.php
+++ b/src/Entity/DTO/UserSessionMaterialStatusDTO.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\DTO;
+
+use App\Attribute as IA;
+use OpenApi\Attributes as OA;
+
+#[IA\DTO("userSessionMaterialStatuses")]
+#[IA\ExposeGraphQL]
+#[OA\Schema(
+    title: "UserSessionMaterialStatus",
+    properties: [
+        new OA\Property(
+            "id",
+            description: "ID",
+            type: "integer"
+        ),
+        new OA\Property(
+            "user",
+            description: "User",
+            type: "integer"
+        ),
+        new OA\Property(
+            "material",
+            description: "SessionLearningMaterial",
+            type: "integer"
+        ),
+        new OA\Property(
+            "status",
+            description: "Status",
+            type: "integer"
+        ),
+    ]
+)]
+class UserSessionMaterialStatusDTO
+{
+    #[IA\Expose]
+    #[IA\Related('users')]
+    #[IA\Type('integer')]
+    public int $user;
+
+    #[IA\Expose]
+    #[IA\Related('sessionLearningMaterials')]
+    #[IA\Type('integer')]
+    public int $material;
+
+    public function __construct(
+        #[IA\Expose]
+        #[IA\Id]
+        #[IA\Type("integer")]
+        public int $id,
+        #[IA\Expose]
+        #[IA\Type("integer")]
+        public int $status,
+    ) {
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -330,6 +330,11 @@ class User implements UserInterface
     #[IA\Type('entityCollection')]
     protected Collection $administeredCurriculumInventoryReports;
 
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserSessionMaterialStatus::class)]
+    #[IA\Expose]
+    #[IA\Type('entityCollection')]
+    protected Collection $sessionMaterialStatuses;
+
     public function __construct()
     {
         $this->directedCourses = new ArrayCollection();
@@ -356,6 +361,7 @@ class User implements UserInterface
         $this->administeredSchools = new ArrayCollection();
         $this->directedPrograms = new ArrayCollection();
         $this->administeredCurriculumInventoryReports = new ArrayCollection();
+        $this->sessionMaterialStatuses = new ArrayCollection();
         $this->addedViaIlios = false;
         $this->enabled = true;
         $this->examined = false;
@@ -1178,5 +1184,31 @@ class User implements UserInterface
     {
         $this->administeredCurriculumInventoryReports->removeElement($report);
         $report->removeAdministrator($this);
+    }
+
+    public function setSessionMaterialStatuses(Collection $sessionMaterialStatuses)
+    {
+        $this->sessionMaterialStatuses = new ArrayCollection();
+
+        foreach ($sessionMaterialStatuses as $slm) {
+            $this->addSessionMaterialStatus($slm);
+        }
+    }
+
+    public function addSessionMaterialStatus(UserSessionMaterialStatus $sessionMaterialStatus)
+    {
+        if (!$this->sessionMaterialStatuses->contains($sessionMaterialStatus)) {
+            $this->sessionMaterialStatuses->add($sessionMaterialStatus);
+        }
+    }
+
+    public function removeSessionMaterialStatus(UserSessionMaterialStatus $sessionMaterialStatus)
+    {
+        $this->sessionMaterialStatuses->removeElement($sessionMaterialStatus);
+    }
+
+    public function getSessionMaterialStatuses(): Collection
+    {
+        return $this->sessionMaterialStatuses;
     }
 }

--- a/src/Entity/UserInterface.php
+++ b/src/Entity/UserInterface.php
@@ -173,4 +173,9 @@ interface UserInterface extends
 
     public function setPrimaryCohort(CohortInterface $primaryCohort = null);
     public function getPrimaryCohort(): ?CohortInterface;
+
+    public function setSessionMaterialStatuses(Collection $sessionMaterialStatuses);
+    public function addSessionMaterialStatus(UserSessionMaterialStatus $sessionMaterialStatus);
+    public function removeSessionMaterialStatus(UserSessionMaterialStatus $sessionMaterialStatus);
+    public function getSessionMaterialStatuses(): Collection;
 }

--- a/src/Entity/UserSessionMaterialStatus.php
+++ b/src/Entity/UserSessionMaterialStatus.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\UserSessionMaterialStatusRepository;
+use App\Traits\TimestampableEntity;
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use App\Attribute as IA;
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Traits\StringableIdEntity;
+
+#[ORM\Table(name: 'user_session_material_status')]
+#[ORM\Entity(repositoryClass: UserSessionMaterialStatusRepository::class)]
+#[IA\Entity]
+class UserSessionMaterialStatus implements UserSessionMaterialStatusInterface
+{
+    use StringableIdEntity;
+    use TimestampableEntity;
+
+    #[ORM\Column(name: 'id', type: 'bigint')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[IA\Expose]
+    #[IA\Type('integer')]
+    #[IA\OnlyReadable]
+    protected string $id; //string because doctrine stores bigint as string for best compatibility
+
+    #[ORM\Column(name: 'status', type: 'integer')]
+    #[IA\Expose]
+    #[IA\Type('integer')]
+    #[Assert\NotNull]
+    #[Assert\Choice([
+        UserSessionMaterialStatusInterface::NONE,
+        UserSessionMaterialStatusInterface::STARTED,
+        UserSessionMaterialStatusInterface::COMPLETE,
+    ])]
+    #[Assert\Type(type: 'integer')]
+    protected int $status;
+
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'sessionMaterialStatuses')]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'user_id', nullable: false, onDelete: 'CASCADE')]
+    #[IA\Expose]
+    #[IA\Type('entity')]
+    #[Assert\NotNull]
+    protected UserInterface $user;
+
+    #[ORM\ManyToOne(targetEntity: SessionLearningMaterial::class)]
+    #[ORM\JoinColumn(
+        name: 'session_learning_material_id',
+        referencedColumnName: 'session_learning_material_id',
+        nullable: false,
+        onDelete: 'CASCADE'
+    )]
+    #[IA\Expose]
+    #[IA\Type('entity')]
+    #[Assert\NotNull]
+    protected SessionLearningMaterialInterface $material;
+
+    #[ORM\Column(name: 'last_updated_at', type: 'datetime')]
+    #[IA\Expose]
+    #[IA\OnlyReadable]
+    #[IA\Type('dateTime')]
+    #[Assert\NotBlank]
+    protected DateTime $updatedAt;
+
+    public function __construct()
+    {
+        $this->updatedAt = new DateTime();
+    }
+
+    /**
+     * Cast ID to a string to meet doctrine bigint requirements
+     */
+    public function setId(int $id)
+    {
+        $this->id = (string) $id;
+    }
+
+    /**
+     * Cast the ID to an int as doctrine stores a string
+     */
+    public function getId(): int
+    {
+        return (int) $this->id;
+    }
+
+    public function setUser(UserInterface $user)
+    {
+        $this->user = $user;
+    }
+
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
+
+    public function setMaterial(SessionLearningMaterialInterface $material)
+    {
+        $this->material = $material;
+    }
+
+    public function getMaterial(): SessionLearningMaterialInterface
+    {
+        return $this->material;
+    }
+
+    public function setStatus(int $status)
+    {
+        $this->status = $status;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+}

--- a/src/Entity/UserSessionMaterialStatusInterface.php
+++ b/src/Entity/UserSessionMaterialStatusInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Traits\IdentifiableEntityInterface;
+use App\Traits\TimestampableEntityInterface;
+
+interface UserSessionMaterialStatusInterface extends
+    IdentifiableEntityInterface,
+    LoggableEntityInterface,
+    TimestampableEntityInterface
+{
+    public const NONE = 0;
+    public const STARTED = 1;
+    public const COMPLETE = 2;
+
+    public function setUser(UserInterface $user);
+    public function getUser(): UserInterface;
+    public function setMaterial(SessionLearningMaterialInterface $material);
+    public function getMaterial(): SessionLearningMaterialInterface;
+    public function setStatus(int $status);
+    public function getStatus(): int;
+}

--- a/src/RelationshipVoter/ElevatedPermissionsViewDTOVoter.php
+++ b/src/RelationshipVoter/ElevatedPermissionsViewDTOVoter.php
@@ -8,12 +8,8 @@ use App\Classes\SessionUserInterface;
 use App\Entity\DTO\AuthenticationDTO;
 use App\Entity\DTO\CourseLearningMaterialDTO;
 use App\Entity\DTO\IngestionExceptionDTO;
-use App\Entity\DTO\LearnerGroupDTO;
-use App\Entity\DTO\LearningMaterialDTO;
 use App\Entity\DTO\OfferingDTO;
 use App\Entity\DTO\PendingUserUpdateDTO;
-use App\Entity\DTO\SessionLearningMaterialDTO;
-use App\Entity\DTO\UserDTO;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
@@ -34,7 +30,6 @@ class ElevatedPermissionsViewDTOVoter extends AbstractVoter
                 || $subject instanceof IngestionExceptionDTO
                 || $subject instanceof OfferingDTO
                 || $subject instanceof PendingUserUpdateDTO
-                || $subject instanceof SessionLearningMaterialDTO
             )
         );
     }

--- a/src/RelationshipVoter/SessionLearningMaterialDTOVoter.php
+++ b/src/RelationshipVoter/SessionLearningMaterialDTOVoter.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\RelationshipVoter;
+
+use App\Classes\SessionUserInterface;
+use App\Entity\DTO\SessionLearningMaterialDTO;
+use DateTime;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class SessionLearningMaterialDTOVoter extends AbstractVoter
+{
+    protected function supports($attribute, $subject): bool
+    {
+        return $attribute === self::VIEW && $subject instanceof SessionLearningMaterialDTO;
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+
+        if ($user->isRoot()) {
+            return true;
+        }
+
+        if ($user->performsNonLearnerFunction()) {
+            return true;
+        }
+
+        return $this->canLearnerSeeMaterial($subject) && $user->isLearnerInSession($subject->session);
+    }
+
+    protected function canLearnerSeeMaterial(SessionLearningMaterialDTO $material): bool
+    {
+        $now = new DateTime();
+        if (isset($material->startDate) && isset($material->endDate)) {
+            return $material->startDate < $now && $material->endDate > $now;
+        } elseif (isset($material->startDate)) {
+            return $material->startDate < $now;
+        } elseif (isset($material->endDate)) {
+            return $material->endDate > $now;
+        }
+
+        return true;
+    }
+}

--- a/src/RelationshipVoter/UserSessionMaterialStatus.php
+++ b/src/RelationshipVoter/UserSessionMaterialStatus.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\RelationshipVoter;
+
+use App\Classes\SessionUserInterface;
+use App\Entity\UserInterface;
+use App\Entity\UserSessionMaterialStatusInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class UserSessionMaterialStatus extends AbstractVoter
+{
+    protected function supports($attribute, $subject): bool
+    {
+        return $subject instanceof UserSessionMaterialStatusInterface
+            && in_array($attribute, [self::CREATE, self::VIEW, self::EDIT, self::DELETE]);
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+        return match ($attribute) {
+            self::VIEW, self::CREATE, self::EDIT, self::DELETE => $user->isTheUser($subject->getUser()),
+            default => false,
+        };
+    }
+}

--- a/src/RelationshipVoter/UserSessionMaterialStatusDTOVoter.php
+++ b/src/RelationshipVoter/UserSessionMaterialStatusDTOVoter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\RelationshipVoter;
+
+use App\Classes\SessionUserInterface;
+use App\Entity\DTO\UserSessionMaterialStatusDTO;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * @package App\RelationshipVoter
+ */
+class UserSessionMaterialStatusDTOVoter extends AbstractVoter
+{
+    protected function supports($attribute, $subject): bool
+    {
+        return $attribute === self::VIEW && $subject instanceof UserSessionMaterialStatusDTO;
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof SessionUserInterface) {
+            return false;
+        }
+
+        return $subject->user === $user->getId();
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1317,6 +1317,38 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
         return $this->dedupeSubArrays($rhett);
     }
 
+    /*
+     * Returns an array of ids of session ids that a student is connected to
+     */
+    public function getLearnerSessionIds(int $userId): array
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select('s1.id AS s1Id, s2.id AS s2Id, s3.id AS s3Id, s4.id AS s4Id')->distinct();
+        $qb->from(User::class, 'u');
+        $qb->leftJoin('u.offerings', 'offering');
+        $qb->leftJoin('u.learnerIlmSessions', 'ilm');
+        $qb->leftJoin('u.learnerGroups', 'learnerGroup');
+        $qb->leftJoin('learnerGroup.offerings', 'offering2');
+        $qb->leftJoin('learnerGroup.ilmSessions', 'ilm2');
+        $qb->leftJoin('offering.session', 's1');
+        $qb->leftJoin('ilm.session', 's2');
+        $qb->leftJoin('offering2.session', 's3');
+        $qb->leftJoin('ilm2.session', 's4');
+        $qb->andWhere($qb->expr()->eq('u.id', ':userId'));
+        $qb->setParameter(':userId', $userId);
+
+        $rhett = [];
+        foreach ($qb->getQuery()->getArrayResult() as $arr) {
+            foreach ($arr as $id) {
+                if (!is_null($id)) {
+                    $rhett[] = $id;
+                }
+            }
+        }
+
+        return array_unique($rhett);
+    }
+
     /**
      * Returns a list of ids of schools which own learner groups instructed by the given user.
      * @param int $userId

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -970,6 +970,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
                 'studentAdvisedSessions',
                 'directedPrograms',
                 'administeredCurriculumInventoryReports',
+                'sessionMaterialStatuses',
             ],
         );
 

--- a/src/Repository/UserSessionMaterialStatusRepository.php
+++ b/src/Repository/UserSessionMaterialStatusRepository.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\DTO\UserSessionMaterialStatusDTO;
+use App\Entity\UserSessionMaterialStatus;
+use App\Service\DTOCacheManager;
+use App\Traits\ImportableEntityRepository;
+use App\Traits\ManagerRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\Persistence\ManagerRegistry;
+
+use function array_values;
+
+class UserSessionMaterialStatusRepository extends ServiceEntityRepository implements
+    DTORepositoryInterface,
+    RepositoryInterface
+{
+    use ManagerRepository;
+    use ImportableEntityRepository;
+
+    public function __construct(
+        ManagerRegistry $registry,
+        protected DTOCacheManager $cacheManager,
+    ) {
+        parent::__construct($registry, UserSessionMaterialStatus::class);
+    }
+
+    public function hydrateDTOsFromIds(array $ids): array
+    {
+        $qb = $this->_em->createQueryBuilder()
+            ->select('x')->distinct()
+            ->from(UserSessionMaterialStatus::class, 'x');
+        $qb->where($qb->expr()->in('x.id', ':ids'));
+        $qb->setParameter(':ids', $ids);
+
+        $dtos = [];
+        foreach ($qb->getQuery()->getResult(AbstractQuery::HYDRATE_ARRAY) as $arr) {
+            $dtos[$arr['id']] = new UserSessionMaterialStatusDTO(
+                (int) $arr['id'], //doctrine stores bigint as a string, we need to cast it back
+                $arr['status'],
+            );
+        }
+
+        return $this->attachAssociationsToDTOs($dtos);
+    }
+
+    protected function attachAssociationsToDTOs(array $dtos): array
+    {
+        if ($dtos === []) {
+            return $dtos;
+        }
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select('x.id AS xId, u.id AS userId, m.id AS materialId')
+            ->from(UserSessionMaterialStatus::class, 'x')
+            ->join('x.user', 'u')
+            ->join('x.material', 'm')
+            ->where($qb->expr()->in('x.id', ':ids'))
+            ->setParameter('ids', array_keys($dtos));
+
+        foreach ($qb->getQuery()->getResult() as $arr) {
+            $dtos[$arr['xId']]->user = $arr['userId'];
+            $dtos[$arr['xId']]->material = $arr['materialId'];
+        }
+
+        return array_values($dtos);
+    }
+
+    protected function attachCriteriaToQueryBuilder(
+        QueryBuilder $qb,
+        array $criteria,
+        ?array $orderBy,
+        ?int $limit,
+        ?int $offset
+    ): void {
+        $this->attachClosingCriteriaToQueryBuilder($qb, $criteria, $orderBy, $limit, $offset);
+    }
+}

--- a/src/Repository/UserSessionMaterialStatusRepository.php
+++ b/src/Repository/UserSessionMaterialStatusRepository.php
@@ -43,6 +43,7 @@ class UserSessionMaterialStatusRepository extends ServiceEntityRepository implem
             $dtos[$arr['id']] = new UserSessionMaterialStatusDTO(
                 (int) $arr['id'], //doctrine stores bigint as a string, we need to cast it back
                 $arr['status'],
+                $arr['updatedAt'],
             );
         }
 

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -20,7 +20,8 @@ class Config
         'requireSecureConnection',
         'errorCaptureEnabled',
         'learningMaterialsDisabled',
-        'academic_year_crosses_calendar_year_boundaries'
+        'academic_year_crosses_calendar_year_boundaries',
+        'material_status_enabled',
     ];
 
     private const INT_NAMES = [

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -48,7 +48,7 @@ class ConfigControllerTest extends WebTestCase
         unset($data['maxUploadSize']);
         $container = $this->kernelBrowser->getContainer();
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'type' => 'form',
                 'locale' => 'en',
@@ -58,6 +58,7 @@ class ConfigControllerTest extends WebTestCase
                 'trackingEnabled' => false,
                 'searchEnabled' => false,
                 'academicYearCrossesCalendarYearBoundaries' => false,
+                'materialStatusEnabled' => false,
             ],
             $data
         );
@@ -66,6 +67,7 @@ class ConfigControllerTest extends WebTestCase
     public function testEnvOverrideForConfigItem()
     {
         $_SERVER['ILIOS_ACADEMIC_YEAR_CROSSES_CALENDAR_YEAR_BOUNDARIES'] = true;
+        $_SERVER['ILIOS_MATERIAL_STATUS_ENABLED'] = true;
 
         $this->kernelBrowser->request('GET', '/application/config');
 
@@ -80,7 +82,7 @@ class ConfigControllerTest extends WebTestCase
         unset($data['maxUploadSize']);
         $container = $this->kernelBrowser->getContainer();
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'type' => 'form',
                 'locale' => 'en',
@@ -90,10 +92,12 @@ class ConfigControllerTest extends WebTestCase
                 'trackingEnabled' => false,
                 'searchEnabled' => false,
                 'academicYearCrossesCalendarYearBoundaries' => true,
+                'materialStatusEnabled' => true,
             ],
             $data
         );
 
         unset($_SERVER['ILIOS_ACADEMIC_YEAR_CROSSES_CALENDAR_YEAR_BOUNDARIES']);
+        unset($_SERVER['ILIOS_MATERIAL_STATUS_ENABLED']);
     }
 }

--- a/tests/DataLoader/LearningMaterialData.php
+++ b/tests/DataLoader/LearningMaterialData.php
@@ -173,7 +173,7 @@ class LearningMaterialData extends AbstractDataLoader
             'owningUser' => "1",
             'copyrightRationale' => 'i own it',
             'copyrightPermission' => true,
-            'sessionLearningMaterials' => ['8'],
+            'sessionLearningMaterials' => ['8', '9'],
             'courseLearningMaterials' => ['10'],
             'filename' => 'testfile.pdf',
             'mimetype' => 'application/pdf',

--- a/tests/DataLoader/SessionData.php
+++ b/tests/DataLoader/SessionData.php
@@ -49,7 +49,7 @@ class SessionData extends AbstractDataLoader
             'terms' => ['1', '4'],
             'sessionObjectives' => [],
             'meshDescriptors' => [],
-            'learningMaterials' => [],
+            'learningMaterials' => ['9'],
             'offerings' => ['3', '4', '5'],
             'administrators' => [],
             'studentAdvisors' => [],

--- a/tests/DataLoader/SessionLearningMaterialData.php
+++ b/tests/DataLoader/SessionLearningMaterialData.php
@@ -117,13 +117,26 @@ class SessionLearningMaterialData extends AbstractDataLoader
             'endDate' => date_format(new DateTime('2 days ago'), 'c'),
         ];
 
+        $arr[] = [
+            'id' => 9,
+            'required' => true,
+            'publicNotes' => true,
+            'notes' => '',
+            'session' => 2,
+            'learningMaterial' => 10,
+            'meshDescriptors' => [],
+            'position' => 1,
+            'startDate' => null,
+            'endDate' => null,
+        ];
+
         return $arr;
     }
 
     public function create(): array
     {
         return [
-            'id' => 9,
+            'id' => 10,
             'required' => false,
             'notes' => 'foo bar baz',
             'publicNotes' => false,

--- a/tests/DataLoader/UserData.php
+++ b/tests/DataLoader/UserData.php
@@ -53,6 +53,7 @@ class UserData extends AbstractDataLoader
             'studentAdvisedSessions' => [],
             'directedPrograms' => ['1'],
             'administeredCurriculumInventoryReports' => ['1'],
+            'sessionMaterialStatuses' => [],
         ];
 
         $arr[] = [
@@ -95,6 +96,7 @@ class UserData extends AbstractDataLoader
             'studentAdvisedSessions' => [],
             'directedPrograms' => [],
             'administeredCurriculumInventoryReports' => [],
+            'sessionMaterialStatuses' => ['1', '2', '3'],
         ];
 
         $arr[] = [
@@ -137,6 +139,7 @@ class UserData extends AbstractDataLoader
             'studentAdvisedSessions' => ['4'],
             'directedPrograms' => [],
             'administeredCurriculumInventoryReports' => [],
+            'sessionMaterialStatuses' => [],
         ];
 
         $arr[] = [
@@ -177,6 +180,7 @@ class UserData extends AbstractDataLoader
             'studentAdvisedSessions' => [],
             'directedPrograms' => [],
             'administeredCurriculumInventoryReports' => [],
+            'sessionMaterialStatuses' => [],
         ];
 
         $arr[] = [
@@ -216,6 +220,7 @@ class UserData extends AbstractDataLoader
             'studentAdvisedSessions' => [],
             'directedPrograms' => [],
             'administeredCurriculumInventoryReports' => [],
+            'sessionMaterialStatuses' => [],
         ];
 
         return $arr;
@@ -260,6 +265,7 @@ class UserData extends AbstractDataLoader
             'studentAdvisedSessions' => [],
             'directedPrograms' => [],
             'administeredCurriculumInventoryReports' => [],
+            'sessionMaterialStatuses' => [],
         ];
     }
 

--- a/tests/DataLoader/UserSessionMaterialStatusData.php
+++ b/tests/DataLoader/UserSessionMaterialStatusData.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\DataLoader;
+
+use App\Entity\DTO\UserSessionMaterialStatusDTO;
+use App\Entity\UserSessionMaterialStatusInterface;
+
+class UserSessionMaterialStatusData extends AbstractDataLoader
+{
+    protected function getData(): array
+    {
+        $arr = [];
+
+        $arr[] = [
+            'id' => 1,
+            'status' => UserSessionMaterialStatusInterface::NONE,
+            'user' => 2,
+            'material' => 1,
+        ];
+
+        $arr[] = [
+            'id' => 2,
+            'status' => UserSessionMaterialStatusInterface::STARTED,
+            'user' => 2,
+            'material' => 3,
+        ];
+
+        $arr[] = [
+            'id' => 3,
+            'status' => UserSessionMaterialStatusInterface::COMPLETE,
+            'user' => 2,
+            'material' => 5,
+        ];
+
+        return $arr;
+    }
+
+    public function create(): array
+    {
+        return [
+            'id' => 4,
+            'status' => UserSessionMaterialStatusInterface::STARTED,
+            'user' => 2,
+            'material' => 1,
+        ];
+    }
+
+    public function createInvalid(): array
+    {
+        return [];
+    }
+
+    public function getDtoClass(): string
+    {
+        return UserSessionMaterialStatusDTO::class;
+    }
+}

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -728,9 +728,9 @@ class CourseTest extends ReadWriteEndpointTest
         $this->assertIsArray($includes['meshDescriptors']);
         $this->assertEquals(['abc1', 'abc2'], $includes['meshDescriptors']);
         $this->assertIsArray($includes['sessionLearningMaterials']);
-        $this->assertEquals(['1'], $includes['sessionLearningMaterials']);
+        $this->assertEquals(['1', '9'], $includes['sessionLearningMaterials']);
         $this->assertIsArray($includes['learningMaterials']);
-        $this->assertEquals(['1'], $includes['learningMaterials']);
+        $this->assertEquals(['1', '10'], $includes['learningMaterials']);
         $this->assertIsArray($includes['users']);
         $this->assertEquals(['1', '2', '4', '5'], $includes['users']);
         $this->assertIsArray($includes['offerings']);

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -158,7 +158,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertTrue($events[0]['attendanceRequired'], 'attendanceRequired is correct for event 0');
         $this->assertEquals(
             count($events[0]['learningMaterials']),
-            9,
+            10,
             'Event 0 has the correct number of learning materials'
         );
         $this->assertEquals(
@@ -211,7 +211,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertTrue($events[1]['attendanceRequired'], 'attendanceRequired is correct for event 1');
         $this->assertEquals(
             count($events[1]['learningMaterials']),
-            9,
+            10,
             'Event 1 has the correct number of learning materials'
         );
 
@@ -257,7 +257,7 @@ class SchooleventsTest extends AbstractEndpointTest
         $this->assertTrue($events[2]['attendanceRequired'], 'attendanceRequired is correct for event 2');
         $this->assertEquals(
             count($events[2]['learningMaterials']),
-            9,
+            10,
             'Event 2 has the correct number of learning materials'
         );
         $this->assertEquals(

--- a/tests/Endpoints/SessionLearningMaterialTest.php
+++ b/tests/Endpoints/SessionLearningMaterialTest.php
@@ -11,8 +11,8 @@ use App\Tests\Fixture\LoadSessionData;
 use App\Tests\Fixture\LoadSessionLearningMaterialData;
 use App\Tests\Fixture\LoadUserData;
 use App\Tests\ReadWriteEndpointTest;
-
 use Symfony\Component\HttpFoundation\Response;
+
 use function date_format;
 use function is_null;
 

--- a/tests/Endpoints/SessionLearningMaterialTest.php
+++ b/tests/Endpoints/SessionLearningMaterialTest.php
@@ -6,10 +6,13 @@ namespace App\Tests\Endpoints;
 
 use App\Tests\Fixture\LoadLearningMaterialData;
 use App\Tests\Fixture\LoadMeshDescriptorData;
+use App\Tests\Fixture\LoadOfferingData;
 use App\Tests\Fixture\LoadSessionData;
 use App\Tests\Fixture\LoadSessionLearningMaterialData;
+use App\Tests\Fixture\LoadUserData;
 use App\Tests\ReadWriteEndpointTest;
 
+use Symfony\Component\HttpFoundation\Response;
 use function date_format;
 use function is_null;
 
@@ -28,6 +31,7 @@ class SessionLearningMaterialTest extends ReadWriteEndpointTest
             LoadSessionData::class,
             LoadLearningMaterialData::class,
             LoadMeshDescriptorData::class,
+            LoadOfferingData::class,
         ];
     }
 
@@ -68,17 +72,73 @@ class SessionLearningMaterialTest extends ReadWriteEndpointTest
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
             'notes' => [[1], ['notes' => 'second slm']],
-            'required' => [[0], ['required' => true]],
+            'required' => [[0, 8], ['required' => true]],
             'notRequired' => [[1, 2, 3, 4, 5, 6, 7], ['required' => false]],
-            'publicNotes' => [[1, 2, 3, 4, 5, 6, 7], ['publicNotes' => true]],
+            'publicNotes' => [[1, 2, 3, 4, 5, 6, 7, 8], ['publicNotes' => true]],
             'notPublicNotes' => [[0], ['publicNotes' => false]],
             'session' => [[0], ['session' => 1]],
             'learningMaterial' => [[0], ['learningMaterial' => 1]],
             'meshDescriptors' => [[1, 2, 3, 4, 5, 6, 7], ['meshDescriptors' => ['abc2']]],
             'position' => [[1, 2, 3, 4, 5, 6, 7], ['position' => 0]],
-            'school' => [[0, 1, 2, 3, 4, 5, 6, 7], ['schools' => 1]],
-            'schools' => [[0, 1, 2, 3, 4, 5, 6, 7], ['schools' => [1]]],
+            'school' => [[0, 1, 2, 3, 4, 5, 6, 7, 8], ['schools' => 1]],
+            'schools' => [[0, 1, 2, 3, 4, 5, 6, 7, 8], ['schools' => [1]]],
         ];
+    }
+
+    public function testCanViewOneAsLearnerInSessionWhenAvailable()
+    {
+        $url = $this->getUrl(
+            $this->kernelBrowser,
+            "app_api_sessionlearningmaterials_getone",
+            ['version' => $this->apiVersion, 'id' => 1]
+        );
+        $this->createJsonRequest(
+            'GET',
+            $url,
+            null,
+            $this->getTokenForUser($this->kernelBrowser, 5)
+        );
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+        $response = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('sessionLearningMaterials', $response);
+        $this->assertCount(1, $response['sessionLearningMaterials']);
+
+        $data = $response['sessionLearningMaterials'][0];
+
+        $this->assertEquals(1, $data['id']);
+        $this->assertArrayNotHasKey('notes', $data);
+    }
+
+    public function testCanViewAllAsLearnerInSessionWhenAvailable()
+    {
+        $this->createJsonRequest(
+            'GET',
+            $this->getUrl(
+                $this->kernelBrowser,
+                "app_api_sessionlearningmaterials_getall",
+                ['version' => $this->apiVersion]
+            ),
+            null,
+            $this->getTokenForUser($this->kernelBrowser, 5)
+        );
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+        $responses = json_decode($response->getContent(), true)['sessionLearningMaterials'];
+
+        $this->assertCount(5, $responses);
+        $this->assertEquals(1, $responses[0]['id']);
+        $this->assertArrayNotHasKey('notes', $responses[0]);
+        $this->assertEquals(2, $responses[1]['id']);
+        $this->assertEquals('second slm', $responses[1]['notes']);
+        $this->assertEquals(3, $responses[2]['id']);
+        $this->assertEquals('third slm', $responses[2]['notes']);
+        $this->assertEquals(5, $responses[3]['id']);
+        $this->assertEquals('fifth slm', $responses[3]['notes']);
+        $this->assertEquals(7, $responses[4]['id']);
+        $this->assertEquals('seventh slm', $responses[4]['notes']);
     }
 
     /**

--- a/tests/Endpoints/UserSessionMaterialStatusTest.php
+++ b/tests/Endpoints/UserSessionMaterialStatusTest.php
@@ -52,6 +52,8 @@ class UserSessionMaterialStatusTest extends ReadWriteEndpointTest
             ]]],
             'material' => [[1], ['material' => 3]],
             'materials' => [[0, 2], ['material' => [1, 5]]],
+            'user' => [[0, 1, 2], ['user' => 2]],
+            'users' => [[0, 1, 2], ['user' => [2]]],
         ];
     }
 

--- a/tests/Endpoints/UserSessionMaterialStatusTest.php
+++ b/tests/Endpoints/UserSessionMaterialStatusTest.php
@@ -54,4 +54,9 @@ class UserSessionMaterialStatusTest extends ReadWriteEndpointTest
             'materials' => [[0, 2], ['material' => [1, 5]]],
         ];
     }
+
+    protected function getTimeStampFields(): array
+    {
+        return ['updatedAt'];
+    }
 }

--- a/tests/Endpoints/UserSessionMaterialStatusTest.php
+++ b/tests/Endpoints/UserSessionMaterialStatusTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Endpoints;
+
+use App\Entity\UserSessionMaterialStatusInterface;
+use App\Tests\Fixture\LoadUserSessionMaterialStatusData;
+use App\Tests\ReadWriteEndpointTest;
+
+/**
+ * UserSessionMaterialStatusTest API endpoint Test.
+ * @group api_1
+ */
+class UserSessionMaterialStatusTest extends ReadWriteEndpointTest
+{
+    protected string $testName =  'userSessionMaterialStatuses';
+
+    protected function getFixtures(): array
+    {
+        return [
+            LoadUserSessionMaterialStatusData::class,
+        ];
+    }
+
+    public function putsToTest(): array
+    {
+        return [
+            'statusStarted' => ['status', UserSessionMaterialStatusInterface::STARTED],
+            'statusComplete' => ['status', UserSessionMaterialStatusInterface::COMPLETE],
+            'material' => ['material', 2],
+        ];
+    }
+
+    public function readOnlyPropertiesToTest(): array
+    {
+        return [
+            'id' => ['id', 1, 99],
+            'updatedAt' => ['updatedAt', 1, '2015-01-01'],
+        ];
+    }
+
+    public function filtersToTest(): array
+    {
+        return [
+            'id' => [[0], ['id' => 1]],
+            'ids' => [[0, 2], ['id' => [1, 3]]],
+            'status' => [[0], ['status' => UserSessionMaterialStatusInterface::NONE]],
+            'statuses' => [[0, 1], ['status' => [
+                UserSessionMaterialStatusInterface::NONE,
+                UserSessionMaterialStatusInterface::STARTED
+            ]]],
+            'material' => [[1], ['material' => 3]],
+            'materials' => [[0, 2], ['material' => [1, 5]]],
+        ];
+    }
+}

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -18,6 +18,7 @@ use App\Tests\Fixture\LoadReportData;
 use App\Tests\Fixture\LoadSessionData;
 use App\Tests\Fixture\LoadSessionLearningMaterialData;
 use App\Tests\Fixture\LoadUserData;
+use App\Tests\Fixture\LoadUserSessionMaterialStatusData;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\ReadWriteEndpointTest;
 
@@ -46,6 +47,7 @@ class UserTest extends ReadWriteEndpointTest
             LoadAuthenticationData::class,
             LoadSessionData::class,
             LoadCurriculumInventoryReportData::class,
+            LoadUserSessionMaterialStatusData::class,
         ];
     }
 

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -200,7 +200,7 @@ class UsereventTest extends AbstractEndpointTest
         );
         $this->assertSame(
             count($events[0]['learningMaterials']),
-            9,
+            10,
             'Event 0 has the correct number of learning materials'
         );
         $this->assertTrue(
@@ -282,7 +282,7 @@ class UsereventTest extends AbstractEndpointTest
         );
         $this->assertSame(
             count($events[1]['learningMaterials']),
-            9,
+            10,
             'Event 1 has the correct number of learning materials'
         );
         $this->assertTrue(
@@ -367,7 +367,7 @@ class UsereventTest extends AbstractEndpointTest
         );
         $this->assertSame(
             count($events[2]['learningMaterials']),
-            9,
+            10,
             'Event 2 has the correct number of learning materials'
         );
         $this->assertTrue(

--- a/tests/Entity/UserSessionMaterialStatusTest.php
+++ b/tests/Entity/UserSessionMaterialStatusTest.php
@@ -46,7 +46,10 @@ class UserSessionMaterialStatusTest extends EntityBase
      */
     public function testConstructor()
     {
+        $now = new DateTime();
         $this->assertInstanceOf(DateTime::class, $this->object->getUpdatedAt());
+        $diff = $now->diff($this->object->getUpdatedAt());
+        $this->assertTrue($diff->s < 2);
     }
 
     /**

--- a/tests/Entity/UserSessionMaterialStatusTest.php
+++ b/tests/Entity/UserSessionMaterialStatusTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\SessionLearningMaterialInterface;
+use App\Entity\UserInterface;
+use App\Entity\UserSessionMaterialStatus;
+use App\Entity\UserSessionMaterialStatusInterface;
+use DateTime;
+use Mockery as m;
+
+/**
+ * @group model
+ */
+class UserSessionMaterialStatusTest extends EntityBase
+{
+    /**
+     * @var UserSessionMaterialStatus
+     */
+    protected $object;
+
+    protected function setUp(): void
+    {
+        $this->object = new UserSessionMaterialStatus();
+    }
+
+    public function testNotNullValidation()
+    {
+        $notNull = [
+            'user',
+            'material',
+            'status'
+        ];
+        $this->validateNotNulls($notNull);
+
+        $this->object->setUser(m::mock(UserInterface::class));
+        $this->object->setMaterial(m::mock(SessionLearningMaterialInterface::class));
+        $this->object->setStatus(UserSessionMaterialStatusInterface::COMPLETE);
+
+        $this->validate(0);
+    }
+    /**
+     * @covers \App\Entity\UserSessionMaterialStatus::__construct
+     */
+    public function testConstructor()
+    {
+        $this->assertInstanceOf(DateTime::class, $this->object->getUpdatedAt());
+    }
+
+    /**
+     * @covers \App\Entity\UserSessionMaterialStatus::setStatus
+     * @covers \App\Entity\UserSessionMaterialStatus::getStatus
+     */
+    public function testSetStatus()
+    {
+        $this->object->setStatus(UserSessionMaterialStatusInterface::NONE);
+        $this->assertSame(UserSessionMaterialStatusInterface::NONE, $this->object->getStatus());
+    }
+
+    /**
+     * @covers \App\Entity\UserSessionMaterialStatus::setUser
+     * @covers \App\Entity\UserSessionMaterialStatus::getUser
+     */
+    public function testSetUser()
+    {
+        $this->entitySetTest('user', "User");
+    }
+
+    /**
+     * @covers \App\Entity\UserSessionMaterialStatus::setMaterial
+     * @covers \App\Entity\UserSessionMaterialStatus::getMaterial
+     */
+    public function testSetMaterial()
+    {
+        $this->entitySetTest('material', "SessionLearningMaterial");
+    }
+}

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -934,4 +934,45 @@ class UserTest extends EntityBase
             'addAdministrator'
         );
     }
+
+    /**
+     * @covers \App\Entity\User::addSessionMaterialStatus
+     */
+    public function testAddSessionMaterialStatus()
+    {
+        $this->entityCollectionAddTest(
+            'sessionMaterialStatus',
+            'UserSessionMaterialStatus',
+            'getSessionMaterialStatuses',
+            'addSessionMaterialStatus'
+        );
+    }
+
+    /**
+     * @covers \App\Entity\User::removeSessionMaterialStatus
+     */
+    public function testRemoveLearningMaterialStatus()
+    {
+        $this->entityCollectionRemoveTest(
+            'sessionMaterialStatus',
+            'UserSessionMaterialStatus',
+            'getSessionMaterialStatuses',
+            'addSessionMaterialStatus',
+            'removeSessionMaterialStatus'
+        );
+    }
+
+    /**
+     * @covers \App\Entity\User::getSessionMaterialStatuses
+     * @covers \App\Entity\User::setSessionMaterialStatuses
+     */
+    public function testGetSessionLearningMaterialStatuses()
+    {
+        $this->entityCollectionSetTest(
+            'sessionMaterialStatus',
+            'UserSessionMaterialStatus',
+            'getSessionMaterialStatuses',
+            'setSessionMaterialStatuses'
+        );
+    }
 }

--- a/tests/Fixture/LoadUserSessionMaterialStatusData.php
+++ b/tests/Fixture/LoadUserSessionMaterialStatusData.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Fixture;
+
+use App\Entity\UserSessionMaterialStatus;
+use App\Tests\DataLoader\UserSessionMaterialStatusData;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class LoadUserSessionMaterialStatusData extends AbstractFixture implements
+    ORMFixtureInterface,
+    DependentFixtureInterface,
+    ContainerAwareInterface
+{
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function load(ObjectManager $manager)
+    {
+        $data = $this->container
+            ->get(UserSessionMaterialStatusData::class)
+            ->getAll();
+        foreach ($data as $arr) {
+            $entity = new UserSessionMaterialStatus();
+            $entity->setId($arr['id']);
+            $entity->setStatus($arr['status']);
+
+            $entity->setUser($this->getReference('users' . $arr['user']));
+            $entity->setMaterial($this->getReference('sessionLearningMaterials' . $arr['material']));
+
+            $manager->persist($entity);
+            $this->addReference('UserSessionMaterialStatuss' . $arr['id'], $entity);
+        }
+
+        $manager->flush();
+    }
+
+    public function getDependencies()
+    {
+        return [
+            LoadUserData::class,
+            LoadSessionLearningMaterialData::class,
+        ];
+    }
+}

--- a/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
+++ b/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
@@ -39,7 +39,6 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
             [IngestionExceptionDTO::class],
             [OfferingDTO::class],
             [PendingUserUpdateDTO::class],
-            [SessionLearningMaterialDTO::class],
         ];
     }
 

--- a/tests/RelationshipVoter/SessionLearningMaterialDTOVoterTest.php
+++ b/tests/RelationshipVoter/SessionLearningMaterialDTOVoterTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\RelationshipVoter;
+
+use App\Classes\SessionUserInterface;
+use App\Entity\DTO\SessionLearningMaterialDTO;
+use App\RelationshipVoter\AbstractVoter;
+use App\RelationshipVoter\SessionLearningMaterialDTOVoter;
+use App\Service\PermissionChecker;
+use DateTime;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class SessionLearningMaterialDTOVoterTest extends AbstractBase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new SessionLearningMaterialDTOVoter($this->permissionChecker);
+    }
+
+    public function testCanViewDTOAsNonLearner()
+    {
+        $dtoId = 1;
+        $userId = 2;
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $user->shouldReceive('getId')->andReturn($userId);
+        $user->shouldReceive('performsNonLearnerFunction')->andReturn(true);
+        $dto = m::mock(SessionLearningMaterialDTO::class);
+        $dto->id = $dtoId;
+
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
+    }
+
+    public function testRootCanViewDTO()
+    {
+        $sessionUser = m::mock(SessionUserInterface::class);
+        $sessionUser->shouldReceive('isRoot')->andReturn(true);
+        $token = $this->createMockTokenWithSessionUser($sessionUser);
+        $dto = m::mock(SessionLearningMaterialDTO::class);
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
+    }
+
+    public function testCanNotViewDTO()
+    {
+        $dtoId = 1;
+        $userId = 2;
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $user->shouldReceive('getId')->andReturn($userId);
+        $user->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $user->shouldReceive('isLearnerInSession')->with(13)->andReturn(false);
+        $dto = m::mock(SessionLearningMaterialDTO::class);
+        $dto->id = $dtoId;
+        $dto->session = 13;
+
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View denied");
+    }
+
+    public function testCanViewDTOIfInSession()
+    {
+        $dtoId = 1;
+        $userId = 2;
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $user->shouldReceive('getId')->andReturn($userId);
+        $user->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $user->shouldReceive('isLearnerInSession')->with(13)->andReturn(true);
+        $dto = m::mock(SessionLearningMaterialDTO::class);
+        $dto->id = $dtoId;
+        $dto->session = 13;
+
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
+    }
+
+    public function testCanNotViewDTOBeforeItIsAvailable()
+    {
+        $dtoId = 1;
+        $userId = 2;
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $user->shouldReceive('getId')->andReturn($userId);
+        $user->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $dto = m::mock(SessionLearningMaterialDTO::class);
+        $dto->id = $dtoId;
+        $dto->startDate = new DateTime('tomorrow');
+
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View denied");
+    }
+
+    public function testCanNotViewDTOAfterItIsAvailable()
+    {
+        $dtoId = 1;
+        $userId = 2;
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $user->shouldReceive('getId')->andReturn($userId);
+        $user->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $dto = m::mock(SessionLearningMaterialDTO::class);
+        $dto->id = $dtoId;
+        $dto->endDate = new DateTime('yesterday');
+
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View denied");
+    }
+
+    public function testCanViewDTOBetweenStartAndEndDates()
+    {
+        $dtoId = 1;
+        $userId = 2;
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $user->shouldReceive('getId')->andReturn($userId);
+        $user->shouldReceive('performsNonLearnerFunction')->andReturn(false);
+        $user->shouldReceive('isLearnerInSession')->with(13)->andReturn(true);
+        $dto = m::mock(SessionLearningMaterialDTO::class);
+        $dto->id = $dtoId;
+        $dto->session = 13;
+        $dto->startDate = new DateTime('yesterday');
+        $dto->endDate = new DateTime('tomorrow');
+
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View denied");
+    }
+}

--- a/tests/RelationshipVoter/UserSessionMaterialStatusDTOVoterTest.php
+++ b/tests/RelationshipVoter/UserSessionMaterialStatusDTOVoterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\RelationshipVoter;
+
+use App\Classes\SessionUserInterface;
+use App\Entity\DTO\UserSessionMaterialStatusDTO;
+use App\RelationshipVoter\AbstractVoter;
+use App\RelationshipVoter\UserDTOVoter;
+use App\RelationshipVoter\UserSessionMaterialStatusDTOVoter;
+use App\Service\PermissionChecker;
+use App\Entity\DTO\UserDTO;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * @package App\Tests\RelationshipVoter
+ */
+class UserSessionMaterialStatusDTOVoterTest extends AbstractBase
+{
+    protected $dto;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new UserSessionMaterialStatusDTOVoter($this->permissionChecker);
+    }
+
+    /**
+     * @covers \App\RelationshipVoter\UserSessionMaterialStatusDTOVoter::voteOnAttribute
+     */
+    public function testCanViewDTOifYourself()
+    {
+        $userId = 2;
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $user->shouldReceive('getId')->andReturn($userId);
+        $dto = m::mock(UserSessionMaterialStatusDTO::class);
+        $dto->user = $userId;
+
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
+    }
+
+    /**
+     * @covers \App\RelationshipVoter\UserSessionMaterialStatusDTOVoter::voteOnAttribute
+     */
+    public function testRootCanNotViewDTO()
+    {
+        $sessionUser = m::mock(SessionUserInterface::class);
+        $sessionUser->shouldReceive('isRoot')->andReturn(true);
+        $sessionUser->shouldReceive('getId')->andReturn(13);
+        $token = $this->createMockTokenWithSessionUser($sessionUser);
+        $dto = m::mock(UserSessionMaterialStatusDTO::class);
+        $dto->user = 1;
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View denied");
+    }
+
+    /**
+     * @covers \App\RelationshipVoter\UserSessionMaterialStatusDTOVoter::voteOnAttribute
+     */
+    public function testCanNotViewDTO()
+    {
+        $dtoId = 1;
+        $userId = 2;
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $user = $token->getUser();
+        $user->shouldReceive('getId')->andReturn($userId);
+        $dto = m::mock(UserSessionMaterialStatusDTO::class);
+        $dto->user = $dtoId;
+
+        $response = $this->voter->vote($token, $dto, [AbstractVoter::VIEW]);
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View denied");
+    }
+}

--- a/tests/RelationshipVoter/UserSessionMaterialStatusTest.php
+++ b/tests/RelationshipVoter/UserSessionMaterialStatusTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\RelationshipVoter;
+
+use App\Entity\UserInterface;
+use App\Entity\UserSessionMaterialStatusInterface;
+use App\RelationshipVoter\AbstractVoter;
+use App\RelationshipVoter\UserSessionMaterialStatus as Voter;
+use App\Service\PermissionChecker;
+use Mockery as m;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class UserSessionMaterialStatusTest extends AbstractBase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->permissionChecker = m::mock(PermissionChecker::class);
+        $this->voter = new Voter($this->permissionChecker);
+    }
+
+    public function testSelfHasFullAccess()
+    {
+        $token = $this->createMockTokenWithNonRootSessionUser();
+        $sessionUser = $token->getUser();
+        $user = m::mock(UserInterface::class);
+        $entity = m::mock(UserSessionMaterialStatusInterface::class);
+        foreach ([AbstractVoter::VIEW, AbstractVoter::DELETE, AbstractVoter::EDIT] as $attr) {
+            $sessionUser->shouldReceive('getUser')->andReturn($user);
+            $entity->shouldReceive('getUser')->andReturn($user);
+            $sessionUser->shouldReceive('isTheUser')->with($user)->andReturn(true);
+            $response = $this->voter->vote($token, $entity, [$attr]);
+            $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "${attr} granted");
+        }
+    }
+
+    public function testDenyOtherUserAccess()
+    {
+        $token = $this->createMockTokenWithRootSessionUser();
+        $sessionUser = $token->getUser();
+        $user = m::mock(UserInterface::class);
+        $user2 = m::mock(UserInterface::class);
+        $entity = m::mock(UserSessionMaterialStatusInterface::class);
+        foreach ([AbstractVoter::VIEW, AbstractVoter::DELETE, AbstractVoter::CREATE, AbstractVoter::EDIT] as $attr) {
+            $sessionUser->shouldReceive('getUser')->andReturn($user);
+            $entity->shouldReceive('getUser')->andReturn($user2);
+            $sessionUser->shouldReceive('isTheUser')->with($user2)->andReturn(false);
+            $response = $this->voter->vote($token, $entity, [$attr]);
+            $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "${attr} grandeniedted");
+        }
+    }
+}


### PR DESCRIPTION
This API endpoint allows users to mark session learning materials as
completed making it easier to track deadlines, tasks, and educational
progress. We tie this to the session learning material instead of the LM
directly as the same LM being assigned in multiple sessions should be
individually trackable.

Using a bigint for the ID because this table may grow very large, that's
also why we're tracking the last modified value in order to be able to
run cleanup for very old items and some future point.