### PR TITLE
Sentry Ignore AccessDeniedException

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -6,6 +6,16 @@ when@prod:
         options:
             before_send: 'App\Service\SentryBeforeSend'
             send_default_pii: true
+            integrations:
+                - 'Sentry\Integration\IgnoreErrorsIntegration'
+
+    services:
+        Sentry\Integration\IgnoreErrorsIntegration:
+            arguments:
+                $options:
+                    ignore_exceptions:
+                        - Symfony\Component\Security\Core\Exception\AccessDeniedException
+
 #    If you are using Monolog, you also need these additional configuration and services to log the errors correctly:
 #    https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
 #    register_error_listener: false


### PR DESCRIPTION
Add AccessDeniedException to the list of sentry ignore errors. This will help reduce the number of spam exceptions posted to sentry.