### PR TITLE
setup PHP with 1GB max memory consumption.

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           php-version: ${{ env.latest_php }}
           extensions: apcu
-          ini-values: xdebug.mode=coverage
+          ini-values: xdebug.mode=coverage,memory_limit=1G
       - name: install dependencies
         run: composer install --no-interaction --prefer-dist
       - name: create coverage


### PR DESCRIPTION
this attempts to overcome the out-of-memory failures we're currently
seeing with infection tests.

i'm fishing somewhat in the dark here, since i haven't been able to find any info on how these test machines are spec'ed out RAM wise.