### PR TITLE
Remove Deprecated ObjectHasAttribute Assertions

### DIFF
--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -349,10 +349,10 @@ abstract class AbstractEndpointTest extends WebTestCase
         $content = json_decode($response->getContent());
         $this->assertCount(0, $content->included, var_export($content, true));
         $this->assertIsObject($content->data);
-        $this->assertObjectHasAttribute('id', $content->data);
-        $this->assertObjectHasAttribute('type', $content->data);
-        $this->assertObjectHasAttribute('attributes', $content->data);
-        $this->assertObjectHasAttribute('relationships', $content->data);
+        $this->assertTrue(property_exists($content->data, 'id'));
+        $this->assertTrue(property_exists($content->data, 'type'));
+        $this->assertTrue(property_exists($content->data, 'attributes'));
+        $this->assertTrue(property_exists($content->data, 'relationships'));
 
         return $content->data;
     }
@@ -393,7 +393,7 @@ abstract class AbstractEndpointTest extends WebTestCase
 
         $this->assertJsonApiResponse($response, Response::HTTP_OK);
         $content = json_decode($response->getContent());
-        $this->assertObjectHasAttribute('included', $content);
+        $this->assertTrue(property_exists($content, 'included'));
 
         return $content->included;
     }
@@ -510,10 +510,10 @@ abstract class AbstractEndpointTest extends WebTestCase
                 $diff = $now->diff($stamp);
                 $this->assertTrue($diff->y < 1, "The {$field} timestamp is within the last year");
             }
-            $this->assertObjectHasAttribute('id', $item);
-            $this->assertObjectHasAttribute('type', $item);
-            $this->assertObjectHasAttribute('attributes', $item);
-            $this->assertObjectHasAttribute('relationships', $item);
+            $this->assertTrue(property_exists($item, 'id'));
+            $this->assertTrue(property_exists($item, 'type'));
+            $this->assertTrue(property_exists($item, 'attributes'));
+            $this->assertTrue(property_exists($item, 'relationships'));
 
             $this->compareJsonApiData($data[$i], $item);
         }
@@ -556,10 +556,10 @@ abstract class AbstractEndpointTest extends WebTestCase
                 $diff = $now->diff($stamp);
                 $this->assertTrue($diff->y < 1, "The {$field} timestamp is within the last year");
             }
-            $this->assertObjectHasAttribute('id', $item);
-            $this->assertObjectHasAttribute('type', $item);
-            $this->assertObjectHasAttribute('attributes', $item);
-            $this->assertObjectHasAttribute('relationships', $item);
+            $this->assertTrue(property_exists($item, 'id'));
+            $this->assertTrue(property_exists($item, 'type'));
+            $this->assertTrue(property_exists($item, 'attributes'));
+            $this->assertTrue(property_exists($item, 'relationships'));
 
             $this->compareJsonApiData($data[$i], $item);
         }
@@ -599,7 +599,7 @@ abstract class AbstractEndpointTest extends WebTestCase
                     $this->assertTrue($diff->y < 1, "The {$f} timestamp is within the last year");
                     unset($item->{$f});
                 } else {
-                    $this->assertObjectHasAttribute($f, $item);
+                    $this->assertTrue(property_exists($item, $f));
                 }
             }
             $this->compareGraphQLData($data[$i], $item);
@@ -615,7 +615,7 @@ abstract class AbstractEndpointTest extends WebTestCase
         $data = $loader->getOne();
         $result = $this->getGraphQLFiltered($idField, [$idField => $data[$idField]]);
         $this->assertCount(1, $result);
-        $this->assertObjectHasAttribute($idField, $result[0]);
+        $this->assertTrue(property_exists($result[0], $idField));
         $this->assertEquals($data[$idField], $result[0]->{$idField});
 
         return $result;
@@ -823,10 +823,10 @@ abstract class AbstractEndpointTest extends WebTestCase
         $this->assertJsonApiResponse($response, Response::HTTP_CREATED);
         $obj = json_decode($response->getContent());
         $this->assertIsObject($obj->data);
-        $this->assertObjectHasAttribute('id', $obj->data);
-        $this->assertObjectHasAttribute('type', $obj->data);
-        $this->assertObjectHasAttribute('attributes', $obj->data);
-        $this->assertObjectHasAttribute('relationships', $obj->data);
+        $this->assertTrue(property_exists($obj->data, 'id'));
+        $this->assertTrue(property_exists($obj->data, 'type'));
+        $this->assertTrue(property_exists($obj->data, 'attributes'));
+        $this->assertTrue(property_exists($obj->data, 'relationships'));
 
         return $obj->data;
     }
