### PR TITLE
Fix job failure message formatting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,5 +36,5 @@ jobs:
     - uses: act10ns/slack@v1.6.0
       with:
         status: ${{ job.status }}
-        message: Code Coverage [Job Failed]({{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }})
+        message: Code Coverage Job Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}
       if: failure()

--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -81,5 +81,5 @@ jobs:
     - uses: act10ns/slack@v1.6.0
       with:
         status: ${{ job.status }}
-        message: Failed [to deploy]({{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }})
+        message: Failed to deploy {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}
       if: failure()

--- a/.github/workflows/future-php.yml
+++ b/.github/workflows/future-php.yml
@@ -33,5 +33,5 @@ jobs:
     - uses: act10ns/slack@v1.6.0
       with:
         status: ${{ job.status }}
-        message: PHP v${{ env.latest_php }} (future version) [tests failed]({{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }})
+        message: PHP v${{ env.latest_php }} (future version) tests failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}
       if: failure()

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -43,5 +43,5 @@ jobs:
       - uses: act10ns/slack@v1.6.0
         with:
           status: ${{ job.status }}
-          message: Infection [tests failed]({{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }})
+          message: Infection tests failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}
         if: failure()

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -51,5 +51,5 @@ jobs:
     - uses: act10ns/slack@v1.6.0
       with:
         status: ${{ job.status }}
-        message: Update Dependency [Job Failed]({{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }})
+        message: Update Dependency Job Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}
       if: failure()


### PR DESCRIPTION
Turns out this action doesn't parse markdown so we'll just send the link ugly.