### PR TITLE
Fix Session Relationship on SessionLearningMaterial

### DIFF
--- a/src/Entity/DTO/SessionLearningMaterialDTO.php
+++ b/src/Entity/DTO/SessionLearningMaterialDTO.php
@@ -102,6 +102,7 @@ class SessionLearningMaterialDTO
     public ?DateTime $endDate;
 
     #[IA\Expose]
+    #[IA\Related('sessions')]
     #[IA\Type('integer')]
     public int $session;
 


### PR DESCRIPTION
Missed an attribute here which made it impossible to traverse to the session in GraphQL. Added some tests too.