### PR TITLE
updates symfony recipe for doctrine migrations bundle.

### DIFF
--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -6,4 +6,4 @@ doctrine_migrations:
     storage:
         table_storage:
             table_name: 'migration_versions'
-    enable_profiler: '%kernel.debug%'
+    enable_profiler: false

--- a/symfony.lock
+++ b/symfony.lock
@@ -93,12 +93,12 @@
         ]
     },
     "doctrine/doctrine-migrations-bundle": {
-        "version": "3.1",
+        "version": "3.2",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
+            "branch": "main",
             "version": "3.1",
-            "ref": "ee609429c9ee23e22d6fa5728211768f51ed2818"
+            "ref": "1d01ec03c6ecbd67c3375c5478c9a423ae5d6a33"
         },
         "files": [
             "config/packages/doctrine_migrations.yaml",


### PR DESCRIPTION
the latest recipe turns off the profiler by default, so let's roll with
that too.