### PR TITLE
Bump API to v3.8

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,7 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
-    ilios_api_version: v3.7
+    ilios_api_version: v3.8
     env(TRUSTED_PROXIES):
     env(ILIOS_REDIS_URL):
     env(ILIOS_CACHE_DECRYPTION_KEY):


### PR DESCRIPTION
To encompass changes to the filters and content in our GraphQL API. While this API isn't versioned we need the version bump to ensure we load a compatible frontend.

Refs: #4587 #4555 #4573 #4574 #4583 #4581