### PR TITLE
Allow composer to run as root in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -276,6 +276,7 @@ COPY docker/php-apache-entrypoint /usr/local/bin/
 
 ENV \
 COMPOSER_HOME=/tmp \
+COMPOSER_ALLOW_SUPERUSER=1 \
 APP_ENV=prod \
 APP_DEBUG=false \
 MAILER_DSN=null://null \


### PR DESCRIPTION
There is new code in composer 2.4.2 that checks if composer is running in a container that isn't working for our php-apache container so we need to set this value ourselves to ensure we can build.