### PR TITLE
Share File Storage Between Containers

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -28,6 +28,7 @@ services:
       - ILIOS_ELASTICSEARCH_HOSTS=elasticsearch
       - ILIOS_REDIS_URL=redis://redis
       - ILIOS_FEATURE_DTO_CACHING=false
+      - ILIOS_FILE_SYSTEM_STORAGE_PATH=/ilios-storage
     volumes:
       # The "cached" option has no effect on Linux but improves performance on Mac
       - ./:/srv/app:rw,cached
@@ -35,6 +36,8 @@ services:
       - /srv/app/var
       # Share the frontend files
       - ./var/frontend:/srv/app/var/frontend:rw,cached
+      # Share storage between containers and make writes to the container authoritative with "delegated"
+      - shared-storage:/ilios-storage:delegated
     depends_on:
       - db
       - redis
@@ -47,6 +50,7 @@ services:
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_ELASTICSEARCH_HOSTS=http://elasticsearch:9200
       - ILIOS_REDIS_URL=redis://redis
+      - ILIOS_FILE_SYSTEM_STORAGE_PATH=/ilios-storage
     depends_on:
         - db
         - elasticsearch
@@ -56,6 +60,8 @@ services:
       - ./:/srv/app:rw,cached
       # Remove the var/ directory from the bind-mount for better performance
       - /srv/app/var
+      # Share storage between containers and make writes to the container authoritative with "delegated"
+      - shared-storage:/ilios-storage:delegated
   elasticsearch:
     build:
       context: .
@@ -71,3 +77,6 @@ services:
       target: redis
     ports:
       - "6379:6379"
+
+volumes:
+  shared-storage:

--- a/docker/fpm/docker-entrypoint.sh
+++ b/docker/fpm/docker-entrypoint.sh
@@ -6,7 +6,7 @@ if [ "${1#-}" != "$1" ]; then
 	set -- php-fpm "$@"
 fi
 
-mkdir -p var/cache var/log var/tmp
+mkdir -p var/cache var/log var/tmp $ILIOS_STORAGE
 if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 	
 	if [ "$ILIOS_DATABASE_URL" ]; then


### PR DESCRIPTION
In order to be able to view uploads and index materials in different containers we have to share the file storage between them. In production this is done with S3 usually, but here I've created a names volume and ensured files are shared there. When the container boots it will create this directory if it doesn't exist, which is required in order to give it good permissions, but shouldn't be an issue for any other reason.