### PR TITLE
Replace interface with attribute

### DIFF
--- a/src/MessageHandler/CourseIndexHandler.php
+++ b/src/MessageHandler/CourseIndexHandler.php
@@ -7,9 +7,10 @@ namespace App\MessageHandler;
 use App\Message\CourseIndexRequest;
 use App\Repository\CourseRepository;
 use App\Service\Index\Curriculum;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-class CourseIndexHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+class CourseIndexHandler
 {
     public function __construct(
         private Curriculum $curriculumIndex,

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -9,9 +9,10 @@ use App\Message\LearningMaterialIndexRequest;
 use App\Repository\LearningMaterialRepository;
 use App\Service\Index\LearningMaterials;
 use App\Service\NonCachingIliosFileSystem;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-class LearningMaterialIndexHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+class LearningMaterialIndexHandler
 {
     public function __construct(
         private LearningMaterials $learningMaterialsIndex,

--- a/src/MessageHandler/MeshDescriptorIndexHandler.php
+++ b/src/MessageHandler/MeshDescriptorIndexHandler.php
@@ -7,9 +7,10 @@ namespace App\MessageHandler;
 use App\Message\MeshDescriptorIndexRequest;
 use App\Repository\MeshDescriptorRepository;
 use App\Service\Index\Mesh;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-class MeshDescriptorIndexHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+class MeshDescriptorIndexHandler
 {
     public function __construct(private Mesh $meshIndex, private MeshDescriptorRepository $repository)
     {

--- a/src/MessageHandler/UserIndexHandler.php
+++ b/src/MessageHandler/UserIndexHandler.php
@@ -7,9 +7,10 @@ namespace App\MessageHandler;
 use App\Message\UserIndexRequest;
 use App\Repository\UserRepository;
 use App\Service\Index\Users;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-class UserIndexHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+class UserIndexHandler
 {
     public function __construct(private Users $usersIndex, private UserRepository $userRepository)
     {


### PR DESCRIPTION
In Symfony 6.3 using the interface for this is deprecated, we need to use an attribute instead.