### PR TITLE
 use attributes to declare command names, aliases, and descriptions. 

### DIFF
--- a/src/Command/AddDirectoryUserCommand.php
+++ b/src/Command/AddDirectoryUserCommand.php
@@ -7,20 +7,26 @@ namespace App\Command;
 use App\Repository\AuthenticationRepository;
 use App\Repository\SchoolRepository;
 use App\Repository\UserRepository;
-use Exception;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use App\Service\Directory;
+use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Add a user by looking them up in the directory
  *
  * Class AddDirectoryUserCommand
  */
+#[AsCommand(
+    name: 'ilios:add-directory-user',
+    description: 'Add a user to ilios.',
+    aliases: ['ilios:directory:add-user']
+)]
 class AddDirectoryUserCommand extends Command
 {
     public function __construct(
@@ -35,9 +41,6 @@ class AddDirectoryUserCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:add-directory-user')
-            ->setAliases(['ilios:directory:add-user'])
-            ->setDescription('Add a user to ilios.')
             ->addArgument(
                 'campusId',
                 InputArgument::REQUIRED,
@@ -71,7 +74,7 @@ class AddDirectoryUserCommand extends Command
 
         if (!$userRecord) {
             $output->writeln("<error>Unable to find campus ID {$campusId} in the directory.</error>");
-            return 0;
+            return Command::SUCCESS;
         }
 
         $table = new Table($output);
@@ -121,6 +124,6 @@ class AddDirectoryUserCommand extends Command
             $output->writeln('<comment>Canceled.</comment>');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Command/AddNewStudentsToSchoolCommand.php
@@ -9,6 +9,7 @@ use App\Repository\SchoolRepository;
 use App\Repository\UserRepository;
 use App\Repository\UserRoleRepository;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,6 +23,11 @@ use App\Service\Directory;
  *
  * Class AddNewStudentsToSchoolCommand
  */
+#[AsCommand(
+    name: 'ilios:add-students',
+    description: 'Add students found by a directory filter into a school.',
+    aliases: ['ilios:directory:add-students']
+)]
 class AddNewStudentsToSchoolCommand extends Command
 {
     public function __construct(
@@ -37,9 +43,6 @@ class AddNewStudentsToSchoolCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:add-students')
-            ->setAliases(['ilios:directory:add-students'])
-            ->setDescription('Add students found by a directory filter into a school.')
             ->addArgument(
                 'schoolId',
                 InputArgument::REQUIRED,
@@ -68,7 +71,7 @@ class AddNewStudentsToSchoolCommand extends Command
 
         if (!$students) {
             $output->writeln("<error>{$filter} returned no results.</error>");
-            return 0;
+            return Command::SUCCESS;
         }
         $output->writeln('<info>Found ' . count($students) . ' students in the directory.</info>');
 
@@ -78,7 +81,7 @@ class AddNewStudentsToSchoolCommand extends Command
 
         if ($newStudents === []) {
             $output->writeln("<info>There are no new students to add.</info>");
-            return 0;
+            return Command::SUCCESS;
         }
         $output->writeln(
             '<info>There are ' .
@@ -159,11 +162,11 @@ class AddNewStudentsToSchoolCommand extends Command
                 );
             }
 
-            return 0;
+            return Command::SUCCESS;
         } else {
             $output->writeln('<comment>Update canceled.</comment>');
 
-            return 1;
+            return Command::FAILURE;
         }
     }
 }

--- a/src/Command/AddRootUserCommand.php
+++ b/src/Command/AddRootUserCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Entity\UserInterface;
 use App\Repository\UserRepository;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,13 +18,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Class AddRootUserCommand
  */
