### PR TITLE
Include empty relationships in JSON:API responses

### DIFF
--- a/src/Classes/JsonApiData.php
+++ b/src/Classes/JsonApiData.php
@@ -94,10 +94,12 @@ class JsonApiData
         foreach ($keys as $key) {
             if (array_key_exists($key, $relationships)) {
                 $r = $relationships[$key];
-                $type = $this->getTypeForData($r['data']);
-                $ids = $this->getIdsForData($r['data']);
+                if ($r['data']) {
+                    $type = $this->getTypeForData($r['data']);
+                    $ids = $this->getIdsForData($r['data']);
 
-                $this->prepareSideLoad($type, $ids, $sideLoadFields[$key]);
+                    $this->prepareSideLoad($type, $ids, $sideLoadFields[$key]);
+                }
             }
         }
     }

--- a/src/Normalizer/JsonApiDTONormalizer.php
+++ b/src/Normalizer/JsonApiDTONormalizer.php
@@ -39,12 +39,10 @@ class JsonApiDTONormalizer implements NormalizerInterface
         $related = [];
         foreach ($relatedProperties as $attributeName => $relationshipType) {
             $value = $attributes[$attributeName];
-            if ($value) {
-                $related[$attributeName] = [
-                    'type' => $relationshipType,
-                    'value' => $value,
-                ];
-            }
+            $related[$attributeName] = [
+                'type' => $relationshipType,
+                'value' => $value,
+            ];
 
             unset($attributes[$attributeName]);
         }

--- a/tests/AbstractEndpointTest.php
+++ b/tests/AbstractEndpointTest.php
@@ -141,13 +141,6 @@ abstract class AbstractEndpointTest extends WebTestCase
             }
         }
 
-        // Remove empty relationships as they won't be present in JSON:API
-        foreach ($expected as $key => $value) {
-            if ($value === []) {
-                unset($expected[$key]);
-            }
-        }
-
         $this->compareData($expected, $transformed);
     }
 


### PR DESCRIPTION
I'm not sure why these have been left off, from what I can tell in the specification at
https://jsonapi.org/format/1.0/#document-resource-object-linkage related items are always supposed to be included in the response and leaving them off is a bug, plus it breaks relationship data tracking on the frontend because EmberData doesn't know to update the inverse side when something is saved.

Fixes #4953