### PR TITLE
Sleep between bulk requests

### DIFF
--- a/src/Classes/OpenSearchBase.php
+++ b/src/Classes/OpenSearchBase.php
@@ -166,6 +166,8 @@ class OpenSearchBase
                 $results['errors'] = true;
             }
             $results['items'] = array_merge($results['items'], $rhett['items']);
+            //allow search time to catch up https://github.com/opensearch-project/opensearch-php/blob/9457c505e9bce68ca81932a461159517635aeba1/USER_GUIDE.md?plain=1#L139-L140
+            sleep(2);
         }
 
         return $results;


### PR DESCRIPTION
According to the docs for open search we need to give the index a few seconds to catch up after submitting a bulk requests. This should eliminate the "429 Too Many Requests" errors we sometimes see when indexing to an empty search host.