+#[AsCommand(
+    name: 'ilios:add-root-user',
+    description: 'Grants root-level privileges to a given user.',
+    aliases: ['ilios:maintenance:add-root-user']
+)]
 class AddRootUserCommand extends Command
 {
-    /**
-     * @var string
-     */
-    public const COMMAND_NAME = 'ilios:add-root-user';
-
     public function __construct(protected UserRepository $userRepository)
     {
         parent::__construct();
@@ -31,15 +32,7 @@ class AddRootUserCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName(self::COMMAND_NAME)
-            ->setAliases(['ilios:maintenance:add-root-user'])
-            ->setDescription('Grants root-level privileges to a given user.')
-            ->addArgument(
-                'userId',
-                InputArgument::REQUIRED,
-                "The user's id."
-            );
+        $this->addArgument('userId', InputArgument::REQUIRED, "The user's id.");
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
@@ -54,6 +47,6 @@ class AddRootUserCommand extends Command
         $this->userRepository->update($user, true, true);
         $output->writeln("User with id #{$userId} has been granted root-level privileges.");
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -11,6 +11,7 @@ use App\Service\SessionUserProvider;
 use App\Entity\AuthenticationInterface;
 use Exception;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -26,6 +27,11 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  *
  * Class AddUserCommand
  */
+#[AsCommand(
+    name: 'ilios:add-user',
+    description: 'Add a user to ilios.',
+    aliases: ['ilios:maintenance:add-user']
+)]
 class AddUserCommand extends Command
 {
     public function __construct(
@@ -40,10 +46,6 @@ class AddUserCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:add-user')
-            ->setAliases(['ilios:maintenance:add-user'])
-            ->setDescription('Add a user to ilios.');
         $userOptions = [
             'schoolId',
             'firstName',
@@ -182,15 +184,15 @@ class AddUserCommand extends Command
             $output->writeln(
                 '<info>Success! New user #' . $user->getId() . ' ' . $user->getFirstAndLastName() . ' created.</info>'
             );
-            return 0;
+            return Command::SUCCESS;
         } else {
             $output->writeln('<comment>Canceled.</comment>');
 
-            return 1;
+            return Command::FAILURE;
         }
     }
 
-    protected function fillUserRecord(array $userRecord, $input, $output)
+    protected function fillUserRecord(array $userRecord, $input, $output): array
     {
         if (empty($userRecord['firstName'])) {
             $userRecord['firstName'] = $this->askForString('First Name', 1, 50, $input, $output);
@@ -243,7 +245,7 @@ class AddUserCommand extends Command
         return $userRecord;
     }
 
-    protected function askForString($what, $min, $max, $input, $output)
+    protected function askForString($what, $min, $max, $input, $output): mixed
     {
         $question = new Question("What is the user's {$what}? ");
         $question->setValidator(function ($answer) use ($what, $min, $max) {

--- a/src/Command/AuditLogExportCommand.php
+++ b/src/Command/AuditLogExportCommand.php
@@ -8,6 +8,7 @@ use App\Repository\AuditLogRepository;
 use DateTime;
 use DateTimeZone;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -23,6 +24,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @link http://symfony.com/doc/current/cookbook/console/logging.html
  * @link http://symfony.com/doc/current/components/console/helpers/table.html
  */
+#[AsCommand(
+    name: 'ilios:export-audit-log',
+    description: 'Exports audit log entries in a given time range and, optionally, deletes them.',
+    aliases: ['ilios:maintenance:export-audit-log']
+)]
 class AuditLogExportCommand extends Command
 {
     public function __construct(protected LoggerInterface $logger, protected AuditLogRepository $auditLogRepository)
@@ -33,9 +39,6 @@ class AuditLogExportCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:export-audit-log')
-            ->setAliases(['ilios:maintenance:export-audit-log'])
-            ->setDescription('Exports audit log entries in a given time range and, optionally, deletes them.')
             ->addOption(
                 'delete',
                 null,

--- a/src/Command/ChangePasswordCommand.php
+++ b/src/Command/ChangePasswordCommand.php
@@ -11,6 +11,7 @@ use App\Service\SessionUserProvider;
 use App\Entity\AuthenticationInterface;
 use Exception;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,6 +22,10 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 /**
  * Change a user's password
  */
+#[AsCommand(
+    name: 'ilios:change-password',
+    description: 'Change the password for a user.'
+)]
 class ChangePasswordCommand extends Command
 {
     public function __construct(
@@ -34,14 +39,7 @@ class ChangePasswordCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:change-password')
-            ->setDescription('Change the password for a user.')
-            ->addArgument(
-                'userId',
-                InputArgument::REQUIRED,
-                'A valid user id.'
-            );
+        $this->addArgument('userId', InputArgument::REQUIRED, 'A valid user id.');
     }
 
     /**
@@ -87,6 +85,6 @@ class ChangePasswordCommand extends Command
 
         $output->writeln('<info>Password Changed.</info>');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ChangeUsernameCommand.php
+++ b/src/Command/ChangeUsernameCommand.php
@@ -10,6 +10,7 @@ use App\Repository\AuthenticationRepository;
 use App\Repository\UserRepository;
 use Exception;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,6 +20,10 @@ use Symfony\Component\Console\Question\Question;
 /**
  * Change a user's username
  */
+#[AsCommand(
+    name: 'ilios:change-username',
+    description: 'Change the username for a user.'
+)]
 class ChangeUsernameCommand extends Command
 {
     public function __construct(
@@ -30,14 +35,7 @@ class ChangeUsernameCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:change-username')
-            ->setDescription('Change the username for a user.')
-            ->addArgument(
-                'userId',
-                InputArgument::REQUIRED,
-                'A valid user id.'
-            );
+        $this->addArgument('userId', InputArgument::REQUIRED, 'A valid user id.');
     }
 
     /**
@@ -82,6 +80,6 @@ class ChangeUsernameCommand extends Command
 
         $output->writeln('<info>Username Changed.</info>');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/CheckS3PermissionsCommand.php
+++ b/src/Command/CheckS3PermissionsCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Exception\IliosFilesystemException;
 use App\Service\Config;
 use App\Service\IliosFileSystem;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,6 +17,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Class CheckS3PermissionsCommand
  */
+#[AsCommand(
+    name: 'ilios:check-s3-permissions',
+    description: 'Checks the configured S3 filesystem for any permission issues.'
+)]
 class CheckS3PermissionsCommand extends Command
 {
     public function __construct(
@@ -23,13 +28,6 @@ class CheckS3PermissionsCommand extends Command
         protected IliosFileSystem $iliosFileSystem
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('ilios:check-s3-permissions')
-            ->setDescription('Checks the configured S3 filesystem for any permission issues.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/CleanupStringsCommand.php
+++ b/src/Command/CleanupStringsCommand.php
@@ -15,6 +15,7 @@ use App\Repository\SessionRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use HTMLPurifier;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
@@ -29,6 +30,11 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * Class CleanupStringsCommand
  */
+#[AsCommand(
+    name: 'ilios:cleanup-strings',
+    description: 'Cleans up selected text fields in the database.',
+    aliases: ['ilios:maintenance:cleanup-strings']
+)]
 class CleanupStringsCommand extends Command
 {
     /**
@@ -58,9 +64,6 @@ class CleanupStringsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:cleanup-strings')
-            ->setAliases(['ilios:maintenance:cleanup-strings'])
-            ->setDescription('Cleans up selected text fields in the database.')
             ->addOption(
                 'objective-title',
                 null,
@@ -122,14 +125,14 @@ class CleanupStringsCommand extends Command
             $this->removeObjectiveTitleBlankSpace($output);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**
      * Purify objective titles
      * @throws Exception
      */
-    protected function purifyObjectiveTitle(OutputInterface $output)
+    protected function purifyObjectiveTitle(OutputInterface $output): void
     {
         $this->cleanupObjectiveTitle($output, self::CLEANUP_MODE_OBJECTIVE_TITLE_PURIFY_MARKUP);
     }
@@ -194,7 +197,7 @@ class CleanupStringsCommand extends Command
     /**
      * Purify learning material description
      */
-    protected function purifyLearningMaterialDescription(OutputInterface $output)
+    protected function purifyLearningMaterialDescription(OutputInterface $output): void
     {
         $cleaned = 0;
         $offset = 0;
@@ -230,7 +233,7 @@ class CleanupStringsCommand extends Command
     /**
      * Purify course learning material note
      */
-    protected function purifyCourseLearningMaterialNote(OutputInterface $output)
+    protected function purifyCourseLearningMaterialNote(OutputInterface $output): void
     {
         $cleaned = 0;
         $offset = 0;
@@ -265,7 +268,7 @@ class CleanupStringsCommand extends Command
     /**
      * Purify session learning material note
      */
-    protected function purifySessionLearningMaterialNote(OutputInterface $output)
+    protected function purifySessionLearningMaterialNote(OutputInterface $output): void
     {
         $cleaned = 0;
         $offset = 0;
@@ -300,7 +303,7 @@ class CleanupStringsCommand extends Command
     /**
      * Purify session description
      */
-    protected function purifySessionDescription(OutputInterface $output)
+    protected function purifySessionDescription(OutputInterface $output): void
     {
         $cleaned = 0;
         $offset = 0;

--- a/src/Command/CreateServiceTokenCommand.php
+++ b/src/Command/CreateServiceTokenCommand.php
@@ -11,6 +11,7 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,6 +22,10 @@ use App\Service\JsonWebTokenManager;
 /**
  * Create a new service account token.
  */
+#[AsCommand(
+    name: 'ilios:service-token:create',
+    description: 'Creates a new service token for the API with given capabilities.'
+)]
 class CreateServiceTokenCommand extends Command
 {
     public const TTL_KEY = 'ttl';
@@ -39,8 +44,6 @@ class CreateServiceTokenCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:service-token:create')
-            ->setDescription('Creates a new service token for the API with given capabilities.')
             ->addOption(
                 self::WRITEABLE_SCHOOLS_KEY,
                 null,

--- a/src/Command/CreateUserTokenCommand.php
+++ b/src/Command/CreateUserTokenCommand.php
@@ -8,6 +8,7 @@ use App\Classes\SessionUser;
 use App\Entity\UserInterface;
 use App\Repository\UserRepository;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -20,6 +21,11 @@ use App\Service\JsonWebTokenManager;
  *
  * Class CreateUserTokenCommand
  */
+#[AsCommand(
+    name: 'ilios:create-user-token',
+    description: 'Create a new API token for a user.',
+    aliases: ['ilios:maintenance:create-user-token']
+)]
 class CreateUserTokenCommand extends Command
 {
     public function __construct(
@@ -32,9 +38,6 @@ class CreateUserTokenCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:create-user-token')
-            ->setAliases(['ilios:maintenance:create-user-token'])
-            ->setDescription('Create a new API token for a user.')
             ->addArgument(
                 'userId',
                 InputArgument::REQUIRED,
@@ -63,6 +66,6 @@ class CreateUserTokenCommand extends Command
         $output->writeln('Success!');
         $output->writeln('Token ' . $jwt);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/DeleteServiceTokenCommand.php
+++ b/src/Command/DeleteServiceTokenCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\Entity\ServiceTokenInterface;
 use App\Repository\ServiceTokenRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,6 +15,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Deletes a service token.
  */
+#[AsCommand(
+    name: 'ilios:service-token:delete',
+    description: 'Deletes a given service token.'
+)]
 class DeleteServiceTokenCommand extends Command
 {
     public const ID_KEY = 'id';
@@ -25,14 +30,7 @@ class DeleteServiceTokenCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:service-token:delete')
-            ->setDescription('Deletes a given service token.')
-            ->addArgument(
-                self::ID_KEY,
-                InputArgument::REQUIRED,
-                "The token ID.",
-            );
+        $this->addArgument(self::ID_KEY, InputArgument::REQUIRED, "The token ID.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/DisableServiceTokenCommand.php
+++ b/src/Command/DisableServiceTokenCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\Entity\ServiceTokenInterface;
 use App\Repository\ServiceTokenRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,6 +15,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Disables a service token.
  */
+#[AsCommand(
+    name: 'ilios:service-token:disable',
+    description: 'Disable a given service token.'
+)]
 class DisableServiceTokenCommand extends Command
 {
     public const ID_KEY = 'id';
@@ -25,14 +30,7 @@ class DisableServiceTokenCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:service-token:disable')
-            ->setDescription('Disable a given service token.')
-            ->addArgument(
-                self::ID_KEY,
-                InputArgument::REQUIRED,
-                "The token ID.",
-            );
+        $this->addArgument(self::ID_KEY, InputArgument::REQUIRED, "The token ID.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/EnableServiceTokenCommand.php
+++ b/src/Command/EnableServiceTokenCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\Entity\ServiceTokenInterface;
 use App\Repository\ServiceTokenRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,6 +15,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Enables a service token.
  */
+#[AsCommand(
+    name: 'ilios:service-token:enable',
+    description: 'Enables a given service token.'
+)]
 class EnableServiceTokenCommand extends Command
 {
     public const ID_KEY = 'id';
@@ -25,14 +30,7 @@ class EnableServiceTokenCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:service-token:enable')
-            ->setDescription('Enables a given service token.')
-            ->addArgument(
-                self::ID_KEY,
-                InputArgument::REQUIRED,
-                "The token ID.",
-            );
+        $this->addArgument(self::ID_KEY, InputArgument::REQUIRED, "The token ID.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/ExportMeshUniverseCommand.php
+++ b/src/Command/ExportMeshUniverseCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Repository\MeshDescriptorRepository;
 use App\Service\CsvWriter;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,6 +19,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Class ExportMeshUniverseCommand
  */
+#[AsCommand(
+    name: 'ilios:export-mesh-universe',
+    description: 'Dumps the contents of all mesh_* tables into dataimport files.'
+)]
 class ExportMeshUniverseCommand extends Command
 {
     use LockableTrait;
@@ -30,13 +35,6 @@ class ExportMeshUniverseCommand extends Command
         parent::__construct();
     }
 
-    protected function configure(): void
-    {
-        $this
-            ->setName('ilios:export-mesh-universe')
-            ->setDescription('Dumps the contents of all mesh_* tables into dataimport files.');
-    }
-
     /**
      * @inheritdoc
      * @throws Exception
@@ -45,7 +43,7 @@ class ExportMeshUniverseCommand extends Command
     {
         if (!$this->lock()) {
             $output->writeln('The command is already running in another process.');
-            return 0;
+            return Command::SUCCESS;
         }
 
         $header = [
@@ -100,7 +98,7 @@ class ExportMeshUniverseCommand extends Command
         $this->writeToFile($header, $data, 'mesh_tree.csv');
 
         $this->release();
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**
@@ -109,7 +107,7 @@ class ExportMeshUniverseCommand extends Command
      * @param string $fileName
      * @throws Exception
      */
-    protected function writeToFile($header, $data, $fileName)
+    protected function writeToFile(array $header, array $data, string $fileName): void
     {
         $this->writer->writeToFile($header, $data, $this->kernelProjectDir . '/config/dataimport/' . $fileName);
     }

--- a/src/Command/FindUserCommand.php
+++ b/src/Command/FindUserCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -16,6 +17,11 @@ use App\Service\Directory;
  *
  * Class FindUserCommand
  */
+#[AsCommand(
+    name: 'ilios:find-user',
+    description: 'Find a user in the directory.',
+    aliases: ['ilios:directory:find-user']
+)]
 class FindUserCommand extends Command
 {
     public function __construct(
@@ -27,9 +33,6 @@ class FindUserCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:find-user')
-            ->setAliases(['ilios:directory:find-user'])
-            ->setDescription('Find a user in the directory.')
             ->addArgument(
                 'searchTerms',
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,
@@ -43,7 +46,7 @@ class FindUserCommand extends Command
         $userRecords = $this->directory->find($searchTerms);
         if (!$userRecords) {
             $output->writeln('<error>Unable to find anyone matching those terms in the directory.</error>');
-            return 0;
+            return Command::SUCCESS;
         }
 
         $rows = array_map(fn($arr) => [
@@ -60,6 +63,6 @@ class FindUserCommand extends Command
         ;
         $table->render();
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/FixLearningMaterialMimeTypesCommand.php
+++ b/src/Command/FixLearningMaterialMimeTypesCommand.php
@@ -8,6 +8,7 @@ use App\Entity\LearningMaterialInterface;
 use App\Repository\LearningMaterialRepository;
 use App\Service\TemporaryFileSystem;
 use ErrorException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,6 +19,11 @@ use App\Service\IliosFileSystem;
 /**
  * Cleanup incorrectly stored mime types for learning materials.
  */
+#[AsCommand(
+    name: 'ilios:fix-mime-types',
+    description: 'Cleanup incorrectly stored mime types for learning materials.',
+    aliases: ['ilios:maintenance:fix-mime-types']
+)]
 class FixLearningMaterialMimeTypesCommand extends Command
 {
     public function __construct(
@@ -26,14 +32,6 @@ class FixLearningMaterialMimeTypesCommand extends Command
         protected LearningMaterialRepository $learningMaterialRepository
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('ilios:fix-mime-types')
-            ->setAliases(['ilios:maintenance:fix-mime-types'])
-            ->setDescription('Cleanup incorrectly stored mime types for learning materials.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -125,15 +123,15 @@ class FixLearningMaterialMimeTypesCommand extends Command
                 }
             }
 
-            return 0;
+            return Command::SUCCESS;
         } else {
             $output->writeln('<comment>Update canceled.</comment>');
 
-            return 1;
+            return Command::FAILURE;
         }
     }
 
-    protected function getMimetypeForFileName($name)
+    protected function getMimetypeForFileName(?string $name): string
     {
         //taken from https://stackoverflow.com/questions/35299457/getting-mime-type-from-file-name-in-php
         $typesByExtension = [

--- a/src/Command/GenerateCurriculumInventoryVerificationPreviewCommand.php
+++ b/src/Command/GenerateCurriculumInventoryVerificationPreviewCommand.php
@@ -8,6 +8,7 @@ use App\Repository\CurriculumInventoryReportRepository;
 use App\Service\CurriculumInventory\VerificationPreviewBuilder;
 use App\Entity\CurriculumInventoryReportInterface;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableCell;
@@ -20,6 +21,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Class GenerateCurriculumInventoryVerificationPreviewCommand
  * @package App\Command
  */
+#[AsCommand(
+    name: 'ilios:generate-curriculum-inventory-verification-report-preview',
+    description: 'Generates a preview of the verification report tables for a given curriculum inventory report'
+)]
 class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
 {
     /**
@@ -75,17 +80,12 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
         );
         $this->printAllResourceTypesTable($output, $preview['all_resource_types']);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:generate-curriculum-inventory-verification-report-preview')
-            ->setDescription(
-                'Generates a preview of the verification report tables for a given curriculum inventory report'
-            )
-            ->addArgument('reportId', InputArgument::REQUIRED, 'The ID of the CI report to preview.');
+        $this->addArgument('reportId', InputArgument::REQUIRED, 'The ID of the CI report to preview.');
     }
 
     protected function printAllResourceTypesTable(OutputInterface $output, array $data): void
@@ -344,7 +344,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
      * @param OutputInterface $output
      * @param string $title
      */
-    protected function printTableHeadline(OutputInterface $output, $title): void
+    protected function printTableHeadline(OutputInterface $output, string $title): void
     {
         $output->writeln('');
         $output->writeln("<options=bold,underscore>{$title}</>");

--- a/src/Command/GenerateEndpointTestCommand.php
+++ b/src/Command/GenerateEndpointTestCommand.php
@@ -10,6 +10,7 @@ use Doctrine\Inflector\Inflector;
 use Exception;
 use ReflectionClass;
 use ReflectionProperty;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,6 +22,11 @@ use Twig\Environment;
  *
  * Class GenerateEndpointTestCommand
  */
+#[AsCommand(
+    name: 'ilios:generate:endpoint-test',
+    description: 'Creates basic test for an endpoint.',
+    hidden: true
+)]
 class GenerateEndpointTestCommand extends Command
 {
     public function __construct(
@@ -34,15 +40,7 @@ class GenerateEndpointTestCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:generate:endpoint-test')
-            ->setHidden(true)
-            ->setDescription('Creates basic test for an endpoint.')
-            ->addArgument(
-                'entityShortcut',
-                InputArgument::REQUIRED,
-                'The name of an entity e.g. App\Entity\Session.'
-            );
+        $this->addArgument('entityShortcut', InputArgument::REQUIRED, 'The name of an entity e.g. App\Entity\Session.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -89,6 +87,6 @@ class GenerateEndpointTestCommand extends Command
 
         print $content;
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ImportDefaultDataCommand.php
+++ b/src/Command/ImportDefaultDataCommand.php
@@ -22,12 +22,18 @@ use App\Repository\UserRoleRepository;
 use App\Repository\VocabularyRepository;
 use App\Service\DefaultDataImporter;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'ilios:import-default-data',
+    description: 'Imports default application data into Ilios. Only works with an empty database schema.',
+    aliases: ['ilios:setup:import-default-data']
+)]
 class ImportDefaultDataCommand extends Command
 {
     use LockableTrait;
@@ -54,14 +60,6 @@ class ImportDefaultDataCommand extends Command
         parent::__construct();
     }
 
-    protected function configure(): void
-    {
-        $this
-            ->setName('ilios:import-default-data')
-            ->setAliases(['ilios:setup:import-default-data'])
-            ->setDescription('Imports default application data into Ilios. Only works with an empty database schema.');
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
@@ -82,7 +80,7 @@ class ImportDefaultDataCommand extends Command
         $referenceMap = [];
         try {
             // ACHTUNG!
-            // we MUST clear the the aamc_method and application_configs table as part of the import process,
+            // we MUST clear the aamc_method and application_configs table as part of the import process,
             // since it gets pre-populated with data in the previous step of the installation
             // process (when migrations are running).
             // So let's just clear all records out here first, in order to avoid data duplication issues.

--- a/src/Command/ImportMeshUniverseCommand.php
+++ b/src/Command/ImportMeshUniverseCommand.php
@@ -8,6 +8,7 @@ use App\Repository\MeshDescriptorRepository;
 use App\Service\Index\Mesh;
 use Ilios\MeSH\Parser;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -20,6 +21,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Class ImportMeshUniverseCommand
  */
+#[AsCommand(
+    name: 'ilios:import-mesh-universe',
+    description: 'Imports the MeSH universe into Ilios.',
+    aliases: ['ilios:maintenance:import-mesh-universe']
+)]
 class ImportMeshUniverseCommand extends Command
 {
     use LockableTrait;
@@ -43,9 +49,6 @@ class ImportMeshUniverseCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:import-mesh-universe')
-            ->setAliases(['ilios:maintenance:import-mesh-universe'])
-            ->setDescription('Imports the MeSH universe into Ilios.')
             ->addOption(
                 'url',
                 'u',
@@ -71,7 +74,7 @@ class ImportMeshUniverseCommand extends Command
     {
         if (!$this->lock()) {
             $output->writeln('The command is already running in another process.');
-            return 0;
+            return Command::SUCCESS;
         }
         $steps = $this->meshIndex->isEnabled() ? 5 : 4;
         $startTime = time();
@@ -112,7 +115,7 @@ class ImportMeshUniverseCommand extends Command
         $output->writeln("Finished MeSH universe import in {$duration} seconds.");
         $this->release();
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getUri(InputInterface $input): string

--- a/src/Command/Index/CreateCommand.php
+++ b/src/Command/Index/CreateCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command\Index;
 
 use App\Service\Index\Manager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -12,21 +13,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Create Search Index
  */
+#[AsCommand(
+    name: 'ilios:index:create',
+    description: 'Create and empty search index'
+)]
 class CreateCommand extends Command
 {
-    public const COMMAND_NAME = 'ilios:index:create';
-
     public function __construct(
         protected Manager $indexManager
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName(self::COMMAND_NAME)
-            ->setDescription('Create and empty search index');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -39,6 +35,6 @@ class CreateCommand extends Command
             $output->writeln("<info>Done.</info>");
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/Index/DropCommand.php
+++ b/src/Command/Index/DropCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command\Index;
 
 use App\Service\Index\Manager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -13,10 +14,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Drop Search Index
  */
+#[AsCommand(
+    name: 'ilios:index:drop',
+    description: 'Drop the search index removing all documents and settings'
+)]
 class DropCommand extends Command
 {
-    public const COMMAND_NAME = 'ilios:index:drop';
-
     public function __construct(
         protected Manager $indexManager
     ) {
@@ -26,8 +29,6 @@ class DropCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(self::COMMAND_NAME)
-            ->setDescription('Drop the search index removing all documents and settings')
             ->addOption(
                 'force',
                 null,
@@ -46,12 +47,12 @@ class DropCommand extends Command
             $output->writeln('');
             $output->writeln('Please run the operation with --force to execute');
             $output->writeln('<error>All data will be lost!</error>');
-            return 2;
+            return Command::INVALID;
         }
         $output->writeln("<info>Dropping the index.</info>");
         $this->indexManager->drop();
         $output->writeln("<info>Ok.</info>");
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/Index/UpdateCommand.php
+++ b/src/Command/Index/UpdateCommand.php
@@ -12,6 +12,7 @@ use App\Repository\CourseRepository;
 use App\Repository\LearningMaterialRepository;
 use App\Repository\MeshDescriptorRepository;
 use App\Repository\UserRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,10 +21,12 @@ use Symfony\Component\Messenger\MessageBusInterface;
 /**
  * Queues the updating of all indexed items
  */
+#[AsCommand(
+    name: 'ilios:index:update',
+    description: 'Queue everything to be updated in the index.'
+)]
 class UpdateCommand extends Command
 {
-    public const COMMAND_NAME = 'ilios:index:update';
-
     public function __construct(
         protected UserRepository $userRepository,
         protected CourseRepository $courseRepository,
@@ -34,13 +37,6 @@ class UpdateCommand extends Command
         parent::__construct();
     }
 
-    protected function configure(): void
-    {
-        $this
-            ->setName(self::COMMAND_NAME)
-            ->setDescription('Queue everything to be updated in the index.');
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->queueUsers($output);
@@ -49,10 +45,10 @@ class UpdateCommand extends Command
         $this->queueCourses($output);
         $this->queueMesh($output);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
-    protected function queueUsers(OutputInterface $output)
+    protected function queueUsers(OutputInterface $output): void
     {
         $allIds = $this->userRepository->getIds();
         $count = count($allIds);
@@ -63,7 +59,7 @@ class UpdateCommand extends Command
         $output->writeln("<info>{$count} users have been queued for indexing.</info>");
     }
 
-    protected function queueCourses(OutputInterface $output)
+    protected function queueCourses(OutputInterface $output): void
     {
         $allIds = $this->courseRepository->getIds();
         $count = count($allIds);
@@ -74,7 +70,7 @@ class UpdateCommand extends Command
         $output->writeln("<info>{$count} courses have been queued for indexing.</info>");
     }
 
-    protected function queueLearningMaterials(OutputInterface $output)
+    protected function queueLearningMaterials(OutputInterface $output): void
     {
         $allIds = $this->learningMaterialRepository->getFileLearningMaterialIds();
         $count = count($allIds);
@@ -84,7 +80,7 @@ class UpdateCommand extends Command
         $output->writeln("<info>{$count} learning materials have been queued for indexing.</info>");
     }
 
-    protected function queueMesh(OutputInterface $output)
+    protected function queueMesh(OutputInterface $output): void
     {
         $allIds = $this->descriptorRepository->getIds();
         $count = count($allIds);

--- a/src/Command/InstallFirstUserCommand.php
+++ b/src/Command/InstallFirstUserCommand.php
@@ -13,6 +13,7 @@ use App\Entity\SchoolInterface;
 use App\Entity\UserInterface;
 use Exception;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -26,26 +27,16 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  *
  * Class InstallFirstUserCommand
  */
+#[AsCommand(
+    name: 'ilios:setup-first-user',
+    description: 'Creates a first user account with root privileges.',
+    aliases: ['ilios:setup:first-user']
+)]
 class InstallFirstUserCommand extends Command
 {
-    /**
-     * @var string
-     */
     private const USERNAME = 'first_user';
-
-    /**
-     * @var string
-     */
     private const PASSWORD = 'Ch4nge_m3';
-
-    /**
-     * @var string
-     */
     private const FIRST_NAME = 'First';
-
-    /**
-     * @var string
-     */
     private const LAST_NAME = 'User';
 
     /**
@@ -64,9 +55,6 @@ class InstallFirstUserCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:setup-first-user')
-            ->setAliases(['ilios:setup:first-user'])
-            ->setDescription('Creates a first user account with root privileges.')
             ->addOption(
                 'school',
                 null,
@@ -173,6 +161,6 @@ class InstallFirstUserCommand extends Command
         $output->writeln(sprintf("You may now log in as '%s' with the password '%s'.", self::USERNAME, self::PASSWORD));
         $output->writeln('Please change this password as soon as possible.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/InvalidateUserTokenCommand.php
+++ b/src/Command/InvalidateUserTokenCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Repository\AuthenticationRepository;
 use App\Repository\UserRepository;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,6 +19,11 @@ use DateTime;
  *
  * Class InvalidateUserTokenCommand
  */
+#[AsCommand(
+    name: 'ilios:invalidate-user-tokens',
+    description: 'Invalidate all user tokens issued before now.',
+    aliases: ['ilios:maintenance:invalidate-user-tokens']
+)]
 class InvalidateUserTokenCommand extends Command
 {
     public function __construct(
@@ -29,15 +35,7 @@ class InvalidateUserTokenCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:invalidate-user-tokens')
-            ->setAliases(['ilios:maintenance:invalidate-user-tokens'])
-            ->setDescription('Invalidate all user tokens issued before now.')
-            ->addArgument(
-                'userId',
-                InputArgument::REQUIRED,
-                'A valid user id.'
-            );
+        $this->addArgument('userId', InputArgument::REQUIRED, 'A valid user id.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -67,6 +65,6 @@ class InvalidateUserTokenCommand extends Command
             ' have been invalidated.'
         );
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ListConfigValuesCommand.php
+++ b/src/Command/ListConfigValuesCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Entity\ApplicationConfig;
 use App\Repository\ApplicationConfigRepository;
 use Doctrine\DBAL\Exception\ConnectionException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,6 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Class ListConfigValuesCommand
  * @package App\Command
  */
+#[AsCommand(
+    name: 'ilios:list-config-values',
+    description: 'Read configuration values from the DB',
+    aliases: ['ilios:maintenance:list-config-values']
+)]
 class ListConfigValuesCommand extends Command
 {
     /**
@@ -29,19 +35,11 @@ class ListConfigValuesCommand extends Command
      */
     public function __construct(
         protected ApplicationConfigRepository $applicationConfigRepository,
-        protected $environment,
-        protected $kernelSecret,
-        protected $databaseUrl
+        protected string $environment,
+        protected string $kernelSecret,
+        protected string $databaseUrl
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('ilios:list-config-values')
-            ->setAliases(['ilios:maintenance:list-config-values'])
-            ->setDescription('Read configuration values from the DB');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/ListRootUsersCommand.php
+++ b/src/Command/ListRootUsersCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Repository\UserRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,24 +16,16 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Class ListRootUsersCommand
  */
+#[AsCommand(
+    name: 'ilios:list-root-users',
+    description: 'Lists all users with root-level privileges.',
+    aliases: ['ilios:maintenance:list-root-users']
+)]
 class ListRootUsersCommand extends Command
 {
-    /**
-     * @var string
-     */
-    public const COMMAND_NAME = 'ilios:list-root-users';
-
     public function __construct(protected UserRepository $userRepository)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName(self::COMMAND_NAME)
-            ->setAliases(['ilios:maintenance:list-root-users'])
-            ->setDescription('Lists all users with root-level privileges.');
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
@@ -41,7 +34,7 @@ class ListRootUsersCommand extends Command
 
         if (empty($users)) {
             $output->writeln("No users with root-level privileges found.");
-            return 0;
+            return Command::SUCCESS;
         }
 
         $rows = array_map(fn($dto) => [
@@ -60,6 +53,6 @@ class ListRootUsersCommand extends Command
         ;
         $table->render();
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ListSchoolConfigValuesCommand.php
+++ b/src/Command/ListSchoolConfigValuesCommand.php
@@ -8,6 +8,7 @@ use App\Entity\SchoolConfigInterface;
 use App\Entity\SchoolInterface;
 use App\Repository\SchoolConfigRepository;
 use App\Repository\SchoolRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -17,6 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Get a school configuration value from the DB
  */
+#[AsCommand(
+    name: 'ilios:list-school-config-values',
+    description: 'Read school configuration values from the DB',
+    aliases: ['ilios:maintenance:list-school-config-values']
+)]
 class ListSchoolConfigValuesCommand extends Command
 {
     public function __construct(
@@ -28,16 +34,7 @@ class ListSchoolConfigValuesCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:list-school-config-values')
-            ->setAliases(['ilios:maintenance:list-school-config-values'])
-            ->setDescription('Read school configuration values from the DB')
-            //required arguments
-            ->addArgument(
-                'school',
-                InputArgument::REQUIRED,
-                'ID of the school.'
-            );
+        $this->addArgument('school', InputArgument::REQUIRED, 'ID of the school.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -46,7 +43,7 @@ class ListSchoolConfigValuesCommand extends Command
         $school = $this->schoolRepository->findOneBy(['id' => $schoolId]);
         if (!$school) {
             $output->writeln("<error>There are no schools with id {$schoolId}.</error>");
-            return 1;
+            return Command::FAILURE;
         }
         /** @var SchoolConfigInterface[] $configs */
         $configs = $this->schoolConfigRepository->findBy(['school' => $schoolId], ['name' => 'asc']);
@@ -60,6 +57,6 @@ class ListSchoolConfigValuesCommand extends Command
             $table->render();
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ListServiceTokensCommand.php
+++ b/src/Command/ListServiceTokensCommand.php
@@ -9,6 +9,7 @@ use App\Repository\ServiceTokenRepository;
 use DateInterval;
 use DateTimeImmutable;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,6 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Lists out service tokens, with some filtering options.
  */
+#[AsCommand(
+    name: 'ilios:service-token:list',
+    description: 'List service tokens.',
+    aliases: ['ilios:maintenance:service-token:list']
+)]
 class ListServiceTokensCommand extends Command
 {
     public const EXCLUDE_DISABLED_KEY = 'exclude-disabled';
@@ -33,9 +39,6 @@ class ListServiceTokensCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:service-token:list')
-            ->setAliases(['ilios:maintenance:service-token:list'])
-            ->setDescription('List service tokens.')
             ->addOption(
                 self::EXCLUDE_DISABLED_KEY,
                 null,

--- a/src/Command/MigrateIlios2LearningMaterialsCommand.php
+++ b/src/Command/MigrateIlios2LearningMaterialsCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\Repository\LearningMaterialRepository;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -21,6 +22,12 @@ use Symfony\Component\HttpFoundation\File\File;
  *
  * Class MigrateIlios2LearningMaterialsCommand
  */
+#[AsCommand(
+    name: 'ilios:migrate-learning-materials',
+    description: 'Migrate Ilios2 Learning Materials to Ilios3 Structure',
+    aliases: ['ilios:setup:migrate-learning-materials'],
+    hidden: true
+)]
 class MigrateIlios2LearningMaterialsCommand extends Command
 {
     public function __construct(
@@ -33,16 +40,7 @@ class MigrateIlios2LearningMaterialsCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:migrate-learning-materials')
-            ->setAliases(['ilios:setup:migrate-learning-materials'])
-            ->setHidden(true)
-            ->setDescription('Migrate Ilios2 Learning Materials to Ilios3 Structure')
-            ->addArgument(
-                'pathToIlios2',
-                InputArgument::REQUIRED,
-                'The path to your Ilios2 installation.'
-            );
+        $this->addArgument('pathToIlios2', InputArgument::REQUIRED, 'The path to your Ilios2 installation.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -107,6 +105,6 @@ class MigrateIlios2LearningMaterialsCommand extends Command
             $output->writeln('<comment>Migration canceled.</comment>');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/RemoveRootUserCommand.php
+++ b/src/Command/RemoveRootUserCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Entity\UserInterface;
 use App\Repository\UserRepository;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,13 +18,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Class RemoveRootUserCommand
  */
+#[AsCommand(
+    name: 'ilios:remove-root-user',
+    description: 'Revokes root-level privileges from a given user.',
+    aliases: ['ilios:maintenance:remove-root-user'],
+)]
 class RemoveRootUserCommand extends Command
 {
-    /**
-     * @var string
-     */
-    public const COMMAND_NAME = 'ilios:remove-root-user';
-
     public function __construct(protected UserRepository $userRepository)
     {
         parent::__construct();
@@ -31,15 +32,7 @@ class RemoveRootUserCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName(self::COMMAND_NAME)
-            ->setAliases(['ilios:maintenance:remove-root-user'])
-            ->setDescription('Revokes root-level privileges from a given user.')
-            ->addArgument(
-                'userId',
-                InputArgument::REQUIRED,
-                "The user's id."
-            );
+        $this->addArgument('userId', InputArgument::REQUIRED, "The user's id.");
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
@@ -54,6 +47,6 @@ class RemoveRootUserCommand extends Command
         $this->userRepository->update($user, true, true);
         $output->writeln("Root-level privileges have been revoked from user with id #{$userId}.");
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/RolloverCourseCommand.php
+++ b/src/Command/RolloverCourseCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Service\CourseRollover;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -16,11 +17,13 @@ use Symfony\Component\Console\Input\InputArgument;
  *
  * Class RolloverCourseCommand
  */
+#[AsCommand(
+    name: 'ilios:rollover-course',
+    description: 'Roll over a course to a new year using its course_id',
+    aliases: ['ilios:maintenance:rollover-course'],
+)]
 class RolloverCourseCommand extends Command
 {
-    /**
-     * RolloverCourseCommand constructor.
-     */
     public function __construct(protected CourseRollover $service)
     {
         parent::__construct();
@@ -29,9 +32,6 @@ class RolloverCourseCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:rollover-course')
-            ->setAliases(['ilios:maintenance:rollover-course'])
-            ->setDescription('Roll over a course to a new year using its course_id')
             //required arguments
             ->addArgument(
                 'courseId',
@@ -157,6 +157,6 @@ class RolloverCourseCommand extends Command
         //output message with the new courseId on success
         $output->writeln("This course has been rolled over. The new course id is {$newCourse->getId()}.");
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/RolloverCurriculumInventoryReportCommand.php
+++ b/src/Command/RolloverCurriculumInventoryReportCommand.php
@@ -8,6 +8,7 @@ use App\Entity\CurriculumInventoryReportInterface;
 use App\Repository\CurriculumInventoryReportRepository;
 use App\Service\CurriculumInventory\ReportRollover;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -17,6 +18,11 @@ use Symfony\Component\Console\Input\InputArgument;
 /**
  * Rolls over (copies) a given curriculum inventory report.
  */
+#[AsCommand(
+    name: 'ilios:rollover-ci-report',
+    description: 'Rolls over (copies) a given curriculum inventory report.',
+    aliases: ['ilios:maintenance:rollover-ci-report'],
+)]
 class RolloverCurriculumInventoryReportCommand extends Command
 {
     public function __construct(
@@ -29,9 +35,6 @@ class RolloverCurriculumInventoryReportCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:rollover-ci-report')
-            ->setAliases(['ilios:maintenance:rollover-ci-report'])
-            ->setDescription('Rolls over (copies) a given curriculum inventory report.')
             //required arguments
             ->addArgument(
                 'reportId',
@@ -79,6 +82,6 @@ class RolloverCurriculumInventoryReportCommand extends Command
         //output message with the new courseId on success
         $output->writeln("The given report has been rolled over. The new report id is {$newReport->getId()}.");
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/SendChangeAlertsCommand.php
+++ b/src/Command/SendChangeAlertsCommand.php
@@ -11,6 +11,7 @@ use App\Repository\AlertRepository;
 use App\Repository\AuditLogRepository;
 use App\Repository\OfferingRepository;
 use App\Service\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,6 +26,11 @@ use Twig\Environment;
  *
  * Class SendChangeAlertsCommand
  */
+#[AsCommand(
+    name: 'ilios:send-change-alerts',
+    description: 'Sends out change alert message to configured email recipients.',
+    aliases: ['ilios:messaging:send-change-alerts'],
+)]
 class SendChangeAlertsCommand extends Command
 {
     private const DEFAULT_TEMPLATE_NAME = 'offeringchangealert.text.twig';
@@ -45,9 +51,6 @@ class SendChangeAlertsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:send-change-alerts')
-            ->setAliases(['ilios:messaging:send-change-alerts'])
-            ->setDescription('Sends out change alert message to configured email recipients.')
             ->addOption(
                 'dry-run',
                 null,
@@ -63,7 +66,7 @@ class SendChangeAlertsCommand extends Command
         $alerts = $this->alertRepository->findBy(['dispatched' => false, 'tableName' => 'offering']);
         if ($alerts === []) {
             $output->writeln("<info>No undispatched offering alerts found.</info>");
-            return 0;
+            return Command::SUCCESS;
         }
 
         $templateCache = [];
@@ -165,7 +168,7 @@ class SendChangeAlertsCommand extends Command
             $output->writeln("<info>Marked {$dispatched} offering change alerts as dispatched.</info>");
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Command/SendTeachingRemindersCommand.php
+++ b/src/Command/SendTeachingRemindersCommand.php
@@ -10,6 +10,7 @@ use App\Entity\UserInterface;
 use App\Repository\OfferingRepository;
 use App\Repository\SchoolRepository;
 use App\Service\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,6 +27,11 @@ use Twig\Environment;
  *
  * Class SendTeachingRemindersCommand
  */
+#[AsCommand(
+    name: 'ilios:send-teaching-reminders',
+    description: 'Sends teaching reminders to educators.',
+    aliases: ['ilios:messaging:send-teaching-reminders'],
+)]
 class SendTeachingRemindersCommand extends Command
 {
     public const DEFAULT_TEMPLATE_NAME = 'teachingreminder.text.twig';
@@ -47,9 +53,6 @@ class SendTeachingRemindersCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:send-teaching-reminders')
-            ->setAliases(['ilios:messaging:send-teaching-reminders'])
-            ->setDescription('Sends teaching reminders to educators.')
             ->addArgument(
                 'sender',
                 InputArgument::REQUIRED,
@@ -102,7 +105,7 @@ class SendTeachingRemindersCommand extends Command
             foreach ($errors as $error) {
                 $output->writeln("<error>{$error}</error>");
             }
-            return 1;
+            return Command::FAILURE;
         }
 
         $daysInAdvance = (int) $input->getOption('days');
@@ -127,7 +130,7 @@ class SendTeachingRemindersCommand extends Command
 
         if ($offerings === []) {
             $output->writeln('<info>No offerings with pending teaching reminders found.</info>');
-            return 0;
+            return Command::SUCCESS;
         }
 
         // mail out a reminder per instructor per offering.
@@ -176,7 +179,7 @@ class SendTeachingRemindersCommand extends Command
 
         $output->writeln("<info>Sent {$i} teaching reminders.</info>");
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Command/SendTestEmailCommand.php
+++ b/src/Command/SendTestEmailCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -16,6 +17,10 @@ use Symfony\Component\Mime\Email;
  *
  * Class SendTestEmailCommand
  */
+#[AsCommand(
+    name: 'ilios:send-test-email',
+    description: 'Sends out a test email, useful for ensuring email is working.',
+)]
 class SendTestEmailCommand extends Command
 {
     public function __construct(protected MailerInterface $mailer)
@@ -26,8 +31,6 @@ class SendTestEmailCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:send-test-email')
-            ->setDescription('Sends out a test email, useful for ensuring email is working.')
             ->addArgument(
                 'from',
                 InputArgument::REQUIRED,

--- a/src/Command/SetConfigValueCommand.php
+++ b/src/Command/SetConfigValueCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Entity\ApplicationConfig;
 use App\Repository\ApplicationConfigRepository;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,6 +20,11 @@ use Symfony\Component\Console\Input\InputArgument;
  * Class SetConfigValueCommand
  * @package App\Command
  */
+#[AsCommand(
+    name: 'ilios:set-config-value',
+    description: 'Set a configuration value in the DB',
+    aliases: ['ilios:maintenance:set-config-value'],
+)]
 class SetConfigValueCommand extends Command
 {
     /**
@@ -32,9 +38,6 @@ class SetConfigValueCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:set-config-value')
-            ->setAliases(['ilios:maintenance:set-config-value'])
-            ->setDescription('Set a configuration value in the DB')
             //required arguments
             ->addArgument(
                 'name',

--- a/src/Command/SetSchoolConfigValueCommand.php
+++ b/src/Command/SetSchoolConfigValueCommand.php
@@ -8,6 +8,7 @@ use App\Entity\SchoolConfig;
 use App\Entity\SchoolInterface;
 use App\Repository\SchoolConfigRepository;
 use App\Repository\SchoolRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,6 +17,11 @@ use Symfony\Component\Console\Input\InputArgument;
 /**
  * Set a school configuration value in the DB
  */
+#[AsCommand(
+    name: 'ilios:set-school-config-value',
+    description: 'Set a school configuration value in the DB',
+    aliases: ['ilios:maintenance:set-school-config-value'],
+)]
 class SetSchoolConfigValueCommand extends Command
 {
     public function __construct(
@@ -28,9 +34,6 @@ class SetSchoolConfigValueCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:set-school-config-value')
-            ->setAliases(['ilios:maintenance:set-school-config-value'])
-            ->setDescription('Set a configuration value in the DB')
             //required arguments
             ->addArgument(
                 'school',
@@ -58,7 +61,7 @@ class SetSchoolConfigValueCommand extends Command
         $school = $this->schoolRepository->findOneBy(['id' => $schoolId]);
         if (!$school) {
             $output->writeln("<error>There are no schools with id {$schoolId}.</error>");
-            return 1;
+            return Command::FAILURE;
         }
 
         $config = $this->schoolConfigRepository->findOneBy(['school' => $school->getId(), 'name' => $name]);
@@ -73,6 +76,6 @@ class SetSchoolConfigValueCommand extends Command
 
         $output->writeln('<info>Done.</info>');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/SetupAuthenticationCommand.php
+++ b/src/Command/SetupAuthenticationCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\Entity\ApplicationConfig;
 use App\Repository\ApplicationConfigRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,19 +19,16 @@ use Symfony\Component\Console\Question\Question;
  * Class SetupAuthenticationCommand
  * @package App\Command
  */
+#[AsCommand(
+    name: 'ilios:setup-authentication',
+    description: 'Sets up authentication.',
+    aliases: ['ilios:setup:authentication'],
+)]
 class SetupAuthenticationCommand extends Command
 {
     public function __construct(protected ApplicationConfigRepository $applicationConfigRepository)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('ilios:setup-authentication')
-            ->setAliases(['ilios:setup:authentication'])
-            ->setDescription('Sets up authentication.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -73,7 +71,7 @@ class SetupAuthenticationCommand extends Command
 
         $output->writeln('<info>Authentication Setup Successfully!</info>');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function setupForm(): array

--- a/src/Command/SyncAllUsersCommand.php
+++ b/src/Command/SyncAllUsersCommand.php
@@ -10,6 +10,7 @@ use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use App\Entity\AuthenticationInterface;
 use App\Entity\UserInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,6 +21,11 @@ use App\Service\Directory;
  *
  * Class SyncUserCommand
  */
+#[AsCommand(
+    name: 'ilios:sync-users',
+    description: 'Sync all users against the directory by their campus ID.',
+    aliases: ['ilios:directory:sync-users'],
+)]
 class SyncAllUsersCommand extends Command
 {
     public function __construct(
@@ -30,14 +36,6 @@ class SyncAllUsersCommand extends Command
         protected EntityManagerInterface $em
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('ilios:sync-users')
-            ->setAliases(['ilios:directory:sync-users'])
-            ->setDescription('Sync all users against the directory by their campus ID.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -245,10 +243,10 @@ class SyncAllUsersCommand extends Command
             "{$updated} users updated.</info>"
         );
 
-        return 0;
+        return Command::SUCCESS;
     }
 
-    protected function validateDirectoryRecord(array $record, OutputInterface $output)
+    protected function validateDirectoryRecord(array $record, OutputInterface $output): bool
     {
         $valid = true;
         $requiredFields = ['firstName', 'lastName', 'email', 'username'];

--- a/src/Command/SyncFormerStudentsCommand.php
+++ b/src/Command/SyncFormerStudentsCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Entity\UserRoleInterface;
 use App\Repository\UserRepository;
 use App\Repository\UserRoleRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -21,6 +22,11 @@ use App\Service\Directory;
  *
  * Class SyncFormerStudentsCommand
  */
+#[AsCommand(
+    name: 'ilios:sync-former-students',
+    description: 'Sync former students from the directory.',
+    aliases: ['ilios:directory:sync-former-students'],
+)]
 class SyncFormerStudentsCommand extends Command
 {
     public function __construct(
@@ -34,9 +40,6 @@ class SyncFormerStudentsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:sync-former-students')
-            ->setAliases(['ilios:directory:sync-former-students'])
-            ->setDescription('Sync former students from the directory.')
             ->addArgument(
                 'filter',
                 InputArgument::REQUIRED,
@@ -53,7 +56,7 @@ class SyncFormerStudentsCommand extends Command
 
         if (!$formerStudents) {
             $output->writeln("<error>{$filter} returned no results.</error>");
-            return 0;
+            return Command::SUCCESS;
         }
         $output->writeln('<info>Found ' . count($formerStudents) . ' former students in the directory.</info>');
 
@@ -63,7 +66,7 @@ class SyncFormerStudentsCommand extends Command
         $usersToUpdate = $notFormerStudents->filter(fn(UserInterface $user) => !$user->isUserSyncIgnore());
         if (!$usersToUpdate->count() > 0) {
             $output->writeln("<info>There are no students to update.</info>");
-            return 0;
+            return Command::SUCCESS;
         }
         $output->writeln(
             '<info>There are ' .
@@ -100,11 +103,11 @@ class SyncFormerStudentsCommand extends Command
 
             $output->writeln('<info>Former students updated successfully!</info>');
 
-            return 0;
+            return Command::SUCCESS;
         } else {
             $output->writeln('<comment>Update canceled,</comment>');
 
-            return 1;
+            return Command::FAILURE;
         }
     }
 }

--- a/src/Command/SyncStudentStatusCommand.php
+++ b/src/Command/SyncStudentStatusCommand.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Command;
 
-use App\Entity\UserRoleInterface;
 use App\Repository\UserRepository;
 use App\Repository\UserRoleRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -19,6 +19,10 @@ use App\Service\Directory;
 /**
  * Syncs students from the directory.
  */
+#[AsCommand(
+    name: 'ilios:sync-students',
+    description: 'Sync students from the directory.'
+)]
 class SyncStudentStatusCommand extends Command
 {
     public function __construct(
@@ -32,8 +36,6 @@ class SyncStudentStatusCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ilios:sync-students')
-            ->setDescription('Sync students from the directory.')
             ->addArgument(
                 'filter',
                 InputArgument::REQUIRED,
@@ -50,7 +52,7 @@ class SyncStudentStatusCommand extends Command
 
         if (!$students) {
             $output->writeln("<error>{$filter} returned no results.</error>");
-            return 0;
+            return Command::SUCCESS;
         }
         $output->writeln('<info>Found ' . count($students) . ' students in the directory.</info>');
 
@@ -63,7 +65,7 @@ class SyncStudentStatusCommand extends Command
         );
         if ($usersToUpdate === []) {
             $output->writeln("<info>There are no students to update.</info>");
-            return 0;
+            return Command::SUCCESS;
         }
         $output->writeln(
             '<info>There are ' .
@@ -97,11 +99,11 @@ class SyncStudentStatusCommand extends Command
 
             $output->writeln('<info>Students updated successfully!</info>');
 
-            return 0;
+            return Command::SUCCESS;
         } else {
             $output->writeln('<comment>Update canceled,</comment>');
 
-            return 1;
+            return Command::FAILURE;
         }
     }
 }

--- a/src/Command/SyncUserCommand.php
+++ b/src/Command/SyncUserCommand.php
@@ -9,6 +9,7 @@ use App\Repository\AuthenticationRepository;
 use App\Repository\PendingUserUpdateRepository;
 use App\Repository\UserRepository;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,6 +23,11 @@ use App\Service\Directory;
  *
  * Class SyncUserCommand
  */
+#[AsCommand(
+    name: 'ilios:sync-user',
+    description: 'Sync a user from the directory.',
+    aliases: ['ilios:directory:sync-user'],
+)]
 class SyncUserCommand extends Command
 {
     public function __construct(
@@ -35,15 +41,7 @@ class SyncUserCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setName('ilios:sync-user')
-            ->setAliases(['ilios:directory:sync-user'])
-            ->setDescription('Sync a user from the directory.')
-            ->addArgument(
-                'userId',
-                InputArgument::REQUIRED,
-                'A valid user id.'
-            );
+        $this->addArgument('userId', InputArgument::REQUIRED, 'A valid user id.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -60,7 +58,7 @@ class SyncUserCommand extends Command
 
         if (!$userRecord) {
             $output->writeln('<error>Unable to find ' . $user->getCampusId() . ' in the directory.');
-            return 1;
+            return Command::FAILURE;
         }
 
         $table = new Table($output);
@@ -132,11 +130,11 @@ class SyncUserCommand extends Command
 
             $output->writeln('<info>User updated successfully!</info>');
 
-            return 0;
+            return Command::SUCCESS;
         } else {
             $output->writeln('<comment>Update canceled.</comment>');
 
-            return 1;
+            return Command::FAILURE;
         }
     }
 }

--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -9,6 +9,7 @@ use App\Service\Config;
 use App\Service\Fetch;
 use DateTime;
 use SimpleXMLElement;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,22 +30,23 @@ use function is_dir;
  * Class UpdateFrontendCommand
  * @package App\Command
  */
+#[AsCommand(
+    name: 'ilios:update-frontend',
+    description: 'Updates the frontend to the latest version.',
+    aliases: ['ilios:maintenance:update-frontend'],
+)]
 class UpdateFrontendCommand extends Command implements CacheWarmerInterface
 {
     private const UNPACKED_DIRECTORY = '/deploy-dist/';
     private const FRONTEND_FILES = '/var/frontend/';
-
     private const STAGING_CDN_ASSET_DOMAIN = 'https://frontend-archive-staging.iliosproject.org/';
     private const STAGING_ASSET_LIST = 'https://frontend-archive-staging.s3.us-west-2.amazonaws.com/';
     private const PRODUCTION_CDN_ASSET_DOMAIN = 'https://frontend-archive-production.iliosproject.org/';
     private const PRODUCTION_ASSET_LIST = 'https://frontend-archive-production.s3.us-west-2.amazonaws.com/';
-
     private const STAGING = 'stage';
     private const PRODUCTION = 'prod';
-
     protected string $productionTemporaryFileStore;
     protected string $stagingTemporaryFileStore;
-    protected string $publicDirectory;
     protected string $frontendAssetDirectory;
     protected ?OutputInterface $output;
 
@@ -72,9 +74,6 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
     protected function configure(): void
     {
         $this
-            ->setName('ilios:update-frontend')
-            ->setAliases(['ilios:maintenance:update-frontend'])
-            ->setDescription('Updates the frontend to the latest version.')
             ->addOption(
                 'staging-build',
                 null,
@@ -125,11 +124,11 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
             }
             $output->writeln("<info>Frontend updated successfully{$message}!</info>");
 
-            return 0;
+            return Command::SUCCESS;
         } catch (Exception) {
             $output->writeln("<error>No matching frontend found{$message}!</error>");
 
-            return 1;
+            return Command::FAILURE;
         }
     }
 

--- a/src/Command/ValidateLearningMaterialPathsCommand.php
+++ b/src/Command/ValidateLearningMaterialPathsCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Repository\LearningMaterialRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,6 +18,11 @@ use App\Service\IliosFileSystem;
  *
  * Class SyncUserCommand
  */
+#[AsCommand(
+    name: 'ilios:validate-learning-materials',
+    description: 'Validate file paths for learning materials',
+    aliases: ['ilios:maintenance:validate-learning-materials'],
+)]
 class ValidateLearningMaterialPathsCommand extends Command
 {
     public function __construct(
@@ -24,14 +30,6 @@ class ValidateLearningMaterialPathsCommand extends Command
         protected LearningMaterialRepository $learningMaterialRepository
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('ilios:validate-learning-materials')
-            ->setAliases(['ilios:maintenance:validate-learning-materials'])
-            ->setDescription('Validate file paths for learning materials');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -82,9 +80,9 @@ class ValidateLearningMaterialPathsCommand extends Command
             ;
             $table->render();
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/WaitForDatabaseCommand.php
+++ b/src/Command/WaitForDatabaseCommand.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,21 +17,16 @@ use function sleep;
  * Wait for the database to become available
  * Useful for running before another command like migrate
  */
+#[AsCommand(
+    name: 'ilios:wait-for-database',
+    description: 'Wait for a database connection.'
+)]
 class WaitForDatabaseCommand extends Command
 {
-    public const COMMAND_NAME = 'ilios:wait-for-database';
-
     public function __construct(
         protected EntityManagerInterface $entityManager,
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName(self::COMMAND_NAME)
-            ->setDescription('Wait for a database connection.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/WaitForIndexCommand.php
+++ b/src/Command/WaitForIndexCommand.php
@@ -8,6 +8,7 @@ use App\Service\Index\Manager;
 use Exception;
 use OpenSearch\Client;
 use OpenSearch\Common\Exceptions\NoNodesAvailableException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,22 +19,17 @@ use function sleep;
  * Wait for the search index to become available
  * Useful for running before another command like consume messages
  */
+#[AsCommand(
+    name: 'ilios:wait-for-index',
+    description: 'Wait for a connection to index.',
+)]
 class WaitForIndexCommand extends Command
 {
-    public const COMMAND_NAME = 'ilios:wait-for-index';
-
     public function __construct(
         protected ?Client $client,
         protected Manager $indexManager,
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName(self::COMMAND_NAME)
-            ->setDescription('Wait for a connection to index.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/tests/Command/AddDirectoryUserCommandTest.php
+++ b/tests/Command/AddDirectoryUserCommandTest.php
@@ -28,8 +28,6 @@ class AddDirectoryUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:add-directory-user';
-
     protected m\MockInterface $userRepository;
     protected m\MockInterface $authenticationRepository;
     protected m\MockInterface $schoolRepository;
@@ -53,7 +51,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -110,9 +108,8 @@ class AddDirectoryUserCommandTest extends KernelTestCase
         $this->commandTester->setInputs(['Yes']);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'campusId'         => 'abc',
-            'schoolId'         => '1',
+            'campusId' => 'abc',
+            'schoolId' => '1',
         ]);
 
 
@@ -135,9 +132,8 @@ class AddDirectoryUserCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['campusId' => 1])->andReturn($user);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'campusId'         => '1',
-            'schoolId'         => '1'
+            'campusId' => '1',
+            'schoolId' => '1'
         ]);
     }
 
@@ -147,9 +143,8 @@ class AddDirectoryUserCommandTest extends KernelTestCase
         $this->schoolRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'campusId'         => '1',
-            'schoolId'         => '1'
+            'campusId' => '1',
+            'schoolId' => '1'
         ]);
     }
 
