### PR TITLE
Fix query alias for session course filter

### DIFF
--- a/src/Repository/SessionRepository.php
+++ b/src/Repository/SessionRepository.php
@@ -222,9 +222,9 @@ class SessionRepository extends ServiceEntityRepository implements
 
         if (array_key_exists('courses', $criteria)) {
             $ids = $criteria['courses'];
-            $qb->join('x.course', 's_course');
+            $qb->join('x.course', 'c_course');
             $qb->andWhere(
-                $qb->expr()->in('s_course.id', ':courses')
+                $qb->expr()->in('c_course.id', ':courses')
             );
             $qb->setParameter(':courses', $ids);
         }

--- a/tests/Endpoints/SessionTest.php
+++ b/tests/Endpoints/SessionTest.php
@@ -141,6 +141,7 @@ class SessionTest extends ReadWriteEndpointTest
             'instructorGroups' => [[0, 4], ['instructorGroups' => [1]]],
             'competencies' => [[0], ['competencies' => [1]]],
             'schools' => [[3], ['schools' => [2]]],
+            'schoolsAndCourses' => [[3], ['schools' => [2], 'courses' => [4]]],
         ];
     }
 


### PR DESCRIPTION
Copypasta from the school filter tried to double alias s_courses which breaks when sending both a course and school filter.