### PR TITLE
Prevent Changing Root Status Through Patch Request

### DIFF
--- a/src/Service/ApiRequestParser.php
+++ b/src/Service/ApiRequestParser.php
@@ -190,13 +190,21 @@ class ApiRequestParser
     {
         $type = $request->getAcceptableContentTypes();
         if (in_array("application/vnd.api+json", $type)) {
-            $obj = json_decode($request->getContent());
-            $data = $this->dataShaper->flattenJsonApiData($obj->data);
+            $data = $this->extractJsonApiPatchDataFromRequest($request);
         } else {
             $data = $this->extractPutDataFromRequest($request, $object);
         }
         $json = json_encode($data);
 
         return $this->serializer->deserialize($json, $entity::class, 'json', ['object_to_populate' => $entity]);
+    }
+
+    /**
+     * Parse json:api PATCH request and pull out data,
+     */
+    public function extractJsonApiPatchDataFromRequest(Request $request): array
+    {
+        $obj = json_decode($request->getContent());
+        return $this->dataShaper->flattenJsonApiData($obj->data);
     }
 }

--- a/tests/Endpoints/AbstractEndpoint.php
+++ b/tests/Endpoints/AbstractEndpoint.php
@@ -1073,7 +1073,7 @@ abstract class AbstractEndpoint extends WebTestCase
     /**
      * PUT a single item to the JSON:API
      */
-    protected function patchOneJsonApi(object $data): object
+    protected function patchOneJsonApi(object $data, $userId = 2): object
     {
         $endpoint = strtolower($data->data->type);
         $this->createJsonApiRequest(
@@ -1084,7 +1084,7 @@ abstract class AbstractEndpoint extends WebTestCase
                 ['version' => $this->apiVersion, 'id' => $data->data->id]
             ),
             json_encode($data),
-            $this->getAuthenticatedUserToken($this->kernelBrowser)
+            $this->getTokenForUser($this->kernelBrowser, $userId)
         );
         $response = $this->kernelBrowser->getResponse();
         $this->assertJsonApiResponse($response, Response::HTTP_OK);

--- a/tests/Traits/JsonControllerTest.php
+++ b/tests/Traits/JsonControllerTest.php
@@ -217,16 +217,42 @@ trait JsonControllerTest
 
     /**
      * Tests to ensure that a user cannot access a certain function
-     *
-     * @param KernelBrowser $browser
-     * @param string $userId
-     * @param string $method
-     * @param string $url
-     * @param string $data
      */
-    protected function canNot(KernelBrowser $browser, $userId, $method, $url, $data = null)
-    {
+    protected function canNot(
+        KernelBrowser $browser,
+        int $userId,
+        string $method,
+        string $url,
+        string $data = null
+    ): void {
         $this->makeJsonRequest(
+            $browser,
+            $method,
+            $url,
+            $data,
+            $this->getTokenForUser($browser, $userId)
+        );
+
+        $response = $browser->getResponse();
+        $this->assertEquals(
+            Response::HTTP_FORBIDDEN,
+            $response->getStatusCode(),
+            "User #{$userId} should be prevented from {$method} at {$url}" .
+            substr(var_export($response->getContent(), true), 0, 400)
+        );
+    }
+
+    /**
+     * Tests to ensure that a user cannot access a certain function
+     */
+    protected function canNotJsonApi(
+        KernelBrowser $browser,
+        int $userId,
+        string $method,
+        string $url,
+        string $data = null
+    ): void {
+        $this->makeJsonApiRequest(
             $browser,
             $method,
             $url,


### PR DESCRIPTION
We prevent modifying the root status of a user via a PUT request in the users controller, but we were not doing this same check for PATCH. This would allow school administrators to upgrade any user, including themselves, to have root permissions.

I also discovered the our existing tests for PATCH were not working correctly because the rejection could come from the permissions system and not the controller check if the user we tested with lacked the privilege to modify a user.