### PR TITLE
Refine build failure notifications

### DIFF
--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -81,5 +81,5 @@ jobs:
     - uses: act10ns/slack@v1.6.0
       with:
         status: ${{ job.status }}
-        steps: ${{ toJson(steps) }}
-      if: always()
+        message: Failed to deploy {{ matrix.image }}
+      if: failure()


### PR DESCRIPTION
Only notify on failure, and send a message instead of a list of step.