### PR TITLE
Disable DTO Cache in Development Containers

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -27,7 +27,7 @@ services:
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
       - ILIOS_REDIS_URL=redis://redis
-      - ILIOS_FEATURE_DTO_CACHING=true
+      - ILIOS_FEATURE_DTO_CACHING=false
     volumes:
       # The "cached" option has no effect on Linux but improves performance on Mac
       - ./:/srv/app:rw,cached


### PR DESCRIPTION
This feature isn't ready to be enabled by default yet, it's not working.