### PR TITLE
Add a consume-messages-dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,6 +195,15 @@ ENTRYPOINT bin/console ilios:wait-for-database; \
            bin/console messenger:consume async
 
 ###############################################################################
+# Single purpose container that starts a message consumer
+# configured for development and verbose output
+###############################################################################
+FROM fpm-dev as consume-messages-dev
+ENTRYPOINT bin/console ilios:wait-for-database; \
+           bin/console ilios:wait-for-index; \
+           bin/console messenger:consume async -vv
+
+###############################################################################
 # MySQL configured as needed for Ilios
 ###############################################################################
 FROM mysql:8.0-oracle as mysql

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -41,9 +41,8 @@ services:
   messages:
     build:
       context: .
-      target: consume-messages
+      target: consume-messages-dev
     environment:
-      - APP_ENV=dev
       - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=8.0
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_ELASTICSEARCH_HOSTS=http://elasticsearch:9200


### PR DESCRIPTION
For development it's super helpful to have the verbose output of messages being consumed and to include the higher memory and other symfony development PHP config tweaks. I have the container building, but not deploying because I don't know if this is something anyone else would want to use outside of ilios local development.