### PR TITLE
Small Filter Improvement

### DIFF
--- a/src/Traits/ManagerRepository.php
+++ b/src/Traits/ManagerRepository.php
@@ -273,9 +273,12 @@ trait ManagerRepository
     ): void {
         if ($criteria !== []) {
             foreach ($criteria as $key => $value) {
-                $values = is_array($value) ? $value : [$value];
-                $qb->andWhere($qb->expr()->in("x.{$key}", ":{$key}"));
-                $qb->setParameter(":{$key}", $values);
+                if (is_array($value)) {
+                    $qb->andWhere($qb->expr()->in("x.{$key}", ":{$key}"));
+                } else {
+                    $qb->andWhere($qb->expr()->eq("x.{$key}", ":{$key}"));
+                }
+                $qb->setParameter(":{$key}", $value);
             }
         }
 


### PR DESCRIPTION
We've been treating all filter input as an array, however this is slightly less efficient (and actually an issue when we do GraphQL Filtering) so instead let's look for single value equality for single values and only IN for sets.