### PR TITLE
Stop sending MethodNotAllowed exceptions to sentry

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -19,6 +19,7 @@ when@prod:
                     ignore_exceptions:
                         - Symfony\Component\Security\Core\Exception\AccessDeniedException
                         - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+                        - Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
 
 #        If you are using Monolog, you also need these additional configuration and services to log the errors correctly:
 #        https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration


### PR DESCRIPTION
These are scan attempts and don't need to be logged.