### PR TITLE
Better Sentry Version Tagging

### DIFF
--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -68,6 +68,7 @@ jobs:
 
   sentry-release:
     name: Create Sentry Release
+    needs: tags
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -76,7 +77,7 @@ jobs:
       - name: Create a Sentry.io release
         run: |
           # Create new Sentry release
-          export SENTRY_RELEASE=$(sentry-cli releases propose-version)
+          export SENTRY_RELEASE=${{needs.tags.outputs.patch}}
           sentry-cli releases new $SENTRY_RELEASE
           sentry-cli releases set-commits --auto $SENTRY_RELEASE
           sentry-cli releases finalize $SENTRY_RELEASE


### PR DESCRIPTION
Sentry isn't doing a good job auto-detecting our tags, let's use the version we're already extracting and roll with that.