### PR TITLE
allow composer plugin to be installed from the php-http/discovery package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,8 @@
       "symfony/flex": true,
       "phpstan/extension-installer": true,
       "symfony/runtime": true,
-      "infection/extension-installer": true
+      "infection/extension-installer": true,
+      "php-http/discovery": true
     }
   },
   "minimum-stability": "stable",


### PR DESCRIPTION
on my latest `composer install`, i was confronted with this question:

```
php-http/discovery contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "php-http/discovery" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y

```

_i said YES!!_

here's the updated composer file, so that _you_ won't have to make choices.