### PR TITLE
More memory for fpm-dev PHP

### DIFF
--- a/docker/fpm/symfony.dev.ini
+++ b/docker/fpm/symfony.dev.ini
@@ -9,3 +9,6 @@ opcache.max_accelerated_files = 20000
 opcache.memory_consumption = 256
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
+
+# symfony needs more memory for the web toolbar and debug mode
+memory_limit = 1G


### PR DESCRIPTION
Symfony in dev mode records a lot of debugging info for us, we need to
give it more memory for each run.