### PR TITLE
Report Workflow Failures to Slack

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,8 @@ env:
   ILIOS_FILE_SYSTEM_STORAGE_PATH: /tmp
   SYMFONY_DEPRECATIONS_HELPER: disabled=1
   CC_TEST_REPORTER_ID: c2e072c72320901c23741e4c25bfd28e149441b5a19ba9abb8cf80ca0363ff9a
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
+
 jobs:
   coverage:
     name: Test and Calculate Coverage
@@ -31,3 +33,8 @@ jobs:
         coverageCommand: vendor/bin/phpunit --coverage-clover build/coverage.xml
         coverageLocations:
           build/coverage.xml:clover
+    - uses: act10ns/slack@v1.6.0
+      with:
+        status: ${{ job.status }}
+        message: Code Coverage Job Failed
+      if: failure()

--- a/.github/workflows/future-php.yml
+++ b/.github/workflows/future-php.yml
@@ -10,6 +10,7 @@ env:
   ILIOS_SECRET: ThisTokenIsNotSoSecretChangeIt
   ILIOS_FILE_SYSTEM_STORAGE_PATH: /tmp
   SYMFONY_DEPRECATIONS_HELPER: disabled=1
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
   future_php: 8.2
 
 jobs:
@@ -29,3 +30,8 @@ jobs:
       run: composer install --no-interaction --prefer-dist
     - name: Run Tests
       run: vendor/bin/phpunit
+    - uses: act10ns/slack@v1.6.0
+      with:
+        status: ${{ job.status }}
+        message: PHP v${{ env.latest_php }} (future version) tests failed
+      if: failure()

--- a/.github/workflows/future-php.yml
+++ b/.github/workflows/future-php.yml
@@ -10,17 +10,18 @@ env:
   ILIOS_SECRET: ThisTokenIsNotSoSecretChangeIt
   ILIOS_FILE_SYSTEM_STORAGE_PATH: /tmp
   SYMFONY_DEPRECATIONS_HELPER: disabled=1
+  future_php: 8.2
 
 jobs:
   test:
-    name: Test
+    name: Test PHP v${{ env.latest_php }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use PHP 8.1
+    - name: Use PHP ${{ env.latest_php }}
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.1
+        php-version: ${{ env.latest_php }}
         coverage: none
         tools: pecl
         extensions: apcu

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -13,6 +13,8 @@ env:
   MESSENGER_TRANSPORT_DSN: doctrine://default
   latest_php: 8.1
   DOCKER_BUILDKIT: 1
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
+
 jobs:
   infection:
     name: Infection tests
@@ -37,3 +39,8 @@ jobs:
           name: infection-html
           path: build/coverage/infection.html
           retention-days: 1
+    - uses: act10ns/slack@v1.6.0
+      with:
+        status: ${{ job.status }}
+        message: Infection tests failed
+      if: failure()

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '15 14 * * 1' # weekly, on Monday morning (UTC)
 
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
+
 jobs:
   update:
     name: Tests
@@ -45,3 +48,8 @@ jobs:
           committer: Zorgbort <info@iliosproject.org>
           author: Zorgbort <info@iliosproject.org>
           labels: dependencies
+    - uses: act10ns/slack@v1.6.0
+      with:
+        status: ${{ job.status }}
+        message: Update Dependency Job Failed
+      if: failure()


### PR DESCRIPTION
When these scheduled jobs fail the error notification only goes to the
person who merged the last PR on the workflow file. Instead this will
report these issues to the team ilios slack.

While I was adding these notification I noticed that our future PHP test was running on the wrong version of PHP, updated that as well.