### PR TITLE
Cast JWT userId into a string

### DIFF
--- a/src/Service/JsonWebTokenManager.php
+++ b/src/Service/JsonWebTokenManager.php
@@ -33,7 +33,7 @@ class JsonWebTokenManager
     public function getUserIdFromToken($jwt): int
     {
         $arr = $this->decode($jwt);
-        return $arr['user_id'];
+        return (int) $arr['user_id'];
     }
 
     public function getIssuedAtFromToken($jwt): DateTimeInterface

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -54,6 +54,12 @@ class JsonWebTokenManagerTest extends TestCase
         $this->assertSame(42, $this->obj->getUserIdFromToken($jwt));
     }
 
+    public function testGetUserIdFromTokenString()
+    {
+        $jwt = $this->buildToken(['user_id' => '123']);
+        $this->assertSame(123, $this->obj->getUserIdFromToken($jwt));
+    }
+
     public function testGetIssuedAtFromToken()
     {
         $yesterday = new DateTime('yesterday');
@@ -160,7 +166,7 @@ class JsonWebTokenManagerTest extends TestCase
             'aud' => 'ilios',
             'iat' => $now->format('U'),
             'exp' => $now->modify('+1 year')->format('U'),
-            'user_id' => 42
+            'user_id' => 42,
         ];
 
         $merged = array_merge($default, $values);


### PR DESCRIPTION
Sometimes when this token gets generated the userId is a string, we need
to cast it back to an int to satisfy the contract for this method.

Fixes #4268