### PR TITLE
re-establish interface compliance for warmUp() method.

### DIFF
--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -132,7 +132,7 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
         }
     }
 
-    public function warmUp($cacheDir): array
+    public function warmUp($cacheDir, string $buildDir = null): array
     {
         try {
             $currentVersion = $this->downloadAndExtractAllArchives(self::PRODUCTION);


### PR DESCRIPTION
the method signature in the WarmableInterface changed in Symfony 6.4.

see https://symfony.com/blog/new-in-symfony-6-4-build-dir-improvements

this sets things right again.

refs #5158 