### PR TITLE
Pass Correct Documentation Attribute Value

### DIFF
--- a/src/Controller/API/CurriculumInventoryReports.php
+++ b/src/Controller/API/CurriculumInventoryReports.php
@@ -373,7 +373,7 @@ class CurriculumInventoryReports extends AbstractApiController
         summary: 'Rollover a report by ID.',
         requestBody: new OA\RequestBody(
             required: true,
-            content: new OA\MediaType(
+            content: [new OA\MediaType(
                 mediaType: 'application/x-www-form-urlencoded',
                 schema: new OA\Schema(
                     properties: [
@@ -400,7 +400,7 @@ class CurriculumInventoryReports extends AbstractApiController
                     ],
                     type: 'object'
                 )
-            )
+            )]
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),


### PR DESCRIPTION
According [to the docs](https://zircote.github.io/swagger-php/reference/attributes.html#requestbody) this is supposed to be an array, so I've wrapped it that way. As far as I can tell this value isn't displayed in our docs so I'm not sure where to test.