### PR TITLE
Replace netcat package in admin container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
 ENV GITHUB_ACCOUNT_SSH_USERS=''
 
 RUN apt-get update && \
-    apt-get install -y wget openssh-server sudo netcat default-mysql-client vim telnet && \
+    apt-get install -y wget openssh-server sudo netcat-traditional default-mysql-client vim telnet && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y
 


### PR DESCRIPTION
PHP 8.1 images are now based on debian bookwork (v12) which doesn't have the netcat package. Instead it has both a netcat-traditional and a netcat-openbsd. I stuck with traditional because we're only using it in our internal healthcheck and it does just one thing.