### PR TITLE
Add getSupportedTypes to Normalizers

### DIFF
--- a/src/Denormalizer/EntityDenormalizer.php
+++ b/src/Denormalizer/EntityDenormalizer.php
@@ -179,9 +179,15 @@ class EntityDenormalizer implements DenormalizerInterface
         return $this->entityMetadata->isAnIliosEntity($type);
     }
 
+    /**
+     * The only things we denormalize are entities, for anything else *[null] tells
+     * symfony to not even bother.
+     */
     public function getSupportedTypes(?string $format): array
     {
-        $types = [];
+        $types = [
+            '*' => null,
+        ];
         foreach ($this->entityMetadata->getEntityList() as $name) {
             $types[$name] = true;
         }

--- a/src/Normalizer/DTONormalizer.php
+++ b/src/Normalizer/DTONormalizer.php
@@ -86,12 +86,22 @@ class DTONormalizer implements NormalizerInterface
         return $format === 'json' && $this->entityMetadata->isAnIliosDto($classNameOrObject);
     }
 
+    /**
+     * Send *[null] to indicate we don't support anything by default
+     * if it's a json request we will cache and support all the DTOs
+     */
     public function getSupportedTypes(?string $format): array
     {
-        $types = [];
-        foreach ($this->entityMetadata->getDtoList() as $name) {
-            $types[$name] = true;
+        $types = [
+            '*' => null,
+        ];
+
+        if ($format === 'json') {
+            foreach ($this->entityMetadata->getDtoList() as $name) {
+                $types[$name] = true;
+            }
         }
+
 
         return $types;
     }

--- a/src/Normalizer/EntityNormalizer.php
+++ b/src/Normalizer/EntityNormalizer.php
@@ -92,11 +92,19 @@ class EntityNormalizer implements NormalizerInterface
     }
 
 
+    /**
+     * Send *[null] to indicate we don't support anything by default
+     * if it's a json-api request we will cache and support all the entities
+     */
     public function getSupportedTypes(?string $format): array
     {
-        $types = [];
-        foreach ($this->entityMetadata->getEntityList() as $name) {
-            $types[$name] = true;
+        $types = [
+            '*' => null,
+        ];
+        if ($format === 'json') {
+            foreach ($this->entityMetadata->getEntityList() as $name) {
+                $types[$name] = true;
+            }
         }
 
         return $types;

--- a/src/Normalizer/FactoryNormalizer.php
+++ b/src/Normalizer/FactoryNormalizer.php
@@ -69,16 +69,14 @@ class FactoryNormalizer implements NormalizerInterface, NormalizationAwareInterf
         return in_array($class, $decoratedTypes);
     }
 
+    /**
+     * For the most part we cannot cache normalization of any types because we rely on the $context
+     * in our supportsNormalization method. However, when the $format isn't supported we can cache that.
+     */
     public function getSupportedTypes(?string $format): array
     {
-        if (!in_array($format, ['json', 'json-api'])) {
-            return [];
-        }
-
         return [
-            LearningMaterial::class => true,
-            LearningMaterialDTO::class => true,
-            CurriculumInventoryReportDTO::class => true,
+            '*' => !in_array($format, ['json', 'json-api']),
         ];
     }
 }

--- a/src/Normalizer/FactoryNormalizer.php
+++ b/src/Normalizer/FactoryNormalizer.php
@@ -68,4 +68,17 @@ class FactoryNormalizer implements NormalizerInterface, NormalizationAwareInterf
         $class = is_object($data) ? $data::class : $data;
         return in_array($class, $decoratedTypes);
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        if (!in_array($format, ['json', 'json-api'])) {
+            return [];
+        }
+
+        return [
+            LearningMaterial::class => true,
+            LearningMaterialDTO::class => true,
+            CurriculumInventoryReportDTO::class => true,
+        ];
+    }
 }

--- a/src/Normalizer/JsonApiDTONormalizer.php
+++ b/src/Normalizer/JsonApiDTONormalizer.php
@@ -83,4 +83,17 @@ class JsonApiDTONormalizer implements NormalizerInterface
     {
         return $format === 'json-api' && $this->entityMetadata->isAnIliosDto($data);
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        if ($format !== 'json-api') {
+            return [];
+        }
+        $types = [];
+        foreach ($this->entityMetadata->getDtoList() as $name) {
+            $types[$name] = true;
+        }
+
+        return $types;
+    }
 }

--- a/src/Normalizer/JsonApiDTONormalizer.php
+++ b/src/Normalizer/JsonApiDTONormalizer.php
@@ -84,15 +84,22 @@ class JsonApiDTONormalizer implements NormalizerInterface
         return $format === 'json-api' && $this->entityMetadata->isAnIliosDto($data);
     }
 
+    /**
+     * Send *[null] to indicate we don't support anything by default
+     * if it's a json-api request we will cache and support all the DTOs
+     */
     public function getSupportedTypes(?string $format): array
     {
-        if ($format !== 'json-api') {
-            return [];
+        $types = [
+            '*' => null,
+        ];
+
+        if ($format === 'json-api') {
+            foreach ($this->entityMetadata->getDtoList() as $name) {
+                $types[$name] = true;
+            }
         }
-        $types = [];
-        foreach ($this->entityMetadata->getDtoList() as $name) {
-            $types[$name] = true;
-        }
+
 
         return $types;
     }


### PR DESCRIPTION
This allows symfony to cache what kinds of objects each normalizer can take which is a performance boost.

Not implementing this method is deprecated and will be required in Symfony 7.

Found a little performance boost here as well, by sending the `[*] = null` we can notify Symfony that for every other thing we not only don't cache it, we don't support it at all.

https://blackfire.io/profiles/compare/d7ed299e-b528-44c9-b8d9-45cedce1b6b8/graph shows a 8% speedup. 🔥 