### PR TITLE
prevent php-http/discovery from executing code during a composer run.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,8 @@
       "symfony/flex": true,
       "phpstan/extension-installer": true,
       "symfony/runtime": true,
-      "infection/extension-installer": true
+      "infection/extension-installer": true,
+      "php-http/discovery": false
     }
   },
   "minimum-stability": "stable",


### PR DESCRIPTION
refs https://github.com/ilios/ilios/pull/4705