### PR TITLE
check for database platform by classname, not against name.

### DIFF
--- a/src/Classes/MysqlMigration.php
+++ b/src/Classes/MysqlMigration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Classes;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -12,7 +13,7 @@ abstract class MysqlMigration extends AbstractMigration
     public function preUp(Schema $schema): void
     {
         $this->abortIf(
-            $this->connection->getDatabasePlatform()->getName() != 'mysql',
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
             "Migration can only be executed safely on mysql."
         );
     }
@@ -20,7 +21,7 @@ abstract class MysqlMigration extends AbstractMigration
     public function preDown(Schema $schema): void
     {
         $this->abortIf(
-            $this->connection->getDatabasePlatform()->getName() != 'mysql',
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
             "Migration can only be executed safely on mysql."
         );
     }


### PR DESCRIPTION
the name-checking functionality has been deprecated, this is the supported equivalent.

fixes #4865 