### PR TITLE
Remove ClockMock and accept the slight delay

### DIFF
--- a/src/EventListener/TimestampEntityChanges.php
+++ b/src/EventListener/TimestampEntityChanges.php
@@ -6,7 +6,6 @@ namespace App\EventListener;
 
 use DateTime;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
-use Doctrine\ORM\Event\OnFlushEventArgs;
 use App\Service\Timestamper;
 use App\Traits\TimestampableEntityInterface;
 use App\Traits\OfferingsEntityInterface;
@@ -57,26 +56,26 @@ class TimestampEntityChanges
      */
     protected function stamp(object $entity)
     {
-        $timestamp = new Datetime();
+        $now = DateTime::createFromFormat('U', (string) time());
 
         if ($entity instanceof TimestampableEntityInterface) {
-            $this->timeStamper->add($entity, $timestamp);
-            $entity->setUpdatedAt($timestamp);
+            $this->timeStamper->add($entity, $now);
+            $entity->setUpdatedAt($now);
         }
 
         if ($entity instanceof OfferingsEntityInterface) {
             $offerings = $entity->getOfferings();
             foreach ($offerings as $offering) {
-                $this->timeStamper->add($offering, $timestamp);
-                $offering->setUpdatedAt($timestamp);
+                $this->timeStamper->add($offering, $now);
+                $offering->setUpdatedAt($now);
             }
         }
 
         if ($entity instanceof SessionStampableInterface) {
             $sessions = $entity->getSessions();
             foreach ($sessions as $session) {
-                $this->timeStamper->add($session, $timestamp);
-                $session->setUpdatedAt($timestamp);
+                $this->timeStamper->add($session, $now);
+                $session->setUpdatedAt($now);
             }
         }
     }

--- a/src/Service/Timestamper.php
+++ b/src/Service/Timestamper.php
@@ -30,7 +30,7 @@ class Timestamper
         if (!array_key_exists($class, $this->entities[$ts])) {
             $this->entities[$ts][$class] = [];
         }
-        // When and entity has already been deleted it will lose it's ID, so we need to record it here
+        // When and entity has already been deleted it will lose its ID, so we need to record it here
         $this->entities[$ts][$class][] = (string) $entity;
     }
 
