### PR TITLE
Use docker tools for git context on containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,6 @@ jobs:
           - opensearch
           - redis
     steps:
-    - uses: actions/checkout@v4
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Build ${{ matrix.image }}
@@ -177,7 +176,6 @@ jobs:
           - opensearch
           - redis
      steps:
-     - uses: actions/checkout@v4
      - name: Set up QEMU
        uses: docker/setup-qemu-action@v3
        with:

--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -73,6 +73,7 @@ jobs:
     - name: Deploy to Docker Registry
       uses: docker/build-push-action@v5
       with:
+        context: .
         tags: ilios/${{ matrix.image }}:${{needs.tags.outputs.major}},ilios/${{ matrix.image }}:${{needs.tags.outputs.minor}},ilios/${{ matrix.image }}:${{needs.tags.outputs.patch}}
         build-args: ILIOS_VERSION=${{needs.tags.outputs.patch}}
         target: ${{ matrix.image }}

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -24,9 +24,6 @@ jobs:
           - opensearch
           - redis
     steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -44,7 +44,6 @@ jobs:
           - opensearch
           - redis
     steps:
-    - uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:


### PR DESCRIPTION
The build-push-action from docker manages git for us, in most cases this has been fine. However, for our nightly re-builds we've been pulling off of HEAD instead of the tag we expect. I've removed the checkout from most places so it's clearer what is happening and setup the nightly re-build to use the local git context and not re-checkout the code before building.

Fixes #5107