@@ -877,10 +877,10 @@ abstract class AbstractEndpointTest extends WebTestCase
         $obj = json_decode($response->getContent());
         $this->assertIsArray($obj->data);
         foreach ($obj->data as $data) {
-            $this->assertObjectHasAttribute('id', $data);
-            $this->assertObjectHasAttribute('type', $data);
-            $this->assertObjectHasAttribute('attributes', $data);
-            $this->assertObjectHasAttribute('relationships', $data);
+            $this->assertTrue(property_exists($data, 'id'));
+            $this->assertTrue(property_exists($data, 'type'));
+            $this->assertTrue(property_exists($data, 'attributes'));
+            $this->assertTrue(property_exists($data, 'relationships'));
         }
 
         return $obj->data;
@@ -1092,10 +1092,10 @@ abstract class AbstractEndpointTest extends WebTestCase
         $this->assertJsonApiResponse($response, Response::HTTP_OK);
         $obj = json_decode($response->getContent());
         $this->assertIsObject($obj->data);
-        $this->assertObjectHasAttribute('id', $obj->data);
-        $this->assertObjectHasAttribute('type', $obj->data);
-        $this->assertObjectHasAttribute('attributes', $obj->data);
-        $this->assertObjectHasAttribute('relationships', $obj->data);
+        $this->assertTrue(property_exists($obj->data, 'id'));
+        $this->assertTrue(property_exists($obj->data, 'type'));
+        $this->assertTrue(property_exists($obj->data, 'attributes'));
+        $this->assertTrue(property_exists($obj->data, 'relationships'));
 
         return $obj->data;
     }

--- a/tests/Endpoints/CourseObjectiveTest.php
+++ b/tests/Endpoints/CourseObjectiveTest.php
@@ -243,10 +243,10 @@ class CourseObjectiveTest extends ReadWriteEndpointTest
         $this->assertCount(1, $content->data->courseObjectives);
 
         $courseObjective = $content->data->courseObjectives[0];
-        $this->assertObjectHasAttribute('id', $courseObjective);
+        $this->assertTrue(property_exists($courseObjective, 'id'));
         $this->assertEquals($data['id'], $courseObjective->id);
-        $this->assertObjectHasAttribute('course', $courseObjective);
-        $this->assertObjectHasAttribute('id', $courseObjective->course);
+        $this->assertTrue(property_exists($courseObjective, 'course'));
+        $this->assertTrue(property_exists($courseObjective->course, 'id'));
         $this->assertEquals($data['course'], $courseObjective->course->id);
     }
 }

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -775,7 +775,7 @@ class CourseTest extends ReadWriteEndpointTest
 
         $this->assertJsonApiResponse($response, Response::HTTP_OK);
         $content = json_decode($response->getContent());
-        $this->assertObjectHasAttribute('included', $content);
+        $this->assertTrue(property_exists($content, 'included'));
 
         $types = array_column($content->included, 'type');
         $this->assertCount(2, $content->included);
@@ -807,23 +807,23 @@ class CourseTest extends ReadWriteEndpointTest
         $this->assertCount(1, $result);
 
         $course = $result[0];
-        $this->assertObjectHasAttribute('id', $course);
+        $this->assertTrue(property_exists($course, 'id'));
         $this->assertEquals($data['id'], $course->id);
-        $this->assertObjectHasAttribute('school', $course);
-        $this->assertObjectHasAttribute('id', $course->school);
+        $this->assertTrue(property_exists($course, 'school'));
+        $this->assertTrue(property_exists($course->school, 'id'));
         $this->assertEquals($data['school'], $course->school->id);
         $this->assertCount(2, $course->sessions);
 
-        $this->assertObjectHasAttribute('id', $course->sessions[0]);
+        $this->assertTrue(property_exists($course->sessions[0], 'id'));
         $this->assertEquals(1, $course->sessions[0]->id);
-        $this->assertObjectHasAttribute('administrators', $course->sessions[0]);
+        $this->assertTrue(property_exists($course->sessions[0], 'administrators'));
         $this->assertCount(1, $course->sessions[0]->administrators);
-        $this->assertObjectHasAttribute('id', $course->sessions[0]->administrators[0]);
+        $this->assertTrue(property_exists($course->sessions[0]->administrators[0], 'id'));
         $this->assertEquals(1, $course->sessions[0]->administrators[0]->id);
 