@@ -157,8 +152,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'schoolId'         => '1'
+            'schoolId' => '1'
         ]);
     }
 
@@ -166,8 +160,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'campusId'         => '1',
+            'campusId' => '1',
         ]);
     }
 }

--- a/tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -30,8 +30,6 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:add-students';
-
     protected m\MockInterface $userRepository;
     protected m\MockInterface $userRolerepository;
     protected m\MockInterface $schoolRepository;
@@ -58,7 +56,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -146,9 +144,8 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
 
         $this->commandTester->setInputs(['Yes']);
         $this->commandTester->execute([
-            'command'   => self::COMMAND_NAME,
-            'schoolId'    => 1,
-            'filter'    => 'FILTER',
+            'schoolId' => 1,
+            'filter' => 'FILTER',
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -180,9 +177,8 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
         $this->schoolRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'filter'         => 'FILTER',
-            'schoolId'         => '1'
+            'filter' => 'FILTER',
+            'schoolId' => '1'
         ]);
     }
 
@@ -190,8 +186,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'schoolId'         => '1'
+            'schoolId' => '1'
         ]);
     }
 
@@ -199,8 +194,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'filter'         => '1',
+            'filter' => '1',
         ]);
     }
 }

--- a/tests/Command/AddRootUserCommandTest.php
+++ b/tests/Command/AddRootUserCommandTest.php
@@ -37,7 +37,7 @@ class AddRootUserCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(AddRootUserCommand::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -61,7 +61,6 @@ class AddRootUserCommandTest extends KernelTestCase
         $user->shouldReceive('setRoot');
 
         $this->commandTester->execute([
-            'command' => AddRootUserCommand::COMMAND_NAME,
             'userId' => $userId
         ]);
 
@@ -79,9 +78,7 @@ class AddRootUserCommandTest extends KernelTestCase
     public function testMissingInput(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute([
-            'command' => AddRootUserCommand::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
     }
 
     /**
@@ -94,7 +91,6 @@ class AddRootUserCommandTest extends KernelTestCase
 
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command' => AddRootUserCommand::COMMAND_NAME,
             'userId' => $userId
         ]);
     }

--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -31,8 +31,6 @@ class AddUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:add-user';
-
     protected m\MockInterface $userRepository;
     protected m\MockInterface $authenticationRepository;
     protected m\MockInterface $schoolRepository;
@@ -57,11 +55,10 @@ class AddUserCommandTest extends KernelTestCase
             $this->hasher,
             $this->sessionUserProvider
         );
-
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
 
         // Override the question helper to fix testing issue with hidden password input
         $helper = new TestQuestionHelper();
@@ -91,7 +88,6 @@ class AddUserCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
                 '--firstName' => 'first',
                 '--lastName' => 'last',
@@ -115,7 +111,6 @@ class AddUserCommandTest extends KernelTestCase
         $this->expectException(Exception::class);
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
             ]
         );
@@ -129,7 +124,6 @@ class AddUserCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
                 '--lastName' => 'last',
                 '--email' => 'email@example.com',
@@ -152,7 +146,6 @@ class AddUserCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
                 '--firstName' => 'first',
                 '--email' => 'email@example.com',
@@ -175,7 +168,6 @@ class AddUserCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
                 '--firstName' => 'first',
                 '--lastName' => 'last',
@@ -198,7 +190,6 @@ class AddUserCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
                 '--firstName' => 'first',
                 '--email' => 'email@example.com',
@@ -221,7 +212,6 @@ class AddUserCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
                 '--firstName' => 'first',
                 '--lastName' => 'last',
@@ -244,7 +234,6 @@ class AddUserCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
                 '--firstName' => 'first',
                 '--lastName' => 'last',
@@ -267,7 +256,6 @@ class AddUserCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
                 '--firstName' => 'first',
                 '--lastName' => 'last',
@@ -290,7 +278,6 @@ class AddUserCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command' => self::COMMAND_NAME,
                 '--schoolId' => '1',
                 '--firstName' => 'first',
                 '--lastName' => 'last',

--- a/tests/Command/AuditLogExportCommandTest.php
+++ b/tests/Command/AuditLogExportCommandTest.php
@@ -41,9 +41,16 @@ class AuditLogExportCommandTest extends KernelTestCase
         $application = new Application($kernel);
         $command = new AuditLogExportCommand($this->logger, $this->auditLogRepository);
         $application->add($command);
-
-        $command = $application->find('ilios:export-audit-log');
+        $command = $application->find($command->getName());
         $this->commandTester = new CommandTester($command);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->auditLogRepository);
+        unset($this->commandTester);
+        unset($this->logger);
     }
 
     /**

--- a/tests/Command/ChangePasswordCommandTest.php
+++ b/tests/Command/ChangePasswordCommandTest.php
@@ -29,8 +29,6 @@ class ChangePasswordCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:change-password';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $userRepository;
     protected m\MockInterface $authenticationRepository;
@@ -54,7 +52,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
 
         // Override the question helper to fix testing issue with hidden password input
         $helper = new TestQuestionHelper();
@@ -92,7 +90,7 @@ class ChangePasswordCommandTest extends KernelTestCase
 
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
-        $this->commandTester->execute(['command' => self::COMMAND_NAME, 'userId' => '1']);
+        $this->commandTester->execute(['userId' => '1']);
 
 
         $output = $this->commandTester->getDisplay();
@@ -122,8 +120,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
 
 
@@ -139,14 +136,13 @@ class ChangePasswordCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
     }
 
     public function testUserRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/ChangeUsernameCommandTest.php
+++ b/tests/Command/ChangeUsernameCommandTest.php
@@ -26,8 +26,6 @@ class ChangeUsernameCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:change-username';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $userRepository;
     protected m\MockInterface $authenticationRepository;
@@ -37,7 +35,6 @@ class ChangeUsernameCommandTest extends KernelTestCase
         parent::setUp();
         $this->userRepository = m::mock(UserRepository::class);
         $this->authenticationRepository = m::mock(AuthenticationRepository::class);
-
         $command = new ChangeUsernameCommand(
             $this->userRepository,
             $this->authenticationRepository
@@ -45,7 +42,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -74,8 +71,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
 
 
@@ -102,8 +98,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
 
 
@@ -124,8 +119,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
 
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
     }
 
@@ -139,8 +133,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
 
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
     }
 
@@ -154,8 +147,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
 
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
     }
 
@@ -175,8 +167,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
 
 
@@ -203,8 +194,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
 
 
@@ -220,14 +210,13 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
     }
 
     public function testUserRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/CleanupS3FilesystemCacheCommandTest.php
+++ b/tests/Command/CleanupS3FilesystemCacheCommandTest.php
@@ -26,7 +26,6 @@ class CleanupS3FilesystemCacheCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:cleanup-s3-cache';
     private const CACHE_DIR = __DIR__ . '/test';
 
     protected CommandTester $commandTester;
@@ -41,12 +40,11 @@ class CleanupS3FilesystemCacheCommandTest extends KernelTestCase
         $this->diskSpace = m::mock(DiskSpace::class);
         $factory->shouldReceive('getS3LocalFilesystemCache')->once()->andReturn($this->filesystem);
         $factory->shouldReceive('getLocalS3CacheDirectory')->once()->andReturn(self::CACHE_DIR);
-
         $command = new CleanupS3FilesystemCacheCommand($factory, $this->diskSpace);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -67,9 +65,7 @@ class CleanupS3FilesystemCacheCommandTest extends KernelTestCase
         $this->diskSpace->shouldReceive('totalSpace')->once()->with(self::CACHE_DIR)->andReturn(100);
 
 
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -119,9 +115,7 @@ class CleanupS3FilesystemCacheCommandTest extends KernelTestCase
         $this->filesystem->shouldReceive('delete')->with('file1');
         $this->filesystem->shouldReceive('delete')->with('file3');
 
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
 

--- a/tests/Command/CleanupStringsCommandTest.php
+++ b/tests/Command/CleanupStringsCommandTest.php
@@ -39,8 +39,6 @@ class CleanupStringsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:cleanup-strings';
-
     protected HTMLPurifier $purifier;
     protected m\MockInterface $em;
     protected m\MockInterface $sessionObjectiveRepository;
@@ -82,7 +80,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -147,7 +145,6 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->times(3);
         $this->em->shouldReceive('clear')->times(3);
         $this->commandTester->execute([
-            'command'           => self::COMMAND_NAME,
             '--objective-title' => true
         ]);
 
@@ -200,7 +197,6 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->times(3);
         $this->em->shouldReceive('clear')->times(3);
         $this->commandTester->execute([
-            'command'           => self::COMMAND_NAME,
             '--objective-title-blankspace' => true
         ]);
 
@@ -230,7 +226,6 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute([
-            'command'           => self::COMMAND_NAME,
             '--learningmaterial-description' => true
         ]);
 
@@ -274,7 +269,6 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->twice();
         $this->commandTester->execute([
-            'command'           => self::COMMAND_NAME,
             '--learningmaterial-note' => true
         ]);
 
@@ -310,7 +304,6 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute([
-            'command'           => self::COMMAND_NAME,
             '--session-description' => true
         ]);
 
@@ -341,7 +334,6 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute([
-            'command'           => self::COMMAND_NAME,
             '--session-description' => true
         ]);
 
@@ -379,7 +371,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
 
-        $this->commandTester->execute([ 'command' => self::COMMAND_NAME, '--learningmaterial-links' => true ]);
+        $this->commandTester->execute(['--learningmaterial-links' => true]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString("1 learning material links updated, 0 failures.", $output);
@@ -417,7 +409,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
 
-        $this->commandTester->execute([ 'command' => self::COMMAND_NAME, '--learningmaterial-links' => true ]);
+        $this->commandTester->execute(['--learningmaterial-links' => true]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString("1 learning material links updated, 0 failures.", $output);
@@ -453,7 +445,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
 
-        $this->commandTester->execute([ 'command' => self::COMMAND_NAME, '--learningmaterial-links' => true ]);
+        $this->commandTester->execute(['--learningmaterial-links' => true]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString("0 learning material links updated, 0 failures.", $output);
@@ -496,7 +488,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->times(3);
         $this->em->shouldReceive('clear')->times(3);
 
-        $this->commandTester->execute([ 'command' => self::COMMAND_NAME, '--learningmaterial-links' => true ]);
+        $this->commandTester->execute(['--learningmaterial-links' => true]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString("{$total} learning material links updated, 0 failures.", $output);
@@ -523,7 +515,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
 
-        $this->commandTester->execute([ 'command' => self::COMMAND_NAME, '--learningmaterial-links' => true ]);
+        $this->commandTester->execute(['--learningmaterial-links' => true]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString("0 learning material links updated, 1 failures.", $output);
@@ -550,7 +542,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
 
-        $this->commandTester->execute([ 'command' => self::COMMAND_NAME, '--learningmaterial-links' => true ]);
+        $this->commandTester->execute(['--learningmaterial-links' => true]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString("1 learning material links updated, 0 failures.", $output);
@@ -581,7 +573,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('clear')->once();
 
         $this->commandTester->execute(
-            [ 'command' => self::COMMAND_NAME,'--learningmaterial-links' => true ],
+            [ '--learningmaterial-links' => true],
             [ 'verbosity' => OutputInterface::VERBOSITY_VERBOSE],
         );
 

--- a/tests/Command/CreateServiceTokenCommandTest.php
+++ b/tests/Command/CreateServiceTokenCommandTest.php
@@ -29,8 +29,6 @@ class CreateServiceTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:service-token:create';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $jwtManager;
     protected m\MockInterface $tokenProvider;
@@ -50,7 +48,7 @@ class CreateServiceTokenCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -92,7 +90,6 @@ class CreateServiceTokenCommandTest extends KernelTestCase
             })->andReturn('abcde');
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             CreateServiceTokenCommand::TTL_KEY => CreateServiceTokenCommand::TTL_MAX_VALUE,
             CreateServiceTokenCommand::DESCRIPTION_KEY => 'lorem ipsum',
         ]);
@@ -146,7 +143,6 @@ class CreateServiceTokenCommandTest extends KernelTestCase
             })->andReturn('abcde');
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             CreateServiceTokenCommand::TTL_KEY => CreateServiceTokenCommand::TTL_MAX_VALUE,
             CreateServiceTokenCommand::DESCRIPTION_KEY => 'lorem ipsum',
             '--' . CreateServiceTokenCommand::WRITEABLE_SCHOOLS_KEY => $schoolIdsInput,
@@ -181,7 +177,6 @@ class CreateServiceTokenCommandTest extends KernelTestCase
             })->andReturn('abcde');
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             CreateServiceTokenCommand::TTL_KEY => $ttl,
             CreateServiceTokenCommand::DESCRIPTION_KEY => 'lorem ipsum',
         ]);
@@ -192,7 +187,6 @@ class CreateServiceTokenCommandTest extends KernelTestCase
     {
         $this->expectExceptionMessage('Not enough arguments (missing: "description").');
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             CreateServiceTokenCommand::TTL_KEY => CreateServiceTokenCommand::TTL_MAX_VALUE,
         ]);
         $this->assertEquals(Command::INVALID, $this->commandTester->getStatusCode());
@@ -202,7 +196,6 @@ class CreateServiceTokenCommandTest extends KernelTestCase
     {
         $this->expectExceptionMessage('Not enough arguments (missing: "ttl").');
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             CreateServiceTokenCommand::DESCRIPTION_KEY => 'lorem ipsum',
         ]);
         $this->assertEquals(Command::INVALID, $this->commandTester->getStatusCode());
@@ -211,7 +204,6 @@ class CreateServiceTokenCommandTest extends KernelTestCase
     public function testTtlExceedsAllowedMaximum(): void
     {
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             CreateServiceTokenCommand::TTL_KEY => 'P1000D', // one.thousand.days.
             CreateServiceTokenCommand::DESCRIPTION_KEY => 'lorem ipsum',
         ]);
@@ -225,7 +217,6 @@ class CreateServiceTokenCommandTest extends KernelTestCase
     public function testInvalidTtl(): void
     {
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             CreateServiceTokenCommand::TTL_KEY => 'nyet',
             CreateServiceTokenCommand::DESCRIPTION_KEY => 'lorem ipsum',
         ]);

--- a/tests/Command/CreateUserTokenCommandTest.php
+++ b/tests/Command/CreateUserTokenCommandTest.php
@@ -25,8 +25,6 @@ class CreateUserTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:create-user-token';
-
     protected m\MockInterface $userRepository;
     protected CommandTester $commandTester;
     protected m\MockInterface $jwtManager;
@@ -41,7 +39,7 @@ class CreateUserTokenCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -63,8 +61,7 @@ class CreateUserTokenCommandTest extends KernelTestCase
         $this->jwtManager->shouldReceive('createJwtFromUserId')->with(1, 'PT8H')->andReturn('123JWT');
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
 
 
@@ -81,9 +78,8 @@ class CreateUserTokenCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn($user);
         $this->jwtManager->shouldReceive('createJwtFromUserId')->with(1, '108Franks')->andReturn('123JWT');
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'       => '1',
-            '--ttl'        => '108Franks'
+            'userId' => '1',
+            '--ttl' => '108Franks'
         ]);
 
 
@@ -99,14 +95,13 @@ class CreateUserTokenCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
     }
 
     public function testUserRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/DeleteServiceTokenCommandTest.php
+++ b/tests/Command/DeleteServiceTokenCommandTest.php
@@ -23,8 +23,6 @@ class DeleteServiceTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:service-token:delete';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $serviceTokenRepository;
 
@@ -36,7 +34,7 @@ class DeleteServiceTokenCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -55,7 +53,6 @@ class DeleteServiceTokenCommandTest extends KernelTestCase
         $this->serviceTokenRepository->shouldReceive('delete')->with($serviceTokenMock);
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             DeleteServiceTokenCommand::ID_KEY => (string) $tokenId,
         ]);
 
@@ -73,7 +70,6 @@ class DeleteServiceTokenCommandTest extends KernelTestCase
         $this->serviceTokenRepository->shouldReceive('findOneById')->with($tokenId)->andReturn(null);
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             DeleteServiceTokenCommand::ID_KEY => (string) $tokenId,
         ]);
 

--- a/tests/Command/DisableServiceTokenCommandTest.php
+++ b/tests/Command/DisableServiceTokenCommandTest.php
@@ -23,8 +23,6 @@ class DisableServiceTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:service-token:disable';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $serviceTokenRepository;
 
@@ -36,7 +34,7 @@ class DisableServiceTokenCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -57,7 +55,6 @@ class DisableServiceTokenCommandTest extends KernelTestCase
         $this->serviceTokenRepository->shouldReceive('update')->with($serviceTokenMock);
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             DisableServiceTokenCommand::ID_KEY => (string) $tokenId,
         ]);
 
@@ -77,7 +74,6 @@ class DisableServiceTokenCommandTest extends KernelTestCase
         $this->serviceTokenRepository->shouldReceive('findOneById')->with($tokenId)->andReturn($serviceTokenMock);
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             DisableServiceTokenCommand::ID_KEY => (string) $tokenId,
         ]);
 
@@ -95,7 +91,6 @@ class DisableServiceTokenCommandTest extends KernelTestCase
         $this->serviceTokenRepository->shouldReceive('findOneById')->with($tokenId)->andReturn(null);
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             DisableServiceTokenCommand::ID_KEY => (string) $tokenId,
         ]);
 

--- a/tests/Command/EnableServiceTokenCommandTest.php
+++ b/tests/Command/EnableServiceTokenCommandTest.php
@@ -23,8 +23,6 @@ class EnableServiceTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:service-token:enable';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $serviceTokenRepository;
 
@@ -36,7 +34,7 @@ class EnableServiceTokenCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -57,7 +55,6 @@ class EnableServiceTokenCommandTest extends KernelTestCase
         $this->serviceTokenRepository->shouldReceive('update')->with($serviceTokenMock);
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             EnableServiceTokenCommand::ID_KEY => (string) $tokenId,
         ]);
 
@@ -77,7 +74,6 @@ class EnableServiceTokenCommandTest extends KernelTestCase
         $this->serviceTokenRepository->shouldReceive('findOneById')->with($tokenId)->andReturn($serviceTokenMock);
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             EnableServiceTokenCommand::ID_KEY => (string) $tokenId,
         ]);
 
@@ -95,7 +91,6 @@ class EnableServiceTokenCommandTest extends KernelTestCase
         $this->serviceTokenRepository->shouldReceive('findOneById')->with($tokenId)->andReturn(null);
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             EnableServiceTokenCommand::ID_KEY => (string) $tokenId,
         ]);
 

--- a/tests/Command/ExportMeshUniverseCommandTest.php
+++ b/tests/Command/ExportMeshUniverseCommandTest.php
@@ -17,8 +17,6 @@ class ExportMeshUniverseCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:export-mesh-universe';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $repository;
     protected m\MockInterface $writer;
@@ -36,7 +34,7 @@ class ExportMeshUniverseCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 

--- a/tests/Command/FindUserCommandTest.php
+++ b/tests/Command/FindUserCommandTest.php
@@ -22,8 +22,6 @@ class FindUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:find-user';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $directory;
 
@@ -35,7 +33,7 @@ class FindUserCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -61,8 +59,7 @@ class FindUserCommandTest extends KernelTestCase
         $this->directory->shouldReceive('find')->with(['a', 'b'])->andReturn([$fakeDirectoryUser]);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'searchTerms'         => ['a', 'b']
+            'searchTerms' => ['a', 'b']
         ]);
 
 
@@ -76,6 +73,6 @@ class FindUserCommandTest extends KernelTestCase
     public function testTermRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
+++ b/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
@@ -26,8 +26,6 @@ class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:fix-mime-types';
-
     protected m\MockInterface $iliosFileSystem;
     protected m\MockInterface $temporaryFileSystem;
     protected m\MockInterface $learningMaterialRepository;
@@ -48,7 +46,7 @@ class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -79,9 +77,7 @@ class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
         $this->learningMaterialRepository->shouldReceive('flushAndClear')->once();
 
         $this->commandTester->setInputs(['Yes']);
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -109,9 +105,7 @@ class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
         $this->learningMaterialRepository->shouldReceive('flushAndClear')->once();
 
         $this->commandTester->setInputs(['Yes']);
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -140,9 +134,7 @@ class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
         $this->learningMaterialRepository->shouldReceive('flushAndClear')->once();
 
         $this->commandTester->setInputs(['Yes']);
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -171,9 +163,7 @@ class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
         $this->learningMaterialRepository->shouldReceive('flushAndClear')->once();
 
         $this->commandTester->setInputs(['Yes']);
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -207,9 +197,7 @@ class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
         $this->learningMaterialRepository->shouldReceive('flushAndClear')->once();
 
         $this->commandTester->setInputs(['Yes']);
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -245,9 +233,7 @@ class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
         $this->learningMaterialRepository->shouldReceive('flushAndClear')->once();
 
         $this->commandTester->setInputs(['Yes']);
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(

--- a/tests/Command/ImportDefaultDataCommandTest.php
+++ b/tests/Command/ImportDefaultDataCommandTest.php
@@ -59,8 +59,6 @@ class ImportDefaultDataCommandTest extends KernelTestCase
     protected m\MockInterface $userRoleRepository;
     protected m\MockInterface $vocabularyRepository;
 
-    private const COMMAND_NAME = 'ilios:import-default-data';
-
     public function setUp(): void
     {
         $this->defaultDataImporter = m::mock(DefaultDataImporter::class);
@@ -103,7 +101,7 @@ class ImportDefaultDataCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 

--- a/tests/Command/ImportMeshUniverseCommandTest.php
+++ b/tests/Command/ImportMeshUniverseCommandTest.php
@@ -31,11 +31,6 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     protected m\MockInterface $meshIndex;
     protected CommandTester $commandTester;
 
-    /**
-     * @var string
-     */
-    private const COMMAND_NAME = 'ilios:import-mesh-universe';
-
     public function setUp(): void
     {
         parent::setUp();
@@ -47,7 +42,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 

--- a/tests/Command/Index/CreateCommandTest.php
+++ b/tests/Command/Index/CreateCommandTest.php
@@ -31,7 +31,7 @@ class CreateCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(CreateCommand::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -42,7 +42,6 @@ class CreateCommandTest extends KernelTestCase
     {
         parent::tearDown();
         unset($this->indexManager);
-        unset($this->commandTester);
     }
 
     public function testCreateWithIndexDisabled(): void
@@ -50,9 +49,7 @@ class CreateCommandTest extends KernelTestCase
         $this->indexManager->shouldReceive('isEnabled')->once()->andReturn(false);
         $this->indexManager->shouldNotReceive('create');
 
-        $this->commandTester->execute([
-            'command' => CreateCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -65,9 +62,7 @@ class CreateCommandTest extends KernelTestCase
         $this->indexManager->shouldReceive('isEnabled')->once()->andReturn(true);
         $this->indexManager->shouldReceive('create')->once();
 
-        $this->commandTester->execute([
-            'command' => CreateCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(

--- a/tests/Command/Index/DropCommandTest.php
+++ b/tests/Command/Index/DropCommandTest.php
@@ -22,7 +22,6 @@ class DropCommandTest extends KernelTestCase
     protected CommandTester $commandTester;
     protected m\MockInterface $indexManager;
 
-
     public function setUp(): void
     {
         parent::setUp();
@@ -32,7 +31,7 @@ class DropCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(DropCommand::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -48,9 +47,7 @@ class DropCommandTest extends KernelTestCase
 
     public function testRequireForce(): void
     {
-        $this->commandTester->execute([
-            'command' => DropCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -64,7 +61,6 @@ class DropCommandTest extends KernelTestCase
         $this->indexManager->shouldReceive('drop')->once();
 
         $this->commandTester->execute([
-            'command' => DropCommand::COMMAND_NAME,
             '--force' => true,
         ]);
 

--- a/tests/Command/InstallFirstUserCommandTest.php
+++ b/tests/Command/InstallFirstUserCommandTest.php
@@ -30,8 +30,6 @@ class InstallFirstUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:setup-first-user';
-
     protected m\MockInterface $userRepository;
     protected m\MockInterface $authenticationRepository;
     protected m\MockInterface $schoolRepository;
@@ -58,7 +56,7 @@ class InstallFirstUserCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -77,7 +75,6 @@ class InstallFirstUserCommandTest extends KernelTestCase
     {
         $this->getReadyForInput();
         $this->commandTester->execute([
-            'command'  => self::COMMAND_NAME,
             '--school' => '1',
             '--email' => 'email@example.com',
         ]);
@@ -91,7 +88,6 @@ class InstallFirstUserCommandTest extends KernelTestCase
         $this->schoolRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             '--school' => '1'
         ]);
     }
@@ -102,7 +98,6 @@ class InstallFirstUserCommandTest extends KernelTestCase
         $this->schoolRepository->shouldReceive('findBy')->with([], ['title' => 'ASC'])->andReturn([]);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             '--school' => '1'
         ]);
     }
@@ -112,7 +107,6 @@ class InstallFirstUserCommandTest extends KernelTestCase
         $this->getReadyForInput();
         $this->commandTester->setInputs(['0', 'Yes']);
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             '--email' => 'email@example.com',
         ]);
         $this->checkOuput();
@@ -123,7 +117,6 @@ class InstallFirstUserCommandTest extends KernelTestCase
         $this->getReadyForInput();
         $this->commandTester->setInputs(['email@example.com', 'Yes']);
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             '--school' => '1',
         ]);
         $this->checkOuput();

--- a/tests/Command/InvalidateUserTokenCommandTest.php
+++ b/tests/Command/InvalidateUserTokenCommandTest.php
@@ -26,8 +26,6 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:invalidate-user-tokens';
-
     protected m\MockInterface $userRepository;
     protected m\MockInterface $authenticationRepository;
     protected CommandTester $commandTester;
@@ -42,7 +40,7 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -70,8 +68,7 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn($user);
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -103,8 +100,7 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('create')->andReturn($authentication);
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -119,14 +115,13 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
     }
 
     public function testUserRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/ListConfigValuesCommandTest.php
+++ b/tests/Command/ListConfigValuesCommandTest.php
@@ -24,8 +24,6 @@ class ListConfigValuesCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:list-config-values';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $applicationConfigRepository;
 
@@ -42,7 +40,7 @@ class ListConfigValuesCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -66,9 +64,7 @@ class ListConfigValuesCommandTest extends KernelTestCase
             ->once()
             ->andReturn([$mockConfig]);
 
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
             '/\sthe-name\s|\sthe-value\s/',
@@ -97,9 +93,7 @@ class ListConfigValuesCommandTest extends KernelTestCase
             ->once()
             ->andThrow($exception);
 
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
             '/^Unable to connect to database./',

--- a/tests/Command/ListRootUsersCommandTest.php
+++ b/tests/Command/ListRootUsersCommandTest.php
@@ -35,7 +35,7 @@ class ListRootUsersCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(ListRootUsersCommand::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -93,9 +93,7 @@ class ListRootUsersCommandTest extends KernelTestCase
 
         $this->userRepository->shouldReceive('findDTOsBy')->with(['root' => true])->andReturn($users);
 
-        $this->commandTester->execute([
-            'command' => ListRootUsersCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
         $output = $this->commandTester->getDisplay();
 
         $this->assertMatchesRegularExpression(
@@ -118,9 +116,7 @@ class ListRootUsersCommandTest extends KernelTestCase
             ->with(['root' => true])
             ->andReturn([]);
 
-        $this->commandTester->execute([
-            'command' => ListRootUsersCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
         $output = $this->commandTester->getDisplay();
         $this->assertEquals('No users with root-level privileges found.', trim($output));
     }

--- a/tests/Command/ListSchoolConfigValuesCommandTest.php
+++ b/tests/Command/ListSchoolConfigValuesCommandTest.php
@@ -25,8 +25,6 @@ class ListSchoolConfigValuesCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:list-school-config-values';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $schoolRepository;
     protected m\MockInterface $schoolConfigRepository;
@@ -40,7 +38,7 @@ class ListSchoolConfigValuesCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -68,8 +66,7 @@ class ListSchoolConfigValuesCommandTest extends KernelTestCase
             ->andReturn([$mockConfig]);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'school'         => '1'
+            'school' => '1'
         ]);
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -81,8 +78,6 @@ class ListSchoolConfigValuesCommandTest extends KernelTestCase
     public function testSchoolRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/ListServiceTokensCommandTest.php
+++ b/tests/Command/ListServiceTokensCommandTest.php
@@ -25,8 +25,6 @@ class ListServiceTokensCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:service-token:list';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $serviceTokenRepository;
 
@@ -38,7 +36,7 @@ class ListServiceTokensCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -70,9 +68,7 @@ class ListServiceTokensCommandTest extends KernelTestCase
         $this->serviceTokenRepository->shouldReceive('findBy')->andReturn([
             $serviceToken1, $serviceToken2
         ]);
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
         $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
         $output = trim($this->commandTester->getDisplay());
         $this->assertStringStartsWith('Service Tokens', $output);
@@ -93,9 +89,7 @@ class ListServiceTokensCommandTest extends KernelTestCase
     public function testNoTokensFound(): void
     {
         $this->serviceTokenRepository->shouldReceive('findBy')->andReturn([]);
-        $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
         $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
         $output = trim($this->commandTester->getDisplay());
         $this->assertEquals("Service Tokens\n\nNo tokens found.", $output);
@@ -105,7 +99,6 @@ class ListServiceTokensCommandTest extends KernelTestCase
     {
         $this->serviceTokenRepository->shouldReceive('findBy')->withArgs([['enabled' => true]])->andReturn([]);
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             '--' . ListServiceTokensCommand::EXCLUDE_DISABLED_KEY => true,
         ]);
         $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
@@ -134,7 +127,6 @@ class ListServiceTokensCommandTest extends KernelTestCase
             ->shouldReceive('findBy')
             ->andReturn([$serviceToken1, $serviceToken2]);
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             '--' . ListServiceTokensCommand::EXCLUDE_EXPIRED_KEY => true,
         ]);
         $output = trim($this->commandTester->getDisplay());
@@ -169,7 +161,6 @@ class ListServiceTokensCommandTest extends KernelTestCase
             ->shouldReceive('findBy')
             ->andReturn([$serviceToken1, $serviceToken2]);
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             '--' . ListServiceTokensCommand::EXPIRES_WITHIN_KEY => $expiresWithin,
         ]);
         $output = trim($this->commandTester->getDisplay());

--- a/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
+++ b/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
@@ -27,8 +27,6 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:migrate-learning-materials';
-
     protected m\MockInterface $symfonyFileSystem;
     protected m\MockInterface $iliosFileSystem;
     protected m\MockInterface $learningMaterialRepository;
@@ -49,7 +47,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -90,8 +88,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
         $this->commandTester->setInputs(['Yes']);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'pathToIlios2'         => __DIR__ . '/'
+            'pathToIlios2' => __DIR__ . '/'
         ]);
 
 
@@ -120,8 +117,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
 
         $this->commandTester->setInputs(['Yes']);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'pathToIlios2'         => 'path'
+            'pathToIlios2' => 'path'
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -140,14 +136,13 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
         $this->symfonyFileSystem->shouldReceive('exists')->with('badpath')->andReturn(false);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'pathToIlios2'         => 'badpath'
+            'pathToIlios2' => 'badpath'
         ]);
     }
 
     public function testIlios2PathRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/RemoveRootUserCommandTest.php
