### PR TITLE
Cleanup ID persistence and docs

### DIFF
--- a/src/Entity/DTO/AlertChangeTypeDTO.php
+++ b/src/Entity/DTO/AlertChangeTypeDTO.php
@@ -14,7 +14,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/AlertDTO.php
+++ b/src/Entity/DTO/AlertDTO.php
@@ -14,7 +14,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "tableRowId",

--- a/src/Entity/DTO/ApplicationConfigDTO.php
+++ b/src/Entity/DTO/ApplicationConfigDTO.php
@@ -14,7 +14,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "name",

--- a/src/Entity/DTO/AssessmentOptionDTO.php
+++ b/src/Entity/DTO/AssessmentOptionDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "name",

--- a/src/Entity/DTO/CohortDTO.php
+++ b/src/Entity/DTO/CohortDTO.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/CompetencyDTO.php
+++ b/src/Entity/DTO/CompetencyDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/CourseClerkshipTypeDTO.php
+++ b/src/Entity/DTO/CourseClerkshipTypeDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/CourseDTO.php
+++ b/src/Entity/DTO/CourseDTO.php
@@ -16,7 +16,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/CourseLearningMaterialDTO.php
+++ b/src/Entity/DTO/CourseLearningMaterialDTO.php
@@ -17,7 +17,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "notes",

--- a/src/Entity/DTO/CourseObjectiveDTO.php
+++ b/src/Entity/DTO/CourseObjectiveDTO.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/CurriculumInventoryAcademicLevelDTO.php
+++ b/src/Entity/DTO/CurriculumInventoryAcademicLevelDTO.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "name",

--- a/src/Entity/DTO/CurriculumInventoryExportDTO.php
+++ b/src/Entity/DTO/CurriculumInventoryExportDTO.php
@@ -17,7 +17,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "report",

--- a/src/Entity/DTO/CurriculumInventoryInstitutionDTO.php
+++ b/src/Entity/DTO/CurriculumInventoryInstitutionDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "name",

--- a/src/Entity/DTO/CurriculumInventoryReportDTO.php
+++ b/src/Entity/DTO/CurriculumInventoryReportDTO.php
@@ -17,7 +17,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "name",

--- a/src/Entity/DTO/CurriculumInventorySequenceBlockDTO.php
+++ b/src/Entity/DTO/CurriculumInventorySequenceBlockDTO.php
@@ -17,7 +17,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/CurriculumInventorySequenceDTO.php
+++ b/src/Entity/DTO/CurriculumInventorySequenceDTO.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/IlmSessionDTO.php
+++ b/src/Entity/DTO/IlmSessionDTO.php
@@ -17,7 +17,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "session",

--- a/src/Entity/DTO/IngestionExceptionDTO.php
+++ b/src/Entity/DTO/IngestionExceptionDTO.php
@@ -14,7 +14,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "uid",