-        $this->assertObjectHasAttribute('id', $course->sessions[1]);
+        $this->assertTrue(property_exists($course->sessions[1], 'id'));
         $this->assertEquals(2, $course->sessions[1]->id);
-        $this->assertObjectHasAttribute('administrators', $course->sessions[1]);
+        $this->assertTrue(property_exists($course->sessions[1], 'administrators'));
         $this->assertCount(0, $course->sessions[1]->administrators);
     }
 
@@ -851,18 +851,18 @@ class CourseTest extends ReadWriteEndpointTest
         $this->assertCount(1, $result);
 
         $course = $result[0];
-        $this->assertObjectHasAttribute('id', $course);
+        $this->assertTrue(property_exists($course, 'id'));
         $this->assertEquals($data['id'], $course->id);
         $this->assertCount(2, $course->sessions);
 
-        $this->assertObjectHasAttribute('id', $course->sessions[0]);
+        $this->assertTrue(property_exists($course->sessions[0], 'id'));
         $this->assertEquals(1, $course->sessions[0]->id);
-        $this->assertObjectHasAttribute('administrators', $course->sessions[0]);
+        $this->assertTrue(property_exists($course->sessions[0], 'administrators'));
         $this->assertCount(0, $course->sessions[0]->administrators);
 
-        $this->assertObjectHasAttribute('id', $course->sessions[1]);
+        $this->assertTrue(property_exists($course->sessions[1], 'id'));
         $this->assertEquals(2, $course->sessions[1]->id);
-        $this->assertObjectHasAttribute('administrators', $course->sessions[1]);
+        $this->assertTrue(property_exists($course->sessions[1], 'administrators'));
         $this->assertCount(0, $course->sessions[1]->administrators);
     }
 }

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -412,7 +412,7 @@ class LearningMaterialTest extends ReadWriteEndpointTest
         $lms = array_filter($includes, fn(object $obj) => $obj->id === $id && $obj->type === 'learningMaterials');
         $lm = array_shift($lms);
         $this->assertEquals('thirdlm', $lm->attributes->title);
-        $this->assertObjectHasAttribute('absoluteFileUri', $lm->attributes);
+        $this->assertTrue(property_exists($lm->attributes, 'absoluteFileUri'));
         $this->assertNotEmpty($lm->attributes->absoluteFileUri);
         $this->kernelBrowser->request(
             'GET',

--- a/tests/Endpoints/ProgramTest.php
+++ b/tests/Endpoints/ProgramTest.php
@@ -193,10 +193,10 @@ class ProgramTest extends ReadWriteEndpointTest
         $this->assertIsArray($content->data->programs);
         $this->assertCount(1, $content->data->programs);
         $program = $content->data->programs[0];
-        $this->assertObjectHasAttribute('id', $program);
+        $this->assertTrue(property_exists($program, 'id'));
         $this->assertEquals($data['id'], $program->id);
-        $this->assertObjectHasAttribute('school', $program);
-        $this->assertObjectHasAttribute('id', $program->school);
+        $this->assertTrue(property_exists($program, 'school'));
+        $this->assertTrue(property_exists($program->school, 'id'));
         $this->assertEquals($data['school'], $program->school->id);
     }
 }

--- a/tests/Traits/JsonControllerTest.php
+++ b/tests/Traits/JsonControllerTest.php
@@ -85,8 +85,8 @@ trait JsonControllerTest
                 'Invalid JSON: [' . $response->getContent() . ']'
             );
             $this->assertIsObject($decode);
-            $this->assertObjectHasAttribute('data', $decode);
-            $this->assertObjectHasAttribute('included', $decode);
+            $this->assertTrue(property_exists($decode, 'data'));
+            $this->assertTrue(property_exists($decode, 'included'));
         }
     }
 
@@ -121,9 +121,8 @@ trait JsonControllerTest
             'Invalid JSON: [' . $response->getContent() . ']'
         );
         $this->assertIsObject($decode);
-        $this->assertObjectHasAttribute(
-            'data',
-            $decode,
+        $this->assertTrue(
+            property_exists($decode, 'data'),
             var_export($decode->errors ?? 'Unknown Error', true)
         );
     }


### PR DESCRIPTION
PHPUnit has deprecated these assertions and recommends using property_exists in their place. They will be removed in PHPUnit v10 which has already been released.

Fixes #4643 