### PR TITLE
Adjust Sentry Sampling

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -6,7 +6,7 @@ when@prod:
         options:
             before_send: 'App\Service\SentryBeforeSend'
             send_default_pii: true
-            traces_sample_rate: 0.1
+            traces_sampler: 'sentry.callback.traces_sampler'
             integrations:
                 - 'Sentry\Integration\IgnoreErrorsIntegration'
         tracing:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -189,3 +189,7 @@ services:
       class: Symfony\Component\Cache\Adapter\TagAwareAdapterInterface
       factory: [ 'App\Service\DynamicCacheFactory', 'getCache' ]
       arguments: ['namespace', '%env(resolve:ILIOS_REDIS_URL)%', '%kernel.environment%', '%kernel.cache_dir%', '%env(base64:ILIOS_CACHE_DECRYPTION_KEY)%']
+
+    sentry.callback.traces_sampler:
+      class: 'App\Service\SentryTraceSampler'
+      factory: [ '@App\Service\SentryTraceSampler', 'getTracesSampler' ]

--- a/src/Service/SentryTraceSampler.php
+++ b/src/Service/SentryTraceSampler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Sentry\Tracing\SamplingContext;
+
+class SentryTraceSampler
+{
+    private const SKIP_ROUTES = ['app_ics_geticsfeed', 'app_download_downloadmaterials'];
+
+    /**
+     * Don't sample ICS or LM transactions as they are very noisy
+     * everything else we sample 10% of
+     */
+    public function getTracesSampler(): callable
+    {
+        return function (SamplingContext $context): float {
+            $tags = $context->getTransactionContext()->getTags();
+            if (in_array($tags['route'], self::SKIP_ROUTES)) {
+                return 0;
+            }
+            return 0.1;
+        };
+    }
+}


### PR DESCRIPTION
Our sampling is getting overwhelmed with requests for LM files and ICS feeds. These are fairly slow operations and not something we're able to optimize right now. Let's skip sampling these so we can focus on other areas.