### PR TITLE
Drop doctrine/annotations dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "ext-xmlwriter": "*",
     "ext-zlib": "*",
     "composer/composer": "^2.1",
-    "doctrine/annotations": "^1.0",
     "doctrine/doctrine-bundle": "^2.6",
     "doctrine/doctrine-fixtures-bundle": "^3.0",
     "doctrine/doctrine-migrations-bundle": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "241a284b097d7fea4390f4af8ee86879",
+    "content-hash": "5c48269c02e6fbb4c33bd2a828f11ff0",
     "packages": [
         {
             "name": "async-aws/core",


### PR DESCRIPTION
We're not using annotations directly anymore having moved to attributes across the board.

(hopefully 😉)