### PR TITLE
Add PHP 8.2 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.1]
+        php-version: [8.1, 8.2]
 
     steps:
     - uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.1]
+        php-version: [8.1, 8.2]
 
     steps:
     - uses: actions/checkout@v3
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.1]
+        php-version: [8.1, 8.2]
 
     steps:
       - uses: actions/checkout@v3
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.1]
+        php-version: [8.1, 8.2]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
With the release today we should start testing against PHP 8.2 to ensure compatibility.