### PR TITLE
prepare to upgrade to PHPUnit 10.

### DIFF
--- a/bin/phpunit
+++ b/bin/phpunit
@@ -6,9 +6,13 @@ if (!ini_get('date.timezone')) {
 }
 
 if (is_file(dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit')) {
-    define('PHPUNIT_COMPOSER_INSTALL', dirname(__DIR__).'/vendor/autoload.php');
-    require PHPUNIT_COMPOSER_INSTALL;
-    PHPUnit\TextUI\Command::main();
+    if (PHP_VERSION_ID >= 80000) {
+        require dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit';
+    } else {
+        define('PHPUNIT_COMPOSER_INSTALL', dirname(__DIR__).'/vendor/autoload.php');
+        require PHPUNIT_COMPOSER_INSTALL;
+        PHPUnit\TextUI\Command::main();
+    }
 } else {
     if (!is_file(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php')) {
         echo "Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.\n";

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
     "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan": "@stable",
     "phpstan/phpstan-symfony": "@stable",
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^10.5",
     "squizlabs/php_codesniffer": "@stable",
     "symfony/browser-kit": "@stable",
     "symfony/css-selector": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
     "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan": "@stable",
     "phpstan/phpstan-symfony": "@stable",
-    "phpunit/phpunit": "^10.5",
+    "phpunit/phpunit": "^9.6",
     "squizlabs/php_codesniffer": "@stable",
     "symfony/browser-kit": "@stable",
     "symfony/css-selector": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03db08cf01542d511d9190131b75896b",
+    "content-hash": "b0ed840d9c29389d5064a1fa64e86ef4",
     "packages": [
         {
             "name": "async-aws/core",
@@ -14155,16 +14155,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.9",
+            "version": "9.2.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "a56a9ab2f680246adcf3db43f38ddf1765774735"
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a56a9ab2f680246adcf3db43f38ddf1765774735",
-                "reference": "a56a9ab2f680246adcf3db43f38ddf1765774735",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
                 "shasum": ""
             },
             "require": {
@@ -14172,18 +14172,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.15",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^3.0",
-                "sebastian/complexity": "^3.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/lines-of-code": "^2.0",
-                "sebastian/version": "^4.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.1"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -14192,7 +14192,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
@@ -14221,7 +14221,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.9"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
             },
             "funding": [
                 {
@@ -14229,32 +14229,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-23T12:23:20+00:00"
+            "time": "2023-09-19T04:57:46+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.1.0",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -14281,8 +14281,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -14290,28 +14289,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T06:24:48+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -14319,7 +14318,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -14345,7 +14344,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
             },
             "funding": [
                 {
@@ -14353,32 +14352,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2020-09-28T05:58:55+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.1",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -14404,8 +14403,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
             },
             "funding": [
                 {
@@ -14413,32 +14411,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T14:07:24+00:00"
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -14464,7 +14462,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
             "funding": [
                 {
@@ -14472,23 +14470,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.1",
+            "version": "9.6.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d5d9dca6a902d05b34c4bcbc7c1636ce1dc25408"
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d5d9dca6a902d05b34c4bcbc7c1636ce1dc25408",
-                "reference": "d5d9dca6a902d05b34c4bcbc7c1636ce1dc25408",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -14498,26 +14497,27 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.5",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.1",
-                "sebastian/global-state": "^6.0.1",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.28",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.8",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.5",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^3.2",
+                "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -14525,7 +14525,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -14557,7 +14557,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.1"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
             },
             "funding": [
                 {
@@ -14573,7 +14573,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:57:05+00:00"
+            "time": "2023-12-01T16:55:19+00:00"
         },
         {
             "name": "sanmai/later",
@@ -14706,28 +14706,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -14750,7 +14750,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
             },
             "funding": [
                 {
@@ -14758,32 +14758,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:15+00:00"
+            "time": "2020-09-28T06:08:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "2.0.0",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -14806,7 +14806,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
             },
             "funding": [
                 {
@@ -14814,32 +14814,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:43+00:00"
+            "time": "2020-10-26T13:08:54+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -14861,7 +14861,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
             },
             "funding": [
                 {
@@ -14869,36 +14869,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.1",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
-                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
                 "shasum": ""
             },
             "require": {
-                "ext-dom": "*",
-                "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.3"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -14937,8 +14935,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
             },
             "funding": [
                 {
@@ -14946,33 +14943,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-14T13:18:12+00:00"
+            "time": "2022-09-14T12:41:17+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.1.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957"
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68cfb347a44871f01e33ab0ef8215966432f6957",
-                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
-                "php": ">=8.1"
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -14995,8 +14992,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.1.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
             },
             "funding": [
                 {
@@ -15004,33 +15000,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-28T11:50:59+00:00"
+            "time": "2020-10-26T15:52:27+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.3",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
+                "phpunit/phpunit": "^9.3",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -15062,8 +15058,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -15071,27 +15066,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-01T07:48:21+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.0.1",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -15099,7 +15094,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -15118,7 +15113,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "https://github.com/sebastianbergmann/environment",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -15126,8 +15121,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -15135,34 +15129,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-11T05:39:26+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.1",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc"
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64f51654862e0f5e318db7e9dcc2292c63cdbddc",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -15204,8 +15198,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
             },
             "funding": [
                 {
@@ -15213,35 +15206,38 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-24T13:22:09+00:00"
+            "time": "2022-09-14T06:03:37+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.1",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -15266,8 +15262,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
             },
             "funding": [
                 {
@@ -15275,33 +15270,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-19T07:19:23+00:00"
+            "time": "2023-08-02T09:26:13+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d"
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/649e40d279e243d985aa8fb6e74dd5bb28dc185d",
-                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
-                "php": ">=8.1"
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -15324,8 +15319,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
             },
             "funding": [
                 {
@@ -15333,34 +15327,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T09:25:50+00:00"
+            "time": "2020-11-28T06:42:11+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -15382,7 +15376,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
             },
             "funding": [
                 {
@@ -15390,32 +15384,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -15437,7 +15431,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
             },
             "funding": [
                 {
@@ -15445,32 +15439,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.0",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -15500,7 +15494,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -15508,32 +15502,87 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:05:40+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
-            "name": "sebastian/type",
-            "version": "4.0.0",
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -15556,7 +15605,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -15564,29 +15613,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -15609,7 +15658,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
             },
             "funding": [
                 {
@@ -15617,7 +15666,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a201d96d50a62ee1999e32b2e2b8bf9d",
+    "content-hash": "03db08cf01542d511d9190131b75896b",
     "packages": [
         {
             "name": "async-aws/core",
@@ -14155,16 +14155,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.29",
+            "version": "10.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
+                "reference": "a56a9ab2f680246adcf3db43f38ddf1765774735"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a56a9ab2f680246adcf3db43f38ddf1765774735",
+                "reference": "a56a9ab2f680246adcf3db43f38ddf1765774735",
                 "shasum": ""
             },
             "require": {
@@ -14172,18 +14172,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.15",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -14192,7 +14192,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -14221,7 +14221,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.9"
             },
             "funding": [
                 {
@@ -14229,32 +14229,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-19T04:57:46+00:00"
+            "time": "2023-11-23T12:23:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -14281,7 +14281,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -14289,28 +14290,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -14318,7 +14319,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -14344,7 +14345,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -14352,32 +14353,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -14403,7 +14404,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -14411,32 +14413,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -14462,7 +14464,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -14470,24 +14472,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.15",
+            "version": "10.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
+                "reference": "d5d9dca6a902d05b34c4bcbc7c1636ce1dc25408"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d5d9dca6a902d05b34c4bcbc7c1636ce1dc25408",
+                "reference": "d5d9dca6a902d05b34c4bcbc7c1636ce1dc25408",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -14497,27 +14498,26 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.5",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.1",
+                "sebastian/global-state": "^6.0.1",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -14525,7 +14525,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -14557,7 +14557,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.1"
             },
             "funding": [
                 {
@@ -14573,7 +14573,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:55:19+00:00"
+            "time": "2023-12-01T16:57:05+00:00"
         },
         {
             "name": "sanmai/later",
@@ -14706,28 +14706,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -14750,7 +14750,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
             },
             "funding": [
                 {
@@ -14758,32 +14758,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2023-02-03T06:58:15+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -14806,7 +14806,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -14814,32 +14814,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -14861,7 +14861,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -14869,34 +14869,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -14935,7 +14937,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
             },
             "funding": [
                 {
@@ -14943,33 +14946,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2023-08-14T13:18:12+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68cfb347a44871f01e33ab0ef8215966432f6957",
+                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.1-dev"
                 }
             },
             "autoload": {
@@ -14992,7 +14995,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.1.0"
             },
             "funding": [
                 {
@@ -15000,33 +15004,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-09-28T11:50:59+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^10.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -15058,7 +15062,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
             },
             "funding": [
                 {
@@ -15066,27 +15071,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2023-05-01T07:48:21+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -15094,7 +15099,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -15113,7 +15118,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -15121,7 +15126,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
             },
             "funding": [
                 {
@@ -15129,34 +15135,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2023-04-11T05:39:26+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64f51654862e0f5e318db7e9dcc2292c63cdbddc",
+                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -15198,7 +15204,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.1"
             },
             "funding": [
                 {
@@ -15206,38 +15213,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2023-09-24T13:22:09+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.6",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -15262,7 +15266,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
             },
             "funding": [
                 {
@@ -15270,33 +15275,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-02T09:26:13+00:00"
+            "time": "2023-07-19T07:19:23+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/649e40d279e243d985aa8fb6e74dd5bb28dc185d",
+                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -15319,7 +15324,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.1"
             },
             "funding": [
                 {
@@ -15327,34 +15333,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-08-31T09:25:50+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -15376,7 +15382,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -15384,32 +15390,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -15431,7 +15437,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -15439,32 +15445,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -15494,7 +15500,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -15502,87 +15508,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -15605,7 +15556,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -15613,29 +15564,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -15658,7 +15609,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -15666,7 +15617,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -16438,5 +16389,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,15 +6,13 @@
          backupGlobals="false"
          colors="true"
          bootstrap="tests/bootstrap.php"
-         convertDeprecationsToExceptions="false"
+         failOnDeprecation="true"
 >
     <php>
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
-        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
     </php>
 
     <testsuites>
@@ -23,15 +21,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
+    </source>
 
     <extensions>
     </extensions>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,13 +6,15 @@
          backupGlobals="false"
          colors="true"
          bootstrap="tests/bootstrap.php"
-         failOnDeprecation="true"
+         convertDeprecationsToExceptions="false"
 >
     <php>
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="9.6" />
     </php>
 
     <testsuites>
@@ -21,11 +23,15 @@
         </testsuite>
     </testsuites>
 
-    <source>
+    <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </source>
+    </coverage>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 
     <extensions>
     </extensions>

--- a/symfony.lock
+++ b/symfony.lock
@@ -734,12 +734,12 @@
         "version": "v5.3.0"
     },
     "symfony/phpunit-bridge": {
-        "version": "6.3",
+        "version": "7.0",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "6.3",
-            "ref": "01dfaa98c58f7a7b5a9b30e6edb7074af7ed9819"
+            "ref": "1f5830c331065b6e4c9d5fa2105e322d29fcd573"
         },
         "files": [
             ".env.test",

--- a/tests/Classes/SessionUserTest.php
+++ b/tests/Classes/SessionUserTest.php
@@ -1451,7 +1451,7 @@ class SessionUserTest extends TestCase
         $this->assertFalse($sessionUser->isThePrimarySchool($otherSchool));
     }
 
-    public function rolesInSessionProvider(): array
+    public static function rolesInSessionProvider(): array
     {
         $sessionId = 2;
         return [

--- a/tests/Command/CleanupStringsCommandTest.php
+++ b/tests/Command/CleanupStringsCommandTest.php
@@ -350,7 +350,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         );
     }
 
-    public function correctLearningMaterialLinksProvider(): array
+    public static function correctLearningMaterialLinksProvider(): array
     {
         return [
             ['iliosproject.org', 'https://iliosproject.org'],
@@ -382,7 +382,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->assertStringContainsString("1 learning material links updated, 0 failures.", $output);
     }
 
-    public function correctLearningMaterialLinksWhithoutFetchingProvider(): array
+    public static function correctLearningMaterialLinksWhithoutFetchingProvider(): array
     {
         return [
             [' http://iliosproject.org', 'http://iliosproject.org'],
@@ -420,7 +420,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->assertStringContainsString("1 learning material links updated, 0 failures.", $output);
     }
 
-    public function correctLearningMaterialLinksNoChangesProvider(): array
+    public static function correctLearningMaterialLinksNoChangesProvider(): array
     {
         return [
             [null],

--- a/tests/Command/CreateServiceTokenCommandTest.php
+++ b/tests/Command/CreateServiceTokenCommandTest.php
@@ -104,7 +104,7 @@ class CreateServiceTokenCommandTest extends KernelTestCase
         );
     }
 
-    public function createTokenWithWriteableSchoolsProvider(): array
+    public static function createTokenWithWriteableSchoolsProvider(): array
     {
         return [
             ['1', [1]],

--- a/tests/Command/SendChangeAlertsCommandTest.php
+++ b/tests/Command/SendChangeAlertsCommandTest.php
@@ -300,9 +300,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
         $this->assertStringContainsString("Marked 1 offering change alerts as dispatched.", $output);
     }
 
-
-
-    public function executeProvider(): array
+    public static function executeProvider(): array
     {
         $schoolA = new School();
         $schoolA->setId(1);
@@ -410,8 +408,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
         ];
     }
 
-
-    public function executeRecipientWithoutEmailProvider(): array
+    public static function executeRecipientWithoutEmailProvider(): array
     {
         $school = new School();
         $course = new Course();
@@ -431,8 +428,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
         return [[ $alert, $offering ]];
     }
 
-
-    public function executeNoRecipientsConfiguredProvider(): array
+    public static function executeNoRecipientsConfiguredProvider(): array
     {
         $school = new School();
         $school->setId(1);
@@ -452,8 +448,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
         return [[ $alert, $offering ]];
     }
 
-
-    public function executeDeletedOfferingProvider(): array
+    public static function executeDeletedOfferingProvider(): array
     {
         $school = new School();
         $course = new Course();

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -10,7 +10,7 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 
 /**
  * General API tests.
@@ -18,7 +18,7 @@ use App\Tests\Traits\JsonControllerTest;
  */
 class ApiControllerTest extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
 
     protected string $apiVersion = 'v3';
 

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -10,7 +10,7 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 
 /**
  * General API tests.
@@ -18,7 +18,7 @@ use App\Tests\Traits\JsonControllerTestable;
  */
 class ApiControllerTest extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
 
     protected string $apiVersion = 'v3';
 

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -8,7 +8,7 @@ use App\Service\JsonWebTokenManager;
 use App\Tests\Fixture\LoadAuthenticationData;
 use App\Tests\Fixture\LoadServiceTokenData;
 use App\Tests\GetUrlTrait;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 use DateTime;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
@@ -27,7 +27,7 @@ use function var_export;
  */
 class AuthControllerTest extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
     use GetUrlTrait;
 
     protected string $apiVersion = 'v3';

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -8,7 +8,7 @@ use App\Service\JsonWebTokenManager;
 use App\Tests\Fixture\LoadAuthenticationData;
 use App\Tests\Fixture\LoadServiceTokenData;
 use App\Tests\GetUrlTrait;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 use DateTime;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
@@ -27,7 +27,7 @@ use function var_export;
  */
 class AuthControllerTest extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
     use GetUrlTrait;
 
     protected string $apiVersion = 'v3';

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -6,7 +6,7 @@ namespace App\Tests\Controller;
 
 use App\Tests\Fixture\LoadApplicationConfigData;
 use App\Tests\TestVersionProvider;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ConfigControllerTest extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
 
     protected KernelBrowser $kernelBrowser;
 

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -6,7 +6,7 @@ namespace App\Tests\Controller;
 
 use App\Tests\Fixture\LoadApplicationConfigData;
 use App\Tests\TestVersionProvider;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ConfigControllerTest extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
 
     protected KernelBrowser $kernelBrowser;
 

--- a/tests/Controller/CurriculumInventoryDownloadControllerTest.php
+++ b/tests/Controller/CurriculumInventoryDownloadControllerTest.php
@@ -19,7 +19,7 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 
 /**
  * @coversDefaultClass \App\Controller\CurriculumInventoryDownloadController
@@ -27,7 +27,7 @@ use App\Tests\Traits\JsonControllerTestable;
  */
 class CurriculumInventoryDownloadControllerTest extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
     use GetUrlTrait;
 
     protected KernelBrowser $kernelBrowser;

--- a/tests/Controller/CurriculumInventoryDownloadControllerTest.php
+++ b/tests/Controller/CurriculumInventoryDownloadControllerTest.php
@@ -19,7 +19,7 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 
 /**
  * @coversDefaultClass \App\Controller\CurriculumInventoryDownloadController
@@ -27,7 +27,7 @@ use App\Tests\Traits\JsonControllerTest;
  */
 class CurriculumInventoryDownloadControllerTest extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
     use GetUrlTrait;
 
     protected KernelBrowser $kernelBrowser;

--- a/tests/Controller/DownloadControllerTest.php
+++ b/tests/Controller/DownloadControllerTest.php
@@ -19,7 +19,7 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 
 /**
  * @coversDefaultClass \App\Controller\DownloadController
@@ -27,7 +27,7 @@ use App\Tests\Traits\JsonControllerTestable;
  */
 class DownloadControllerTest extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
     use GetUrlTrait;
 
     protected ProxyReferenceRepository $fixtures;

--- a/tests/Controller/DownloadControllerTest.php
+++ b/tests/Controller/DownloadControllerTest.php
@@ -19,7 +19,7 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 
 /**
  * @coversDefaultClass \App\Controller\DownloadController
@@ -27,7 +27,7 @@ use App\Tests\Traits\JsonControllerTest;
  */
 class DownloadControllerTest extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
     use GetUrlTrait;
 
     protected ProxyReferenceRepository $fixtures;

--- a/tests/Controller/ErrorControllerTest.php
+++ b/tests/Controller/ErrorControllerTest.php
@@ -10,7 +10,7 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 
 /**
  * @coversDefaultClass \App\Controller\ErrorController
@@ -18,7 +18,7 @@ use App\Tests\Traits\JsonControllerTestable;
  */
 class ErrorControllerTest extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
 
     protected KernelBrowser $kernelBrowser;
 

--- a/tests/Controller/ErrorControllerTest.php
+++ b/tests/Controller/ErrorControllerTest.php
@@ -10,7 +10,7 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 
 /**
  * @coversDefaultClass \App\Controller\ErrorController
@@ -18,7 +18,7 @@ use App\Tests\Traits\JsonControllerTest;
  */
 class ErrorControllerTest extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
 
     protected KernelBrowser $kernelBrowser;
 

--- a/tests/Controller/IcsControllerTest.php
+++ b/tests/Controller/IcsControllerTest.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\DataLoader\SessionData;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 
 /**
  * @coversDefaultClass \App\Controller\IcsController
@@ -26,7 +26,7 @@ use App\Tests\Traits\JsonControllerTest;
  */
 class IcsControllerTest extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
     use GetUrlTrait;
 
     protected string $apiVersion = 'v3';

--- a/tests/Controller/IcsControllerTest.php
+++ b/tests/Controller/IcsControllerTest.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use App\Tests\DataLoader\SessionData;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 
 /**
  * @coversDefaultClass \App\Controller\IcsController
@@ -26,7 +26,7 @@ use App\Tests\Traits\JsonControllerTestable;
  */
 class IcsControllerTest extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
     use GetUrlTrait;
 
     protected string $apiVersion = 'v3';

--- a/tests/Controller/UploadControllerTest.php
+++ b/tests/Controller/UploadControllerTest.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 
 /**
  * @coversDefaultClass \App\Controller\UploadController
@@ -20,7 +20,7 @@ use App\Tests\Traits\JsonControllerTestable;
  */
 class UploadControllerTest extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
 
     protected KernelBrowser $kernelBrowser;
     protected string $fakeTestFileDir;

--- a/tests/Controller/UploadControllerTest.php
+++ b/tests/Controller/UploadControllerTest.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 
 /**
  * @coversDefaultClass \App\Controller\UploadController
@@ -20,7 +20,7 @@ use App\Tests\Traits\JsonControllerTest;
  */
 class UploadControllerTest extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
 
     protected KernelBrowser $kernelBrowser;
     protected string $fakeTestFileDir;

--- a/tests/Endpoints/AamcMethodTest.php
+++ b/tests/Endpoints/AamcMethodTest.php
@@ -30,7 +30,7 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'description' => ['description', 'lorem ipsum'],
@@ -43,7 +43,7 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [];
     }
@@ -51,7 +51,7 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 'AM001']],
@@ -62,9 +62,13 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
             'notActive' => [[1], ['active' => false]],
         ];
     }
-    public function graphQLFiltersToTest(): array
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => ['AM001', 'AM002']]];
 
         return $filters;

--- a/tests/Endpoints/AamcMethodTest.php
+++ b/tests/Endpoints/AamcMethodTest.php
@@ -136,4 +136,22 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
             json_encode([])
         );
     }
+
+    public function testPutReadOnly(
+        ?string $key = null,
+        mixed $id = null,
+        mixed $value = null,
+        bool $skipped = false
+    ): void {
+        $this->markTestSkipped('test not applicable');
+    }
+
+    public function testPutReadOnlyWithServiceToken(
+        ?string $key = null,
+        mixed $id = null,
+        mixed $value = null,
+        bool $skipped = false
+    ): void {
+        $this->markTestSkipped('test not applicable');
+    }
 }

--- a/tests/Endpoints/AamcMethodTest.php
+++ b/tests/Endpoints/AamcMethodTest.php
@@ -27,9 +27,6 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -40,17 +37,11 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -63,9 +54,6 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/AamcPcrsTest.php
+++ b/tests/Endpoints/AamcPcrsTest.php
@@ -31,7 +31,7 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'description' => ['description', 'lorem ipsum'],
@@ -43,7 +43,7 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [];
     }
@@ -51,13 +51,21 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 'aamc-pcrs-comp-c0101']],
             'description' => [[1], ['description' => 'second description']],
             'competencies' => [[0], ['competencies' => [1]]],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
+    {
+        return self::filtersToTest();
     }
 
     public function testPostTermAamcResourceType(): void

--- a/tests/Endpoints/AamcPcrsTest.php
+++ b/tests/Endpoints/AamcPcrsTest.php
@@ -28,9 +28,6 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -40,17 +37,11 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -60,9 +51,6 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         return self::filtersToTest();

--- a/tests/Endpoints/AamcPcrsTest.php
+++ b/tests/Endpoints/AamcPcrsTest.php
@@ -193,4 +193,22 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
             json_encode([])
         );
     }
+
+    public function testPutReadOnly(
+        ?string $key = null,
+        mixed $id = null,
+        mixed $value = null,
+        bool $skipped = false
+    ): void {
+        $this->markTestSkipped('test not applicable');
+    }
+
+    public function testPutReadOnlyWithServiceToken(
+        ?string $key = null,
+        mixed $id = null,
+        mixed $value = null,
+        bool $skipped = false
+    ): void {
+        $this->markTestSkipped('test not applicable');
+    }
 }

--- a/tests/Endpoints/AamcResourceTypeTest.php
+++ b/tests/Endpoints/AamcResourceTypeTest.php
@@ -27,9 +27,6 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -40,17 +37,11 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -61,9 +52,6 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         return self::filtersToTest();

--- a/tests/Endpoints/AamcResourceTypeTest.php
+++ b/tests/Endpoints/AamcResourceTypeTest.php
@@ -150,4 +150,22 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
             json_encode([])
         );
     }
+
+    public function testPutReadOnly(
+        ?string $key = null,
+        mixed $id = null,
+        mixed $value = null,
+        bool $skipped = false
+    ): void {
+        $this->markTestSkipped('test not applicable');
+    }
+
+    public function testPutReadOnlyWithServiceToken(
+        ?string $key = null,
+        mixed $id = null,
+        mixed $value = null,
+        bool $skipped = false
+    ): void {
+        $this->markTestSkipped('test not applicable');
+    }
 }

--- a/tests/Endpoints/AamcResourceTypeTest.php
+++ b/tests/Endpoints/AamcResourceTypeTest.php
@@ -30,7 +30,7 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'sure thing'],
@@ -43,7 +43,7 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [];
     }
@@ -51,7 +51,7 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[2], ['id' => 'RE003']],
@@ -59,6 +59,14 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
             'description' => [[1], ['description' => 'second description']],
             'terms' => [[0], ['terms' => [1]]],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
+    {
+        return self::filtersToTest();
     }
 
     public function testPostTermAamcResourceType(): void

--- a/tests/Endpoints/AbstractEndpoint.php
+++ b/tests/Endpoints/AbstractEndpoint.php
@@ -15,7 +15,7 @@ use Doctrine\Inflector\Inflector;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use App\Tests\DataLoader\DataLoaderInterface;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,7 +34,7 @@ use function var_export;
  */
 abstract class AbstractEndpoint extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
     use GetUrlTrait;
 
     protected string $apiVersion = 'v3';

--- a/tests/Endpoints/AbstractEndpoint.php
+++ b/tests/Endpoints/AbstractEndpoint.php
@@ -15,7 +15,7 @@ use Doctrine\Inflector\Inflector;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use App\Tests\DataLoader\DataLoaderInterface;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,7 +34,7 @@ use function var_export;
  */
 abstract class AbstractEndpoint extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
     use GetUrlTrait;
 
     protected string $apiVersion = 'v3';

--- a/tests/Endpoints/AbstractReadEndpoint.php
+++ b/tests/Endpoints/AbstractReadEndpoint.php
@@ -16,7 +16,15 @@ abstract class AbstractReadEndpoint extends AbstractEndpoint implements GetEndpo
 
     protected bool $enableGetTestsWithServiceToken = true;
 
-    abstract public function filtersToTest(): array;
+    /**
+     * @inheritdoc
+     */
+    abstract public static function filtersToTest(): array;
+
+    /**
+     * @inheritdoc
+     */
+    abstract public static function graphQLFiltersToTest(): array;
 
     public function testGetOne(): void
     {
@@ -120,11 +128,6 @@ abstract class AbstractReadEndpoint extends AbstractEndpoint implements GetEndpo
     {
         $this->anonymousAccessDeniedOneTest();
         $this->anonymousAccessDeniedAllTest();
-    }
-
-    public function graphQLFiltersToTest(): array
-    {
-        return $this->filtersToTest();
     }
 
     protected function runGetOneTest(string $jwt): void

--- a/tests/Endpoints/AbstractReadEndpoint.php
+++ b/tests/Endpoints/AbstractReadEndpoint.php
@@ -16,14 +16,8 @@ abstract class AbstractReadEndpoint extends AbstractEndpoint implements GetEndpo
 
     protected bool $enableGetTestsWithServiceToken = true;
 
-    /**
-     * @inheritdoc
-     */
     abstract public static function filtersToTest(): array;
 
-    /**
-     * @inheritdoc
-     */
     abstract public static function graphQLFiltersToTest(): array;
 
     public function testGetOne(): void

--- a/tests/Endpoints/AcademicYearTest.php
+++ b/tests/Endpoints/AcademicYearTest.php
@@ -28,7 +28,7 @@ class AcademicYearTest extends AbstractReadEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             // 'id' => [[1], ['id' => 2013]], // skipped
@@ -36,6 +36,14 @@ class AcademicYearTest extends AbstractReadEndpoint
             // 'title' => [[1], ['id' => 2013]], // skipped
             // 'titles' => [[0, 2], ['id' => [2012, 2016]]], // skipped
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
+    {
+        return self::filtersToTest();
     }
 
     public function testPostIs404()

--- a/tests/Endpoints/AcademicYearTest.php
+++ b/tests/Endpoints/AcademicYearTest.php
@@ -25,9 +25,6 @@ class AcademicYearTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -38,9 +35,6 @@ class AcademicYearTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         return self::filtersToTest();

--- a/tests/Endpoints/AcademicYearTest.php
+++ b/tests/Endpoints/AcademicYearTest.php
@@ -232,4 +232,19 @@ class AcademicYearTest extends AbstractReadEndpoint
         }
         $this->filterTest($filters, $expectedData, $jwt);
     }
+
+    public function testFilters(array $dataKeys = [], array $filterParts = []): void
+    {
+        $this->markTestSkipped('test not applicable');
+    }
+
+    public function testFiltersWithServiceToken(array $dataKeys = [], array $filterParts = []): void
+    {
+        $this->markTestSkipped('test not applicable');
+    }
+
+    public function testGraphQLFilters(array $dataKeys = [], array $filterParts = [], $skipped = false): void
+    {
+        $this->markTestSkipped('test not applicable');
+    }
 }

--- a/tests/Endpoints/ApplicationConfigTest.php
+++ b/tests/Endpoints/ApplicationConfigTest.php
@@ -27,9 +27,6 @@ class ApplicationConfigTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -38,9 +35,6 @@ class ApplicationConfigTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -48,9 +42,6 @@ class ApplicationConfigTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -61,9 +52,6 @@ class ApplicationConfigTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         return self::filtersToTest();

--- a/tests/Endpoints/ApplicationConfigTest.php
+++ b/tests/Endpoints/ApplicationConfigTest.php
@@ -30,7 +30,7 @@ class ApplicationConfigTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'value' => ['value', 'lorem'],
@@ -41,7 +41,7 @@ class ApplicationConfigTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -51,7 +51,7 @@ class ApplicationConfigTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -59,6 +59,14 @@ class ApplicationConfigTest extends AbstractReadWriteEndpoint
             'name' => [[1], ['name' => 'second name']],
             'value' => [[2], ['value' => 'third value']],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
+    {
+        return self::filtersToTest();
     }
 
     public function testAccessDeniedWithServiceToken(): void

--- a/tests/Endpoints/AssessmentOptionTest.php
+++ b/tests/Endpoints/AssessmentOptionTest.php
@@ -27,9 +27,6 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -38,9 +35,6 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -48,9 +42,6 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -61,9 +52,6 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/AssessmentOptionTest.php
+++ b/tests/Endpoints/AssessmentOptionTest.php
@@ -30,7 +30,7 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'name' => ['name', 'lorem ipsum'],
@@ -41,7 +41,7 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -51,7 +51,7 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -60,9 +60,13 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
             'sessionTypes' => [[0], ['sessionTypes' => [1]]],
         ];
     }
-    public function graphQLFiltersToTest(): array
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/AuthenticationTest.php
+++ b/tests/Endpoints/AuthenticationTest.php
@@ -50,9 +50,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -61,9 +58,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -71,9 +65,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -82,9 +73,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         return self::filtersToTest();
@@ -295,7 +283,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication users
      * 'user' as the Primary Key
-     * @inheritdoc
      */
     protected function runDeleteTest(string $jwt): void
     {
@@ -307,7 +294,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication uses
      * 'user' the ID
-     * @inheritdoc
      */
     protected function getOneTest(string $jwt): array
     {
@@ -341,7 +327,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
      * Overridden because authentication users
      * 'user' as the Primary Key
      * @dataProvider putsToTest
-     * @inheritdoc
      */
     protected function runPutTest($key, $value, string $jwt): void
     {
@@ -363,7 +348,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication users
      * 'user' as the Primary Key
-     * @inheritdoc
      */
     protected function runPutForAllDataTest(string $jwt): void
     {
@@ -379,7 +363,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication users
      * 'user' as the Primary Key
-     * @inheritdoc
      */
     protected function runPatchForAllDataJsonApiTest(string $jwt): void
     {
@@ -397,7 +380,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication users
      * 'user' as the Primary Key
-     * @inheritdoc
      */
     protected function runPostManyTest(string $jwt): void
     {
@@ -409,7 +391,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication users
      * 'user' as the Primary Key
-     * @inheritdoc
      */
     protected function runPostManyJsonApiTest(string $jwt): void
     {
@@ -421,7 +402,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication users
      * 'user' as the Primary Key
-     * @inheritdoc
      */
     protected function postTest(array $data, array $postData, string $jwt): array
     {
@@ -439,7 +419,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication users
      * 'user' as the Primary Key
-     * @inheritdoc
      */
     protected function putTest(array $data, array $postData, mixed $id, string $jwt, $new = false): array
     {
@@ -457,7 +436,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication users
      * 'user' as the Primary Key
-     * @inheritdoc
      */
     protected function postManyTest(array $data, string $jwt): array
     {
@@ -503,7 +481,6 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * Overridden because authentication users
      * 'user' as the Primary Key
-     * @inheritdoc
      */
     protected function getOne(
         string $endpoint,

--- a/tests/Endpoints/AuthenticationTest.php
+++ b/tests/Endpoints/AuthenticationTest.php
@@ -53,7 +53,7 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'username' => ['username', 'devnull'],
@@ -64,7 +64,7 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'invalidateTokenIssuedBefore' => ['invalidateTokenIssuedBefore', 1, 99],
@@ -74,12 +74,20 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'user' => [[1], ['user' => 2]],
             'username' => [[1], ['username' => 'newuser']],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
+    {
+        return self::filtersToTest();
     }
 
     public function testPostMultipleAuthenticationWithEmptyPassword(): void

--- a/tests/Endpoints/CohortTest.php
+++ b/tests/Endpoints/CohortTest.php
@@ -35,9 +35,6 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -48,9 +45,6 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -58,9 +52,6 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -76,9 +67,6 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CohortTest.php
+++ b/tests/Endpoints/CohortTest.php
@@ -38,7 +38,7 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'dev null'],
@@ -51,7 +51,7 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -61,7 +61,7 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -76,10 +76,12 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
         ];
     }
 
-
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/CompetencyTest.php
+++ b/tests/Endpoints/CompetencyTest.php
@@ -41,9 +41,6 @@ class CompetencyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -57,9 +54,6 @@ class CompetencyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -67,9 +61,6 @@ class CompetencyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -91,9 +82,6 @@ class CompetencyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CompetencyTest.php
+++ b/tests/Endpoints/CompetencyTest.php
@@ -44,7 +44,7 @@ class CompetencyTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'rhababerbarbara'],
@@ -60,7 +60,7 @@ class CompetencyTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -70,7 +70,7 @@ class CompetencyTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -91,10 +91,12 @@ class CompetencyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/CourseClerkshipTypeTest.php
+++ b/tests/Endpoints/CourseClerkshipTypeTest.php
@@ -27,9 +27,6 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -38,9 +35,6 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -48,9 +42,6 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -61,9 +52,6 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CourseClerkshipTypeTest.php
+++ b/tests/Endpoints/CourseClerkshipTypeTest.php
@@ -30,7 +30,7 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'too much salt!'],
@@ -41,7 +41,7 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -51,7 +51,7 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -61,10 +61,12 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/CourseLearningMaterialTest.php
+++ b/tests/Endpoints/CourseLearningMaterialTest.php
@@ -31,7 +31,7 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'notes' => ['notes', 'needs more salt'],
@@ -49,7 +49,7 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -59,7 +59,7 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -76,10 +76,12 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/CourseLearningMaterialTest.php
+++ b/tests/Endpoints/CourseLearningMaterialTest.php
@@ -28,9 +28,6 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -46,9 +43,6 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -56,9 +50,6 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -76,9 +67,6 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CourseObjectiveTest.php
+++ b/tests/Endpoints/CourseObjectiveTest.php
@@ -39,7 +39,7 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'enough with the salt already'],
@@ -53,12 +53,15 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [];
     }
 
-    public function filtersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -74,9 +77,12 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
         $filters['ancestor'] = [[1], ['ancestor' => 1]];
 
@@ -116,7 +122,7 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
     }
 
 
-    public function inputSanitationTestProvider(): array
+    public static function inputSanitationTestProvider(): array
     {
         return [
             ['foo', 'foo'],

--- a/tests/Endpoints/CourseObjectiveTest.php
+++ b/tests/Endpoints/CourseObjectiveTest.php
@@ -53,9 +53,14 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
+    /**
+     * @inheritdoc
+     */
     public static function readOnlyPropertiesToTest(): array
     {
-        return [];
+        return [
+            'id' => ['id', 1, 99],
+        ];
     }
 
     /**

--- a/tests/Endpoints/CourseObjectiveTest.php
+++ b/tests/Endpoints/CourseObjectiveTest.php
@@ -53,9 +53,6 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -63,9 +60,6 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -82,9 +76,6 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -59,7 +59,7 @@ class CourseTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'icicles are not a snack'],
@@ -95,7 +95,7 @@ class CourseTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -105,7 +105,7 @@ class CourseTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -143,9 +143,12 @@ class CourseTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
 
         return $filters;
@@ -918,7 +921,7 @@ class CourseTest extends AbstractReadWriteEndpoint
     }
 
 
-    protected function qsToTest(): array
+    public static function qsToTest(): array
     {
         return [
             ['first', [0]],

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -56,9 +56,6 @@ class CourseTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -92,9 +89,6 @@ class CourseTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -102,9 +96,6 @@ class CourseTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -143,9 +134,6 @@ class CourseTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CurrentSessionTest.php
+++ b/tests/Endpoints/CurrentSessionTest.php
@@ -12,14 +12,14 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTest;
+use App\Tests\Traits\JsonControllerTestable;
 
 /**
  * @group api_3
  */
 class CurrentSessionTest extends WebTestCase
 {
-    use JsonControllerTest;
+    use JsonControllerTestable;
     use GetUrlTrait;
 
     protected KernelBrowser $kernelBrowser;

--- a/tests/Endpoints/CurrentSessionTest.php
+++ b/tests/Endpoints/CurrentSessionTest.php
@@ -12,14 +12,14 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use App\Tests\Traits\JsonControllerTestable;
+use App\Tests\Traits\TestableJsonController;
 
 /**
  * @group api_3
  */
 class CurrentSessionTest extends WebTestCase
 {
-    use JsonControllerTestable;
+    use TestableJsonController;
     use GetUrlTrait;
 
     protected KernelBrowser $kernelBrowser;

--- a/tests/Endpoints/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/Endpoints/CurriculumInventoryAcademicLevelTest.php
@@ -32,7 +32,7 @@ class CurriculumInventoryAcademicLevelTest extends AbstractReadEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -46,9 +46,12 @@ class CurriculumInventoryAcademicLevelTest extends AbstractReadEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/Endpoints/CurriculumInventoryAcademicLevelTest.php
@@ -29,9 +29,6 @@ class CurriculumInventoryAcademicLevelTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -46,9 +43,6 @@ class CurriculumInventoryAcademicLevelTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CurriculumInventoryInstitutionTest.php
+++ b/tests/Endpoints/CurriculumInventoryInstitutionTest.php
@@ -27,7 +27,7 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'name' => ['name', 'school of learning'],
@@ -44,7 +44,7 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -54,7 +54,7 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -70,9 +70,12 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/CurriculumInventoryInstitutionTest.php
+++ b/tests/Endpoints/CurriculumInventoryInstitutionTest.php
@@ -24,9 +24,6 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -41,9 +38,6 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -51,9 +45,6 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -70,9 +61,6 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/Endpoints/CurriculumInventoryReportTest.php
@@ -35,9 +35,6 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -59,9 +56,6 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -69,9 +63,6 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -89,9 +80,6 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/Endpoints/CurriculumInventoryReportTest.php
@@ -38,7 +38,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'name' => ['name', 'salt'],
@@ -62,7 +62,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -72,7 +72,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -89,9 +89,12 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
@@ -25,9 +25,6 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -53,9 +50,6 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -63,9 +57,6 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -95,9 +86,6 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
@@ -28,7 +28,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'a block of salt'],
@@ -56,7 +56,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -66,7 +66,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -94,9 +94,13 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
             'excludedSessions' => [[0], ['sessions' => [1]]],
         ];
     }
-    public function graphQLFiltersToTest(): array
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/CurriculumInventorySequenceTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceTest.php
@@ -24,9 +24,6 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -34,9 +31,6 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -44,9 +38,6 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -57,9 +48,6 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/CurriculumInventorySequenceTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceTest.php
@@ -27,7 +27,7 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'description' => ['description', 'some text here'],
@@ -37,7 +37,7 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -47,7 +47,7 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -57,9 +57,12 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/GetEndpointTestInterface.php
+++ b/tests/Endpoints/GetEndpointTestInterface.php
@@ -16,12 +16,12 @@ interface GetEndpointTestInterface
      * positions:  array of the positions the expected items from the DataLoader
      * filter: array containing the filterKey and filterValue we are testing
      */
-    public function filtersToTest(): array;
+    public static function filtersToTest(): array;
 
     /**
      * An array of GraphQL filters to test.
      */
-    public function graphQLFiltersToTest(): array;
+    public static function graphQLFiltersToTest(): array;
 
     /**
      * Test fetching a single object

--- a/tests/Endpoints/IlmSessionTest.php
+++ b/tests/Endpoints/IlmSessionTest.php
@@ -29,7 +29,7 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'hours' => ['hours', 10.25],
@@ -44,7 +44,7 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -54,7 +54,7 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -70,9 +70,12 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/IlmSessionTest.php
+++ b/tests/Endpoints/IlmSessionTest.php
@@ -26,9 +26,6 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -41,9 +38,6 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -51,9 +45,6 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -70,9 +61,6 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/IngestionExceptionTest.php
+++ b/tests/Endpoints/IngestionExceptionTest.php
@@ -23,9 +23,6 @@ class IngestionExceptionTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -36,9 +33,6 @@ class IngestionExceptionTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         return self::filtersToTest();

--- a/tests/Endpoints/IngestionExceptionTest.php
+++ b/tests/Endpoints/IngestionExceptionTest.php
@@ -26,7 +26,7 @@ class IngestionExceptionTest extends AbstractReadEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -34,6 +34,14 @@ class IngestionExceptionTest extends AbstractReadEndpoint
             'uid' => [[1], ['uid' => 'second exception']],
             'user' => [[1], ['user' => 2]],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
+    {
+        return self::filtersToTest();
     }
 
     public function testPostIs404(): void

--- a/tests/Endpoints/InstructorGroupTest.php
+++ b/tests/Endpoints/InstructorGroupTest.php
@@ -40,7 +40,7 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'admin group'],
@@ -55,7 +55,7 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -65,7 +65,7 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -86,9 +86,12 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/InstructorGroupTest.php
+++ b/tests/Endpoints/InstructorGroupTest.php
@@ -37,9 +37,6 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -52,9 +49,6 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -62,9 +56,6 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -86,9 +77,6 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/LearnerGroupTest.php
+++ b/tests/Endpoints/LearnerGroupTest.php
@@ -33,9 +33,6 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -56,9 +53,6 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -66,9 +60,6 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -93,9 +84,6 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/LearnerGroupTest.php
+++ b/tests/Endpoints/LearnerGroupTest.php
@@ -36,7 +36,7 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'group of learners'],
@@ -59,7 +59,7 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -69,7 +69,7 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -93,9 +93,12 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/LearningMaterialStatusTest.php
+++ b/tests/Endpoints/LearningMaterialStatusTest.php
@@ -23,9 +23,6 @@ class LearningMaterialStatusTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -35,9 +32,6 @@ class LearningMaterialStatusTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/LearningMaterialStatusTest.php
+++ b/tests/Endpoints/LearningMaterialStatusTest.php
@@ -26,7 +26,7 @@ class LearningMaterialStatusTest extends AbstractReadEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -35,9 +35,12 @@ class LearningMaterialStatusTest extends AbstractReadEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -55,9 +55,6 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -77,9 +74,6 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -91,9 +85,6 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -132,9 +123,6 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -58,7 +58,7 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'a document'],
@@ -80,7 +80,7 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -94,7 +94,7 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -132,9 +132,12 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
         unset($filters['school']);
 
@@ -146,7 +149,7 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
         return ['uploadDate'];
     }
 
-    public function qsToTest(): array
+    public static function qsToTest(): array
     {
         return [
             ['first', [0]],

--- a/tests/Endpoints/LearningMaterialUserRoleTest.php
+++ b/tests/Endpoints/LearningMaterialUserRoleTest.php
@@ -23,10 +23,6 @@ class LearningMaterialUserRoleTest extends AbstractReadEndpoint
         ];
     }
 
-
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -36,9 +32,6 @@ class LearningMaterialUserRoleTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/LearningMaterialUserRoleTest.php
+++ b/tests/Endpoints/LearningMaterialUserRoleTest.php
@@ -27,7 +27,7 @@ class LearningMaterialUserRoleTest extends AbstractReadEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -36,9 +36,12 @@ class LearningMaterialUserRoleTest extends AbstractReadEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/MeshConceptTest.php
+++ b/tests/Endpoints/MeshConceptTest.php
@@ -26,7 +26,7 @@ class MeshConceptTest extends AbstractMeshEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => '1']],
@@ -42,9 +42,9 @@ class MeshConceptTest extends AbstractMeshEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => ['1', '2']]];
 
         return $filters;

--- a/tests/Endpoints/MeshConceptTest.php
+++ b/tests/Endpoints/MeshConceptTest.php
@@ -23,9 +23,6 @@ class MeshConceptTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [

--- a/tests/Endpoints/MeshDescriptorTest.php
+++ b/tests/Endpoints/MeshDescriptorTest.php
@@ -51,7 +51,7 @@ class MeshDescriptorTest extends AbstractMeshEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 'abc1']],
@@ -75,9 +75,12 @@ class MeshDescriptorTest extends AbstractMeshEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => ['abc2', 'abc3']]];
         unset($filters['school']);
 
@@ -89,7 +92,7 @@ class MeshDescriptorTest extends AbstractMeshEndpoint
         return ['updatedAt', 'createdAt'];
     }
 
-    public function qsToTest(): array
+    public static function qsToTest(): array
     {
         return [
             ['abc1', [0]],

--- a/tests/Endpoints/MeshDescriptorTest.php
+++ b/tests/Endpoints/MeshDescriptorTest.php
@@ -48,9 +48,6 @@ class MeshDescriptorTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -75,9 +72,6 @@ class MeshDescriptorTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/MeshPreviousIndexingTest.php
+++ b/tests/Endpoints/MeshPreviousIndexingTest.php
@@ -29,9 +29,6 @@ class MeshPreviousIndexingTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -42,9 +39,6 @@ class MeshPreviousIndexingTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/MeshPreviousIndexingTest.php
+++ b/tests/Endpoints/MeshPreviousIndexingTest.php
@@ -32,7 +32,7 @@ class MeshPreviousIndexingTest extends AbstractMeshEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -42,9 +42,12 @@ class MeshPreviousIndexingTest extends AbstractMeshEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/MeshQualifierTest.php
+++ b/tests/Endpoints/MeshQualifierTest.php
@@ -24,7 +24,7 @@ class MeshQualifierTest extends AbstractMeshEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => '1']],
@@ -34,9 +34,12 @@ class MeshQualifierTest extends AbstractMeshEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => ['1', '2']]];
 
         return $filters;

--- a/tests/Endpoints/MeshQualifierTest.php
+++ b/tests/Endpoints/MeshQualifierTest.php
@@ -21,9 +21,6 @@ class MeshQualifierTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -34,9 +31,6 @@ class MeshQualifierTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/MeshTermTest.php
+++ b/tests/Endpoints/MeshTermTest.php
@@ -23,9 +23,6 @@ class MeshTermTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -44,9 +41,6 @@ class MeshTermTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/MeshTermTest.php
+++ b/tests/Endpoints/MeshTermTest.php
@@ -26,7 +26,7 @@ class MeshTermTest extends AbstractMeshEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -44,9 +44,12 @@ class MeshTermTest extends AbstractMeshEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/MeshTreeTest.php
+++ b/tests/Endpoints/MeshTreeTest.php
@@ -21,9 +21,6 @@ class MeshTreeTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -34,9 +31,6 @@ class MeshTreeTest extends AbstractMeshEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/MeshTreeTest.php
+++ b/tests/Endpoints/MeshTreeTest.php
@@ -24,7 +24,7 @@ class MeshTreeTest extends AbstractMeshEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -34,9 +34,12 @@ class MeshTreeTest extends AbstractMeshEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/OfferingTest.php
+++ b/tests/Endpoints/OfferingTest.php
@@ -83,9 +83,6 @@ class OfferingTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -94,9 +91,6 @@ class OfferingTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -116,9 +110,6 @@ class OfferingTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();
@@ -356,7 +347,6 @@ class OfferingTest extends AbstractReadWriteEndpoint
 
     /**
      * Check for updated alerts in addition to other info
-     * @inheritdoc
      */
     protected function postTest(array $data, array $postData, string $jwt): array
     {
@@ -385,7 +375,6 @@ class OfferingTest extends AbstractReadWriteEndpoint
 
     /**
      * Check for updated alerts in addition to other info
-     * @inheritdoc
      */
     protected function postJsonApiTest(object $postData, array $data, string $jwt): array
     {
@@ -419,7 +408,6 @@ class OfferingTest extends AbstractReadWriteEndpoint
 
     /**
      * Allow dates to be skipped if required for a test
-     * @inheritdoc
      */
     protected function compareData(array $expected, array $result): void
     {
@@ -435,7 +423,6 @@ class OfferingTest extends AbstractReadWriteEndpoint
 
     /**
      * Allow dates to be skipped if required for a test
-     * @inheritdoc
      */
     protected function compareGraphQLData(array $expected, object $result): void
     {

--- a/tests/Endpoints/OfferingTest.php
+++ b/tests/Endpoints/OfferingTest.php
@@ -74,7 +74,7 @@ class OfferingTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'session' => ['session', 3],
@@ -86,7 +86,7 @@ class OfferingTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -97,7 +97,7 @@ class OfferingTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -116,9 +116,12 @@ class OfferingTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[3, 4], ['ids' => [4, 5]]];
 
         return $filters;

--- a/tests/Endpoints/OfferingTest.php
+++ b/tests/Endpoints/OfferingTest.php
@@ -59,7 +59,7 @@ class OfferingTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function changeTypePutsToTest(): array
+    public static function changeTypePutsToTest(): array
     {
         return [
             'room' => ['room', 'room 101', AlertChangeTypeInterface::CHANGE_TYPE_LOCATION],

--- a/tests/Endpoints/PendingUserUpdateTest.php
+++ b/tests/Endpoints/PendingUserUpdateTest.php
@@ -29,7 +29,7 @@ class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointI
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'type' => ['type', 'something'],
@@ -42,7 +42,7 @@ class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointI
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -52,7 +52,7 @@ class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointI
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -64,5 +64,13 @@ class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointI
             'users' => [[0], ['users' => [1]]],
             'schools' => [[1], ['schools' => [2]]],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
+    {
+        return self::filtersToTest();
     }
 }

--- a/tests/Endpoints/PendingUserUpdateTest.php
+++ b/tests/Endpoints/PendingUserUpdateTest.php
@@ -26,9 +26,6 @@ class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointI
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -39,9 +36,6 @@ class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointI
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -49,9 +43,6 @@ class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointI
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -66,9 +57,6 @@ class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointI
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         return self::filtersToTest();

--- a/tests/Endpoints/ProgramTest.php
+++ b/tests/Endpoints/ProgramTest.php
@@ -36,7 +36,7 @@ class ProgramTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'history of consciousness'],
@@ -52,7 +52,7 @@ class ProgramTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -62,7 +62,7 @@ class ProgramTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -82,9 +82,12 @@ class ProgramTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
 
         return $filters;

--- a/tests/Endpoints/ProgramTest.php
+++ b/tests/Endpoints/ProgramTest.php
@@ -33,9 +33,6 @@ class ProgramTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -49,9 +46,6 @@ class ProgramTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -59,9 +53,6 @@ class ProgramTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -82,9 +73,6 @@ class ProgramTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/ProgramYearObjectiveTest.php
+++ b/tests/Endpoints/ProgramYearObjectiveTest.php
@@ -39,7 +39,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'gather all the salt'],
@@ -54,12 +54,15 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [];
     }
 
-    public function filtersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -75,9 +78,12 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;
@@ -166,7 +172,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
     }
 
 
-    public function inputSanitationTestProvider(): array
+    public static function inputSanitationTestProvider(): array
     {
         return [
             ['foo', 'foo'],

--- a/tests/Endpoints/ProgramYearObjectiveTest.php
+++ b/tests/Endpoints/ProgramYearObjectiveTest.php
@@ -54,9 +54,14 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
+    /**
+     * @inheritdoc
+     */
     public static function readOnlyPropertiesToTest(): array
     {
-        return [];
+        return [
+            'id' => ['id', 1, 99],
+        ];
     }
 
     /**

--- a/tests/Endpoints/ProgramYearObjectiveTest.php
+++ b/tests/Endpoints/ProgramYearObjectiveTest.php
@@ -54,9 +54,6 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -64,9 +61,6 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -83,9 +77,6 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/ProgramYearTest.php
+++ b/tests/Endpoints/ProgramYearTest.php
@@ -45,7 +45,7 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'startYear' => ['startYear', 2012],
@@ -62,7 +62,7 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -72,7 +72,7 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -94,9 +94,12 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
         $filters['startYear'] = [[1], ['startYear' => 2014]];
 

--- a/tests/Endpoints/ProgramYearTest.php
+++ b/tests/Endpoints/ProgramYearTest.php
@@ -42,9 +42,6 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -59,9 +56,6 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -69,9 +63,6 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -94,9 +85,6 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/PutEndpointTestInterface.php
+++ b/tests/Endpoints/PutEndpointTestInterface.php
@@ -18,7 +18,7 @@ interface PutEndpointTestInterface
      * the key for each item is reflected in the failure message
      * each one will be separately tested in a PUT request
      */
-    public function putsToTest(): array;
+    public static function putsToTest(): array;
 
     /**
      * @return array [field, value, id]
@@ -32,7 +32,7 @@ interface PutEndpointTestInterface
      * the key for each item is reflected in the failure message
      * each one will be separately tested in a PUT request
      */
-    public function readOnlyPropertiesToTest(): array;
+    public static function readOnlyPropertiesToTest(): array;
 
     /**
      * @param string $key

--- a/tests/Endpoints/ReportTest.php
+++ b/tests/Endpoints/ReportTest.php
@@ -31,7 +31,7 @@ class ReportTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'lorem ipsum'],
@@ -46,7 +46,7 @@ class ReportTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -57,7 +57,7 @@ class ReportTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -72,9 +72,12 @@ class ReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
         unset($filters['prepositionalObjectTableRowId']);
 

--- a/tests/Endpoints/ReportTest.php
+++ b/tests/Endpoints/ReportTest.php
@@ -28,9 +28,6 @@ class ReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -43,9 +40,6 @@ class ReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -54,9 +48,6 @@ class ReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -72,9 +63,6 @@ class ReportTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/SchoolConfigTest.php
+++ b/tests/Endpoints/SchoolConfigTest.php
@@ -27,7 +27,7 @@ class SchoolConfigTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'value' => ['value', 'lorem'],
@@ -39,7 +39,7 @@ class SchoolConfigTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -49,7 +49,7 @@ class SchoolConfigTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -58,5 +58,13 @@ class SchoolConfigTest extends AbstractReadWriteEndpoint
             'value' => [[2], ['value' => 'third value']],
             'school' => [[2], ['school' => 2]],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
+    {
+        return self::filtersToTest();
     }
 }

--- a/tests/Endpoints/SchoolConfigTest.php
+++ b/tests/Endpoints/SchoolConfigTest.php
@@ -24,9 +24,6 @@ class SchoolConfigTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -36,9 +33,6 @@ class SchoolConfigTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -46,9 +40,6 @@ class SchoolConfigTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -60,9 +51,6 @@ class SchoolConfigTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         return self::filtersToTest();

--- a/tests/Endpoints/SchoolTest.php
+++ b/tests/Endpoints/SchoolTest.php
@@ -39,9 +39,6 @@ class SchoolTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -62,9 +59,6 @@ class SchoolTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -72,9 +66,6 @@ class SchoolTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -96,9 +87,6 @@ class SchoolTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/SchoolTest.php
+++ b/tests/Endpoints/SchoolTest.php
@@ -42,7 +42,7 @@ class SchoolTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'iliosAdministratorEmail' => ['iliosAdministratorEmail', 'lorem.ipsum@dev.null'],
@@ -65,7 +65,7 @@ class SchoolTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -75,7 +75,7 @@ class SchoolTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -96,9 +96,12 @@ class SchoolTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/SessionLearningMaterialTest.php
+++ b/tests/Endpoints/SessionLearningMaterialTest.php
@@ -37,7 +37,7 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'notes' => ['notes', 'something else'],
@@ -55,7 +55,7 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -65,7 +65,7 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -84,9 +84,12 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Endpoints/SessionLearningMaterialTest.php
+++ b/tests/Endpoints/SessionLearningMaterialTest.php
@@ -34,9 +34,6 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -52,9 +49,6 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -62,9 +56,6 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -84,9 +75,6 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/SessionObjectiveTest.php
+++ b/tests/Endpoints/SessionObjectiveTest.php
@@ -52,9 +52,14 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
+    /**
+     * @inheritdoc
+     */
     public static function readOnlyPropertiesToTest(): array
     {
-        return [];
+        return [
+            'id' => ['id', 1, 99],
+        ];
     }
 
     /**

--- a/tests/Endpoints/SessionObjectiveTest.php
+++ b/tests/Endpoints/SessionObjectiveTest.php
@@ -52,9 +52,6 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -62,9 +59,6 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -84,9 +78,6 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/SessionObjectiveTest.php
+++ b/tests/Endpoints/SessionObjectiveTest.php
@@ -39,7 +39,7 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'lorem ipsum'],
@@ -52,12 +52,15 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [];
     }
 
-    public function filtersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -76,15 +79,18 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;
     }
 
-    public function inputSanitationTestProvider(): array
+    public static function inputSanitationTestProvider(): array
     {
         return [
             ['foo', 'foo'],

--- a/tests/Endpoints/SessionTest.php
+++ b/tests/Endpoints/SessionTest.php
@@ -45,8 +45,6 @@ class SessionTest extends AbstractReadWriteEndpoint
     }
 
     /**
-     * @inheritDoc
-     *
      * returns an array of field / value pairs to modify
      * the key for each item is reflected in the failure message
      * each one will be separately tested in a PUT request
@@ -86,8 +84,6 @@ class SessionTest extends AbstractReadWriteEndpoint
     }
 
     /**
-     * @inheritDoc
-     *
      * returns an array of field / value pairs that are readOnly
      * the key for each item is reflected in the failure message
      * each one will be separately tested in a PUT request
@@ -102,8 +98,6 @@ class SessionTest extends AbstractReadWriteEndpoint
 
 
     /**
-     * @inheritDoc
-     *
      * returns an array of filters to test
      * the key for each item is reflected in the failure message
      * the first item is an array of the positions the expected items

--- a/tests/Endpoints/SessionTest.php
+++ b/tests/Endpoints/SessionTest.php
@@ -51,7 +51,7 @@ class SessionTest extends AbstractReadWriteEndpoint
      * the key for each item is reflected in the failure message
      * each one will be separately tested in a PUT request
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'lorem ipsum'],
@@ -92,7 +92,7 @@ class SessionTest extends AbstractReadWriteEndpoint
      * the key for each item is reflected in the failure message
      * each one will be separately tested in a PUT request
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -110,7 +110,7 @@ class SessionTest extends AbstractReadWriteEndpoint
      * can be found in the data loader
      * the second item is the filter we are testing
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -146,9 +146,9 @@ class SessionTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
         $filters['multipleCourse'] = [[0, 1, 3], ['courses' => [1, 4]]];
         $filters['multipleSessionTypes'] = [[1, 2, 3], ['sessionTypes' => [2]]];
@@ -252,7 +252,7 @@ class SessionTest extends AbstractReadWriteEndpoint
         $this->putTest($data, $postData, $id, $jwt);
     }
 
-    protected function qsToTest(): array
+    public static function qsToTest(): array
     {
         return [
             ['ess', [0, 2, 3, 4, 5, 6, 7]],

--- a/tests/Endpoints/SessionTypeTest.php
+++ b/tests/Endpoints/SessionTypeTest.php
@@ -60,7 +60,7 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'lorem ipsum'],
@@ -78,7 +78,7 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -88,7 +88,7 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -115,9 +115,12 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
         $filters['schools'] = [[0, 1], ['schools' => [1]]];
 

--- a/tests/Endpoints/SessionTypeTest.php
+++ b/tests/Endpoints/SessionTypeTest.php
@@ -57,9 +57,6 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -75,9 +72,6 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -85,9 +79,6 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -115,9 +106,6 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/TermTest.php
+++ b/tests/Endpoints/TermTest.php
@@ -51,9 +51,6 @@ class TermTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -71,9 +68,6 @@ class TermTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -81,9 +75,6 @@ class TermTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -115,9 +106,6 @@ class TermTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/TermTest.php
+++ b/tests/Endpoints/TermTest.php
@@ -54,7 +54,7 @@ class TermTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'description' => ['description', 'lorem'],
@@ -74,7 +74,7 @@ class TermTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -84,7 +84,7 @@ class TermTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -115,9 +115,12 @@ class TermTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;

--- a/tests/Endpoints/UserRoleTest.php
+++ b/tests/Endpoints/UserRoleTest.php
@@ -24,9 +24,6 @@ class UserRoleTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -36,9 +33,6 @@ class UserRoleTest extends AbstractReadEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         return self::filtersToTest();

--- a/tests/Endpoints/UserRoleTest.php
+++ b/tests/Endpoints/UserRoleTest.php
@@ -27,12 +27,20 @@ class UserRoleTest extends AbstractReadEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
             'title' => [[1], ['title' => 'Something Else']],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
+    {
+        return self::filtersToTest();
     }
 }

--- a/tests/Endpoints/UserSessionMaterialStatusTest.php
+++ b/tests/Endpoints/UserSessionMaterialStatusTest.php
@@ -27,7 +27,7 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'statusStarted' => ['status', UserSessionMaterialStatusInterface::STARTED],
@@ -36,7 +36,7 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -44,7 +44,10 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function filtersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -61,9 +64,12 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
         $filters['materials'] = [[0, 2], ['materials' => [1, 5]]];
         $filters['users'] = [[0, 1, 2], ['users' => [2]]];

--- a/tests/Endpoints/UserSessionMaterialStatusTest.php
+++ b/tests/Endpoints/UserSessionMaterialStatusTest.php
@@ -44,9 +44,6 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -64,9 +61,6 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -57,9 +57,6 @@ class UserTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -107,9 +104,6 @@ class UserTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -117,9 +111,6 @@ class UserTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -60,7 +60,7 @@ class UserTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'lastName' => ['lastName', 'ipsum'],
@@ -110,7 +110,7 @@ class UserTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -120,7 +120,7 @@ class UserTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -177,15 +177,15 @@ class UserTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
 
         return $filters;
     }
 
-    public function qsToTest(): array
+    public static function qsToTest(): array
     {
         return [
             ['first', [1]],

--- a/tests/Endpoints/VocabularyTest.php
+++ b/tests/Endpoints/VocabularyTest.php
@@ -23,9 +23,6 @@ class VocabularyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function putsToTest(): array
     {
         return [
@@ -36,9 +33,6 @@ class VocabularyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function readOnlyPropertiesToTest(): array
     {
         return [
@@ -46,9 +40,6 @@ class VocabularyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public static function filtersToTest(): array
     {
         return [
@@ -62,9 +53,6 @@ class VocabularyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function graphQLFiltersToTest(): array
     {
         $filters = self::filtersToTest();

--- a/tests/Endpoints/VocabularyTest.php
+++ b/tests/Endpoints/VocabularyTest.php
@@ -26,7 +26,7 @@ class VocabularyTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function putsToTest(): array
+    public static function putsToTest(): array
     {
         return [
             'title' => ['title', 'foo bar'],
@@ -39,7 +39,7 @@ class VocabularyTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function readOnlyPropertiesToTest(): array
+    public static function readOnlyPropertiesToTest(): array
     {
         return [
             'id' => ['id', 1, 99],
@@ -49,7 +49,7 @@ class VocabularyTest extends AbstractReadWriteEndpoint
     /**
      * @inheritDoc
      */
-    public function filtersToTest(): array
+    public static function filtersToTest(): array
     {
         return [
             'id' => [[0], ['id' => 1]],
@@ -62,9 +62,12 @@ class VocabularyTest extends AbstractReadWriteEndpoint
         ];
     }
 
-    public function graphQLFiltersToTest(): array
+    /**
+     * @inheritdoc
+     */
+    public static function graphQLFiltersToTest(): array
     {
-        $filters = $this->filtersToTest();
+        $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
 
         return $filters;

--- a/tests/Entity/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Entity/CurriculumInventorySequenceBlockTest.php
@@ -242,8 +242,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
         );
     }
 
-
-    public function compareSequenceBlocksWithOrderedStrategyProvider(): array
+    public static function compareSequenceBlocksWithOrderedStrategyProvider(): array
     {
         $rhett = [];
 
@@ -291,8 +290,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
         );
     }
 
-
-    public function compareSequenceBlocksWithDefaultStrategyProvider(): array
+    public static function compareSequenceBlocksWithDefaultStrategyProvider(): array
     {
         $rhett = [];
 

--- a/tests/QEndpointTrait.php
+++ b/tests/QEndpointTrait.php
@@ -9,7 +9,7 @@ use Exception;
 
 trait QEndpointTrait
 {
-    abstract protected function qsToTest(): array;
+    abstract public static function qsToTest(): array;
     abstract protected function getDataLoader(): DataLoaderInterface;
     abstract protected function jsonApiFilterTest(array $filters, array $expectedData, string $jwt): void;
     abstract protected function filterTest(array $filters, array $expectedData, string $jwt): void;

--- a/tests/RelationshipVoter/AamcMethodTest.php
+++ b/tests/RelationshipVoter/AamcMethodTest.php
@@ -58,7 +58,7 @@ class AamcMethodTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [AamcMethodInterface::class, true],
@@ -66,7 +66,7 @@ class AamcMethodTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/AamcPcrsTest.php
+++ b/tests/RelationshipVoter/AamcPcrsTest.php
@@ -57,7 +57,7 @@ class AamcPcrsTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [AamcPcrsInterface::class, true],
@@ -65,7 +65,7 @@ class AamcPcrsTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/AamcResourceTypeTest.php
+++ b/tests/RelationshipVoter/AamcResourceTypeTest.php
@@ -58,7 +58,7 @@ class AamcResourceTypeTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [AamcResourceTypeInterface::class, true],
@@ -66,7 +66,7 @@ class AamcResourceTypeTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/AbstractBase.php
+++ b/tests/RelationshipVoter/AbstractBase.php
@@ -118,7 +118,7 @@ abstract class AbstractBase extends TestCase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
     }
 
-    abstract public function supportsTypeProvider(): array;
+    abstract public static function supportsTypeProvider(): array;
 
     /**
      * @dataProvider supportsTypeProvider
@@ -128,7 +128,7 @@ abstract class AbstractBase extends TestCase
         $this->assertEquals($this->voter->supportsType($className), $isSupported);
     }
 
-    abstract public function supportsAttributesProvider(): array;
+    abstract public static function supportsAttributesProvider(): array;
 
     /**
      * @dataProvider supportsAttributesProvider

--- a/tests/RelationshipVoter/ApplicationConfigDTOTest.php
+++ b/tests/RelationshipVoter/ApplicationConfigDTOTest.php
@@ -33,7 +33,7 @@ class ApplicationConfigDTOTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [ApplicationConfigDTO::class, true],
@@ -41,7 +41,7 @@ class ApplicationConfigDTOTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/ApplicationConfigTest.php
+++ b/tests/RelationshipVoter/ApplicationConfigTest.php
@@ -57,7 +57,7 @@ class ApplicationConfigTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [ApplicationConfigInterface::class, true],
@@ -65,7 +65,7 @@ class ApplicationConfigTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/AssessmentOptionTest.php
+++ b/tests/RelationshipVoter/AssessmentOptionTest.php
@@ -57,7 +57,7 @@ class AssessmentOptionTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [AssessmentOptionInterface::class, true],
@@ -65,7 +65,7 @@ class AssessmentOptionTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/AuthenticationTest.php
+++ b/tests/RelationshipVoter/AuthenticationTest.php
@@ -134,7 +134,7 @@ class AuthenticationTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [AuthenticationInterface::class, true],
@@ -142,7 +142,7 @@ class AuthenticationTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CohortTest.php
+++ b/tests/RelationshipVoter/CohortTest.php
@@ -54,7 +54,7 @@ class CohortTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CohortInterface::class, true],
@@ -62,7 +62,7 @@ class CohortTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CompetencyTest.php
+++ b/tests/RelationshipVoter/CompetencyTest.php
@@ -111,7 +111,7 @@ class CompetencyTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CompetencyInterface::class, true],
@@ -119,7 +119,7 @@ class CompetencyTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CourseClerkshipTypeTest.php
+++ b/tests/RelationshipVoter/CourseClerkshipTypeTest.php
@@ -49,7 +49,7 @@ class CourseClerkshipTypeTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CourseClerkshipTypeInterface::class, true],
@@ -57,7 +57,7 @@ class CourseClerkshipTypeTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CourseLearningMaterialTest.php
+++ b/tests/RelationshipVoter/CourseLearningMaterialTest.php
@@ -133,7 +133,7 @@ class CourseLearningMaterialTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CourseLearningMaterialInterface::class, true],
@@ -141,7 +141,7 @@ class CourseLearningMaterialTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CourseTest.php
+++ b/tests/RelationshipVoter/CourseTest.php
@@ -129,7 +129,7 @@ class CourseTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CourseInterface::class, true],
@@ -138,7 +138,7 @@ class CourseTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/RelationshipVoter/CurriculumInventoryAcademicLevelTest.php
@@ -36,7 +36,7 @@ class CurriculumInventoryAcademicLevelTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventoryAcademicLevelInterface::class, true],
@@ -44,7 +44,7 @@ class CurriculumInventoryAcademicLevelTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CurriculumInventoryExportTest.php
+++ b/tests/RelationshipVoter/CurriculumInventoryExportTest.php
@@ -96,7 +96,7 @@ class CurriculumInventoryExportTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create allowed");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventoryExportInterface::class, true],
@@ -104,7 +104,7 @@ class CurriculumInventoryExportTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CurriculumInventoryInstitutionTest.php
+++ b/tests/RelationshipVoter/CurriculumInventoryInstitutionTest.php
@@ -110,7 +110,7 @@ class CurriculumInventoryInstitutionTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventoryInstitutionInterface::class, true],
@@ -118,7 +118,7 @@ class CurriculumInventoryInstitutionTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CurriculumInventoryReportTest.php
+++ b/tests/RelationshipVoter/CurriculumInventoryReportTest.php
@@ -141,7 +141,7 @@ class CurriculumInventoryReportTest extends AbstractBase
         }
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventoryReportInterface::class, true],
@@ -149,7 +149,7 @@ class CurriculumInventoryReportTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CurriculumInventorySequenceBlockTest.php
+++ b/tests/RelationshipVoter/CurriculumInventorySequenceBlockTest.php
@@ -166,7 +166,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractBase
         }
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventorySequenceBlockInterface::class, true],
@@ -174,7 +174,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/CurriculumInventorySequenceTest.php
+++ b/tests/RelationshipVoter/CurriculumInventorySequenceTest.php
@@ -166,7 +166,7 @@ class CurriculumInventorySequenceTest extends AbstractBase
         }
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventorySequenceInterface::class, true],
@@ -174,7 +174,7 @@ class CurriculumInventorySequenceTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
+++ b/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
@@ -30,7 +30,7 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
         $this->voter = new Voter();
     }
 
-    public function dtoProvider()
+    public static function dtoProvider(): array
     {
         return [
             [AuthenticationDTO::class],
@@ -77,7 +77,7 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [AuthenticationDTO::class, true],
@@ -89,7 +89,7 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -60,7 +60,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
         $this->voter = new Voter();
     }
 
-    public function canViewDTOProvider()
+    public static function canViewDTOProvider(): array
     {
         return [
             [AamcMethodDTO::class],
@@ -115,7 +115,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [AamcMethodDTO::class, true],
@@ -158,7 +158,7 @@ class GreenlightViewDtoVoterTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/IlmSessionTest.php
+++ b/tests/RelationshipVoter/IlmSessionTest.php
@@ -144,7 +144,7 @@ class IlmSessionTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [IlmSessionInterface::class, true],
@@ -152,7 +152,7 @@ class IlmSessionTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/IngestionExceptionTest.php
+++ b/tests/RelationshipVoter/IngestionExceptionTest.php
@@ -44,7 +44,7 @@ class IngestionExceptionTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [IngestionExceptionInterface::class, true],
@@ -52,7 +52,7 @@ class IngestionExceptionTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/InstructorGroupTest.php
+++ b/tests/RelationshipVoter/InstructorGroupTest.php
@@ -110,7 +110,7 @@ class InstructorGroupTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [InstructorGroupInterface::class, true],
@@ -118,7 +118,7 @@ class InstructorGroupTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/LearnerGroupDTOVoterTest.php
+++ b/tests/RelationshipVoter/LearnerGroupDTOVoterTest.php
@@ -62,7 +62,7 @@ class LearnerGroupDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View not allowed");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [LearnerGroupDTO::class, true],
@@ -70,7 +70,7 @@ class LearnerGroupDTOVoterTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/LearnerGroupTest.php
+++ b/tests/RelationshipVoter/LearnerGroupTest.php
@@ -123,7 +123,7 @@ class LearnerGroupTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [LearnerGroupInterface::class, true],
@@ -131,7 +131,7 @@ class LearnerGroupTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/LearningMaterialStatusTest.php
+++ b/tests/RelationshipVoter/LearningMaterialStatusTest.php
@@ -33,7 +33,7 @@ class LearningMaterialStatusTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [LearningMaterialStatusInterface::class, true],
@@ -41,7 +41,7 @@ class LearningMaterialStatusTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/LearningMaterialTest.php
+++ b/tests/RelationshipVoter/LearningMaterialTest.php
@@ -87,7 +87,7 @@ class LearningMaterialTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [LearningMaterialInterface::class, true],
@@ -95,7 +95,7 @@ class LearningMaterialTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/MeshTest.php
+++ b/tests/RelationshipVoter/MeshTest.php
@@ -25,7 +25,7 @@ class MeshTest extends AbstractBase
         $this->voter = new Voter();
     }
 
-    public function meshEntitiesProvider(): array
+    public static function meshEntitiesProvider(): array
     {
         return [
             [MeshConceptInterface::class],
@@ -56,7 +56,7 @@ class MeshTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [MeshConceptInterface::class, true],
@@ -69,7 +69,7 @@ class MeshTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/OfferingTest.php
+++ b/tests/RelationshipVoter/OfferingTest.php
@@ -154,7 +154,7 @@ class OfferingTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [OfferingInterface::class, true],
@@ -162,7 +162,7 @@ class OfferingTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/PendingUserUpdateTest.php
+++ b/tests/RelationshipVoter/PendingUserUpdateTest.php
@@ -109,7 +109,7 @@ class PendingUserUpdateTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Delete denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [PendingUserUpdateInterface::class, true],
@@ -117,7 +117,7 @@ class PendingUserUpdateTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/ProgramTest.php
+++ b/tests/RelationshipVoter/ProgramTest.php
@@ -110,7 +110,7 @@ class ProgramTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [ProgramInterface::class, true],
@@ -118,7 +118,7 @@ class ProgramTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/ProgramYearTest.php
+++ b/tests/RelationshipVoter/ProgramYearTest.php
@@ -110,7 +110,7 @@ class ProgramYearTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Edit denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [ProgramYearInterface::class, true],
@@ -118,7 +118,7 @@ class ProgramYearTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/ReportDTOVoterTest.php
+++ b/tests/RelationshipVoter/ReportDTOVoterTest.php
@@ -66,7 +66,7 @@ class ReportDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View allowed");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [ReportDTO::class, true],
@@ -74,7 +74,7 @@ class ReportDTOVoterTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/ReportTest.php
+++ b/tests/RelationshipVoter/ReportTest.php
@@ -103,7 +103,7 @@ class ReportTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [ReportInterface::class, true],
@@ -111,7 +111,7 @@ class ReportTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/SchoolConfigTest.php
+++ b/tests/RelationshipVoter/SchoolConfigTest.php
@@ -110,7 +110,7 @@ class SchoolConfigTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SchoolConfigInterface::class, true],
@@ -118,7 +118,7 @@ class SchoolConfigTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/SchoolEventTest.php
+++ b/tests/RelationshipVoter/SchoolEventTest.php
@@ -663,7 +663,7 @@ class SchoolEventTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SchoolEvent::class, true],
@@ -671,7 +671,7 @@ class SchoolEventTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/SchoolTest.php
+++ b/tests/RelationshipVoter/SchoolTest.php
@@ -72,7 +72,7 @@ class SchoolTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SchoolInterface::class, true],
@@ -80,7 +80,7 @@ class SchoolTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/SessionLearningMaterialDTOVoterTest.php
+++ b/tests/RelationshipVoter/SessionLearningMaterialDTOVoterTest.php
@@ -132,7 +132,7 @@ class SessionLearningMaterialDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SessionLearningMaterialDTO::class, true],
@@ -140,7 +140,7 @@ class SessionLearningMaterialDTOVoterTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/SessionLearningMaterialTest.php
+++ b/tests/RelationshipVoter/SessionLearningMaterialTest.php
@@ -214,7 +214,7 @@ class SessionLearningMaterialTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SessionLearningMaterialInterface::class, true],
@@ -222,7 +222,7 @@ class SessionLearningMaterialTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/SessionTest.php
+++ b/tests/RelationshipVoter/SessionTest.php
@@ -139,7 +139,7 @@ class SessionTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SessionInterface::class, true],
@@ -147,7 +147,7 @@ class SessionTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/SessionTypeTest.php
+++ b/tests/RelationshipVoter/SessionTypeTest.php
@@ -110,7 +110,7 @@ class SessionTypeTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SessionTypeInterface::class, true],
@@ -118,7 +118,7 @@ class SessionTypeTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/TemporaryFileSystemTest.php
+++ b/tests/RelationshipVoter/TemporaryFileSystemTest.php
@@ -43,7 +43,7 @@ class TemporaryFileSystemTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [TemporaryFileSystem::class, true],
@@ -51,7 +51,7 @@ class TemporaryFileSystemTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, false],

--- a/tests/RelationshipVoter/TermTest.php
+++ b/tests/RelationshipVoter/TermTest.php
@@ -123,7 +123,7 @@ class TermTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [TermInterface::class, true],
@@ -131,7 +131,7 @@ class TermTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/UserDTOVoterTest.php
+++ b/tests/RelationshipVoter/UserDTOVoterTest.php
@@ -93,7 +93,7 @@ class UserDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [UserDTO::class, true],
@@ -101,7 +101,7 @@ class UserDTOVoterTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/UserEventTest.php
+++ b/tests/RelationshipVoter/UserEventTest.php
@@ -1033,7 +1033,7 @@ class UserEventTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [UserEvent::class, true],
@@ -1041,7 +1041,7 @@ class UserEventTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/UserMaterialTest.php
+++ b/tests/RelationshipVoter/UserMaterialTest.php
@@ -68,7 +68,7 @@ class UserMaterialTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "View denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [UserMaterial::class, true],
@@ -76,7 +76,7 @@ class UserMaterialTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/UserRoleTest.php
+++ b/tests/RelationshipVoter/UserRoleTest.php
@@ -33,7 +33,7 @@ class UserRoleTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "View allowed");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [UserRoleInterface::class, true],
@@ -41,7 +41,7 @@ class UserRoleTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/UserSessionMaterialStatusDTOVoterTest.php
+++ b/tests/RelationshipVoter/UserSessionMaterialStatusDTOVoterTest.php
@@ -74,7 +74,7 @@ class UserSessionMaterialStatusDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "DTO View denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [UserSessionMaterialStatusDTO::class, true],
@@ -82,7 +82,7 @@ class UserSessionMaterialStatusDTOVoterTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/UserSessionMaterialStatusTest.php
+++ b/tests/RelationshipVoter/UserSessionMaterialStatusTest.php
@@ -59,7 +59,7 @@ class UserSessionMaterialStatusTest extends AbstractBase
         }
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [UserSessionMaterialStatusInterface::class, true],
@@ -67,7 +67,7 @@ class UserSessionMaterialStatusTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/UserTest.php
+++ b/tests/RelationshipVoter/UserTest.php
@@ -136,7 +136,7 @@ class UserTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [UserInterface::class, true],
@@ -144,7 +144,7 @@ class UserTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/RelationshipVoter/VocabularyTest.php
+++ b/tests/RelationshipVoter/VocabularyTest.php
@@ -110,7 +110,7 @@ class VocabularyTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_DENIED, $response, "Create denied");
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [VocabularyInterface::class, true],
@@ -118,7 +118,7 @@ class VocabularyTest extends AbstractBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],

--- a/tests/Service/CurriculumInventory/Export/XmlPrinterTest.php
+++ b/tests/Service/CurriculumInventory/Export/XmlPrinterTest.php
@@ -37,7 +37,7 @@ class XmlPrinterTest extends TestCase
         parent::tearDown();
     }
 
-    public function inventoryDataProvider(): array
+    public static function inventoryDataProvider(): array
     {
         $academicLevel1 = new CurriculumInventoryAcademicLevel();
         $academicLevel1->setName('Year 1');

--- a/tests/Service/CurriculumInventory/ReportRolloverTest.php
+++ b/tests/Service/CurriculumInventory/ReportRolloverTest.php
@@ -77,7 +77,7 @@ class ReportRolloverTest extends TestCase
         unset($this->reportRepository);
     }
 
-    public function reportProvider()
+    public static function reportProvider(): array
     {
         $report = new CurriculumInventoryReport();
         $report->setId(1);

--- a/tests/Service/DefaultPermissionMatrixTest.php
+++ b/tests/Service/DefaultPermissionMatrixTest.php
@@ -51,7 +51,7 @@ class DefaultPermissionMatrixTest extends TestCase
         unset($this->permissionMatrix);
     }
 
-    public function hasPermissionProvider()
+    public static function hasPermissionProvider(): array
     {
         return [
             [

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -185,16 +185,16 @@ class JsonWebTokenManagerTest extends TestCase
         $this->assertEquals($this->obj->getExpiresAtFromToken($jwt)->getTimestamp(), $expiresAt->getTimestamp());
     }
 
-    public function getWriteableSchoolIdsFromTokenProvider(): array
+    public static function getWriteableSchoolIdsFromTokenProvider(): array
     {
         return [
-            [$this->buildJwt(), []],
-            [$this->buildUserJwt(), []],
-            [$this->buildUserJwt(['writeable_schools' => [1, 2, 3]]), []],
-            [$this->buildServiceTokenJwt(), []],
-            [$this->buildServiceTokenJwt(['writeable_schools' => []]), []],
-            [$this->buildServiceTokenJwt(['writeable_schools' => '1,2,3']), []],
-            [$this->buildServiceTokenJwt(['writeable_schools' => [1, 2, 3]]), [1, 2, 3]],
+            [self::buildJwt(), []],
+            [self::buildUserJwt(), []],
+            [self::buildUserJwt(['writeable_schools' => [1, 2, 3]]), []],
+            [self::buildServiceTokenJwt(), []],
+            [self::buildServiceTokenJwt(['writeable_schools' => []]), []],
+            [self::buildServiceTokenJwt(['writeable_schools' => '1,2,3']), []],
+            [self::buildServiceTokenJwt(['writeable_schools' => [1, 2, 3]]), [1, 2, 3]],
         ];
     }
 
@@ -207,12 +207,12 @@ class JsonWebTokenManagerTest extends TestCase
         $this->assertEquals($this->obj->getWriteableSchoolIdsFromToken($jwt), $schoolIds);
     }
 
-    public function isUserTokenProvider(): array
+    public static function isUserTokenProvider(): array
     {
         return [
-            [$this->buildJwt(), false,],
-            [$this->buildServiceTokenJwt(), false],
-            [$this->buildUserJwt(), true],
+            [self::buildJwt(), false],
+            [self::buildServiceTokenJwt(), false],
+            [self::buildUserJwt(), true],
         ];
     }
 
@@ -225,12 +225,12 @@ class JsonWebTokenManagerTest extends TestCase
         $this->assertEquals($this->obj->isUserToken($jwt), $expected);
     }
 
-    public function isServiceTokenProvider(): array
+    public static function isServiceTokenProvider(): array
     {
         return [
-            [$this->buildJwt(), false,],
-            [$this->buildUserJwt(), false],
-            [$this->buildServiceTokenJwt(), true],
+            [self::buildJwt(), false,],
+            [self::buildUserJwt(), false],
+            [self::buildServiceTokenJwt(), true],
         ];
     }
 
@@ -243,17 +243,17 @@ class JsonWebTokenManagerTest extends TestCase
         $this->assertEquals($this->obj->isServiceToken($jwt), $expected);
     }
 
-    protected function buildUserJwt(array $values = [], $secretKey = 'ilios.jwt.key.secret'): string
+    protected static function buildUserJwt(array $values = [], $secretKey = 'ilios.jwt.key.secret'): string
     {
-        return $this->buildJwt(array_merge([JsonWebTokenManager::USER_ID_KEY => 42], $values), $secretKey);
+        return self::buildJwt(array_merge([JsonWebTokenManager::USER_ID_KEY => 42], $values), $secretKey);
     }
 
-    protected function buildServiceTokenJwt(array $values = [], $secretKey = 'ilios.jwt.key.secret'): string
+    protected static function buildServiceTokenJwt(array $values = [], $secretKey = 'ilios.jwt.key.secret'): string
     {
-        return $this->buildJwt(array_merge([JsonWebTokenManager::TOKEN_ID_KEY => 12], $values), $secretKey);
+        return self::buildJwt(array_merge([JsonWebTokenManager::TOKEN_ID_KEY => 12], $values), $secretKey);
     }
 
-    protected function buildJwt(array $values = [], $secretKey = 'ilios.jwt.key.secret'): string
+    protected static function buildJwt(array $values = [], $secretKey = 'ilios.jwt.key.secret'): string
     {
         $now = new DateTime();
         $default = [

--- a/tests/Service/ServiceTokenUserProviderTest.php
+++ b/tests/Service/ServiceTokenUserProviderTest.php
@@ -35,7 +35,7 @@ class ServiceTokenUserProviderTest extends TestCase
         unset($this->provider);
     }
 
-    public function supportsClassProvider(): array
+    public static function supportsClassProvider(): array
     {
         return [
             [ServiceTokenUser::class, true],

--- a/tests/Service/SessionUserProviderTest.php
+++ b/tests/Service/SessionUserProviderTest.php
@@ -38,7 +38,7 @@ class SessionUserProviderTest extends TestCase
         unset($this->provider);
     }
 
-    public function supportsClassProvider(): array
+    public static function supportsClassProvider(): array
     {
         return [
             [SessionUser::class, true],

--- a/tests/ServiceTokenVoter/AbstractBase.php
+++ b/tests/ServiceTokenVoter/AbstractBase.php
@@ -22,7 +22,7 @@ abstract class AbstractBase extends TestCase
         unset($this->voter);
     }
 
-    abstract public function supportsTypeProvider(): array;
+    abstract public static function supportsTypeProvider(): array;
 
     /**
      * @dataProvider supportsTypeProvider
@@ -32,7 +32,7 @@ abstract class AbstractBase extends TestCase
         $this->assertEquals($this->voter->supportsType($className), $isSupported);
     }
 
-    abstract public function supportsAttributesProvider(): array;
+    abstract public static function supportsAttributesProvider(): array;
 
     /**
      * @dataProvider supportsAttributesProvider

--- a/tests/ServiceTokenVoter/AbstractReadWriteBase.php
+++ b/tests/ServiceTokenVoter/AbstractReadWriteBase.php
@@ -38,7 +38,7 @@ abstract class AbstractReadWriteBase extends AbstractBase
         );
     }
 
-    abstract public function writePermissionsProvider(): array;
+    abstract public static function writePermissionsProvider(): array;
 
     /**
      * @dataProvider writePermissionsProvider

--- a/tests/ServiceTokenVoter/AbstractReadonlyBase.php
+++ b/tests/ServiceTokenVoter/AbstractReadonlyBase.php
@@ -17,22 +17,7 @@ abstract class AbstractReadonlyBase extends AbstractBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
-    {
-        return array_merge(
-            array_map(
-                function (array $a) {
-                    return [$a[0], true];
-                },
-                $this->subjectProvider()
-            ),
-            [
-                [self::class, false],
-            ]
-        );
-    }
-
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -49,7 +34,7 @@ abstract class AbstractReadonlyBase extends AbstractBase
         ];
     }
 
-    abstract public function subjectProvider(): array;
+    abstract public static function subjectProvider(): array;
 
     /**
      * @dataProvider subjectProvider

--- a/tests/ServiceTokenVoter/CohortTest.php
+++ b/tests/ServiceTokenVoter/CohortTest.php
@@ -20,7 +20,7 @@ class CohortTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CohortInterface::class, true],
@@ -28,7 +28,7 @@ class CohortTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -45,7 +45,7 @@ class CohortTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/CompetencyTest.php
+++ b/tests/ServiceTokenVoter/CompetencyTest.php
@@ -18,7 +18,7 @@ class CompetencyTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CompetencyInterface::class, true],
@@ -26,7 +26,7 @@ class CompetencyTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -43,7 +43,7 @@ class CompetencyTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/CourseLearningMaterialTest.php
+++ b/tests/ServiceTokenVoter/CourseLearningMaterialTest.php
@@ -19,7 +19,7 @@ class CourseLearningMaterialTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CourseLearningMaterialInterface::class, true],
@@ -27,7 +27,7 @@ class CourseLearningMaterialTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class CourseLearningMaterialTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/CourseObjectiveTest.php
+++ b/tests/ServiceTokenVoter/CourseObjectiveTest.php
@@ -19,7 +19,7 @@ class CourseObjectiveTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CourseObjectiveInterface::class, true],
@@ -27,7 +27,7 @@ class CourseObjectiveTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class CourseObjectiveTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/CourseTest.php
+++ b/tests/ServiceTokenVoter/CourseTest.php
@@ -18,7 +18,7 @@ class CourseTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CourseInterface::class, true],
@@ -26,7 +26,7 @@ class CourseTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -43,7 +43,7 @@ class CourseTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/CurriculumInventoryExportTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventoryExportTest.php
@@ -19,7 +19,7 @@ class CurriculumInventoryExportTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventoryExportInterface::class, true],
@@ -27,7 +27,7 @@ class CurriculumInventoryExportTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class CurriculumInventoryExportTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/CurriculumInventoryInstitutionTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventoryInstitutionTest.php
@@ -18,7 +18,7 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventoryInstitutionInterface::class, true],
@@ -26,7 +26,7 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -43,7 +43,7 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/CurriculumInventoryReportTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventoryReportTest.php
@@ -18,7 +18,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventoryReportInterface::class, true],
@@ -26,7 +26,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -43,7 +43,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/CurriculumInventorySequenceBlockTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventorySequenceBlockTest.php
@@ -19,7 +19,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventorySequenceBlockInterface::class, true],
@@ -27,7 +27,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/CurriculumInventorySequenceTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventorySequenceTest.php
@@ -19,7 +19,7 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [CurriculumInventorySequenceInterface::class, true],
@@ -27,7 +27,7 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/GreenlightViewDTOVoterTest.php
+++ b/tests/ServiceTokenVoter/GreenlightViewDTOVoterTest.php
@@ -58,7 +58,7 @@ class GreenlightViewDTOVoterTest extends AbstractReadonlyBase
         $this->voter = new GreenlightViewDTOVoter();
     }
 
-    public function subjectProvider(): array
+    public static function subjectProvider(): array
     {
         return [
             [AamcMethodDTO::class],
@@ -105,6 +105,57 @@ class GreenlightViewDTOVoterTest extends AbstractReadonlyBase
             [UserDTO::class],
             [UserRoleDTO::class],
             [VocabularyDTO::class],
+        ];
+    }
+
+    public static function supportsTypeProvider(): array
+    {
+        return [
+            [AamcMethodDTO::class, true],
+            [AamcPcrsDTO::class, true],
+            [AamcResourceTypeDTO::class, true],
+            [AssessmentOptionDTO::class, true],
+            [AuthenticationDTO::class, true],
+            [CohortDTO::class, true],
+            [CompetencyDTO::class, true],
+            [CourseClerkshipTypeDTO::class, true],
+            [CourseDTO::class, true],
+            [CourseLearningMaterialDTO::class, true],
+            [CourseObjectiveDTO::class, true],
+            [CurriculumInventoryAcademicLevelDTO::class, true],
+            [CurriculumInventoryInstitutionDTO::class, true],
+            [CurriculumInventoryReportDTO::class, true],
+            [CurriculumInventorySequenceBlockDTO::class, true],
+            [CurriculumInventorySequenceDTO::class, true],
+            [IlmSessionDTO::class, true],
+            [IngestionExceptionDTO::class, true],
+            [InstructorGroupDTO::class, true],
+            [LearnerGroupDTO::class, true],
+            [LearningMaterialDTO::class, true],
+            [LearningMaterialStatusDTO::class, true],
+            [LearningMaterialUserRoleDTO::class, true],
+            [MeshConceptDTO::class, true],
+            [MeshDescriptorDTO::class, true],
+            [MeshPreviousIndexingDTO::class, true],
+            [MeshQualifierDTO::class, true],
+            [MeshTermDTO::class, true],
+            [MeshTreeDTO::class, true],
+            [OfferingDTO::class, true],
+            [PendingUserUpdateDTO::class, true],
+            [ProgramDTO::class, true],
+            [ProgramYearDTO::class, true],
+            [ProgramYearObjectiveDTO::class, true],
+            [SchoolConfigDTO::class, true],
+            [SchoolDTO::class, true],
+            [SessionDTO::class, true],
+            [SessionLearningMaterialDTO::class, true],
+            [SessionObjectiveDTO::class, true],
+            [SessionTypeDTO::class, true],
+            [TermDTO::class, true],
+            [UserDTO::class, true],
+            [UserRoleDTO::class, true],
+            [VocabularyDTO::class, true],
+            [self::class, false]
         ];
     }
 }

--- a/tests/ServiceTokenVoter/IlmSessionTest.php
+++ b/tests/ServiceTokenVoter/IlmSessionTest.php
@@ -20,7 +20,7 @@ class IlmSessionTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [IlmSessionInterface::class, true],
@@ -28,7 +28,7 @@ class IlmSessionTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -45,7 +45,7 @@ class IlmSessionTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/InstructorGroupTest.php
+++ b/tests/ServiceTokenVoter/InstructorGroupTest.php
@@ -18,7 +18,7 @@ class InstructorGroupTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [InstructorGroupInterface::class, true],
@@ -26,7 +26,7 @@ class InstructorGroupTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -43,7 +43,7 @@ class InstructorGroupTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/LearnerGroupTest.php
+++ b/tests/ServiceTokenVoter/LearnerGroupTest.php
@@ -19,7 +19,7 @@ class LearnerGroupTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [LearnerGroupInterface::class, true],
@@ -27,7 +27,7 @@ class LearnerGroupTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class LearnerGroupTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/OfferingTest.php
+++ b/tests/ServiceTokenVoter/OfferingTest.php
@@ -20,7 +20,7 @@ class OfferingTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [OfferingInterface::class, true],
@@ -28,7 +28,7 @@ class OfferingTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -45,7 +45,7 @@ class OfferingTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/PendingUserUpdateTest.php
+++ b/tests/ServiceTokenVoter/PendingUserUpdateTest.php
@@ -19,7 +19,7 @@ class PendingUserUpdateTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [PendingUserUpdateInterface::class, true],
@@ -27,7 +27,7 @@ class PendingUserUpdateTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class PendingUserUpdateTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::DELETE],

--- a/tests/ServiceTokenVoter/ProgramTest.php
+++ b/tests/ServiceTokenVoter/ProgramTest.php
@@ -18,7 +18,7 @@ class ProgramTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [ProgramInterface::class, true],
@@ -26,7 +26,7 @@ class ProgramTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -43,7 +43,7 @@ class ProgramTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/ProgramYearObjectiveTest.php
+++ b/tests/ServiceTokenVoter/ProgramYearObjectiveTest.php
@@ -20,7 +20,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [ProgramYearObjectiveInterface::class, true],
@@ -28,7 +28,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -45,7 +45,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/ProgramYearTest.php
+++ b/tests/ServiceTokenVoter/ProgramYearTest.php
@@ -19,7 +19,7 @@ class ProgramYearTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [ProgramYearInterface::class, true],
@@ -27,7 +27,7 @@ class ProgramYearTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class ProgramYearTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/ReadonlyEntityVoterTest.php
+++ b/tests/ServiceTokenVoter/ReadonlyEntityVoterTest.php
@@ -32,7 +32,7 @@ class ReadonlyEntityVoterTest extends AbstractReadonlyBase
         $this->voter = new Voter();
     }
 
-    public function subjectProvider(): array
+    public static function subjectProvider(): array
     {
         return [
             [AamcMethodInterface::class],
@@ -53,6 +53,31 @@ class ReadonlyEntityVoterTest extends AbstractReadonlyBase
             [MeshTreeInterface::class],
             [UserInterface::class],
             [UserRoleInterface::class],
+        ];
+    }
+
+    public static function supportsTypeProvider(): array
+    {
+        return [
+            [AamcMethodInterface::class, true],
+            [AamcPcrsInterface::class, true],
+            [AamcResourceTypeInterface::class, true],
+            [AssessmentOptionInterface::class, true],
+            [CourseClerkshipTypeInterface::class, true],
+            [CurriculumInventoryAcademicLevelInterface::class, true],
+            [IngestionExceptionInterface::class, true],
+            [LearningMaterialInterface::class, true],
+            [LearningMaterialStatusInterface::class, true],
+            [LearningMaterialUserRoleInterface::class, true],
+            [MeshConceptInterface::class, true],
+            [MeshDescriptorInterface::class, true],
+            [MeshPreviousIndexingInterface::class, true],
+            [MeshQualifierInterface::class, true],
+            [MeshTermInterface::class, true],
+            [MeshTreeInterface::class, true],
+            [UserInterface::class, true],
+            [UserRoleInterface::class, true],
+            [self::class, false],
         ];
     }
 }

--- a/tests/ServiceTokenVoter/SchoolTest.php
+++ b/tests/ServiceTokenVoter/SchoolTest.php
@@ -17,7 +17,7 @@ class SchoolTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SchoolInterface::class, true],
@@ -25,7 +25,7 @@ class SchoolTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -42,7 +42,7 @@ class SchoolTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::EDIT],

--- a/tests/ServiceTokenVoter/SessionLearningMaterialTest.php
+++ b/tests/ServiceTokenVoter/SessionLearningMaterialTest.php
@@ -20,7 +20,7 @@ class SessionLearningMaterialTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SessionLearningMaterialInterface::class, true],
@@ -28,7 +28,7 @@ class SessionLearningMaterialTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -45,7 +45,7 @@ class SessionLearningMaterialTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/SessionObjectiveTest.php
+++ b/tests/ServiceTokenVoter/SessionObjectiveTest.php
@@ -20,7 +20,7 @@ class SessionObjectiveTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SessionObjectiveInterface::class, true],
@@ -28,7 +28,7 @@ class SessionObjectiveTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -45,7 +45,7 @@ class SessionObjectiveTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/SessionTest.php
+++ b/tests/ServiceTokenVoter/SessionTest.php
@@ -19,7 +19,7 @@ class SessionTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SessionInterface::class, true],
@@ -27,7 +27,7 @@ class SessionTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class SessionTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/SessionTypeTest.php
+++ b/tests/ServiceTokenVoter/SessionTypeTest.php
@@ -18,7 +18,7 @@ class SessionTypeTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [SessionTypeInterface::class, true],
@@ -26,7 +26,7 @@ class SessionTypeTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -43,7 +43,7 @@ class SessionTypeTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/TermTest.php
+++ b/tests/ServiceTokenVoter/TermTest.php
@@ -19,7 +19,7 @@ class TermTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [TermInterface::class, true],
@@ -27,7 +27,7 @@ class TermTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -44,7 +44,7 @@ class TermTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/ServiceTokenVoter/VocabularyTest.php
+++ b/tests/ServiceTokenVoter/VocabularyTest.php
@@ -18,7 +18,7 @@ class VocabularyTest extends AbstractReadWriteBase
         $this->voter = new Voter();
     }
 
-    public function supportsTypeProvider(): array
+    public static function supportsTypeProvider(): array
     {
         return [
             [VocabularyInterface::class, true],
@@ -26,7 +26,7 @@ class VocabularyTest extends AbstractReadWriteBase
         ];
     }
 
-    public function supportsAttributesProvider(): array
+    public static function supportsAttributesProvider(): array
     {
         return [
             [VoterPermissions::VIEW, true],
@@ -43,7 +43,7 @@ class VocabularyTest extends AbstractReadWriteBase
         ];
     }
 
-    public function writePermissionsProvider(): array
+    public static function writePermissionsProvider(): array
     {
         return [
             [VoterPermissions::CREATE],

--- a/tests/Traits/JsonControllerTestable.php
+++ b/tests/Traits/JsonControllerTestable.php
@@ -15,10 +15,7 @@ use App\Service\JsonWebTokenManager;
 use function json_decode;
 use function substr;
 
-/**
- * Class JsonControllerTest
- */
-trait JsonControllerTest
+trait JsonControllerTestable
 {
     /**
      * Create a JSON:API request

--- a/tests/Traits/TestableJsonController.php
+++ b/tests/Traits/TestableJsonController.php
@@ -15,7 +15,7 @@ use App\Service\JsonWebTokenManager;
 use function json_decode;
 use function substr;
 
-trait JsonControllerTestable
+trait TestableJsonController
 {
     /**
      * Create a JSON:API request


### PR DESCRIPTION
PHPUnit v10 is still a no-go, b/c the PHPUnit/Symfony bridge isn't ready for it yet.

we can still frontload the upgrade by addressing all deprecations that would result in breakage:

- data provider need to be public and static in v10, this makes it so.
- all test methods relying on data providers where the provider yields no data need to be marked as skipped, in order to prevent test failures in v10.