### PR TITLE
Prevent double IDs from breaking user sync

### DIFF
--- a/src/Command/SyncAllUsersCommand.php
+++ b/src/Command/SyncAllUsersCommand.php
@@ -66,7 +66,6 @@ class SyncAllUsersCommand extends Command
                 $users = $this->userRepository->findBy([
                     'campusId' => $recordArray['campusId'],
                     'enabled' => true,
-                    'userSyncIgnore' => false,
                 ]);
                 if (count($users) == 0) {
                     //this shouldn't happen unless the user gets updated between

--- a/tests/Command/SyncAllUsersCommandTest.php
+++ b/tests/Command/SyncAllUsersCommandTest.php
@@ -131,7 +131,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -195,7 +195,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -260,7 +260,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -325,7 +325,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -389,7 +389,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -462,7 +462,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -527,7 +527,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -592,7 +592,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -656,7 +656,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -720,7 +720,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -788,7 +788,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -868,7 +868,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user1, $user2])
             ->once();
         $this->userRepository
@@ -925,7 +925,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -981,7 +981,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -1037,7 +1037,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -1093,7 +1093,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -1211,7 +1211,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user])
             ->once();
         $this->userRepository
@@ -1289,7 +1289,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
             ->mock();
         $this->userRepository
             ->shouldReceive('findBy')
-            ->with(['campusId' => 'abc', 'enabled' => true, 'userSyncIgnore' => false])
+            ->with(['campusId' => 'abc', 'enabled' => true])
             ->andReturn([$user1])
             ->once();
         $this->userRepository->shouldReceive('update')->with($user1, false)->once();


### PR DESCRIPTION
When a user is in the system twice with the same campus ID we can't ignore the second entry just because it is disabled. This can cause serious database issues when we attempt to update the non-disable account's username or other unique information. We have to stop the sync in this case.

Fixes #4417