@@ -40,14 +40,13 @@ class Timestamper
             /** @var EntityManager $om */
             $om = $this->registry->getManager();
             foreach ($this->entities as $timestamp => $entities) {
-                $dateTime = new DateTime();
-                $dateTime->setTimestamp($timestamp);
+                $dateTime = DateTime::createFromFormat('U', (string) $timestamp);
                 foreach ($entities as $class => $ids) {
                     if ($ids !== []) {
                         $qb = $om->createQueryBuilder();
                         $qb->update($class, 'c')
                             ->set('c.updatedAt', ':timestamp')
-                            ->where($qb->expr()->in('c.id', $ids))
+                            ->where($qb->expr()->in('c.id', array_unique($ids)))
                             ->setParameter('timestamp', $dateTime);
                         $query = $qb->getQuery();
                         $query->execute();

--- a/tests/Endpoints/AbstractEndpoint.php
+++ b/tests/Endpoints/AbstractEndpoint.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Endpoints;
 
+use App\EventListener\TimestampEntityChanges;
 use App\Service\InflectorFactory;
-use App\Service\Timestamper;
 use App\Tests\Fixture\LoadAuthenticationData;
 use App\Tests\GetUrlTrait;
 use DateTime;
@@ -13,7 +13,6 @@ use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\Inflector\Inflector;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
-use Symfony\Bridge\PhpUnit\ClockMock;
 use App\Tests\DataLoader\DataLoaderInterface;
 use App\Tests\Traits\JsonControllerTest;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -59,7 +58,6 @@ abstract class AbstractEndpoint extends WebTestCase
         $executor = $this->databaseTool->loadFixtures($fixtures);
         $this->fixtures = $executor->getReferenceRepository();
 
-        ClockMock::register(Timestamper::class);
         $this->inflector = InflectorFactory::create();
     }
 
@@ -1445,11 +1443,10 @@ abstract class AbstractEndpoint extends WebTestCase
         $relatedResponseKey,
         $relatedData
     ) {
-        ClockMock::withClockMock(true);
         $endpoint = $this->getPluralName();
         $responseKey = $this->getCamelCasedPluralName();
         $initialState = $this->getOne($endpoint, $responseKey, $id);
-        sleep(10);
+        sleep(2);
         $this->putOne($relatedEndpoint, $relatedResponseKey, $relatedData['id'], $relatedData);
         $currentState = $this->getOne($endpoint, $responseKey, $id);
         foreach ($this->getTimeStampFields() as $field) {
@@ -1459,11 +1456,10 @@ abstract class AbstractEndpoint extends WebTestCase
             $diff = $currentStamp->getTimestamp() - $initialStamp->getTimestamp();
             $this->assertTrue(
                 $diff > 0,
-                'The timestamp has increased.  Original: ' . $initialStamp->format('c') .
+                'The timestamp has not increased. Original: ' . $initialStamp->format('c') .
                 ' Now: ' . $currentStamp->format('c')
             );
         }
-        ClockMock::withClockMock(false);
     }
 
     /**
@@ -1479,11 +1475,10 @@ abstract class AbstractEndpoint extends WebTestCase
         $relatedResponseKey,
         $relatedPostData
     ) {
-        ClockMock::withClockMock(true);
         $endpoint = $this->getPluralName();
         $responseKey = $this->getCamelCasedPluralName();
         $initialState = $this->getOne($endpoint, $responseKey, $id);
-        sleep(10);
+        sleep(2);
         $this->postMany($relatedPluralObjectName, $relatedResponseKey, [$relatedPostData]);
         $currentState = $this->getOne($endpoint, $responseKey, $id);
         foreach ($this->getTimeStampFields() as $field) {
@@ -1493,11 +1488,10 @@ abstract class AbstractEndpoint extends WebTestCase
             $diff = $currentStamp->getTimestamp() - $initialStamp->getTimestamp();
             $this->assertTrue(
                 $diff > 0,
-                'The timestamp has increased.  Original: ' . $initialStamp->format('c') .
+                'The timestamp has not increased.  Original: ' . $initialStamp->format('c') .
                 ' Now: ' . $currentStamp->format('c')
             );
         }
-        ClockMock::withClockMock(false);
     }
 
     /**
@@ -1511,11 +1505,10 @@ abstract class AbstractEndpoint extends WebTestCase
         $relatedPluralObjectName,
         $relatedId
     ) {
-        ClockMock::withClockMock(true);
         $endpoint = $this->getPluralName();
         $responseKey = $this->getCamelCasedPluralName();
         $initialState = $this->getOne($endpoint, $responseKey, $id);
-        sleep(10);
+        sleep(2);
         $this->deleteOne($relatedPluralObjectName, $relatedId);
         $currentState = $this->getOne($endpoint, $responseKey, $id);
         foreach ($this->getTimeStampFields() as $field) {
@@ -1525,11 +1518,10 @@ abstract class AbstractEndpoint extends WebTestCase
             $diff = $currentStamp->getTimestamp() - $initialStamp->getTimestamp();
             $this->assertTrue(
                 $diff > 0,
-                'The timestamp has increased.  Original: ' . $initialStamp->format('c') .
+                'The timestamp has not increased.  Original: ' . $initialStamp->format('c') .
                 ' Now: ' . $currentStamp->format('c')
             );
         }
-        ClockMock::withClockMock(false);
     }
 
     protected function pruneData(array $data): array

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -20,7 +20,6 @@ use App\Tests\DataLoader\LearningMaterialData;
 /**
  * LearningMaterial API endpoint Test.
  * @group api_4
- * @group time-sensitive
  */
 class LearningMaterialTest extends AbstractReadWriteEndpoint
 {

--- a/tests/Endpoints/MeshConceptTest.php
+++ b/tests/Endpoints/MeshConceptTest.php
@@ -10,7 +10,6 @@ use App\Tests\Fixture\LoadMeshTermData;
 /**
  * MeshConcept API endpoint Test.
  * @group api_5
- * @group time-sensitive
  */
 class MeshConceptTest extends AbstractMeshEndpoint
 {

--- a/tests/Endpoints/MeshDescriptorTest.php
+++ b/tests/Endpoints/MeshDescriptorTest.php
@@ -22,7 +22,6 @@ use App\Tests\QEndpointTrait;
 /**
  * MeshDescriptor API endpoint Test.
  * @group api_3
- * @group time-sensitive
  */
 class MeshDescriptorTest extends AbstractMeshEndpoint
 {

--- a/tests/Endpoints/MeshQualifierTest.php
+++ b/tests/Endpoints/MeshQualifierTest.php
@@ -9,7 +9,6 @@ use App\Tests\Fixture\LoadMeshQualifierData;
 /**
  * MeshQualifier API endpoint Test.
  * @group api_1
- * @group time-sensitive
  */
 class MeshQualifierTest extends AbstractMeshEndpoint
 {

--- a/tests/Endpoints/MeshTermTest.php
+++ b/tests/Endpoints/MeshTermTest.php
@@ -10,7 +10,6 @@ use App\Tests\Fixture\LoadMeshTermData;
 /**
  * MeshTerm API endpoint Test.
  * @group api_3
- * @group time-sensitive
  */
 class MeshTermTest extends AbstractMeshEndpoint
 {

--- a/tests/Endpoints/OfferingTest.php
+++ b/tests/Endpoints/OfferingTest.php
@@ -19,7 +19,6 @@ use DateTimeZone;
 /**
  * Offering API endpoint Test.
  * @group api_1
- * @group time-sensitive
  */
 class OfferingTest extends AbstractReadWriteEndpoint
 {

--- a/tests/Endpoints/ReportTest.php
+++ b/tests/Endpoints/ReportTest.php
@@ -10,7 +10,6 @@ use App\Tests\Fixture\LoadUserData;
 /**
  * Report API endpoint Test.
  * @group api_4
- * @group time-sensitive
  */
 class ReportTest extends AbstractReadWriteEndpoint
 {

--- a/tests/Endpoints/SessionTest.php
+++ b/tests/Endpoints/SessionTest.php
@@ -21,7 +21,6 @@ use App\Tests\QEndpointTrait;
 /**
  * Session API endpoint Test.
  * @group api_2
- * @group time-sensitive
  */
 class SessionTest extends AbstractReadWriteEndpoint
 {


### PR DESCRIPTION
This creates a few seconds delay in a half dozen tests, but it removes an area of flakeyness from our tests when the mocked clock doesn't do what we expect. Total CI time is about 3min more. Acceptable.

While working on this I made some small changes to the timestamping application code that I think are keep worthy. I've changed the variable name and the way we build a DateTime from a timestamp and I also applied a unique method to the IDs before saving so we don't duplicate a bunch of IDs when we save things in big groups.