### PR TITLE
Send performance data to sentry

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -6,8 +6,11 @@ when@prod:
         options:
             before_send: 'App\Service\SentryBeforeSend'
             send_default_pii: true
+            traces_sample_rate: 0.1
             integrations:
                 - 'Sentry\Integration\IgnoreErrorsIntegration'
+        tracing:
+            enabled: true
 
     services:
         Sentry\Integration\IgnoreErrorsIntegration:


### PR DESCRIPTION
Starting with 10% of transactions, lets start collecting some performance data to identify issues.