### PR TITLE
rm unnecessary security config.

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -29,7 +29,6 @@ security:
       stateless: true
       custom_authenticators:
         - App\Security\JsonWebTokenAuthenticator
-      provider: session_user
 
 
 when@test:


### PR DESCRIPTION
since our main firewall is stateless, we don't need to set a user provider on it.

see https://symfony.com/doc/current/security.html#security-user-providers