### PR TITLE
rm obsolete/deprecated config option.

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,7 +1,6 @@
 framework:
   messenger:
     failure_transport: failed
-    reset_on_message: true
     transports:
       # https://symfony.com/doc/current/messenger.html#transport-configuration
        async: '%env(MESSENGER_TRANSPORT_DSN)%'


### PR DESCRIPTION
Option "reset_on_message" at "framework.messenger" is deprecated. It does nothing and will be removed in version 7.0.

fixes https://github.com/ilios/ilios/issues/4897