--- a/src/Entity/DTO/InstructorGroupDTO.php
+++ b/src/Entity/DTO/InstructorGroupDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/LearnerGroupDTO.php
+++ b/src/Entity/DTO/LearnerGroupDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/LearningMaterialDTO.php
+++ b/src/Entity/DTO/LearningMaterialDTO.php
@@ -21,7 +21,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "string"
+            type: "string",
+            readOnly: true,
         ),
         new OA\Property(
             "description",

--- a/src/Entity/DTO/LearningMaterialStatusDTO.php
+++ b/src/Entity/DTO/LearningMaterialStatusDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/LearningMaterialUserRoleDTO.php
+++ b/src/Entity/DTO/LearningMaterialUserRoleDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/MeshConceptDTO.php
+++ b/src/Entity/DTO/MeshConceptDTO.php
@@ -16,7 +16,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "string"
+            type: "string",
+            readOnly: true,
         ),
         new OA\Property(
             "name",

--- a/src/Entity/DTO/MeshDescriptorDTO.php
+++ b/src/Entity/DTO/MeshDescriptorDTO.php
@@ -16,7 +16,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "string"
+            type: "string",
+            readOnly: true,
         ),
         new OA\Property(
             "name",

--- a/src/Entity/DTO/MeshPreviousIndexingDTO.php
+++ b/src/Entity/DTO/MeshPreviousIndexingDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "previousIndexing",

--- a/src/Entity/DTO/MeshQualifierDTO.php
+++ b/src/Entity/DTO/MeshQualifierDTO.php
@@ -16,7 +16,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "string"
+            type: "string",
+            readOnly: true,
         ),
         new OA\Property(
             "name",

--- a/src/Entity/DTO/MeshTermDTO.php
+++ b/src/Entity/DTO/MeshTermDTO.php
@@ -16,7 +16,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "meshTermUid",

--- a/src/Entity/DTO/MeshTreeDTO.php
+++ b/src/Entity/DTO/MeshTreeDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "treeNumber",

--- a/src/Entity/DTO/OfferingDTO.php
+++ b/src/Entity/DTO/OfferingDTO.php
@@ -17,7 +17,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "room",

--- a/src/Entity/DTO/PendingUserUpdateDTO.php
+++ b/src/Entity/DTO/PendingUserUpdateDTO.php
@@ -14,7 +14,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "type",

--- a/src/Entity/DTO/ProgramDTO.php
+++ b/src/Entity/DTO/ProgramDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/ProgramYearDTO.php
+++ b/src/Entity/DTO/ProgramYearDTO.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "startYear",

--- a/src/Entity/DTO/ProgramYearObjectiveDTO.php
+++ b/src/Entity/DTO/ProgramYearObjectiveDTO.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/ReportDTO.php
+++ b/src/Entity/DTO/ReportDTO.php
@@ -16,7 +16,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/SchoolConfigDTO.php
+++ b/src/Entity/DTO/SchoolConfigDTO.php
@@ -14,7 +14,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "name",

--- a/src/Entity/DTO/SchoolDTO.php
+++ b/src/Entity/DTO/SchoolDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/SessionDTO.php
+++ b/src/Entity/DTO/SessionDTO.php
@@ -17,7 +17,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/SessionLearningMaterialDTO.php
+++ b/src/Entity/DTO/SessionLearningMaterialDTO.php
@@ -17,7 +17,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "notes",

--- a/src/Entity/DTO/SessionObjectiveDTO.php
+++ b/src/Entity/DTO/SessionObjectiveDTO.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "active",

--- a/src/Entity/DTO/SessionTypeDTO.php
+++ b/src/Entity/DTO/SessionTypeDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/TermDTO.php
+++ b/src/Entity/DTO/TermDTO.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/UserDTO.php
+++ b/src/Entity/DTO/UserDTO.php
@@ -16,7 +16,8 @@ use Symfony\Component\Serializer\Annotation\Ignore;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "lastName",

--- a/src/Entity/DTO/UserRoleDTO.php
+++ b/src/Entity/DTO/UserRoleDTO.php
@@ -14,7 +14,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Entity/DTO/UserSessionMaterialStatusDTO.php
+++ b/src/Entity/DTO/UserSessionMaterialStatusDTO.php
@@ -16,7 +16,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "user",

--- a/src/Entity/DTO/VocabularyDTO.php
+++ b/src/Entity/DTO/VocabularyDTO.php
@@ -15,7 +15,8 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             "id",
             description: "ID",
-            type: "integer"
+            type: "integer",
+            readOnly: true,
         ),
         new OA\Property(
             "title",

--- a/src/Traits/ManagerRepository.php
+++ b/src/Traits/ManagerRepository.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Id\AssignedGenerator;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\QueryBuilder;

--- a/tests/Fixture/LoadAamcMethodData.php
+++ b/tests/Fixture/LoadAamcMethodData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\AamcMethod;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,15 +28,17 @@ class LoadAamcMethodData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\AamcMethodData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(AamcMethod::class);
         foreach ($data as $arr) {
             $entity = new AamcMethod();
             $entity->setId($arr['id']);
             $entity->setDescription($arr['description']);
             $entity->setActive($arr['active']);
 
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('aamcMethods' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadAamcMethodData.php
+++ b/tests/Fixture/LoadAamcMethodData.php
@@ -36,7 +36,7 @@ class LoadAamcMethodData extends AbstractFixture implements
             $entity->setDescription($arr['description']);
             $entity->setActive($arr['active']);
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('aamcMethods' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadAamcPcrsData.php
+++ b/tests/Fixture/LoadAamcPcrsData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\AamcPcrs;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,13 +28,15 @@ class LoadAamcPcrsData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\AamcPcrsData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(AamcPcrs::class);
         foreach ($data as $arr) {
             $entity = new AamcPcrs();
             $entity->setId($arr['id']);
             $entity->setDescription($arr['description']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('aamcPcrs' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadAamcPcrsData.php
+++ b/tests/Fixture/LoadAamcPcrsData.php
@@ -34,7 +34,7 @@ class LoadAamcPcrsData extends AbstractFixture implements
             $entity = new AamcPcrs();
             $entity->setId($arr['id']);
             $entity->setDescription($arr['description']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('aamcPcrs' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadAamcResourceTypeData.php
+++ b/tests/Fixture/LoadAamcResourceTypeData.php
@@ -35,7 +35,7 @@ class LoadAamcResourceTypeData extends AbstractFixture implements
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
             $entity->setDescription($arr['description']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('aamcResourceTypes' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadAamcResourceTypeData.php
+++ b/tests/Fixture/LoadAamcResourceTypeData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Fixture;
 
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,14 +28,16 @@ class LoadAamcResourceTypeData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\AamcResourceTypeData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(AamcResourceType::class);
         foreach ($data as $arr) {
             $entity = new AamcResourceType();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
             $entity->setDescription($arr['description']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('aamcResourceTypes' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadAlertChangeTypeData.php
+++ b/tests/Fixture/LoadAlertChangeTypeData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\AlertChangeType;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,14 +28,16 @@ class LoadAlertChangeTypeData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\AlertChangeTypeData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(AlertChangeType::class);
         foreach ($data as $arr) {
             $entity = new AlertChangeType();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
 
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('alertChangeTypes' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadAlertChangeTypeData.php
+++ b/tests/Fixture/LoadAlertChangeTypeData.php
@@ -35,7 +35,7 @@ class LoadAlertChangeTypeData extends AbstractFixture implements
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('alertChangeTypes' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadAlertData.php
+++ b/tests/Fixture/LoadAlertData.php
@@ -50,7 +50,7 @@ class LoadAlertData extends AbstractFixture implements
             foreach ($arr['recipients'] as $id) {
                 $entity->addRecipient($this->getReference('schools' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('alerts' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadAlertData.php
+++ b/tests/Fixture/LoadAlertData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\Alert;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadAlertData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\AlertData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Alert::class);
         foreach ($data as $arr) {
             $entity = new Alert();
             $entity->setId($arr['id']);
@@ -47,10 +50,10 @@ class LoadAlertData extends AbstractFixture implements
             foreach ($arr['recipients'] as $id) {
                 $entity->addRecipient($this->getReference('schools' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('alerts' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadApplicationConfigData.php
+++ b/tests/Fixture/LoadApplicationConfigData.php
@@ -36,7 +36,7 @@ class LoadApplicationConfigData extends AbstractFixture implements
             $entity->setId($arr['id']);
             $entity->setName($arr['name']);
             $entity->setValue($arr['value']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('applicationConfigs' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadApplicationConfigData.php
+++ b/tests/Fixture/LoadApplicationConfigData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Fixture;
 
+use App\Repository\RepositoryInterface;
 use App\Tests\DataLoader\ApplicationConfigData;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -28,14 +29,16 @@ class LoadApplicationConfigData extends AbstractFixture implements
         $data = $this->container
             ->get(ApplicationConfigData::class)
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(ApplicationConfig::class);
         foreach ($data as $arr) {
             $entity = new ApplicationConfig();
             $entity->setId($arr['id']);
             $entity->setName($arr['name']);
             $entity->setValue($arr['value']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('applicationConfigs' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadAssessmentOptionData.php
+++ b/tests/Fixture/LoadAssessmentOptionData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\AssessmentOption;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,14 +28,16 @@ class LoadAssessmentOptionData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\AssessmentOptionData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(AssessmentOption::class);
         foreach ($data as $arr) {
             $entity = new AssessmentOption();
             $entity->setId($arr['id']);
             $entity->setName($arr['name']);
 
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('assessmentOptions' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadAssessmentOptionData.php
+++ b/tests/Fixture/LoadAssessmentOptionData.php
@@ -35,7 +35,7 @@ class LoadAssessmentOptionData extends AbstractFixture implements
             $entity->setId($arr['id']);
             $entity->setName($arr['name']);
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('assessmentOptions' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadAuditLogData.php
+++ b/tests/Fixture/LoadAuditLogData.php
@@ -43,7 +43,7 @@ class LoadAuditLogData extends AbstractFixture implements
             $entity->setValuesChanged($arr['valuesChanged']);
             $entity->setCreatedAt($arr['createdAt']);
             $entity->setAction($arr['action']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
         }
         $manager->flush();
     }

--- a/tests/Fixture/LoadAuditLogData.php
+++ b/tests/Fixture/LoadAuditLogData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\AuditLog;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -33,6 +34,8 @@ class LoadAuditLogData extends AbstractFixture implements
         $data = $this->container
             ->get('app.dataloader.auditlog')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(AuditLog::class);
         foreach ($data as $arr) {
             $entity = new AuditLog();
             $entity->setObjectId($arr['objectId']);
@@ -40,7 +43,7 @@ class LoadAuditLogData extends AbstractFixture implements
             $entity->setValuesChanged($arr['valuesChanged']);
             $entity->setCreatedAt($arr['createdAt']);
             $entity->setAction($arr['action']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
         }
         $manager->flush();
     }

--- a/tests/Fixture/LoadAuthenticationData.php
+++ b/tests/Fixture/LoadAuthenticationData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\Authentication;
+use App\Repository\RepositoryInterface;
 use App\Service\SessionUserProvider;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -37,6 +38,8 @@ class LoadAuthenticationData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\AuthenticationData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Authentication::class);
         foreach ($data as $arr) {
             $user = $this->getReference('users' . $arr['user']);
             $entity = new Authentication();
@@ -49,9 +52,9 @@ class LoadAuthenticationData extends AbstractFixture implements
             }
             $entity->setUser($user);
 
-            $manager->persist($entity);
-            $manager->flush();
+            $repository->update($entity, false, true);
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadAuthenticationData.php
+++ b/tests/Fixture/LoadAuthenticationData.php
@@ -52,7 +52,7 @@ class LoadAuthenticationData extends AbstractFixture implements
             }
             $entity->setUser($user);
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
         }
         $repository->flush();
     }

--- a/tests/Fixture/LoadCohortData.php
+++ b/tests/Fixture/LoadCohortData.php
@@ -37,7 +37,7 @@ class LoadCohortData extends AbstractFixture implements
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
             $entity->setProgramYear($this->getReference('programYears' . $arr['programYear']));
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('cohorts' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadCohortData.php
+++ b/tests/Fixture/LoadCohortData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\Cohort;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,15 +30,17 @@ class LoadCohortData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CohortData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Cohort::class);
         foreach ($data as $arr) {
             $entity = new Cohort();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
             $entity->setProgramYear($this->getReference('programYears' . $arr['programYear']));
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('cohorts' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadCompetencyData.php
+++ b/tests/Fixture/LoadCompetencyData.php
@@ -46,7 +46,7 @@ class LoadCompetencyData extends AbstractFixture implements
             }
             $entity->setSchool($this->getReference('schools' . $arr['school']));
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('competencies' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadCompetencyData.php
+++ b/tests/Fixture/LoadCompetencyData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\Competency;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadCompetencyData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CompetencyData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Competency::class);
         foreach ($data as $arr) {
             $entity = new Competency();
             $entity->setId($arr['id']);
@@ -43,10 +46,10 @@ class LoadCompetencyData extends AbstractFixture implements
             }
             $entity->setSchool($this->getReference('schools' . $arr['school']));
 
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('competencies' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadCourseClerkshipTypeData.php
+++ b/tests/Fixture/LoadCourseClerkshipTypeData.php
@@ -34,7 +34,7 @@ class LoadCourseClerkshipTypeData extends AbstractFixture implements
             $entity = new CourseClerkshipType();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('courseClerkshipTypes' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadCourseClerkshipTypeData.php
+++ b/tests/Fixture/LoadCourseClerkshipTypeData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\CourseClerkshipType;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,13 +28,15 @@ class LoadCourseClerkshipTypeData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CourseClerkshipTypeData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(CourseClerkshipType::class);
         foreach ($data as $arr) {
             $entity = new CourseClerkshipType();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('courseClerkshipTypes' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadCourseData.php
+++ b/tests/Fixture/LoadCourseData.php
@@ -71,7 +71,7 @@ class LoadCourseData extends AbstractFixture implements
             foreach ($arr['meshDescriptors'] as $id) {
                 $entity->addMeshDescriptor($this->getReference('meshDescriptors' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
 
             $this->addReference('courses' . $arr['id'], $entity);
         }

--- a/tests/Fixture/LoadCourseData.php
+++ b/tests/Fixture/LoadCourseData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\Course;
+use App\Repository\RepositoryInterface;
 use DateTime;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -30,6 +31,8 @@ class LoadCourseData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CourseData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Course::class);
         foreach ($data as $arr) {
             $entity = new Course();
             $entity->setId($arr['id']);
@@ -68,11 +71,11 @@ class LoadCourseData extends AbstractFixture implements
             foreach ($arr['meshDescriptors'] as $id) {
                 $entity->addMeshDescriptor($this->getReference('meshDescriptors' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
 
             $this->addReference('courses' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadCourseLearningMaterialData.php
+++ b/tests/Fixture/LoadCourseLearningMaterialData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\CourseLearningMaterial;
+use App\Repository\RepositoryInterface;
 use DateTime;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -30,6 +31,8 @@ class LoadCourseLearningMaterialData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CourseLearningMaterialData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(CourseLearningMaterial::class);
         foreach ($data as $arr) {
             $entity = new CourseLearningMaterial();
             $entity->setId($arr['id']);
@@ -48,10 +51,10 @@ class LoadCourseLearningMaterialData extends AbstractFixture implements
             foreach ($arr['meshDescriptors'] as $id) {
                 $entity->addMeshDescriptor($this->getReference('meshDescriptors' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('courseLearningMaterials' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadCourseLearningMaterialData.php
+++ b/tests/Fixture/LoadCourseLearningMaterialData.php
@@ -51,7 +51,7 @@ class LoadCourseLearningMaterialData extends AbstractFixture implements
             foreach ($arr['meshDescriptors'] as $id) {
                 $entity->addMeshDescriptor($this->getReference('meshDescriptors' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('courseLearningMaterials' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadCourseObjectiveData.php
+++ b/tests/Fixture/LoadCourseObjectiveData.php
@@ -55,7 +55,7 @@ class LoadCourseObjectiveData extends AbstractFixture implements
                 $entity->addProgramYearObjective($this->getReference('programYearObjectives' . $id));
             }
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
 
             $this->addReference('courseObjectives' . $arr['id'], $entity);
         }

--- a/tests/Fixture/LoadCourseObjectiveData.php
+++ b/tests/Fixture/LoadCourseObjectiveData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\CourseObjective;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -29,6 +30,8 @@ class LoadCourseObjectiveData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CourseObjectiveData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(CourseObjective::class);
         foreach ($data as $arr) {
             $entity = new CourseObjective();
             $entity->setId($arr['id']);
@@ -52,11 +55,11 @@ class LoadCourseObjectiveData extends AbstractFixture implements
                 $entity->addProgramYearObjective($this->getReference('programYearObjectives' . $id));
             }
 
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
 
             $this->addReference('courseObjectives' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadCurriculumInventoryAcademicLevelData.php
+++ b/tests/Fixture/LoadCurriculumInventoryAcademicLevelData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\CurriculumInventoryAcademicLevel;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadCurriculumInventoryAcademicLevelData extends AbstractFixture implement
         $data = $this->container
             ->get('App\Tests\DataLoader\CurriculumInventoryAcademicLevelData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(CurriculumInventoryAcademicLevel::class);
         foreach ($data as $arr) {
             $entity = new CurriculumInventoryAcademicLevel();
             $entity->setId($arr['id']);
@@ -36,10 +39,10 @@ class LoadCurriculumInventoryAcademicLevelData extends AbstractFixture implement
             $entity->setLevel($arr['level']);
             $entity->setReport($this->getReference('curriculumInventoryReports' . $arr['report']));
             $entity->setDescription($arr['description']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('curriculumInventoryAcademicLevels' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadCurriculumInventoryAcademicLevelData.php
+++ b/tests/Fixture/LoadCurriculumInventoryAcademicLevelData.php
@@ -39,7 +39,7 @@ class LoadCurriculumInventoryAcademicLevelData extends AbstractFixture implement
             $entity->setLevel($arr['level']);
             $entity->setReport($this->getReference('curriculumInventoryReports' . $arr['report']));
             $entity->setDescription($arr['description']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('curriculumInventoryAcademicLevels' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadCurriculumInventoryExportData.php
+++ b/tests/Fixture/LoadCurriculumInventoryExportData.php
@@ -38,7 +38,7 @@ class LoadCurriculumInventoryExportData extends AbstractFixture implements
             $entity->setReport($this->getReference('curriculumInventoryReports' . $arr['report']));
             $entity->setCreatedBy($this->getReference('users' . $arr['createdBy']));
             $entity->setDocument($arr['document']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('curriculumInventoryExports' . $arr['report'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadCurriculumInventoryExportData.php
+++ b/tests/Fixture/LoadCurriculumInventoryExportData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\CurriculumInventoryExport;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,16 +30,18 @@ class LoadCurriculumInventoryExportData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CurriculumInventoryExportData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(CurriculumInventoryExport::class);
         foreach ($data as $arr) {
             $entity = new CurriculumInventoryExport();
             $entity->setId($arr['id']);
             $entity->setReport($this->getReference('curriculumInventoryReports' . $arr['report']));
             $entity->setCreatedBy($this->getReference('users' . $arr['createdBy']));
             $entity->setDocument($arr['document']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('curriculumInventoryExports' . $arr['report'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadCurriculumInventoryInstitutionData.php
+++ b/tests/Fixture/LoadCurriculumInventoryInstitutionData.php
@@ -46,7 +46,7 @@ class LoadCurriculumInventoryInstitutionData extends AbstractFixture implements
             $entity->setAddressZipCode($arr['addressZipCode']);
             $entity->setAddressCountryCode($arr['addressCountryCode']);
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('curriculumInventoryInstitutions' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadCurriculumInventoryInstitutionData.php
+++ b/tests/Fixture/LoadCurriculumInventoryInstitutionData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\CurriculumInventoryInstitution;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadCurriculumInventoryInstitutionData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CurriculumInventoryInstitutionData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(CurriculumInventoryInstitution::class);
         foreach ($data as $arr) {
             $entity = new CurriculumInventoryInstitution();
             if (!empty($arr['school'])) {
@@ -43,10 +46,10 @@ class LoadCurriculumInventoryInstitutionData extends AbstractFixture implements
             $entity->setAddressZipCode($arr['addressZipCode']);
             $entity->setAddressCountryCode($arr['addressCountryCode']);
 
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('curriculumInventoryInstitutions' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadCurriculumInventoryReportData.php
+++ b/tests/Fixture/LoadCurriculumInventoryReportData.php
@@ -43,7 +43,7 @@ class LoadCurriculumInventoryReportData extends AbstractFixture implements
             $entity->setEndDate(new DateTime($arr['endDate']));
             $entity->setProgram($this->getReference('programs' . $arr['program']));
             $entity->generateToken();
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('curriculumInventoryReports' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadCurriculumInventoryReportData.php
+++ b/tests/Fixture/LoadCurriculumInventoryReportData.php
@@ -7,6 +7,7 @@ namespace App\Tests\Fixture;
 use DateTime;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use App\Entity\CurriculumInventoryReport;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -30,6 +31,8 @@ class LoadCurriculumInventoryReportData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CurriculumInventoryReportData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(CurriculumInventoryReport::class);
         foreach ($data as $arr) {
             $entity = new CurriculumInventoryReport();
             $entity->setId($arr['id']);
@@ -40,10 +43,10 @@ class LoadCurriculumInventoryReportData extends AbstractFixture implements
             $entity->setEndDate(new DateTime($arr['endDate']));
             $entity->setProgram($this->getReference('programs' . $arr['program']));
             $entity->generateToken();
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('curriculumInventoryReports' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadCurriculumInventorySequenceBlockData.php
+++ b/tests/Fixture/LoadCurriculumInventorySequenceBlockData.php
@@ -8,6 +8,7 @@ use App\Tests\DataLoader\CurriculumInventorySequenceBlockData;
 use DateTime;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use App\Entity\CurriculumInventorySequenceBlock;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -31,6 +32,8 @@ class LoadCurriculumInventorySequenceBlockData extends AbstractFixture implement
         $data = $this->container
             ->get(CurriculumInventorySequenceBlockData::class)
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(CurriculumInventorySequenceBlock::class);
         foreach ($data as $arr) {
             $entity = new CurriculumInventorySequenceBlock();
             $entity->setId($arr['id']);
@@ -65,7 +68,7 @@ class LoadCurriculumInventorySequenceBlockData extends AbstractFixture implement
                 $entity->addExcludedSession($this->getReference('sessions' . $sessionId));
             }
 
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('curriculumInventorySequenceBlocks' . $arr['id'], $entity);
         }
         $manager->flush();

--- a/tests/Fixture/LoadCurriculumInventorySequenceBlockData.php
+++ b/tests/Fixture/LoadCurriculumInventorySequenceBlockData.php
@@ -68,7 +68,7 @@ class LoadCurriculumInventorySequenceBlockData extends AbstractFixture implement
                 $entity->addExcludedSession($this->getReference('sessions' . $sessionId));
             }
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('curriculumInventorySequenceBlocks' . $arr['id'], $entity);
         }
         $manager->flush();

--- a/tests/Fixture/LoadCurriculumInventorySequenceData.php
+++ b/tests/Fixture/LoadCurriculumInventorySequenceData.php
@@ -37,7 +37,7 @@ class LoadCurriculumInventorySequenceData extends AbstractFixture implements
             $entity->setId($arr['id']);
             $entity->setDescription($arr['description']);
             $entity->setReport($this->getReference('curriculumInventoryReports' . $arr['report']));
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('curriculumInventorySequences' . $arr['report'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadCurriculumInventorySequenceData.php
+++ b/tests/Fixture/LoadCurriculumInventorySequenceData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\CurriculumInventorySequence;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,15 +30,17 @@ class LoadCurriculumInventorySequenceData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\CurriculumInventorySequenceData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(CurriculumInventorySequence::class);
         foreach ($data as $arr) {
             $entity = new CurriculumInventorySequence();
             $entity->setId($arr['id']);
             $entity->setDescription($arr['description']);
             $entity->setReport($this->getReference('curriculumInventoryReports' . $arr['report']));
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('curriculumInventorySequences' . $arr['report'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadIlmSessionData.php
+++ b/tests/Fixture/LoadIlmSessionData.php
@@ -52,7 +52,7 @@ class LoadIlmSessionData extends AbstractFixture implements
             foreach ($arr['learners'] as $id) {
                 $entity->addLearner($this->getReference('users' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('ilmSessions' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadIlmSessionData.php
+++ b/tests/Fixture/LoadIlmSessionData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\IlmSession;
+use App\Repository\RepositoryInterface;
 use DateTime;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -31,6 +32,8 @@ class LoadIlmSessionData extends AbstractFixture implements
         $data = $this->container
             ->get(IlmSessionData::class)
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(IlmSession::class);
         foreach ($data as $arr) {
             $entity = new IlmSession();
             $entity->setId($arr['id']);
@@ -49,10 +52,10 @@ class LoadIlmSessionData extends AbstractFixture implements
             foreach ($arr['learners'] as $id) {
                 $entity->addLearner($this->getReference('users' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('ilmSessions' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadIngestionExceptionData.php
+++ b/tests/Fixture/LoadIngestionExceptionData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\IngestionException;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,15 +30,17 @@ class LoadIngestionExceptionData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\IngestionExceptionData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(IngestionException::class);
         foreach ($data as $arr) {
             $entity = new IngestionException();
             $entity->setId($arr['id']);
             $entity->setUid($arr['uid']);
             $entity->setUser($this->getReference('users' . $arr['user']));
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('ingestionExceptions' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadIngestionExceptionData.php
+++ b/tests/Fixture/LoadIngestionExceptionData.php
@@ -37,7 +37,7 @@ class LoadIngestionExceptionData extends AbstractFixture implements
             $entity->setId($arr['id']);
             $entity->setUid($arr['uid']);
             $entity->setUser($this->getReference('users' . $arr['user']));
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('ingestionExceptions' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadInstructorGroupData.php
+++ b/tests/Fixture/LoadInstructorGroupData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\InstructorGroup;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadInstructorGroupData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\InstructorGroupData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(InstructorGroup::class);
         foreach ($data as $arr) {
             $entity = new InstructorGroup();
             $entity->setId($arr['id']);
@@ -39,10 +42,10 @@ class LoadInstructorGroupData extends AbstractFixture implements
             if (!empty($arr['school'])) {
                 $entity->setSchool($this->getReference('schools' . $arr['school']));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('instructorGroups' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadInstructorGroupData.php
+++ b/tests/Fixture/LoadInstructorGroupData.php
@@ -42,7 +42,7 @@ class LoadInstructorGroupData extends AbstractFixture implements
             if (!empty($arr['school'])) {
                 $entity->setSchool($this->getReference('schools' . $arr['school']));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('instructorGroups' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadLearnerGroupData.php
+++ b/tests/Fixture/LoadLearnerGroupData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\LearnerGroup;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadLearnerGroupData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\LearnerGroupData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(LearnerGroup::class);
         foreach ($data as $arr) {
             $entity = new LearnerGroup();
             $entity->setId($arr['id']);
@@ -57,10 +60,10 @@ class LoadLearnerGroupData extends AbstractFixture implements
             foreach ($arr['instructorGroups'] as $id) {
                 $entity->addInstructorGroup($this->getReference('instructorGroups' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('learnerGroups' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadLearnerGroupData.php
+++ b/tests/Fixture/LoadLearnerGroupData.php
@@ -60,7 +60,7 @@ class LoadLearnerGroupData extends AbstractFixture implements
             foreach ($arr['instructorGroups'] as $id) {
                 $entity->addInstructorGroup($this->getReference('instructorGroups' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('learnerGroups' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadLearningMaterialData.php
+++ b/tests/Fixture/LoadLearningMaterialData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\LearningMaterial;
+use App\Repository\RepositoryInterface;
 use App\Service\Config;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -45,7 +46,8 @@ class LoadLearningMaterialData extends AbstractFixture implements
         $fs->copy(__FILE__, self::TEST_FILE_PATH);
         $config = $this->container->get(Config::class);
         $storePath = $config->get('file_system_storage_path');
-
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(LearningMaterial::class);
         foreach ($data as $arr) {
             $entity = new LearningMaterial();
             $entity->setId($arr['id']);
@@ -77,10 +79,10 @@ class LoadLearningMaterialData extends AbstractFixture implements
                 $fs->copy(__FILE__, $path);
             }
             $entity->generateToken();
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('learningMaterials' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadLearningMaterialData.php
+++ b/tests/Fixture/LoadLearningMaterialData.php
@@ -79,7 +79,7 @@ class LoadLearningMaterialData extends AbstractFixture implements
                 $fs->copy(__FILE__, $path);
             }
             $entity->generateToken();
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('learningMaterials' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadLearningMaterialStatusData.php
+++ b/tests/Fixture/LoadLearningMaterialStatusData.php
@@ -34,7 +34,7 @@ class LoadLearningMaterialStatusData extends AbstractFixture implements
             $entity = new LearningMaterialStatus();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('learningMaterialStatus' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadLearningMaterialStatusData.php
+++ b/tests/Fixture/LoadLearningMaterialStatusData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\LearningMaterialStatus;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,13 +28,15 @@ class LoadLearningMaterialStatusData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\LearningMaterialStatusData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(LearningMaterialStatus::class);
         foreach ($data as $arr) {
             $entity = new LearningMaterialStatus();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('learningMaterialStatus' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadLearningMaterialUserRoleData.php
+++ b/tests/Fixture/LoadLearningMaterialUserRoleData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\LearningMaterialUserRole;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,13 +28,15 @@ class LoadLearningMaterialUserRoleData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\LearningMaterialUserRoleData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(LearningMaterialUserRole::class);
         foreach ($data as $arr) {
             $entity = new LearningMaterialUserRole();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('learningMaterialUserRoles' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadLearningMaterialUserRoleData.php
+++ b/tests/Fixture/LoadLearningMaterialUserRoleData.php
@@ -34,7 +34,7 @@ class LoadLearningMaterialUserRoleData extends AbstractFixture implements
             $entity = new LearningMaterialUserRole();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('learningMaterialUserRoles' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadMeshConceptData.php
+++ b/tests/Fixture/LoadMeshConceptData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\MeshConcept;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -29,6 +30,8 @@ class LoadMeshConceptData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\MeshConceptData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(MeshConcept::class);
         foreach ($data as $arr) {
             $entity = new MeshConcept();
             $entity->setId($arr['id']);
@@ -41,9 +44,9 @@ class LoadMeshConceptData extends AbstractFixture implements
                 $entity->addDescriptor($this->getReference('meshDescriptors' . $id));
             }
             $this->addReference('meshConcepts' . $arr['id'], $entity);
-            $manager->persist($entity);
-            $manager->flush();
+            $repository->update($entity, false, true);
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadMeshConceptData.php
+++ b/tests/Fixture/LoadMeshConceptData.php
@@ -44,7 +44,7 @@ class LoadMeshConceptData extends AbstractFixture implements
                 $entity->addDescriptor($this->getReference('meshDescriptors' . $id));
             }
             $this->addReference('meshConcepts' . $arr['id'], $entity);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
         }
         $repository->flush();
     }

--- a/tests/Fixture/LoadMeshDescriptorData.php
+++ b/tests/Fixture/LoadMeshDescriptorData.php
@@ -37,7 +37,7 @@ class LoadMeshDescriptorData extends AbstractFixture implements
             $entity->setAnnotation($arr['annotation']);
             $entity->setDeleted($arr['deleted']);
             $this->addReference('meshDescriptors' . $arr['id'], $entity);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
         }
         $repository->flush();
     }

--- a/tests/Fixture/LoadMeshDescriptorData.php
+++ b/tests/Fixture/LoadMeshDescriptorData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\MeshDescriptor;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,6 +28,8 @@ class LoadMeshDescriptorData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\MeshDescriptorData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(MeshDescriptor::class);
         foreach ($data as $arr) {
             $entity = new MeshDescriptor();
             $entity->setId($arr['id']);
@@ -34,8 +37,8 @@ class LoadMeshDescriptorData extends AbstractFixture implements
             $entity->setAnnotation($arr['annotation']);
             $entity->setDeleted($arr['deleted']);
             $this->addReference('meshDescriptors' . $arr['id'], $entity);
-            $manager->persist($entity);
-            $manager->flush();
+            $repository->update($entity, false, true);
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadMeshPreviousIndexingData.php
+++ b/tests/Fixture/LoadMeshPreviousIndexingData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\MeshPreviousIndexing;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -29,15 +30,17 @@ class LoadMeshPreviousIndexingData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\MeshPreviousIndexingData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(MeshPreviousIndexing::class);
         foreach ($data as $arr) {
             $entity = new MeshPreviousIndexing();
             $entity->setId($arr['id']);
             $entity->setDescriptor($this->getReference('meshDescriptors' . $arr['descriptor']));
             $entity->setPreviousIndexing($arr['previousIndexing']);
             $this->addReference('meshPreviousIndexings' . $arr['id'], $entity);
-            $manager->persist($entity);
-            $manager->flush();
+            $repository->update($entity, false, true);
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadMeshPreviousIndexingData.php
+++ b/tests/Fixture/LoadMeshPreviousIndexingData.php
@@ -38,7 +38,7 @@ class LoadMeshPreviousIndexingData extends AbstractFixture implements
             $entity->setDescriptor($this->getReference('meshDescriptors' . $arr['descriptor']));
             $entity->setPreviousIndexing($arr['previousIndexing']);
             $this->addReference('meshPreviousIndexings' . $arr['id'], $entity);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
         }
         $repository->flush();
     }

--- a/tests/Fixture/LoadMeshQualifierData.php
+++ b/tests/Fixture/LoadMeshQualifierData.php
@@ -40,7 +40,7 @@ class LoadMeshQualifierData extends AbstractFixture implements
                 $entity->addDescriptor($this->getReference('meshDescriptors' . $id));
             }
             $this->addReference('meshQualifiers' . $arr['id'], $entity);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
         }
         $repository->flush();
     }

--- a/tests/Fixture/LoadMeshQualifierData.php
+++ b/tests/Fixture/LoadMeshQualifierData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\MeshQualifier;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -29,6 +30,8 @@ class LoadMeshQualifierData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\MeshQualifierData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(MeshQualifier::class);
         foreach ($data as $arr) {
             $entity = new MeshQualifier();
             $entity->setId($arr['id']);
@@ -37,9 +40,9 @@ class LoadMeshQualifierData extends AbstractFixture implements
                 $entity->addDescriptor($this->getReference('meshDescriptors' . $id));
             }
             $this->addReference('meshQualifiers' . $arr['id'], $entity);
-            $manager->persist($entity);
-            $manager->flush();
+            $repository->update($entity, false, true);
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadMeshTermData.php
+++ b/tests/Fixture/LoadMeshTermData.php
@@ -45,7 +45,7 @@ class LoadMeshTermData extends AbstractFixture implements
                 $entity->addConcept($this->getReference('meshConcepts' . $id));
             }
             $this->addReference('meshTerms' . $arr['id'], $entity);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
         }
         $repository->flush();
     }

--- a/tests/Fixture/LoadMeshTermData.php
+++ b/tests/Fixture/LoadMeshTermData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\MeshTerm;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -29,6 +30,8 @@ class LoadMeshTermData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\MeshTermData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(MeshTerm::class);
         foreach ($data as $arr) {
             $entity = new MeshTerm();
             $entity->setId($arr['id']);
@@ -42,9 +45,9 @@ class LoadMeshTermData extends AbstractFixture implements
                 $entity->addConcept($this->getReference('meshConcepts' . $id));
             }
             $this->addReference('meshTerms' . $arr['id'], $entity);
-            $manager->persist($entity);
-            $manager->flush();
+            $repository->update($entity, false, true);
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadMeshTreeData.php
+++ b/tests/Fixture/LoadMeshTreeData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\MeshTree;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -29,15 +30,17 @@ class LoadMeshTreeData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\MeshTreeData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(MeshTree::class);
         foreach ($data as $arr) {
             $entity = new MeshTree();
             $entity->setId($arr['id']);
             $entity->setTreeNumber($arr['treeNumber']);
             $entity->setDescriptor($this->getReference('meshDescriptors' . $arr['descriptor']));
             $this->addReference('meshTrees' . $arr['treeNumber'], $entity);
-            $manager->persist($entity);
-            $manager->flush();
+            $repository->update($entity, false, true);
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadMeshTreeData.php
+++ b/tests/Fixture/LoadMeshTreeData.php
@@ -38,7 +38,7 @@ class LoadMeshTreeData extends AbstractFixture implements
             $entity->setTreeNumber($arr['treeNumber']);
             $entity->setDescriptor($this->getReference('meshDescriptors' . $arr['descriptor']));
             $this->addReference('meshTrees' . $arr['treeNumber'], $entity);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
         }
         $repository->flush();
     }

--- a/tests/Fixture/LoadOfferingData.php
+++ b/tests/Fixture/LoadOfferingData.php
@@ -30,6 +30,8 @@ class LoadOfferingData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\OfferingData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Offering::class);
         foreach ($data as $arr) {
             $entity = new Offering();
             $entity->setId($arr['id']);
@@ -53,10 +55,10 @@ class LoadOfferingData extends AbstractFixture implements
             foreach ($arr['instructors'] as $id) {
                 $entity->addInstructor($this->getReference('users' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('offerings' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadOfferingData.php
+++ b/tests/Fixture/LoadOfferingData.php
@@ -55,7 +55,7 @@ class LoadOfferingData extends AbstractFixture implements
             foreach ($arr['instructors'] as $id) {
                 $entity->addInstructor($this->getReference('users' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('offerings' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadPendingUserUpdateData.php
+++ b/tests/Fixture/LoadPendingUserUpdateData.php
@@ -43,7 +43,7 @@ class LoadPendingUserUpdateData extends AbstractFixture implements
             $entity->setValue($arr['value']);
             $entity->setUser($this->getReference('users' . $arr['user']));
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('pendingUserUpdates' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadPendingUserUpdateData.php
+++ b/tests/Fixture/LoadPendingUserUpdateData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\PendingUserUpdate;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -32,6 +33,8 @@ class LoadPendingUserUpdateData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\PendingUserUpdateData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(PendingUserUpdate::class);
         foreach ($data as $arr) {
             $entity = new PendingUserUpdate();
             $entity->setId($arr['id']);
@@ -40,10 +43,10 @@ class LoadPendingUserUpdateData extends AbstractFixture implements
             $entity->setValue($arr['value']);
             $entity->setUser($this->getReference('users' . $arr['user']));
 
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('pendingUserUpdates' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadProgramData.php
+++ b/tests/Fixture/LoadProgramData.php
@@ -39,7 +39,7 @@ class LoadProgramData extends AbstractFixture implements
             $entity->setShortTitle($arr['shortTitle']);
             $entity->setDuration($arr['duration']);
             $entity->setSchool($this->getReference('schools' . $arr['school']));
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('programs' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadProgramData.php
+++ b/tests/Fixture/LoadProgramData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\Program;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadProgramData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\ProgramData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Program::class);
         foreach ($data as $arr) {
             $entity = new Program();
             $entity->setId($arr['id']);
@@ -36,10 +39,10 @@ class LoadProgramData extends AbstractFixture implements
             $entity->setShortTitle($arr['shortTitle']);
             $entity->setDuration($arr['duration']);
             $entity->setSchool($this->getReference('schools' . $arr['school']));
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('programs' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadProgramYearData.php
+++ b/tests/Fixture/LoadProgramYearData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\ProgramYear;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadProgramYearData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\ProgramYearData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(ProgramYear::class);
         foreach ($data as $arr) {
             $entity = new ProgramYear();
             $entity->setId($arr['id']);
@@ -42,10 +45,10 @@ class LoadProgramYearData extends AbstractFixture implements
             foreach ($arr['competencies'] as $id) {
                 $entity->addCompetency($this->getReference('competencies' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('programYears' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadProgramYearData.php
+++ b/tests/Fixture/LoadProgramYearData.php
@@ -45,7 +45,7 @@ class LoadProgramYearData extends AbstractFixture implements
             foreach ($arr['competencies'] as $id) {
                 $entity->addCompetency($this->getReference('competencies' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('programYears' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadProgramYearObjectiveData.php
+++ b/tests/Fixture/LoadProgramYearObjectiveData.php
@@ -51,7 +51,7 @@ class LoadProgramYearObjectiveData extends AbstractFixture implements
             if (array_key_exists('competency', $arr)) {
                 $entity->setCompetency($this->getReference('competencies' . $arr['competency']));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
 
             $this->addReference('programYearObjectives' . $arr['id'], $entity);
         }

--- a/tests/Fixture/LoadProgramYearObjectiveData.php
+++ b/tests/Fixture/LoadProgramYearObjectiveData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\ProgramYearObjective;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -29,6 +30,8 @@ class LoadProgramYearObjectiveData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\ProgramYearObjectiveData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(ProgramYearObjective::class);
         foreach ($data as $arr) {
             $entity = new ProgramYearObjective();
             $entity->setId($arr['id']);
@@ -48,11 +51,11 @@ class LoadProgramYearObjectiveData extends AbstractFixture implements
             if (array_key_exists('competency', $arr)) {
                 $entity->setCompetency($this->getReference('competencies' . $arr['competency']));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
 
             $this->addReference('programYearObjectives' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadReportData.php
+++ b/tests/Fixture/LoadReportData.php
@@ -6,6 +6,7 @@ namespace App\Tests\Fixture;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use App\Entity\Report;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -29,6 +30,8 @@ class LoadReportData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\ReportData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Report::class);
         foreach ($data as $arr) {
             $entity = new Report();
             $entity->setId($arr['id']);
@@ -45,10 +48,10 @@ class LoadReportData extends AbstractFixture implements
             if (array_key_exists('school', $arr)) {
                 $entity->setSchool($this->getReference('schools' . $arr['school']));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('reports' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadReportData.php
+++ b/tests/Fixture/LoadReportData.php
@@ -48,7 +48,7 @@ class LoadReportData extends AbstractFixture implements
             if (array_key_exists('school', $arr)) {
                 $entity->setSchool($this->getReference('schools' . $arr['school']));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('reports' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadSchoolConfigData.php
+++ b/tests/Fixture/LoadSchoolConfigData.php
@@ -29,16 +29,18 @@ class LoadSchoolConfigData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\SchoolConfigData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(SchoolConfig::class);
         foreach ($data as $arr) {
             $entity = new SchoolConfig();
             $entity->setId($arr['id']);
             $entity->setName($arr['name']);
             $entity->setValue($arr['value']);
             $entity->setSchool($this->getReference('schools' . $arr['school']));
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('schoolConfigs' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadSchoolConfigData.php
+++ b/tests/Fixture/LoadSchoolConfigData.php
@@ -37,7 +37,7 @@ class LoadSchoolConfigData extends AbstractFixture implements
             $entity->setName($arr['name']);
             $entity->setValue($arr['value']);
             $entity->setSchool($this->getReference('schools' . $arr['school']));
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('schoolConfigs' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadSchoolData.php
+++ b/tests/Fixture/LoadSchoolData.php
@@ -39,7 +39,7 @@ class LoadSchoolData extends AbstractFixture implements
             }
             $entity->setIliosAdministratorEmail($arr['iliosAdministratorEmail']);
             $entity->setChangeAlertRecipients($arr['changeAlertRecipients']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('schools' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadSchoolData.php
+++ b/tests/Fixture/LoadSchoolData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\School;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,6 +28,8 @@ class LoadSchoolData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\SchoolData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(School::class);
         foreach ($data as $arr) {
             $entity = new School();
             $entity->setId($arr['id']);
@@ -36,9 +39,9 @@ class LoadSchoolData extends AbstractFixture implements
             }
             $entity->setIliosAdministratorEmail($arr['iliosAdministratorEmail']);
             $entity->setChangeAlertRecipients($arr['changeAlertRecipients']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('schools' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadSessionData.php
+++ b/tests/Fixture/LoadSessionData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\Session;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadSessionData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\SessionData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Session::class);
         foreach ($data as $arr) {
             $entity = new Session();
             $entity->setId($arr['id']);
@@ -82,11 +85,11 @@ class LoadSessionData extends AbstractFixture implements
                     $entity->addPrerequisite($this->getReference($ref));
                 }
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
 
             $this->addReference('sessions' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadSessionData.php
+++ b/tests/Fixture/LoadSessionData.php
@@ -85,7 +85,7 @@ class LoadSessionData extends AbstractFixture implements
                     $entity->addPrerequisite($this->getReference($ref));
                 }
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
 
             $this->addReference('sessions' . $arr['id'], $entity);
         }

--- a/tests/Fixture/LoadSessionLearningMaterialData.php
+++ b/tests/Fixture/LoadSessionLearningMaterialData.php
@@ -53,7 +53,7 @@ class LoadSessionLearningMaterialData extends AbstractFixture implements
             foreach ($arr['meshDescriptors'] as $id) {
                 $entity->addMeshDescriptor($this->getReference('meshDescriptors' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('sessionLearningMaterials' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadSessionLearningMaterialData.php
+++ b/tests/Fixture/LoadSessionLearningMaterialData.php
@@ -30,6 +30,8 @@ class LoadSessionLearningMaterialData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\SessionLearningMaterialData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(SessionLearningMaterial::class);
         foreach ($data as $arr) {
             $entity = new SessionLearningMaterial();
             $entity->setId($arr['id']);
@@ -51,10 +53,10 @@ class LoadSessionLearningMaterialData extends AbstractFixture implements
             foreach ($arr['meshDescriptors'] as $id) {
                 $entity->addMeshDescriptor($this->getReference('meshDescriptors' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('sessionLearningMaterials' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadSessionObjectiveData.php
+++ b/tests/Fixture/LoadSessionObjectiveData.php
@@ -48,7 +48,7 @@ class LoadSessionObjectiveData extends AbstractFixture implements
             if (array_key_exists('ancestor', $arr)) {
                 $entity->setAncestor($this->getReference('sessionObjectives' . $arr['ancestor']));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
 
             $this->addReference('sessionObjectives' . $arr['id'], $entity);
         }

--- a/tests/Fixture/LoadSessionObjectiveData.php
+++ b/tests/Fixture/LoadSessionObjectiveData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\SessionObjective;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -29,6 +30,8 @@ class LoadSessionObjectiveData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\SessionObjectiveData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(SessionObjective::class);
         foreach ($data as $arr) {
             $entity = new SessionObjective();
             $entity->setId($arr['id']);
@@ -45,11 +48,11 @@ class LoadSessionObjectiveData extends AbstractFixture implements
             if (array_key_exists('ancestor', $arr)) {
                 $entity->setAncestor($this->getReference('sessionObjectives' . $arr['ancestor']));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
 
             $this->addReference('sessionObjectives' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadSessionTypeData.php
+++ b/tests/Fixture/LoadSessionTypeData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\SessionType;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -29,6 +30,8 @@ class LoadSessionTypeData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\SessionTypeData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(SessionType::class);
         foreach ($data as $arr) {
             $entity = new SessionType();
             $entity->setId($arr['id']);
@@ -44,10 +47,10 @@ class LoadSessionTypeData extends AbstractFixture implements
             foreach ($arr['aamcMethods'] as $id) {
                 $entity->addAamcMethod($this->getReference('aamcMethods' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('sessionTypes' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadSessionTypeData.php
+++ b/tests/Fixture/LoadSessionTypeData.php
@@ -47,7 +47,7 @@ class LoadSessionTypeData extends AbstractFixture implements
             foreach ($arr['aamcMethods'] as $id) {
                 $entity->addAamcMethod($this->getReference('aamcMethods' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('sessionTypes' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadTermData.php
+++ b/tests/Fixture/LoadTermData.php
@@ -45,7 +45,7 @@ class LoadTermData extends AbstractFixture implements
             foreach ($arr['aamcResourceTypes'] as $id) {
                 $entity->addAamcResourceType($this->getReference('aamcResourceTypes' . $id));
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('terms' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadTermData.php
+++ b/tests/Fixture/LoadTermData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\Term;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadTermData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\TermData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Term::class);
         foreach ($data as $arr) {
             $entity = new Term();
             $entity->setId($arr['id']);
@@ -42,10 +45,10 @@ class LoadTermData extends AbstractFixture implements
             foreach ($arr['aamcResourceTypes'] as $id) {
                 $entity->addAamcResourceType($this->getReference('aamcResourceTypes' . $id));
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('terms' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadUserData.php
+++ b/tests/Fixture/LoadUserData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\User;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,6 +30,8 @@ class LoadUserData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\UserData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(User::class);
         foreach ($data as $arr) {
             $entity = new User();
             $entity->setId($arr['id']);
@@ -81,10 +84,10 @@ class LoadUserData extends AbstractFixture implements
                     $this->getReference('curriculumInventoryReports' . $id)
                 );
             }
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('users' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadUserData.php
+++ b/tests/Fixture/LoadUserData.php
@@ -84,7 +84,7 @@ class LoadUserData extends AbstractFixture implements
                     $this->getReference('curriculumInventoryReports' . $id)
                 );
             }
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('users' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadUserRoleData.php
+++ b/tests/Fixture/LoadUserRoleData.php
@@ -34,7 +34,7 @@ class LoadUserRoleData extends AbstractFixture implements
             $entity = new UserRole();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('userRoles' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadUserRoleData.php
+++ b/tests/Fixture/LoadUserRoleData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\UserRole;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -27,13 +28,15 @@ class LoadUserRoleData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\UserRoleData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(UserRole::class);
         foreach ($data as $arr) {
             $entity = new UserRole();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('userRoles' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 }

--- a/tests/Fixture/LoadUserSessionMaterialStatusData.php
+++ b/tests/Fixture/LoadUserSessionMaterialStatusData.php
@@ -40,7 +40,7 @@ class LoadUserSessionMaterialStatusData extends AbstractFixture implements
             $entity->setUser($this->getReference('users' . $arr['user']));
             $entity->setMaterial($this->getReference('sessionLearningMaterials' . $arr['material']));
 
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('UserSessionMaterialStatuss' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadUserSessionMaterialStatusData.php
+++ b/tests/Fixture/LoadUserSessionMaterialStatusData.php
@@ -30,6 +30,8 @@ class LoadUserSessionMaterialStatusData extends AbstractFixture implements
         $data = $this->container
             ->get(UserSessionMaterialStatusData::class)
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(UserSessionMaterialStatus::class);
         foreach ($data as $arr) {
             $entity = new UserSessionMaterialStatus();
             $entity->setId($arr['id']);
@@ -38,10 +40,10 @@ class LoadUserSessionMaterialStatusData extends AbstractFixture implements
             $entity->setUser($this->getReference('users' . $arr['user']));
             $entity->setMaterial($this->getReference('sessionLearningMaterials' . $arr['material']));
 
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('UserSessionMaterialStatuss' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()

--- a/tests/Fixture/LoadVocabularyData.php
+++ b/tests/Fixture/LoadVocabularyData.php
@@ -38,7 +38,7 @@ class LoadVocabularyData extends AbstractFixture implements
             $entity->setTitle($arr['title']);
             $entity->setActive($arr['active']);
             $entity->setSchool($this->getReference('schools' . $arr['school']));
-            $repository->update($entity, false, true);
+            $repository->update($entity, true, true);
             $this->addReference('vocabularies' . $arr['id'], $entity);
         }
         $repository->flush();

--- a/tests/Fixture/LoadVocabularyData.php
+++ b/tests/Fixture/LoadVocabularyData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Fixture;
 
 use App\Entity\Vocabulary;
+use App\Repository\RepositoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
@@ -29,16 +30,18 @@ class LoadVocabularyData extends AbstractFixture implements
         $data = $this->container
             ->get('App\Tests\DataLoader\VocabularyData')
             ->getAll();
+        /** @var RepositoryInterface $repository */
+        $repository = $manager->getRepository(Vocabulary::class);
         foreach ($data as $arr) {
             $entity = new Vocabulary();
             $entity->setId($arr['id']);
             $entity->setTitle($arr['title']);
             $entity->setActive($arr['active']);
             $entity->setSchool($this->getReference('schools' . $arr['school']));
-            $manager->persist($entity);
+            $repository->update($entity, false, true);
             $this->addReference('vocabularies' . $arr['id'], $entity);
-            $manager->flush();
         }
+        $repository->flush();
     }
 
     public function getDependencies()


### PR DESCRIPTION
We weren't doing the right steps to allow IDs to be forced when creating new doctrine entities. I cleaned that up and used it in our test data loaders and then updated our API docs so we wouldn't indicate that ID can be passed with a POST or PUT request. It can't, it would silently be ignored. 

We could also detect that an ID was passed and then force it to be used, but I think maintain the current ignore behavior and just document it better is a good fix for now.