### PR TITLE
Output a Warning when Index is not Configured

### DIFF
--- a/src/Command/Index/CreateCommand.php
+++ b/src/Command/Index/CreateCommand.php
@@ -32,8 +32,12 @@ class CreateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln("<info>Creating the search index.</info>");
-        $this->indexManager->create();
-        $output->writeln("<info>Done.</info>");
+        if (!$this->indexManager->isEnabled()) {
+            $output->writeln("<comment>Indexing is not currently configured.</comment>");
+        } else {
+            $this->indexManager->create();
+            $output->writeln("<info>Done.</info>");
+        }
 
         return 0;
     }

--- a/tests/Command/Index/CreateCommandTest.php
+++ b/tests/Command/Index/CreateCommandTest.php
@@ -18,12 +18,8 @@ class CreateCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-    /** @var CommandTester */
-    protected $commandTester;
-
-    /** @var m\Mock */
-    protected $indexManager;
-
+    protected CommandTester $commandTester;
+    protected m\MockInterface $indexManager;
 
     public function setUp(): void
     {
@@ -47,8 +43,24 @@ class CreateCommandTest extends KernelTestCase
         unset($this->indexManager);
     }
 
-    public function testDropsWithForce()
+    public function testCreateWithIndexDisabled()
     {
+        $this->indexManager->shouldReceive('isEnabled')->once()->andReturn(false);
+        $this->indexManager->shouldNotReceive('create');
+
+        $this->commandTester->execute([
+            'command' => CreateCommand::COMMAND_NAME,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/Indexing is not currently configured./',
+            $output
+        );
+    }
+    public function testCreateWithIndexEnabled()
+    {
+        $this->indexManager->shouldReceive('isEnabled')->once()->andReturn(true);
         $this->indexManager->shouldReceive('create')->once();
 
         $this->commandTester->execute([


### PR DESCRIPTION
Running ilios:index:create without this check will appear to succeed if indexing isn't configured. This can be very confusing. Instead when the index isn't configured we can output a nice warning.