+++ b/tests/Command/RemoveRootUserCommandTest.php
@@ -37,7 +37,7 @@ class RemoveRootUserCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(RemoveRootUserCommand::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -61,7 +61,6 @@ class RemoveRootUserCommandTest extends KernelTestCase
         $user->shouldReceive('setRoot');
 
         $this->commandTester->execute([
-            'command' => RemoveRootUserCommand::COMMAND_NAME,
             'userId' => $userId
         ]);
 
@@ -79,9 +78,7 @@ class RemoveRootUserCommandTest extends KernelTestCase
     public function testMissingInput(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute([
-            'command' => RemoveRootUserCommand::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
     }
 
     /**
@@ -94,7 +91,6 @@ class RemoveRootUserCommandTest extends KernelTestCase
 
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command' => RemoveRootUserCommand::COMMAND_NAME,
             'userId' => $userId
         ]);
     }

--- a/tests/Command/RolloverCourseCommandTest.php
+++ b/tests/Command/RolloverCourseCommandTest.php
@@ -22,8 +22,6 @@ class RolloverCourseCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:rollover-course';
-
     protected m\MockInterface $service;
     protected CommandTester $commandTester;
 
@@ -36,7 +34,7 @@ class RolloverCourseCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -50,9 +48,7 @@ class RolloverCourseCommandTest extends KernelTestCase
     public function testCommandFailsWithoutArguments(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
     }
 
     public function testCommandPassesArgumentsAndDefaultOptions(): void
@@ -66,7 +62,6 @@ class RolloverCourseCommandTest extends KernelTestCase
             return $course;
         });
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             'courseId' => $courseId,
             'newAcademicYear' => $newAcademicYear,
         ]);
@@ -122,7 +117,6 @@ class RolloverCourseCommandTest extends KernelTestCase
             return $course;
         });
         $commandOptions = [
-            'command' => self::COMMAND_NAME,
             'courseId' => $courseId,
             'newAcademicYear' => $newAcademicYear,
         ];
@@ -150,7 +144,6 @@ class RolloverCourseCommandTest extends KernelTestCase
             return $course;
         });
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             'courseId' => $courseId,
             'newAcademicYear' => $newAcademicYear,
         ]);

--- a/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
+++ b/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
@@ -24,8 +24,6 @@ class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:rollover-ci-report';
-
     protected m\MockInterface $service;
     protected m\MockInterface $reportRepository;
     protected CommandTester $commandTester;
@@ -39,7 +37,7 @@ class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -54,9 +52,7 @@ class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
     public function testCommandFailsWithoutArguments(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
     }
 
     public function testCommandPassesArgumentsAndDefaultOptions(): void
@@ -77,7 +73,6 @@ class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
         $this->reportRepository->shouldReceive('findOneBy')->with(['id' => $reportId])->andReturn($report);
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             'reportId' => $reportId,
         ]);
 
@@ -112,7 +107,6 @@ class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
         $this->reportRepository->shouldReceive('findOneBy')->with(['id' => $reportId])->andReturn($report);
 
         $commandOptions = [
-            'command' => self::COMMAND_NAME,
             'reportId' => $reportId,
         ];
 
@@ -150,7 +144,6 @@ class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
             });
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             'reportId' => $reportId,
         ]);
 

--- a/tests/Command/SendChangeAlertsCommandTest.php
+++ b/tests/Command/SendChangeAlertsCommandTest.php
@@ -48,8 +48,6 @@ class SendChangeAlertsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:send-change-alerts';
-
     protected m\MockInterface $offeringRepository;
     protected m\MockInterface $alertRepository;
     protected m\MockInterface $auditLogRepository;
@@ -87,7 +85,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
             sys_get_temp_dir()
         );
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 

--- a/tests/Command/SendTeachingRemindersCommandTest.php
+++ b/tests/Command/SendTeachingRemindersCommandTest.php
@@ -44,8 +44,6 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:send-teaching-reminders';
-
     protected m\MockInterface $fakeOfferingRepository;
     protected m\MockInterface $fakeSchoolRepository;
     protected m\MockInterface $mailer;
@@ -81,7 +79,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
             $this->testDir
         );
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 

--- a/tests/Command/SendTestEmailCommandTest.php
+++ b/tests/Command/SendTestEmailCommandTest.php
@@ -24,8 +24,6 @@ class SendTestEmailCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:send-test-email';
-
     protected m\MockInterface $mailer;
     protected CommandTester $commandTester;
 
@@ -40,7 +38,7 @@ class SendTestEmailCommandTest extends KernelTestCase
             $this->mailer
         );
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 

--- a/tests/Command/SetConfigValueCommandTest.php
+++ b/tests/Command/SetConfigValueCommandTest.php
@@ -23,8 +23,6 @@ class SetConfigValueCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:set-config-value';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $applicationConfigRepository;
 
@@ -36,7 +34,7 @@ class SetConfigValueCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -61,9 +59,8 @@ class SetConfigValueCommandTest extends KernelTestCase
         $this->applicationConfigRepository->shouldReceive('update')->with($mockConfig, true)->once();
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'name'         => 'foo',
-            'value'        => 'bar',
+            'name' => 'foo',
+            'value' => 'bar',
         ]);
     }
 
@@ -78,9 +75,8 @@ class SetConfigValueCommandTest extends KernelTestCase
         $this->applicationConfigRepository->shouldReceive('update')->with($mockConfig, true)->once();
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'name'         => 'foo',
-            'value'        => 'bar',
+            'name' => 'foo',
+            'value' => 'bar',
         ]);
     }
 
@@ -88,8 +84,7 @@ class SetConfigValueCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'value'        => 'bar',
+            'value' => 'bar',
         ]);
     }
 
@@ -97,8 +92,7 @@ class SetConfigValueCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'name'         => 'foo',
+            'name' => 'foo',
         ]);
     }
 
@@ -115,9 +109,8 @@ class SetConfigValueCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command'      => self::COMMAND_NAME,
-                'name'         => 'foo',
-                '--remove'       => true,
+                'name' => 'foo',
+                '--remove' => true,
             ]
         );
     }
@@ -130,9 +123,8 @@ class SetConfigValueCommandTest extends KernelTestCase
 
         $this->commandTester->execute(
             [
-                'command'      => self::COMMAND_NAME,
-                'name'         => 'foo',
-                '--remove'       => true,
+                'name' => 'foo',
+                '--remove' => true,
             ]
         );
     }

--- a/tests/Command/SetSchoolConfigValueCommandTest.php
+++ b/tests/Command/SetSchoolConfigValueCommandTest.php
@@ -25,8 +25,6 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:set-school-config-value';
-
     protected CommandTester $commandTester;
     protected m\MockInterface $schoolRepository;
     protected m\MockInterface $schoolConfigRepository;
@@ -40,7 +38,7 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -69,10 +67,9 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
         $this->schoolConfigRepository->shouldReceive('update')->with($mockConfig, true)->once();
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'school'         => '1',
-            'name'         => 'foo',
-            'value'        => 'bar',
+            'school' => '1',
+            'name' => 'foo',
+            'value' => 'bar',
         ]);
     }
 
@@ -94,7 +91,6 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
         $this->schoolConfigRepository->shouldReceive('update')->with($mockConfig, true)->once();
 
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             'school' => '1',
             'name' => 'foo',
             'value' => 'bar',
@@ -105,9 +101,8 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'school'         => '1',
-            'value'        => 'bar',
+            'school' => '1',
+            'value' => 'bar',
         ]);
     }
 
@@ -115,9 +110,8 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'school'         => '1',
-            'name'         => 'foo',
+            'school' => '1',
+            'name' => 'foo',
         ]);
     }
 
@@ -125,9 +119,8 @@ class SetSchoolConfigValueCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'name'         => 'foo',
-            'value'         => 'bar',
+            'name' => 'foo',
+            'value' => 'bar',
         ]);
     }
 }

--- a/tests/Command/SetupAuthenticationCommandTest.php
+++ b/tests/Command/SetupAuthenticationCommandTest.php
@@ -21,8 +21,6 @@ class SetupAuthenticationCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:setup-authentication';
-
     protected m\MockInterface $applicationConfigRepository;
     protected CommandTester $commandTester;
 
@@ -37,7 +35,7 @@ class SetupAuthenticationCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -58,9 +56,7 @@ class SetupAuthenticationCommandTest extends KernelTestCase
         $this->applicationConfigRepository->shouldReceive('flush')->once();
 
         $this->commandTester->setInputs(['form']);
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('How will your users authentication to Ilios (defaults to form)?', $output);
@@ -91,9 +87,7 @@ class SetupAuthenticationCommandTest extends KernelTestCase
         $this->applicationConfigRepository->shouldReceive('update')->with($verifySslConfig, false)->once();
         $this->applicationConfigRepository->shouldReceive('flush')->once();
         $this->commandTester->setInputs(['cas', 'URL', '3']);
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('How will your users authentication to Ilios (defaults to form)?', $output);
@@ -131,9 +125,7 @@ class SetupAuthenticationCommandTest extends KernelTestCase
         $this->applicationConfigRepository->shouldReceive('update')->with($bindTemplateConfig, false)->once();
         $this->applicationConfigRepository->shouldReceive('flush')->once();
         $this->commandTester->setInputs(['ldap', 'MOON13', 'PORT88', 'uid=?']);
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('How will your users authentication to Ilios (defaults to form)?', $output);
@@ -170,9 +162,7 @@ class SetupAuthenticationCommandTest extends KernelTestCase
         $this->applicationConfigRepository->shouldReceive('update')->with($attributeConfig, false)->once();
         $this->applicationConfigRepository->shouldReceive('flush')->once();
         $this->commandTester->setInputs(['shibboleth', '/LOGIN', '/LOGOUT', 'cn1']);
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('How will your users authentication to Ilios (defaults to form)?', $output);

--- a/tests/Command/SyncAllUsersCommandTest.php
+++ b/tests/Command/SyncAllUsersCommandTest.php
@@ -27,8 +27,6 @@ class SyncAllUsersCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:sync-users';
-
     protected m\MockInterface $userRepository;
     protected m\MockInterface $authenticationRepository;
     protected m\MockInterface $pendingUserUpdateRepository;
@@ -55,7 +53,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
         $this->pendingUserUpdateRepository->shouldReceive('removeAllPendingUserUpdates')->once();
         $this->userRepository->shouldReceive('resetExaminedFlagForAllUsers')->once();
@@ -122,10 +120,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('update')->with($user, false)->once();
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -187,10 +182,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -252,10 +244,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -317,10 +306,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -389,10 +375,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -454,10 +437,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -519,10 +499,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -584,9 +561,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -648,9 +623,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -713,10 +686,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication, false)->once();
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -784,10 +754,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication, false)->once();
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -861,10 +828,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -917,9 +881,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -972,10 +934,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -1028,10 +987,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -1084,10 +1040,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -1129,9 +1082,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
         $this->pendingUserUpdateRepository->shouldReceive('update')->with($update, false)->once();
 
         $this->em->shouldReceive('flush')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -1199,9 +1150,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -1271,10 +1220,7 @@ class SyncAllUsersCommandTest extends KernelTestCase
 
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->once();
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(

--- a/tests/Command/SyncFormerStudentsCommandTest.php
+++ b/tests/Command/SyncFormerStudentsCommandTest.php
@@ -27,8 +27,6 @@ class SyncFormerStudentsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:sync-former-students';
-
     protected m\MockInterface $userRepository;
     protected m\MockInterface $userRoleRepository;
     protected CommandTester $commandTester;
@@ -45,7 +43,7 @@ class SyncFormerStudentsCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -107,8 +105,7 @@ class SyncFormerStudentsCommandTest extends KernelTestCase
 
         $this->commandTester->setInputs(['Yes']);
         $this->commandTester->execute([
-            'command'   => self::COMMAND_NAME,
-            'filter'    => 'FILTER'
+            'filter' => 'FILTER'
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -138,6 +135,6 @@ class SyncFormerStudentsCommandTest extends KernelTestCase
     public function testFilterRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/SyncStudentStatusCommandTest.php
+++ b/tests/Command/SyncStudentStatusCommandTest.php
@@ -21,8 +21,6 @@ class SyncStudentStatusCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:sync-students';
-
     protected m\MockInterface $userRepository;
     protected m\MockInterface $userRoleRepository;
     protected CommandTester $commandTester;
@@ -39,7 +37,7 @@ class SyncStudentStatusCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -95,8 +93,7 @@ class SyncStudentStatusCommandTest extends KernelTestCase
 
         $this->commandTester->setInputs(['Yes']);
         $this->commandTester->execute([
-            'command'   => self::COMMAND_NAME,
-            'filter'    => 'FILTER'
+            'filter' => 'FILTER'
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -126,6 +123,6 @@ class SyncStudentStatusCommandTest extends KernelTestCase
     public function testFilterRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/SyncUserCommandTest.php
+++ b/tests/Command/SyncUserCommandTest.php
@@ -29,8 +29,6 @@ class SyncUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:sync-user';
-
     protected m\MockInterface $userRepository;
     protected m\MockInterface $authenticationRepository;
     protected m\MockInterface $pendingUserUpdateRepository;
@@ -54,7 +52,7 @@ class SyncUserCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -112,10 +110,8 @@ class SyncUserCommandTest extends KernelTestCase
         $this->commandTester->setInputs(['Yes']);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
-
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -174,10 +170,8 @@ class SyncUserCommandTest extends KernelTestCase
         $this->commandTester->setInputs(['Yes']);
 
         $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME,
-            'userId'         => '1'
+            'userId' => '1'
         ]);
-
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
@@ -202,7 +196,6 @@ class SyncUserCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'command' => self::COMMAND_NAME,
             'userId' => '1'
         ]);
     }
@@ -210,6 +203,6 @@ class SyncUserCommandTest extends KernelTestCase
     public function testUserRequired(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->commandTester->execute(['command' => self::COMMAND_NAME]);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Command/ValidateLearningMaterialPathsCommandTest.php
+++ b/tests/Command/ValidateLearningMaterialPathsCommandTest.php
@@ -23,8 +23,6 @@ class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private const COMMAND_NAME = 'ilios:validate-learning-materials';
-
     protected m\MockInterface $iliosFileSystem;
     protected m\MockInterface $learningMaterialRepository;
     protected CommandTester $commandTester;
@@ -42,7 +40,7 @@ class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(self::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -74,10 +72,7 @@ class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
         $this->iliosFileSystem
             ->shouldReceive('checkLearningMaterialFilePath')->with($badLm)->andReturn(false)->once();
 
-        $this->commandTester->execute([
-            'command'      => self::COMMAND_NAME
-        ]);
-
+        $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(

--- a/tests/Command/WaitForDatabaseCommandTest.php
+++ b/tests/Command/WaitForDatabaseCommandTest.php
@@ -35,7 +35,7 @@ class WaitForDatabaseCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(WaitForDatabaseCommand::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -52,9 +52,7 @@ class WaitForDatabaseCommandTest extends KernelTestCase
         $connection->shouldReceive('executeQuery')->with('Select 1');
         $this->entityManager->shouldReceive('getConnection')->once()->andReturn($connection);
 
-        $this->commandTester->execute([
-            'command' => WaitForDatabaseCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
 
         $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
     }
@@ -69,9 +67,7 @@ class WaitForDatabaseCommandTest extends KernelTestCase
 
         $stopwatch = new Stopwatch();
         $stopwatch->start('test');
-        $this->commandTester->execute([
-            'command' => WaitForDatabaseCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
         $duration = $stopwatch->stop('test')->getDuration();
         $this->assertGreaterThan(2000, $duration);
 

--- a/tests/Command/WaitForIndexCommandTest.php
+++ b/tests/Command/WaitForIndexCommandTest.php
@@ -38,7 +38,7 @@ class WaitForIndexCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
-        $commandInApp = $application->find(WaitForIndexCommand::COMMAND_NAME);
+        $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }
 
@@ -56,9 +56,7 @@ class WaitForIndexCommandTest extends KernelTestCase
         $this->client->shouldReceive('nodes')->andReturn($nodes->getMock());
         $this->indexManager->shouldReceive('hasBeenCreated')->andReturn(true);
 
-        $this->commandTester->execute([
-            'command' => WaitForIndexCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
 
         $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
     }
@@ -73,9 +71,7 @@ class WaitForIndexCommandTest extends KernelTestCase
 
         $stopwatch = new Stopwatch();
         $stopwatch->start('test');
-        $this->commandTester->execute([
-            'command' => WaitForIndexCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
         $duration = $stopwatch->stop('test')->getDuration();
         $this->assertGreaterThan(2000, $duration);
 
@@ -91,9 +87,7 @@ class WaitForIndexCommandTest extends KernelTestCase
 
         $stopwatch = new Stopwatch();
         $stopwatch->start('test');
-        $this->commandTester->execute([
-            'command' => WaitForIndexCommand::COMMAND_NAME,
-        ]);
+        $this->commandTester->execute([]);
         $duration = $stopwatch->stop('test')->getDuration();
         $this->assertGreaterThan(2000, $duration);
 


### PR DESCRIPTION
this speeds things up on the command line.
see https://symfony.com/blog/new-in-symfony-5-3-lazy-command-description
    
minor cleanup/improvements along the way, like fixing typos, improving
descriptions, and adding type hints.
    
streamline test coverage as well - no need to pass the command name to
the command test runner.


refs #5141 