### PR TITLE
replace @coversDefaultClass annotation with @covers

### DIFF
--- a/src/Classes/ServiceTokenUser.php
+++ b/src/Classes/ServiceTokenUser.php
@@ -28,6 +28,9 @@ class ServiceTokenUser implements ServiceTokenUserInterface
         return [];
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function eraseCredentials(): void
     {
         // not implemented.

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  *
  * Search Ilios
  */
-class Search extends AbstractController
+class SearchController extends AbstractController
 {
     public function __construct(
         protected Curriculum $curriculumIndex,

--- a/tests/Classes/PermissionMatrixTest.php
+++ b/tests/Classes/PermissionMatrixTest.php
@@ -9,14 +9,11 @@ use App\Tests\TestCase;
 
 /**
  * Class PermissionMatrixTest
- * @coversDefaultClass \App\Classes\PermissionMatrix
+ * @covers \App\Classes\PermissionMatrix
  */
 class PermissionMatrixTest extends TestCase
 {
-    /**
-     * @var PermissionMatrix
-     */
-    protected $permissionMatrix;
+    protected PermissionMatrix $permissionMatrix;
 
     public function setUp(): void
     {
@@ -30,12 +27,7 @@ class PermissionMatrixTest extends TestCase
         unset($this->permissionMatrix);
     }
 
-    /**
-     * @covers ::setPermission
-     * @covers ::hasPermission
-     * @covers ::getPermittedRoles
-     */
-    public function testHasPermission()
+    public function testHasPermission(): void
     {
         $schoolId = 1;
         $capability = 'foo';
@@ -58,10 +50,7 @@ class PermissionMatrixTest extends TestCase
         $this->assertFalse($this->permissionMatrix->hasPermission($schoolId, $capability, [$role3]));
     }
 
-    /**
-     * @covers ::getPermittedRoles
-     */
-    public function testGetPermittedRoles()
+    public function testGetPermittedRoles(): void
     {
         $schoolId = 1;
         $capability = 'foo';

--- a/tests/Classes/SchoolEventTest.php
+++ b/tests/Classes/SchoolEventTest.php
@@ -14,14 +14,11 @@ use DateTime;
 /**
  * Class SchoolEventTest
  * @package App\Tests\Classes
- * @coversDefaultClass \App\Classes\SchoolEvent
+ * @covers \App\Classes\SchoolEvent
  */
 class SchoolEventTest extends TestCase
 {
-    /**
-     * @var SchoolEvent
-     */
-    protected $schoolEvent;
+    protected SchoolEvent $schoolEvent;
 
     protected function setUp(): void
     {
@@ -32,10 +29,8 @@ class SchoolEventTest extends TestCase
     {
         unset($this->schoolEvent);
     }
-    /**
-     * @covers ::createFromCalendarEvent
-     */
-    public function testCreateFromCalendarEvent()
+
+    public function testCreateFromCalendarEvent(): void
     {
         $schoolId = 100;
         $calendarEvent = new CalendarEvent();
@@ -67,10 +62,7 @@ class SchoolEventTest extends TestCase
         $this->assertSame($calendarEvent->sessionDescription, $schoolEvent->sessionDescription);
     }
 
-    /**
-     * @covers ::clearDataForUnprivilegedUsers
-     */
-    public function testClearDataForUnprivilegedUsers()
+    public function testClearDataForUnprivilegedUsers(): void
     {
         $userMaterial = m::mock(UserMaterial::class);
         $userMaterial->shouldReceive('clearMaterial');
@@ -78,6 +70,18 @@ class SchoolEventTest extends TestCase
         $this->schoolEvent->learningMaterials = [ $userMaterial ];
         $this->schoolEvent->clearDataForUnprivilegedUsers();
         $userMaterial->shouldHaveReceived('clearMaterial')->once();
+        $this->assertEquals($this->schoolEvent->learningMaterials[0], $userMaterial);
+    }
+
+    public function testClearDataForStudentAssociatedWithEvent(): void
+    {
+        $date = new DateTime();
+        $userMaterial = m::mock(UserMaterial::class);
+        $userMaterial->shouldReceive('clearTimedMaterial');
+        $this->schoolEvent->isPublished = true;
+        $this->schoolEvent->learningMaterials = [ $userMaterial ];
+        $this->schoolEvent->clearDataForStudentAssociatedWithEvent($date);
+        $userMaterial->shouldHaveReceived('clearTimedMaterial', [$date])->once();
         $this->assertEquals($this->schoolEvent->learningMaterials[0], $userMaterial);
     }
 }

--- a/tests/Classes/ServiceTokenUserTest.php
+++ b/tests/Classes/ServiceTokenUserTest.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace App\Tests\Classes;
 
 use App\Classes\ServiceTokenUser;
+use App\Classes\ServiceTokenUserInterface;
+use App\Classes\SessionUserInterface;
 use App\Entity\ServiceTokenInterface;
 use App\Tests\TestCase;
 use DateTime;
 use Mockery as m;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * @coversDefaultClass \App\Classes\ServiceTokenUser
+ * @covers \App\Classes\ServiceTokenUser
  */
 class ServiceTokenUserTest extends TestCase
 {
@@ -32,27 +35,18 @@ class ServiceTokenUserTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @covers ::getId
-     */
     public function testGetId(): void
     {
         $this->mockServiceToken->shouldReceive('getId')->andReturn(1);
         $this->assertEquals(1, $this->serviceTokenUser->getId());
     }
 
-    /**
-     * @covers ::getUserIdentifier
-     */
     public function testGetUserIdentifier(): void
     {
         $this->mockServiceToken->shouldReceive('getId')->andReturn(1);
         $this->assertEquals('1', $this->serviceTokenUser->getUserIdentifier());
     }
 
-    /**
-     * @covers ::getExpiresAt
-     */
     public function testGetExpiredAt(): void
     {
         $date = new DateTime();
@@ -60,9 +54,6 @@ class ServiceTokenUserTest extends TestCase
         $this->assertEquals($date, $this->serviceTokenUser->getExpiresAt());
     }
 
-    /**
-     * @covers ::getCreatedAt
-     */
     public function testGetCreatedAt(): void
     {
         $date = new DateTime();
@@ -70,12 +61,35 @@ class ServiceTokenUserTest extends TestCase
         $this->assertEquals($date, $this->serviceTokenUser->getCreatedAt());
     }
 
-    /**
-     * @covers ::isEnabled
-     */
     public function testIsEnabled(): void
     {
         $this->mockServiceToken->shouldReceive('isEnabled')->andReturn(false);
         $this->assertFalse($this->serviceTokenUser->isEnabled());
+    }
+
+    /**
+     * @dataProvider isEqualToProvider
+     */
+    public function testIsEqualTo(UserInterface $user, bool $expected): void
+    {
+        $this->mockServiceToken->shouldReceive('getId')->andReturn(1);
+        $this->assertEquals($expected, $this->serviceTokenUser->isEqualTo($user));
+    }
+
+    public static function isEqualToProvider(): array
+    {
+        $sameTokenUser = m::mock(ServiceTokenUserInterface::class);
+        $sameTokenUser->shouldReceive('getUserIdentifier')->andReturn(1);
+
+        $otherTokenUser = m::mock(ServiceTokenUserInterface::class);
+        $otherTokenUser->shouldReceive('getUserIdentifier')->andReturn(2);
+
+        $sessionUser = m::mock(SessionUserInterface::class);
+
+        return [
+            [ $sameTokenUser, true ],
+            [ $otherTokenUser, false ],
+            [ $sessionUser, false ],
+        ];
     }
 }

--- a/tests/Classes/SessionUserTest.php
+++ b/tests/Classes/SessionUserTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
 /**
  * Class SessionUserTest
- * @coversDefaultClass \App\Classes\SessionUser
+ * @covers \App\Classes\SessionUser
  */
 class SessionUserTest extends TestCase
 {
@@ -56,9 +56,6 @@ class SessionUserTest extends TestCase
         unset($this->userId);
     }
 
-    /**
-     * @covers ::isDirectingCourse
-     */
     public function testIsDirectingCourse()
     {
         $directedCourseAndSchoolIds = ['courseIds' => [1, 2, 3]];
@@ -68,9 +65,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isDirectingCourse(1));
     }
 
-    /**
-     * @covers ::isDirectingCourse
-     */
     public function testIsNotDirectingCourse()
     {
         $directedCourseAndSchoolIds = ['courseIds' => [2, 3]];
@@ -79,9 +73,7 @@ class SessionUserTest extends TestCase
             ->andReturn($directedCourseAndSchoolIds);
         $this->assertFalse($this->sessionUser->isDirectingCourse(1));
     }
-    /**
-     * @covers ::isDirectingProgramLinkedToCourse
-     */
+
     public function testIsDirectingProgramLinkedToCourse()
     {
         $linkedCourseIds = ['courseIds' => [1, 2, 3]];
@@ -91,9 +83,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isDirectingProgramLinkedToCourse(1));
     }
 
-    /**
-     * @covers ::isDirectingProgramLinkedToCourse
-     */
     public function testIsNotDirectingProgramLinkedToCourse()
     {
         $linkedCourseIds = ['courseIds' => [2, 3]];
@@ -103,9 +92,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isDirectingProgramLinkedToCourse(1));
     }
 
-    /**
-     * @covers ::isAdministeringCourse
-     */
     public function testIsAdministeringCourse()
     {
         $administeredCourseAndIds = ['courseIds' => [1, 2, 3]];
@@ -115,9 +101,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isAdministeringCourse(1));
     }
 
-    /**
-     * @covers ::isAdministeringCourse
-     */
     public function testIsNotAdministeringCourse()
     {
         $administeredCourseAndIds = ['courseIds' => [2, 3]];
@@ -127,9 +110,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isAdministeringCourse(1));
     }
 
-    /**
-     * @covers ::isDirectingSchool
-     */
     public function testIsDirectingSchool()
     {
         $directedSchoolIds = [1, 2, 3];
@@ -137,9 +117,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isDirectingSchool(1));
     }
 
-    /**
-     * @covers ::isDirectingSchool
-     */
     public function testIsNotDirectingSchool()
     {
         $directedSchoolIds = [2, 3];
@@ -147,9 +124,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isDirectingSchool(1));
     }
 
-    /**
-     * @covers ::isAdministeringSchool
-     */
     public function testIsAdministeringSchool()
     {
         $administeredSchoolIds = [1, 2, 3];
@@ -157,9 +131,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isAdministeringSchool(1));
     }
 
-    /**
-     * @covers ::isAdministeringSchool
-     */
     public function testIsNotAdministeringSchool()
     {
         $administeredSchoolIds = [2, 3];
@@ -167,9 +138,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isAdministeringSchool(1));
     }
 
-    /**
-     * @covers ::isDirectingCourseInSchool
-     */
     public function testIsDirectingCourseInSchool()
     {
         $directedCourseAndSchoolIds = ['schoolIds' => [1, 2, 3]];
@@ -179,9 +147,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isDirectingCourseInSchool(1));
     }
 
-    /**
-     * @covers ::isDirectingCourseInSchool
-     */
     public function testIsNotDirectingCourseInSchool()
     {
         $directedCourseAndSchoolIds = ['schoolIds' => [2, 3]];
@@ -191,9 +156,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isDirectingCourseInSchool(1));
     }
 
-    /**
-     * @covers ::isAdministeringCourseInSchool
-     */
     public function testIsAdministeringCourseInSchool()
     {
         $administeredCourseAndSchoolIds = ['schoolIds' => [1, 2, 3]];
@@ -203,9 +165,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isAdministeringCourseInSchool(1));
     }
 
-    /**
-     * @covers ::isAdministeringCourseInSchool
-     */
     public function testIsNotAdministeringCourseInSchool()
     {
         $administeredCourseAndSchoolIds = ['schoolIds' => [2, 3]];
@@ -215,9 +174,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isAdministeringCourseInSchool(1));
     }
 
-    /**
-     * @covers ::isAdministeringSessionInSchool
-     */
     public function testIsAdministeringSessionInSchool()
     {
         $administeredSessionCourseAndSchoolIds = ['schoolIds' => [1, 2, 3]];
@@ -227,9 +183,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isAdministeringSessionInSchool(1));
     }
 
-    /**
-     * @covers ::isAdministeringSessionInSchool
-     */
     public function testIsNotAdministeringSessionInSchool()
     {
         $administeredSessionCourseAndSchoolIds = ['schoolIds' => [2, 3]];
@@ -239,9 +192,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isAdministeringSessionInSchool(1));
     }
 
-    /**
-     * @covers ::isTeachingCourseInSchool
-     */
     public function testIsTeachingCourseInSchool()
     {
         $taughtSchoolIds = ['schoolIds' => [1, 2, 3]];
@@ -251,9 +201,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isTeachingCourseInSchool(1));
     }
 
-    /**
-     * @covers ::isTeachingCourseInSchool
-     */
     public function testIsNotTeachingCourseInSchool()
     {
         $taughtSchoolIds = ['schoolIds' => [2, 3]];
@@ -263,9 +210,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isTeachingCourseInSchool(1));
     }
 
-    /**
-     * @covers ::isTeachingCourse
-     */
     public function testIsTeachingCourse()
     {
         $taughtCourseIds = ['courseIds' => [1, 2, 3]];
@@ -275,9 +219,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isTeachingCourse(1));
     }
 
-    /**
-     * @covers ::isTeachingCourse
-     */
     public function testIsNotTeachingCourse()
     {
         $taughtCourseIds = ['courseIds' => [2, 3]];
@@ -287,9 +228,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isTeachingCourse(1));
     }
 
-    /**
-     * @covers ::isAdministeringSessionInCourse
-     */
     public function testIsAdministeringSessionInCourse()
     {
         $administeredCourseIds = ['courseIds' => [1, 2, 3]];
@@ -299,9 +237,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isAdministeringSessionInCourse(1));
     }
 
-    /**
-     * @covers ::isAdministeringSessionInCourse
-     */
     public function testIsNotAdministeringSessionInCourse()
     {
         $administeredCourseIds = ['courseIds' => [2, 3]];
@@ -311,9 +246,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isAdministeringSessionInCourse(1));
     }
 
-    /**
-     * @covers ::isAdministeringSession
-     */
     public function testIsAdministeringSession()
     {
         $administeredSessionIds = ['sessionIds' => [1, 2, 3]];
@@ -323,9 +255,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isAdministeringSession(1));
     }
 
-    /**
-     * @covers ::isAdministeringSession
-     */
     public function testIsNotAdministeringSession()
     {
         $administeredSessionIds = ['sessionIds' => [2, 3]];
@@ -335,9 +264,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isAdministeringSession(1));
     }
 
-    /**
-     * @covers ::isTeachingSession
-     */
     public function testIsTeachingSession()
     {
         $taughtSessionIds = ['sessionIds' => [1, 2, 3]];
@@ -347,9 +273,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isTeachingSession(1));
     }
 
-    /**
-     * @covers ::isTeachingSession
-     */
     public function testIsNotTeachingSession()
     {
         $taughtSessionIds = ['sessionIds' => [2, 3]];
@@ -359,9 +282,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isTeachingSession(1));
     }
 
-    /**
-     * @covers ::isInstructingOffering
-     */
     public function testIsInstructingOffering()
     {
         $taughtSessionIds = ['offeringIds' => [1, 2, 3]];
@@ -371,9 +291,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isInstructingOffering(1));
     }
 
-    /**
-     * @covers ::isInstructingOffering
-     */
     public function testIsNotInstructingOffering()
     {
         $taughtSessionIds = ['offeringIds' => [2, 3]];
@@ -383,9 +300,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isInstructingOffering(1));
     }
 
-    /**
-     * @covers ::isInstructingIlm
-     */
     public function testIsInstructingIlm()
     {
         $taughtSessionIds = ['ilmIds' => [1, 2, 3]];
@@ -395,9 +309,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isInstructingIlm(1));
     }
 
-    /**
-     * @covers ::isInstructingIlm
-     */
     public function testIsNotInstructingIlm()
     {
         $taughtSessionIds = ['ilmIds' => [2, 3]];
@@ -407,9 +318,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isInstructingIlm(1));
     }
 
-    /**
-     * @covers ::isDirectingProgram
-     */
     public function testIsDirectingProgram()
     {
         $directedProgramIds = ['programIds' => [1, 2, 3]];
@@ -419,9 +327,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isDirectingProgram(1));
     }
 
-    /**
-     * @covers ::isDirectingProgram
-     */
     public function testIsNotDirectingProgram()
     {
         $directedProgramIds = ['programIds' => [2, 3]];
@@ -431,9 +336,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isDirectingProgram(1));
     }
 
-    /**
-     * @covers ::isDirectingProgramYear
-     */
     public function testIsDirectingProgramYear()
     {
         $directedProgramYearIds = ['programYearIds' => [1, 2, 3]];
@@ -443,9 +345,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isDirectingProgramYear(1));
     }
 
-    /**
-     * @covers ::isDirectingProgramYear
-     */
     public function testIsNotDirectingProgramYear()
     {
         $directedProgramYearIds = ['programYearIds' => [2, 3]];
@@ -455,9 +354,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isDirectingProgramYear(1));
     }
 
-    /**
-     * @covers ::isDirectingProgramYearInProgram
-     */
     public function testIsDirectingProgramYearInProgram()
     {
         $directedProgramIds = ['programIds' => [1, 2, 3]];
@@ -467,9 +363,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isDirectingProgramYearInProgram(1));
     }
 
-    /**
-     * @covers ::isDirectingProgramYearInProgram
-     */
     public function testIsNotDirectingProgramYearInProgram()
     {
         $directedProgramIds = ['programIds' => [2, 3]];
@@ -479,9 +372,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isDirectingProgramYearInProgram(1));
     }
 
-    /**
-     * @covers ::isAdministeringCurriculumInventoryReport
-     */
     public function testIsAdministeringCurriculumInventoryReport()
     {
         $administeredReportIds = ['reportIds' => [1, 2, 3]];
@@ -491,9 +381,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isAdministeringCurriculumInventoryReport(1));
     }
 
-    /**
-     * @covers ::isAdministeringCurriculumInventoryReport
-     */
     public function testIsNotAdministeringCurriculumInventoryReport()
     {
         $administeredReportIds = ['reportIds' => [2, 3]];
@@ -503,9 +390,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isAdministeringCurriculumInventoryReport(1));
     }
 
-    /**
-     * @covers ::isAdministeringCurriculumInventoryReportInSchool
-     */
     public function testIsAdministeringCurriculumInventoryReportInSchool()
     {
         $administeredSchoolIds = ['schoolIds' => [1, 2, 3]];
@@ -515,9 +399,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isAdministeringCurriculumInventoryReportInSchool(1));
     }
 
-    /**
-     * @covers ::isAdministeringCurriculumInventoryReportInSchool
-     */
     public function testIsNotAdministeringCurriculumInventoryReportInSchool()
     {
         $administeredSchoolIds = ['schoolIds' => [2, 3]];
@@ -527,9 +408,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isAdministeringCurriculumInventoryReportInSchool(1));
     }
 
-    /**
-     * @covers ::isInLearnerGroup()
-     */
     public function testIsInLearnerGroup()
     {
         $learnerGroupIds = [1, 2, 3];
@@ -539,9 +417,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->isInLearnerGroup(1));
     }
 
-    /**
-     * @covers ::isInLearnerGroup()
-     */
     public function testIsNotInLearnerGroup()
     {
         $learnerGroupIds = [2, 3];
@@ -551,10 +426,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->isInLearnerGroup(1));
     }
 
-
-    /**
-     * @covers ::rolesInSchool
-     */
     public function testRolesInSchool()
     {
         $schoolId = 2;
@@ -603,9 +474,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($roles, $this->sessionUser->rolesInSchool($schoolId));
     }
 
-    /**
-     * @covers ::rolesInCourse
-     */
     public function testRolesInCourse()
     {
         $courseId = 2;
@@ -634,7 +502,6 @@ class SessionUserTest extends TestCase
     }
 
     /**
-     * @covers ::rolesInSession
      * @dataProvider rolesInSessionProvider
      */
     public function testRolesInSession(
@@ -655,9 +522,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($expectedRoles, $this->sessionUser->rolesInSession($sessionId));
     }
 
-    /**
-     * @covers ::rolesInProgram
-     */
     public function testRolesInProgram()
     {
         $programId = 2;
@@ -673,9 +537,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($roles, $this->sessionUser->rolesInProgram($programId));
     }
 
-    /**
-     * @covers ::rolesInProgramYear
-     */
     public function testRolesInProgramYear()
     {
         $programYearId = 2;
@@ -687,9 +548,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($roles, $this->sessionUser->rolesInProgramYear($programYearId));
     }
 
-    /**
-     * @covers ::rolesInCurriculumInventoryReport
-     */
     public function testRolesInCurriculumInventoryReport()
     {
         $reportId = 2;
@@ -701,9 +559,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($roles, $this->sessionUser->rolesInCurriculumInventoryReport($reportId));
     }
 
-    /**
-     * @covers ::rolesInCurriculumInventoryReport
-     */
     public function testRolesInCurriculumInventoryReportNoMatchingReport()
     {
         $reportId = 2;
@@ -715,9 +570,6 @@ class SessionUserTest extends TestCase
         $this->assertEmpty($this->sessionUser->rolesInCurriculumInventoryReport($reportId));
     }
 
-    /**
-     * @covers ::rolesInCurriculumInventoryReport
-     */
     public function testRolesInCurriculumInventoryReportNoMatchingRoles()
     {
         $reportId = 2;
@@ -727,9 +579,6 @@ class SessionUserTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsRoot()
     {
         $this->iliosUser = $this->createMockUser($this->userId, $this->school, true);
@@ -737,9 +586,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsCourseDirector()
     {
         $courseIds = [2, 3];
@@ -750,9 +596,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsCourseAdministrator()
     {
         $courseIds = [2, 3];
@@ -767,9 +610,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsSchoolDirector()
     {
         $schoolIds = [2, 3];
@@ -788,9 +628,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsSchoolAdministrator()
     {
         $schoolIds = [2, 3];
@@ -813,9 +650,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsInInstructorGroups()
     {
         $instructorGroupIds = [2, 3];
@@ -842,9 +676,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsTeachingInCourses()
     {
         $courseIds = [2, 3];
@@ -875,9 +706,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsSessionAdministrator()
     {
         $sessionIds = [2, 3];
@@ -912,9 +740,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsInstructingInSessions()
     {
         $sessionIds = [2, 3];
@@ -949,9 +774,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsProgramDirector()
     {
         $programIds = [2, 3];
@@ -990,9 +812,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsProgramYearDirector()
     {
         $programYearIds = [2, 3];
@@ -1035,9 +854,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testPerformsNonLearnerFunctionIfUserIsCurriculumInventoryReportAdministrator()
     {
         $reportIds = [2, 3];
@@ -1084,9 +900,6 @@ class SessionUserTest extends TestCase
         $this->assertTrue($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::performsNonLearnerFunction()
-     */
     public function testDoesNotPerformNonLearnerFunction()
     {
         $reportIds = [2, 3];
@@ -1133,9 +946,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($this->sessionUser->performsNonLearnerFunction());
     }
 
-    /**
-     * @covers ::getDirectedCourseIds
-     */
     public function testGetDirectedCourseIds()
     {
         $courseIds = [2, 3];
@@ -1146,9 +956,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($courseIds, $this->sessionUser->getDirectedCourseIds());
     }
 
-    /**
-     * @covers ::getAdministeredCourseIds
-     */
     public function testGetAdministeredCourseIds()
     {
         $courseIds = [2, 3];
@@ -1159,9 +966,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($courseIds, $this->sessionUser->getAdministeredCourseIds());
     }
 
-    /**
-     * @covers ::getCourseIdsLinkedToProgramsDirectedByUser
-     */
     public function getCourseIdsLinkedToProgramsDirectedByUser()
     {
         $courseIds = [2, 3];
@@ -1172,9 +976,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($courseIds, $this->sessionUser->getCourseIdsLinkedToProgramsDirectedByUser());
     }
 
-    /**
-     * @covers ::getDirectedSchoolIds
-     */
     public function testGetDirectedSchoolIds()
     {
         $schoolIds = [2, 3];
@@ -1185,9 +986,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($schoolIds, $this->sessionUser->getDirectedSchoolIds());
     }
 
-    /**
-     * @covers ::getAdministeredSchoolIds
-     */
     public function testGetAdministeredSchoolIds()
     {
         $schoolIds = [2, 3];
@@ -1198,9 +996,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($schoolIds, $this->sessionUser->getAdministeredSchoolIds());
     }
 
-    /**
-     * @covers ::getDirectedCourseSchoolIds
-     */
     public function testGetDirectedCourseSchoolIds()
     {
         $schoolIds = [2, 3];
@@ -1211,9 +1006,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($schoolIds, $this->sessionUser->getDirectedCourseSchoolIds());
     }
 
-    /**
-     * @covers ::getAdministeredCourseSchoolIds
-     */
     public function testGetAdministeredCourseSchoolIds()
     {
         $schoolIds = [2, 3];
@@ -1224,9 +1016,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($schoolIds, $this->sessionUser->getAdministeredCourseSchoolIds());
     }
 
-    /**
-     * @covers ::getAdministeredSessionSchoolIds
-     */
     public function testGetAdministeredSessionSchoolIds()
     {
         $schoolIds = [2, 3];
@@ -1237,9 +1026,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($schoolIds, $this->sessionUser->getAdministeredSessionSchoolIds());
     }
 
-    /**
-     * @covers ::getAdministeredSessionCourseIds
-     */
     public function testGetAdministeredSessionCourseIds()
     {
         $courseIds = [2, 3];
@@ -1250,9 +1036,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($courseIds, $this->sessionUser->getAdministeredSessionCourseIds());
     }
 
-    /**
-     * @covers ::getTaughtCourseIds
-     */
     public function testGetTaughtCourseIds()
     {
         $courseIds = [2, 3];
@@ -1263,9 +1046,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($courseIds, $this->sessionUser->getTaughtCourseIds());
     }
 
-    /**
-     * @covers ::getAdministeredSessionIds
-     */
     public function testGetAdministeredSessionIds()
     {
         $sessionIds = [2, 3];
@@ -1276,9 +1056,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($sessionIds, $this->sessionUser->getAdministeredSessionIds());
     }
 
-    /**
-     * @covers ::getInstructedSessionIds
-     */
     public function testGetInstructedSessionIds()
     {
         $sessionIds = [2, 3];
@@ -1289,9 +1066,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($sessionIds, $this->sessionUser->getInstructedSessionIds());
     }
 
-    /**
-     * @covers ::getInstructedOfferingIds
-     */
     public function testGetInstructedOfferingIds()
     {
         $userId = 1;
@@ -1303,9 +1077,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($offeringIds, $this->sessionUser->getInstructedOfferingIds());
     }
 
-    /**
-     * @covers ::getInstructedIlmIds
-     */
     public function testGetInstructedIlmIds()
     {
         $userId = 1;
@@ -1317,9 +1088,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($ilmIds, $this->sessionUser->getInstructedIlmIds());
     }
 
-    /**
-     * @covers ::getTaughtCourseSchoolIds
-     */
     public function testGetTaughtCourseSchoolIds()
     {
         $schoolIds = [2, 3];
@@ -1330,9 +1098,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($schoolIds, $this->sessionUser->getTaughtCourseSchoolIds());
     }
 
-    /**
-     * @covers ::getDirectedProgramIds
-     */
     public function testGetDirectedProgramIds()
     {
         $programIds = [2, 3];
@@ -1343,9 +1108,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($programIds, $this->sessionUser->getDirectedProgramIds());
     }
 
-    /**
-     * @covers ::getDirectedProgramYearIds
-     */
     public function testGetDirectedProgramYearIds()
     {
         $programYearIds = [2, 3];
@@ -1356,9 +1118,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($programYearIds, $this->sessionUser->getDirectedProgramYearIds());
     }
 
-    /**
-     * @covers ::getDirectedProgramYearProgramIds
-     */
     public function testGetDirectedProgramYearProgramIds()
     {
         $programIds = [2, 3];
@@ -1369,9 +1128,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($programIds, $this->sessionUser->getDirectedProgramYearProgramIds());
     }
 
-    /**
-     * @covers ::getAdministeredCurriculumInventoryReportIds
-     */
     public function testGetAdministeredCurriculumInventoryReportIds()
     {
         $reportIds = [2, 3];
@@ -1382,9 +1138,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($reportIds, $this->sessionUser->getAdministeredCurriculumInventoryReportIds());
     }
 
-    /**
-     * @covers ::getAdministeredCurriculumInventoryReportSchoolIds
-     */
     public function testGetAdministeredCurriculumInventoryReportSchoolIds()
     {
         $schoolIds = [2, 3];
@@ -1395,9 +1148,6 @@ class SessionUserTest extends TestCase
         $this->assertEquals($schoolIds, $this->sessionUser->getAdministeredCurriculumInventoryReportSchoolIds());
     }
 
-    /**
-     * @covers ::isEqualTo
-     */
     public function testIsEqualTo(): void
     {
         $user1 = new SessionUser($this->createMockUser(1, $this->school), $this->userRepository);
@@ -1410,9 +1160,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($user1->isEqualTo($notAnIliosSessionUser));
     }
 
-    /**
-     * @covers ::isTheUser
-     */
     public function testIsTheUser(): void
     {
         $iliosUser1 = $this->createMockUser(1, $this->school);
@@ -1425,9 +1172,6 @@ class SessionUserTest extends TestCase
         $this->assertFalse($sessionUser->isTheUser($iliosUser2));
     }
 
-    /**
-     * @covers ::isThePrimarySchool
-     */
     public function testIsThePrimarySchool(): void
     {
         $otherSchool = new School();

--- a/tests/Classes/UserMaterialTest.php
+++ b/tests/Classes/UserMaterialTest.php
@@ -12,7 +12,6 @@ use DateTime;
  * Class UserMaterialTest
  * @package App\Tests\Classes
  * @covers \App\Classes\UserMaterial
- * @coversDefaultClass \App\Classes\UserMaterial
  */
 class UserMaterialTest extends TestCase
 {
@@ -54,10 +53,6 @@ class UserMaterialTest extends TestCase
         unset($this->userMaterial);
     }
 
-
-    /**
-     * @covers ::clearMaterial
-     */
     public function testClearMaterial()
     {
         $this->assertNotBlanked($this->userMaterial);
@@ -65,9 +60,6 @@ class UserMaterialTest extends TestCase
         $this->assertBlanked($this->userMaterial);
     }
 
-    /**
-     * @covers ::clearTimedMaterial
-     */
     public function testClearTimedMaterialWithNoDates()
     {
         $this->assertNotBlanked($this->userMaterial);
@@ -75,9 +67,6 @@ class UserMaterialTest extends TestCase
         $this->assertNotBlanked($this->userMaterial);
     }
 
-    /**
-     * @covers ::clearTimedMaterial
-     */
     public function testClearTimedMaterialWithStartDateAndInRange()
     {
         $this->assertNotBlanked($this->userMaterial);
@@ -86,9 +75,6 @@ class UserMaterialTest extends TestCase
         $this->assertNotBlanked($this->userMaterial);
     }
 
-    /**
-     * @covers ::clearTimedMaterial
-     */
     public function testClearTimedMaterialWithStartDateAndOutOfRange()
     {
         $this->assertNotBlanked($this->userMaterial);
@@ -97,9 +83,6 @@ class UserMaterialTest extends TestCase
         $this->assertBlanked($this->userMaterial);
     }
 
-    /**
-     * @covers ::clearTimedMaterial
-     */
     public function testClearTimedMaterialWithEndDateAndInRange()
     {
         $this->assertNotBlanked($this->userMaterial);
@@ -108,9 +91,6 @@ class UserMaterialTest extends TestCase
         $this->assertNotBlanked($this->userMaterial);
     }
 
-    /**
-     * @covers ::clearTimedMaterial
-     */
     public function testClearTimedMaterialWithEndDateAndOutOfRange()
     {
         $this->assertNotBlanked($this->userMaterial);
@@ -119,9 +99,6 @@ class UserMaterialTest extends TestCase
         $this->assertBlanked($this->userMaterial);
     }
 
-    /**
-     * @covers ::clearTimedMaterial
-     */
     public function testClearTimedMaterialWithStartEndDateAndInRange()
     {
         $this->assertNotBlanked($this->userMaterial);
@@ -131,9 +108,6 @@ class UserMaterialTest extends TestCase
         $this->assertNotBlanked($this->userMaterial);
     }
 
-    /**
-     * @covers ::clearTimedMaterial
-     */
     public function testClearTimedMaterialWithStartEndDateAndOutOfRange()
     {
         $this->assertNotBlanked($this->userMaterial);

--- a/tests/Command/ImportDefaultDataCommandTest.php
+++ b/tests/Command/ImportDefaultDataCommandTest.php
@@ -34,7 +34,7 @@ use Mockery as m;
  * Class ImportDefaultDataCommandTest
  * @package App\Tests\Command
  * @group cli
- * @coversDefaultClass \App\Command\ImportDefaultDataCommand
+ * @covers \App\Command\ImportDefaultDataCommand
  */
 class ImportDefaultDataCommandTest extends KernelTestCase
 {
@@ -128,9 +128,6 @@ class ImportDefaultDataCommandTest extends KernelTestCase
         unset($this->commandTester);
     }
 
-    /**
-     * @covers ::execute
-     */
     public function testExecute(): void
     {
         $this->schoolRepository->shouldReceive('findDTOBy')->withAnyArgs()->andReturn(null);
@@ -211,9 +208,6 @@ class ImportDefaultDataCommandTest extends KernelTestCase
         $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
     }
 
-    /**
-     * @covers ::execute
-     */
     public function testExecuteFailsIfDatabaseIsNotEmpty(): void
     {
         $this->schoolRepository->shouldReceive('findDTOBy')->withAnyArgs()->andReturn(

--- a/tests/Command/ImportMeshUniverseCommandTest.php
+++ b/tests/Command/ImportMeshUniverseCommandTest.php
@@ -20,7 +20,7 @@ use Mockery as m;
  * Class ImportMeshUniverseCommandTest
  * @package App\Tests\Command
  * @group cli
- * @coversDefaultClass \App\Command\ImportMeshUniverseCommand
+ * @covers \App\Command\ImportMeshUniverseCommand
  */
 class ImportMeshUniverseCommandTest extends KernelTestCase
 {
@@ -55,9 +55,6 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         unset($this->commandTester);
     }
 
-    /**
-     * @covers ::execute
-     */
     public function testNoArgs(): void
     {
         $this->mockHappyPath();
@@ -77,9 +74,6 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         $this->assertMatchesRegularExpression("/Finished MeSH universe import in \d+ seconds./", $output);
     }
 
-    /**
-     * @covers ::execute
-     */
     public function testGivenFilePath(): void
     {
         $this->mockHappyPath();
@@ -99,9 +93,6 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         $this->assertStringContainsString("1/4: Parsing MeSH XML retrieved from {$path}.", $output);
     }
 
-    /**
-     * @covers ::execute
-     */
     public function testGivenUrl(): void
     {
         $this->mockHappyPath();
@@ -121,9 +112,6 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         $this->assertStringContainsString("1/4: Parsing MeSH XML retrieved from {$url}.", $output);
     }
 
-    /**
-     * @covers ::execute
-     */
     public function testYear2023(): void
     {
         $this->mockHappyPath();
@@ -144,9 +132,6 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         $this->assertStringContainsString("1/4: Parsing MeSH XML retrieved from {$url}.", $output);
     }
 
-    /**
-     * @covers ::execute
-     */
     public function testYear2022(): void
     {
         $this->mockHappyPath();
@@ -167,9 +152,6 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         $this->assertStringContainsString("1/4: Parsing MeSH XML retrieved from {$url}.", $output);
     }
 
-    /**
-     * @covers ::execute
-     */
     public function testInvalidGivenYear(): void
     {
         $year = '1906';
@@ -187,9 +169,6 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         $this->descriptorRepository->shouldNotHaveReceived('flagDescriptorsAsDeleted');
     }
 
-    /**
-     * @covers ::execute
-     */
     public function testIndexesResults(): void
     {
         $this->descriptorRepository->shouldReceive('clearExistingData')->once();

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -22,7 +22,7 @@ use function json_decode;
 use function var_export;
 
 /**
- * @coversDefaultClass \App\Controller\AuthController
+ * @covers \App\Controller\AuthController
  * @group controller
  */
 class AuthControllerTest extends WebTestCase

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @coversDefaultClass \App\Controller\ConfigController
+ * @covers \App\Controller\ConfigController
  * @group controller
  */
 class ConfigControllerTest extends WebTestCase
@@ -38,7 +38,7 @@ class ConfigControllerTest extends WebTestCase
         unset($this->kernelBrowser);
     }
 
-    public function testIndex(): void
+    public function testGetConfig(): void
     {
         $this->kernelBrowser->request('GET', '/application/config');
         $response = $this->kernelBrowser->getResponse();

--- a/tests/Controller/CurriculumInventoryDownloadControllerTest.php
+++ b/tests/Controller/CurriculumInventoryDownloadControllerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\TestableJsonController;
 
 /**
- * @coversDefaultClass \App\Controller\CurriculumInventoryDownloadController
+ * @covers \App\Controller\CurriculumInventoryDownloadController
  * @group controller
  */
 class CurriculumInventoryDownloadControllerTest extends WebTestCase
@@ -57,7 +57,7 @@ class CurriculumInventoryDownloadControllerTest extends WebTestCase
         unset($this->kernelBrowser);
     }
 
-    public function testGetCurriculumInventoryDownload(): void
+    public function testGetAction(): void
     {
         $jwts = [
             $this->createJwtFromUserId($this->kernelBrowser, 1),

--- a/tests/Controller/DirectoryControllerTest.php
+++ b/tests/Controller/DirectoryControllerTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
- * @coversDefaultClass \App\Controller\DirectoryController
+ * @covers \App\Controller\DirectoryController
  * @group controller
  */
 class DirectoryControllerTest extends TestCase

--- a/tests/Controller/DownloadControllerTest.php
+++ b/tests/Controller/DownloadControllerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\TestableJsonController;
 
 /**
- * @coversDefaultClass \App\Controller\DownloadController
+ * @covers \App\Controller\DownloadController
  * @group controller
  */
 class DownloadControllerTest extends WebTestCase

--- a/tests/Controller/ErrorControllerTest.php
+++ b/tests/Controller/ErrorControllerTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\TestableJsonController;
 
 /**
- * @coversDefaultClass \App\Controller\ErrorController
+ * @covers \App\Controller\ErrorController
  * @group controller
  */
 class ErrorControllerTest extends WebTestCase
@@ -39,7 +39,7 @@ class ErrorControllerTest extends WebTestCase
         unset($this->kernelBrowser);
     }
 
-    public function testIndex(): void
+    public function testPostError(): void
     {
         $data = [
             'mainMessage' => 'dev/null',

--- a/tests/Controller/IcsControllerTest.php
+++ b/tests/Controller/IcsControllerTest.php
@@ -21,7 +21,7 @@ use App\Tests\DataLoader\SessionData;
 use App\Tests\Traits\TestableJsonController;
 
 /**
- * @coversDefaultClass \App\Controller\IcsController
+ * @covers \App\Controller\IcsController
  * @group controller
  */
 class IcsControllerTest extends WebTestCase

--- a/tests/Controller/IndexControllerTest.php
+++ b/tests/Controller/IndexControllerTest.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @coversDefaultClass \App\Controller\IndexController
+ * @covers \App\Controller\IndexController
  * @group controller
  */
 class IndexControllerTest extends WebTestCase

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
- * @coversDefaultClass \App\Controller\Search
+ * @covers \App\Controller\Search
  * @group controller
  */
 class SearchControllerTest extends TestCase

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -6,7 +6,7 @@ namespace App\Tests\Controller;
 
 use App\Classes\ServiceTokenUserInterface;
 use App\Classes\SessionUserInterface;
-use App\Controller\Search;
+use App\Controller\SearchController;
 use App\Service\Index\Curriculum;
 use App\Service\Index\Users;
 use App\Service\SessionUserPermissionChecker;
@@ -19,12 +19,12 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
- * @covers \App\Controller\Search
+ * @covers \App\Controller\SearchController
  * @group controller
  */
 class SearchControllerTest extends TestCase
 {
-    protected Search $controller;
+    protected SearchController $controller;
     protected m\MockInterface $mockCurriculumSearch;
     protected m\MockInterface $mockUsersSearch;
     protected m\MockInterface $mockTokenStorage;
@@ -38,7 +38,7 @@ class SearchControllerTest extends TestCase
         $this->mockTokenStorage = m::mock(TokenStorageInterface::class);
         $this->mockPermissionChecker = m::mock(SessionUserPermissionChecker::class);
 
-        $this->controller = new Search(
+        $this->controller = new SearchController(
             $this->mockCurriculumSearch,
             $this->mockUsersSearch,
             $this->mockTokenStorage,

--- a/tests/Controller/UploadControllerTest.php
+++ b/tests/Controller/UploadControllerTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\TestableJsonController;
 
 /**
- * @coversDefaultClass \App\Controller\UploadController
+ * @covers \App\Controller\UploadController
  * @group controller
  */
 class UploadControllerTest extends WebTestCase

--- a/tests/Entity/AuditLogTest.php
+++ b/tests/Entity/AuditLogTest.php
@@ -11,7 +11,7 @@ use function method_exists;
 /**
  * Tests for Entity AuditLog
  * @group model
- * @coversDefaultClass \App\Entity\AuditLog
+ * @covers \App\Entity\AuditLog
  */
 class AuditLogTest extends EntityBase
 {
@@ -46,27 +46,16 @@ class AuditLogTest extends EntityBase
         $this->validate(0);
     }
 
-    /**
-     * @covers ::__construct
-     */
     public function testConstructor(): void
     {
         $this->assertNotEmpty($this->object->getCreatedAt());
     }
 
-    /**
-     * @covers ::setAction
-     * @covers ::getAction
-     */
     public function testSetAction(): void
     {
         $this->basicSetTest('action', 'string');
     }
 
-    /**
-     * @covers ::setObjectId
-     * @covers ::getObjectId
-     */
     public function testSetObjectIdConvertsIntToString(): void
     {
         $this->assertTrue(method_exists($this->object, 'setObjectId'));
@@ -75,55 +64,31 @@ class AuditLogTest extends EntityBase
         $this->assertSame('11', $this->object->getObjectId());
     }
 
-    /**
-     * @covers ::setObjectId
-     * @covers ::getObjectId
-     */
     public function testSetObjectIdString(): void
     {
         $this->basicSetTest('objectId', 'string');
     }
 
-    /**
-     * @covers ::setObjectClass
-     * @covers ::getObjectClass
-     */
     public function testSetObjectClass(): void
     {
         $this->basicSetTest('objectClass', 'string');
     }
 
-    /**
-     * @covers ::setValuesChanged
-     * @covers ::getValuesChanged
-     */
     public function testSetValuesChanged(): void
     {
         $this->basicSetTest('valuesChanged', 'string');
     }
 
-    /**
-     * @covers ::setUser
-     * @covers ::getUser
-     */
     public function testSetUser(): void
     {
         $this->entitySetTest('user', 'User');
     }
 
-    /**
-     * @covers ::setServiceToken
-     * @covers ::getServiceToken
-     */
     public function testSetServiceToken(): void
     {
         $this->entitySetTest('serviceToken', 'ServiceToken');
     }
 
-    /**
-     * @covers ::setCreatedAt
-     * @covers ::getCreatedAt
-     */
     public function testSetCreatedAt(): void
     {
         $this->basicSetTest('createdAt', 'datetime');

--- a/tests/Entity/ServiceTokenTest.php
+++ b/tests/Entity/ServiceTokenTest.php
@@ -9,7 +9,7 @@ use DateTime;
 
 /**
  * @group model
- * @coversDefaultClass \App\Entity\ServiceToken
+ * @covers \App\Entity\ServiceToken
  */
 class ServiceTokenTest extends EntityBase
 {
@@ -42,62 +42,37 @@ class ServiceTokenTest extends EntityBase
         $this->validate(0);
     }
 
-    /**
-     * @covers ::__construct
-     */
     public function testConstructor(): void
     {
         $this->assertEmpty($this->object->getAuditLogs()->toArray());
         $this->assertTrue($this->object->isEnabled());
     }
 
-    /**
-     * @covers ::setDescription
-     * @covers ::getDescription
-     */
     public function testSetDescription(): void
     {
         $this->basicSetTest('description', 'string');
     }
 
-    /**
-     * @covers ::setCreatedAt
-     * @covers ::getCreatedAt
-     */
     public function testSetCreatedAt(): void
     {
         $this->basicSetTest('createdAt', 'datetime');
     }
 
-    /**
-     * @covers ::setExpiresAt
-     * @covers ::getExpiresAt
-     */
     public function testSetExpiresAt(): void
     {
         $this->basicSetTest('expiresAt', 'datetime');
     }
 
-    /**
-     * @covers ::addAuditLog
-     */
     public function testAddAuditLog(): void
     {
         $this->entityCollectionAddTest('auditLog', 'AuditLog');
     }
 
-    /**
-     * @covers ::removeAuditLog
-     */
     public function testRemoveAuditLog(): void
     {
         $this->entityCollectionRemoveTest('auditLog', 'AuditLog');
     }
 
-    /**
-     * @covers ::setAuditLogs
-     * @covers ::getAuditLogs
-     */
     public function testSetAuditLogs(): void
     {
         $this->entityCollectionSetTest('auditLog', 'AuditLog');

--- a/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
+++ b/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 /**
  * Class ElevatedPermissionsViewDtoVoterTest
  * @package App\Tests\RelationshipVoter
- * @coversDefaultClass \App\RelationshipVoter\ElevatedPermissionsViewDTOVoter
+ * @covers \App\RelationshipVoter\ElevatedPermissionsViewDTOVoter
 
  */
 class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
@@ -43,7 +43,6 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
 
     /**
      * @dataProvider dtoProvider
-     * @covers ::voteOnAttribute()
      */
     public function testCanViewDTO(string $class): void
     {
@@ -56,7 +55,6 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
 
     /**
      * @dataProvider dtoProvider
-     * @covers ::voteOnAttribute()
      */
     public function testRootCanViewDTO(string $class): void
     {
@@ -69,7 +67,6 @@ class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
 
     /**
      * @dataProvider dtoProvider
-     * @covers ::voteOnAttribute()
      */
     public function testCanNotViewDTO(string $class): void
     {

--- a/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -49,7 +49,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 /**
  * Class GreenlightViewDtoVoterTest
  * @package App\Tests\RelationshipVoter
- * @coversDefaultClass \App\RelationshipVoter\GreenlightViewDTOVoter
+ * @covers \App\RelationshipVoter\GreenlightViewDTOVoter
  */
 class GreenlightViewDtoVoterTest extends AbstractBase
 {
@@ -104,7 +104,6 @@ class GreenlightViewDtoVoterTest extends AbstractBase
 
     /**
      * @dataProvider canViewDTOProvider
-     * @covers ::voteOnAttribute()
      * @param string $class The fully qualified class name.
      */
     public function testCanViewDTO(string $class): void

--- a/tests/RelationshipVoter/LearnerGroupDTOVoterTest.php
+++ b/tests/RelationshipVoter/LearnerGroupDTOVoterTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 /**
  * Class LearnerGroupDTOVoterTest
  * @package App\Tests\RelationshipVoter
- * @coversDefaultClass \App\RelationshipVoter\LearnerGroupDTOVoter
+ * @covers \App\RelationshipVoter\LearnerGroupDTOVoter
  */
 class LearnerGroupDTOVoterTest extends AbstractBase
 {
@@ -25,9 +25,6 @@ class LearnerGroupDTOVoterTest extends AbstractBase
         $this->voter = new LearnerGroupDTOVoter($this->permissionChecker);
     }
 
-    /**
-     * @covers ::voteOnAttribute()
-     */
     public function testRootCanViewDTO(): void
     {
         $user = $this->createMockRootSessionUser();
@@ -37,9 +34,6 @@ class LearnerGroupDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
     }
 
-    /**
-     * @covers ::voteOnAttribute()
-     */
     public function testUserCanViewDTO(): void
     {
         $user = $this->createMockNonRootSessionUser();
@@ -51,9 +45,6 @@ class LearnerGroupDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
     }
 
-    /**
-     * @covers ::voteOnAttribute()
-     */
     public function testCanNotViewDTO(): void
     {
         $user = $this->createMockNonRootSessionUser();

--- a/tests/RelationshipVoter/ReportDTOVoterTest.php
+++ b/tests/RelationshipVoter/ReportDTOVoterTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 /**
  * Class ReportDTOVoterTest
  * @package App\Tests\RelationshipVoter
- * @coversDefaultClass \App\RelationshipVoter\ReportDTOVoter
+ * @covers \App\RelationshipVoter\ReportDTOVoter
 
  */
 class ReportDTOVoterTest extends AbstractBase
@@ -26,9 +26,6 @@ class ReportDTOVoterTest extends AbstractBase
         $this->voter = new ReportDTOVoter($this->permissionChecker);
     }
 
-    /**
-     * @covers ::voteOnAttribute()
-     */
     public function testCanViewDTO(): void
     {
         $userId = 1;
@@ -41,9 +38,6 @@ class ReportDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
     }
 
-    /**
-     * @covers ::voteOnAttribute()
-     */
     public function testRootCanViewDTO(): void
     {
         $user = $this->createMockRootSessionUser();
@@ -53,9 +47,6 @@ class ReportDTOVoterTest extends AbstractBase
         $this->assertEquals(VoterInterface::ACCESS_GRANTED, $response, "DTO View allowed");
     }
 
-    /**
-     * @covers ::voteOnAttribute()
-     */
     public function testCanNotViewDTO(): void
     {
         $userId = 1;

--- a/tests/Security/JsonWebTokenAuthenticatorTest.php
+++ b/tests/Security/JsonWebTokenAuthenticatorTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use UnexpectedValueException;
 
 /**
- * @coversDefaultClass \App\Security\JsonWebTokenAuthenticator
+ * @covers \App\Security\JsonWebTokenAuthenticator
  */
 class JsonWebTokenAuthenticatorTest extends TestCase
 {
@@ -52,9 +52,6 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         parent::setUp();
     }
 
-    /**
-     * @covers ::supports
-     */
     public function testSupports(): void
     {
         $request = new Request();
@@ -62,18 +59,12 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         $this->assertTrue($this->authenticator->supports($request));
     }
 
-    /**
-     * @covers ::supports
-     */
     public function testSupportsFailsWithoutXHeader(): void
     {
         $request = new Request();
         $this->assertFalse($this->authenticator->supports($request));
     }
 
-    /**
-     * @covers ::supports
-     */
     public function testSupportsFailsWithInvalidTokenInHeader(): void
     {
         $request = new Request();
@@ -81,9 +72,6 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         $this->assertFalse($this->authenticator->supports($request));
     }
 
-    /**
-     * @covers ::onAuthenticationFailure
-     */
     public function testOnAuthenticationFailure(): void
     {
         $exception = new AuthenticationException('lorem ipsum');
@@ -95,9 +83,6 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         $this->assertEquals('Authentication Failed. lorem ipsum', $response->getContent());
     }
 
-    /**
-     * @covers ::onAuthenticationSuccess
-     */
     public function testOnAuthenticationSuccess(): void
     {
         $response = $this->authenticator->onAuthenticationSuccess(
@@ -108,9 +93,6 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         $this->assertNull($response);
     }
 
-    /**
-     * @covers ::authenticate
-     */
     public function testAuthenticateWithUserToken(): void
     {
         $jwt = 'abcde';
@@ -123,9 +105,6 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         $this->assertNull($passport->getAttribute(JsonWebTokenManager::WRITEABLE_SCHOOLS_KEY));
     }
 
-    /**
-     * @covers ::authenticate
-     */
     public function testAuthenticateWithServiceToken(): void
     {
         $jwt = 'abcde';
@@ -144,9 +123,6 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         $this->assertEquals($schoolIds, $passport->getAttribute(JsonWebTokenManager::WRITEABLE_SCHOOLS_KEY));
     }
 
-    /**
-     * @covers ::authenticate
-     */
     public function testAuthenticateFailsWithoutIdentity(): void
     {
         $jwt = 'abcde';
@@ -159,9 +135,6 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         $this->authenticator->authenticate($request);
     }
 
-    /**
-     * @covers ::authenticate
-     */
     public function testAuthenticateFailsWithCorruptedJwt(): void
     {
         $jwt = 'abcde';
@@ -176,9 +149,6 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         $this->authenticator->authenticate($request);
     }
 
-    /**
-     * @covers ::createToken
-     */
     public function testCreateTokenForUser(): void
     {
         $jwt = 'abcde';
@@ -195,9 +165,6 @@ class JsonWebTokenAuthenticatorTest extends TestCase
         $this->assertEquals($userMock, $token->getUser());
     }
 
-    /**
-     * @covers ::createToken
-     */
     public function testCreateTokenForServiceToken(): void
     {
         $jwt = 'abcde';

--- a/tests/Service/ChangeAlertHandlerTest.php
+++ b/tests/Service/ChangeAlertHandlerTest.php
@@ -23,7 +23,7 @@ use App\Tests\TestCase;
 /**
  * Class ChangeAlertHandlerTest
  * @package App\Tests\Service
- * @coversDefaultClass \App\Service\ChangeAlertHandler
+ * @covers \App\Service\ChangeAlertHandler
  */
 class ChangeAlertHandlerTest extends TestCase
 {
@@ -50,9 +50,6 @@ class ChangeAlertHandlerTest extends TestCase
         unset($this->mockAlertChangeTypeRepository);
     }
 
-    /**
-     * @covers ::createAlertForNewOffering
-     */
     public function testCreateAlertForNewOffering(): void
     {
         $school = new School();
@@ -98,9 +95,6 @@ class ChangeAlertHandlerTest extends TestCase
         $this->assertEquals($alert->getChangeTypes()[0], $alertChangeType);
     }
 
-    /**
-     * @covers ::createOrUpdateAlertForUpdatedOffering
-     */
     public function testCreateOrUpdateAlertForUpdatedOfferingExistingAlert(): void
     {
         $school = new School();
@@ -194,9 +188,6 @@ class ChangeAlertHandlerTest extends TestCase
         $this->assertTrue($changeTypes->contains($locationChangeType));
     }
 
-    /**
-     * @covers ::createOrUpdateAlertForUpdatedOffering()
-     */
     public function testCreateOrUpdateAlertForUpdatedOfferingNewAlert(): void
     {
         $school = new School();

--- a/tests/Service/CurriculumInventory/ReportRolloverTest.php
+++ b/tests/Service/CurriculumInventory/ReportRolloverTest.php
@@ -27,7 +27,7 @@ use function count;
 
 /**
  * Class ReportRolloverTest
- * @coversDefaultClass \App\Service\CurriculumInventory\ReportRollover
+ * @covers \App\Service\CurriculumInventory\ReportRollover
  */
 class ReportRolloverTest extends TestCase
 {
@@ -156,7 +156,6 @@ class ReportRolloverTest extends TestCase
         return [[ $report ]];
     }
     /**
-     * @covers ::rollover
      * @dataProvider reportProvider
      * @param CurriculumInventoryReport $report
      */
@@ -207,7 +206,6 @@ class ReportRolloverTest extends TestCase
     }
 
     /**
-     * @covers ::rollover
      * @dataProvider reportProvider
      * @param CurriculumInventoryReportInterface $report
      */
@@ -218,7 +216,6 @@ class ReportRolloverTest extends TestCase
     }
 
     /**
-     * @covers ::rollover
      * @dataProvider reportProvider
      * @param CurriculumInventoryReportInterface $report
      */
@@ -229,7 +226,6 @@ class ReportRolloverTest extends TestCase
     }
 
     /**
-     * @covers ::rollover
      * @dataProvider reportProvider
      * @param CurriculumInventoryReportInterface $report
      */
@@ -249,7 +245,7 @@ class ReportRolloverTest extends TestCase
     protected function assertSequenceBlockEquals(
         CurriculumInventorySequenceBlockInterface $sequenceBlock,
         CurriculumInventorySequenceBlockInterface $newSequenceBlock
-    ) {
+    ): void {
         $this->assertEquals(empty($sequenceBlock->getParent()), empty($newSequenceBlock->getParent()));
         if (! empty($sequenceBlock->getParent())) {
             $this->assertEquals($sequenceBlock->getParent()->getTitle(), $newSequenceBlock->getParent()->getTitle());
@@ -287,7 +283,6 @@ class ReportRolloverTest extends TestCase
     }
 
     /**
-     * @covers ::rollover
      * @dataProvider reportProvider
      * @param CurriculumInventoryReportInterface $report
      */

--- a/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
+++ b/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
@@ -23,7 +23,7 @@ use Mockery\MockInterface;
 /**
  * Class VerificationPreviewBuilderTest
  * @package App\Tests\Service\CurriculumInventory
- * @coversDefaultClass \App\Service\CurriculumInventory\VerificationPreviewBuilder
+ * @covers \App\Service\CurriculumInventory\VerificationPreviewBuilder
  */
 class VerificationPreviewBuilderTest extends TestCase
 {
@@ -357,9 +357,6 @@ class VerificationPreviewBuilderTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @covers ::getAllEventsWithAssessmentsTaggedAsFormativeOrSummative
-     */
     public function testGetAllEventsWithAssessmentsTaggedAsFormativeOrSummative(): void
     {
         $data['events'] = [
@@ -394,9 +391,6 @@ class VerificationPreviewBuilderTest extends TestCase
         ], $rows[2]);
     }
 
-    /**
-     * @covers ::getAllResourceTypes
-     */
     public function testGetAllResourceTypes(): void
     {
         $data['events'] = [
@@ -424,9 +418,6 @@ class VerificationPreviewBuilderTest extends TestCase
         $this->assertEquals(['id' => 3, 'title' => 'Baz', 'count' => 3], $rows[2]);
     }
 
-    /**
-     * @covers ::getClerkshipSequenceBlockAssessmentMethods
-     */
     public function testGetClerkshipSequenceBlockAssessmentMethods(): void
     {
         $data = [];
@@ -571,9 +562,6 @@ class VerificationPreviewBuilderTest extends TestCase
         ], $rows[2]);
     }
 
-    /**
-     * @covers ::getClerkshipSequenceBlockInstructionalTime
-     */
     public function testGetClerkshipSequenceBlockInstructionalTime(): void
     {
         $data = [];
@@ -704,9 +692,6 @@ class VerificationPreviewBuilderTest extends TestCase
         ], $rows[2]);
     }
 
-    /**
-     * @covers ::getInstructionalMethodCounts
-     */
     public function testGetInstructionalMethodCounts(): void
     {
         $data['events'] = [
@@ -745,9 +730,6 @@ class VerificationPreviewBuilderTest extends TestCase
         ], $rows[3]);
     }
 
-    /**
-     * @covers ::getNonClerkshipSequenceBlockAssessmentMethods
-     */
     public function testGetNonClerkshipSequenceBlockAssessmentMethods(): void
     {
         $data = [];
@@ -897,9 +879,6 @@ class VerificationPreviewBuilderTest extends TestCase
         ], $rows[2]);
     }
 
-    /**
-     * @covers ::getNonClerkshipSequenceBlockInstructionalTime
-     */
     public function testGetNonClerkshipSequenceBlockInstructionalTime(): void
     {
         $data = [];
@@ -1027,9 +1006,6 @@ class VerificationPreviewBuilderTest extends TestCase
         ], $rows[2]);
     }
 
-    /**
-     * @covers ::getPrimaryInstructionalMethodsByNonClerkshipSequenceBlock
-     */
     public function testGetPrimaryInstructionalMethodsByNonClerkshipSequenceBlock(): void
     {
         $level1 = new CurriculumInventoryAcademicLevel();
@@ -1155,9 +1131,6 @@ class VerificationPreviewBuilderTest extends TestCase
         ], $rows[2]);
     }
 
-    /**
-     * @covers ::getProgramExpectationsMappedToPcrs
-     */
     public function testGetProgramExpectationsMappedToPcrs(): void
     {
         $data['expectations'] = [
@@ -1213,9 +1186,6 @@ class VerificationPreviewBuilderTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::build
-     */
     public function testBuild(): void
     {
         $report = new CurriculumInventoryReport();

--- a/tests/Service/DefaultDataImporterTest.php
+++ b/tests/Service/DefaultDataImporterTest.php
@@ -12,7 +12,7 @@ use Mockery as m;
 
 /**
  * @package App\Tests\Service
- * @coversDefaultClass \App\Service\DefaultDataImporter
+ * @covers \App\Service\DefaultDataImporter
  */
 class DefaultDataImporterTest extends TestCase
 {
@@ -42,9 +42,6 @@ class DefaultDataImporterTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportAamcMethod(): void
     {
         $input = [
@@ -69,9 +66,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportAamcPcrs(): void
     {
         $input = [
@@ -93,9 +87,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportAamcResourceType(): void
     {
         $input = [
@@ -117,9 +108,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportAlertChangeType(): void
     {
         $input = [
@@ -144,9 +132,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportApplicationConfig(): void
     {
         $input = [
@@ -171,9 +156,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportAssessmentOption(): void
     {
         $input = [
@@ -198,9 +180,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportCompetency(): void
     {
         $input = [
@@ -225,9 +204,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportCourseClerkshipType(): void
     {
         $input = [
@@ -252,9 +228,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportCurriculumInventoryInstitution(): void
     {
         $input = [
@@ -280,9 +253,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportLearningMaterialStatus(): void
     {
         $input = [
@@ -309,9 +279,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportLearningMaterialUserRole(): void
     {
         $input = [
@@ -338,9 +305,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportSchool(): void
     {
         $input = [
@@ -365,9 +329,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportSessionType(): void
     {
         $input = [
@@ -392,9 +353,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportTerm(): void
     {
         $input = [
@@ -419,9 +377,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportUserRole(): void
     {
         $input = [
@@ -446,9 +401,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportVocabulary(): void
     {
         $input = [
@@ -473,9 +425,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportCompetencyToAamcPcrsMapping(): void
     {
         $input = [
@@ -498,9 +447,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportSessionTypeToAamcMethodMapping(): void
     {
         $input = [
@@ -524,9 +470,6 @@ class DefaultDataImporterTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::import
-     */
     public function testImportTermToAamcResourceTypeMapping(): void
     {
         $input = [

--- a/tests/Service/DefaultDataLoaderTest.php
+++ b/tests/Service/DefaultDataLoaderTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
 
 /**
  * @package App\Tests\Service
- * @coversDefaultClass \App\Service\DefaultDataLoader
+ * @covers \App\Service\DefaultDataLoader
  */
 class DefaultDataLoaderTest extends KernelTestCase
 {
@@ -31,23 +31,17 @@ class DefaultDataLoaderTest extends KernelTestCase
         unset($this->projectRootDir);
     }
 
-    /**
-     * @covers ::load
-     */
-    public function testImport(): void
+    public function testLoad(): void
     {
         $defaultDataLoader = new DefaultDataLoader(new DataimportFileLocator($this->projectRootDir));
         $assessmentOptions = $defaultDataLoader->load(DefaultDataImporter::ASSESSMENT_OPTION);
         $this->assertCount(2, $assessmentOptions);
     }
 
-    /**
-     * @covers ::load
-     */
-    public function testImportFailsIfFileNotFound(): void
+    public function testLoadFailsIfFileNotFound(): void
     {
         $this->expectException(FileLocatorFileNotFoundException::class);
         $defaultDataLoader = new DefaultDataLoader(new DataimportFileLocator($this->projectRootDir));
-        $defaultDataLoader->load('gefkarknik');
+        $defaultDataLoader->load('geflarknik');
     }
 }

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -17,7 +17,7 @@ use Mockery as m;
 use App\Service\JsonWebTokenManager;
 
 /**
- * @coversDefaultClass \App\Service\JsonWebTokenManager
+ * @covers \App\Service\JsonWebTokenManager
  */
 class JsonWebTokenManagerTest extends TestCase
 {
@@ -164,9 +164,6 @@ class JsonWebTokenManagerTest extends TestCase
         $this->assertSame(false, $this->obj->getCanCreateOrUpdateUserInAnySchoolFromToken($jwt));
     }
 
-    /**
-     * @covers ::createJwtFromServiceTokenUser
-     */
     public function testCreateJwtFromServiceTokenUser(): void
     {
         $schoolIds = [1, 3];
@@ -199,7 +196,6 @@ class JsonWebTokenManagerTest extends TestCase
     }
 
     /**
-     * @covers ::getWriteableSchoolIdsFromToken
      * @dataProvider getWriteableSchoolIdsFromTokenProvider
      */
     public function testGetWriteableSchoolIdsFromToken(string $jwt, array $schoolIds): void
@@ -217,7 +213,6 @@ class JsonWebTokenManagerTest extends TestCase
     }
 
     /**
-     * @covers ::isUserToken
      * @dataProvider isUserTokenProvider
      */
     public function testIsUserToken(string $jwt, bool $expected): void
@@ -235,7 +230,6 @@ class JsonWebTokenManagerTest extends TestCase
     }
 
     /**
-     * @covers ::isServiceToken
      * @dataProvider isServiceTokenProvider
      */
     public function testIsServiceToken(string $jwt, bool $expected): void

--- a/tests/Service/MeshDescriptorSetTransmogrifierTest.php
+++ b/tests/Service/MeshDescriptorSetTransmogrifierTest.php
@@ -16,7 +16,7 @@ use Ilios\MeSH\Model\Term;
 
 /**
  * Class MeshDescriptorSetTransmogrifierTest
- * @coversDefaultClass \App\Service\MeshDescriptorSetTransmogrifier
+ * @covers \App\Service\MeshDescriptorSetTransmogrifier
  */
 class MeshDescriptorSetTransmogrifierTest extends TestCase
 {
@@ -34,9 +34,6 @@ class MeshDescriptorSetTransmogrifierTest extends TestCase
         unset($this->transmogrifier);
     }
 
-    /**
-     * @covers ::transmogrify
-     */
     public function testTransmogrify(): void
     {
         $descriptor1 = new Descriptor();
@@ -157,9 +154,6 @@ class MeshDescriptorSetTransmogrifierTest extends TestCase
         $this->assertEquals(['3.1'], $data['insert']['mesh_tree']['D03']);
     }
 
-    /**
-     * @covers ::hashTerm
-     */
     public function testHashTerm(): void
     {
         $term1 = new Term();

--- a/tests/Service/SessionUserPermissionCheckerTest.php
+++ b/tests/Service/SessionUserPermissionCheckerTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
 /**
  * Class PermissionCheckerTest
  * @package App\Tests\Service
- * @coversDefaultClass \App\Service\SessionUserPermissionChecker
+ * @covers \App\Service\SessionUserPermissionChecker
  */
 class SessionUserPermissionCheckerTest extends TestCase
 {
@@ -40,9 +40,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         unset($this->permissionMatrix);
     }
 
-    /**
-     * @covers ::canUpdateCourse()
-     */
     public function testCanUpdateAllCourses(): void
     {
         $rolesInSchool = ['foo'];
@@ -71,9 +68,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUpdateCourse()
-     */
     public function testCanUpdateTheirCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -113,9 +107,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUpdateCourse()
-     */
     public function testCanNotUpdateCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -155,9 +146,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUpdateCourse()
-     */
     public function testCanNotUpdateLockedCourses(): void
     {
         $course = m::mock(CourseInterface::class);
@@ -169,9 +157,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUpdateCourse()
-     */
     public function testCanNotUpdateArchivedCourses(): void
     {
         $course = m::mock(CourseInterface::class);
@@ -183,9 +168,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canDeleteCourse()
-     */
     public function testCanDeleteAllCourses(): void
     {
         $rolesInSchool = ['foo'];
@@ -215,9 +197,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canDeleteCourse()
-     */
     public function testCanDeleteTheirCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -257,9 +236,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canDeleteCourse()
-     */
     public function testCanNotDeleteCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -299,9 +275,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canDeleteCourse()
-     */
     public function testCanNotDeleteLockedCourses(): void
     {
         $course = m::mock(CourseInterface::class);
@@ -313,9 +286,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canDeleteCourse()
-     */
     public function testCanNotDeleteArchivedCourses(): void
     {
         $course = m::mock(CourseInterface::class);
@@ -327,9 +297,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canCreateCourse()
-     */
     public function testCanCreateCourse(): void
     {
         $schoolId = 10;
@@ -352,9 +319,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateCourse($sessionUser, $school));
     }
 
-    /**
-     * @covers ::canCreateCourse()
-     */
     public function testCanNotCreateCourse(): void
     {
         $schoolId = 10;
@@ -377,9 +341,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateCourse($sessionUser, $school));
     }
 
-    /**
-     * @covers ::canUnlockCourse()
-     */
     public function testCanUnlockAllCourses(): void
     {
         $rolesInSchool = ['foo'];
@@ -407,9 +368,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUnlockCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUnlockCourse()
-     */
     public function testCanUnlockTheirCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -447,9 +405,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUnlockCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUnlockCourse()
-     */
     public function testCanNotUnlockCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -488,9 +443,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUnlockCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUnlockCourse()
-     */
     public function testCanNotUnlockCourseIfCourseIsArchived(): void
     {
         $course = m::mock(CourseInterface::class);
@@ -501,9 +453,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUnlockCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canLockCourse()
-     */
     public function testCanLockAllCourses(): void
     {
         $rolesInSchool = ['foo'];
@@ -531,9 +480,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canLockCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canLockCourse()
-     */
     public function testCanLockTheirCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -571,9 +517,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canLockCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canLockCourse()
-     */
     public function testCanNotLockCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -612,9 +555,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canLockCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUnlockCourse()
-     */
     public function testCanNotLockCourseIfCourseIsArchived(): void
     {
         $course = m::mock(CourseInterface::class);
@@ -625,9 +565,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canLockCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canArchiveCourse()
-     */
     public function testCanArchiveAllCourses(): void
     {
         $rolesInSchool = ['foo'];
@@ -654,9 +591,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canArchiveCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canArchiveCourse()
-     */
     public function testCanArchiveTheirCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -693,9 +627,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canArchiveCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canArchiveCourse()
-     */
     public function testCanNotArchiveCourses(): void
     {
         $rolesInSchool  = ['foo'];
@@ -733,9 +664,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canArchiveCourse($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUpdateSession()
-     */
     public function testCanUpdateAllSessions(): void
     {
         $rolesInSchool = ['foo'];
@@ -768,9 +696,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canUpdateSession()
-     */
     public function testCanUpdateTheirSessions(): void
     {
         $rolesInSchool  = ['foo'];
@@ -813,9 +738,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canUpdateSession()
-     */
     public function testCanUpdateSessionsIfUserCanUpdateCourse(): void
     {
         $rolesInSchool  = ['foo'];
@@ -871,9 +793,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canUpdateSession()
-     */
     public function testCanNotUpdateSessions(): void
     {
         $rolesInSchool  = ['foo'];
@@ -937,9 +856,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canUpdateSession()
-     */
     public function testCanNotUpdateSessionsInLockedCourse(): void
     {
         $session = m::mock(SessionInterface::class);
@@ -953,9 +869,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canUpdateSession()
-     */
     public function testCanNotUpdateSessionsInArchivedCourse(): void
     {
         $session = m::mock(SessionInterface::class);
@@ -969,9 +882,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canDeleteSession()
-     */
     public function testCanDeleteAllSessions(): void
     {
         $rolesInSchool = ['foo'];
@@ -1004,9 +914,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canDeleteSession()
-     */
     public function testCanDeleteTheirSessions(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1050,9 +957,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canDeleteSession()
-     */
     public function testCanDeleteSessionsIfUserCanUpdateCourse(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1106,9 +1010,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canDeleteSession()
-     */
     public function testCanNotDeleteSessions(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1172,9 +1073,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canDeleteSession()
-     */
     public function testCanNotDeleteSessionsInLockedCourse(): void
     {
         $session = m::mock(SessionInterface::class);
@@ -1188,9 +1086,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canDeleteSession()
-     */
     public function testCanNotDeleteSessionsInArchivedCourse(): void
     {
         $session = m::mock(SessionInterface::class);
@@ -1204,9 +1099,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteSession($sessionUser, $session));
     }
 
-    /**
-     * @covers ::canCreateSession()
-     */
     public function testCanCreateSession(): void
     {
         $rolesInSchool = ['foo'];
@@ -1234,9 +1126,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateSession($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canCreateSession()
-     */
     public function testCanCreateSessionIfUserCanUpdateCourse(): void
     {
         $rolesInSchool = ['foo'];
@@ -1272,9 +1161,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateSession($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canCreateSession()
-     */
     public function testCanNotCreateSession(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1322,9 +1208,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateSession($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canCreateSession()
-     */
     public function testCanNotCreateSessionInLockedCourse(): void
     {
         $course = m::mock(CourseInterface::class);
@@ -1336,9 +1219,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateSession($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canCreateSession()
-     */
     public function testCanNotCreateSessionInArchivedCourse(): void
     {
         $course = m::mock(CourseInterface::class);
@@ -1350,9 +1230,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateSession($sessionUser, $course));
     }
 
-    /**
-     * @covers ::canUpdateSessionType()
-     */
     public function testCanUpdateSessionType(): void
     {
         $schoolId = 10;
@@ -1373,9 +1250,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateSessionType($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateSessionType()
-     */
     public function testCanNotUpdateSessionType(): void
     {
         $schoolId = 10;
@@ -1396,9 +1270,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateSessionType($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteSessionType()
-     */
     public function testCanDeleteSessionType(): void
     {
         $schoolId = 10;
@@ -1419,9 +1290,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteSessionType($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteSessionType()
-     */
     public function testCanNotDeleteSessionType(): void
     {
         $schoolId = 10;
@@ -1442,9 +1310,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteSessionType($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateSessionType()
-     */
     public function testCanCreateSessionType(): void
     {
         $schoolId = 10;
@@ -1465,9 +1330,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateSessionType($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateSessionType()
-     */
     public function testCanNotCreateSessionType(): void
     {
         $schoolId = 10;
@@ -1488,9 +1350,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateSessionType($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateProgram()
-     */
     public function testCanUpdateAllPrograms(): void
     {
         $rolesInSchool = ['foo'];
@@ -1512,9 +1371,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateProgram($sessionUser, $programId, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateProgram()
-     */
     public function testCanUpdateTheirPrograms(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1548,9 +1404,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateProgram($sessionUser, $programId, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateProgram()
-     */
     public function testCanNotUpdatePrograms(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1584,9 +1437,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateProgram($sessionUser, $programId, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteProgram()
-     */
     public function testCanDeleteAllPrograms(): void
     {
         $rolesInSchool = ['foo'];
@@ -1608,9 +1458,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteProgram($sessionUser, $programId, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteProgram()
-     */
     public function testCanDeleteTheirPrograms(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1644,9 +1491,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteProgram($sessionUser, $programId, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteProgram()
-     */
     public function testCanNotDeletePrograms(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1680,9 +1524,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteProgram($sessionUser, $programId, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateProgram()
-     */
     public function testCanCreateProgram(): void
     {
         $schoolId = 10;
@@ -1703,9 +1544,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateProgram($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateProgram()
-     */
     public function testCanNotCreateProgram(): void
     {
         $schoolId = 10;
@@ -1726,9 +1564,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateProgram($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateProgramYear()
-     */
     public function testCanUpdateAllProgramYears(): void
     {
         $rolesInSchool = ['foo'];
@@ -1758,9 +1593,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUpdateProgramYear()
-     */
     public function testCanUpdateTheirProgramYears(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1800,9 +1632,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUpdateProgramYear()
-     */
     public function testCanUpdateProgramYearsIfUserCanUpdateProgram(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1854,9 +1683,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUpdateProgramYear()
-     */
     public function testCanNotUpdateProgramYears(): void
     {
         $rolesInSchool  = ['foo'];
@@ -1918,9 +1744,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUpdateProgramYear()
-     */
     public function testCanNotUpdateLockedProgramYears(): void
     {
         $programYear = m::mock(ProgramYearInterface::class);
@@ -1932,9 +1755,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUpdateProgramYear()
-     */
     public function testCanNotUpdateArchivedProgramYears(): void
     {
         $programYear = m::mock(ProgramYearInterface::class);
@@ -1946,9 +1766,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canDeleteProgramYear()
-     */
     public function testCanDeleteAllProgramYears(): void
     {
         $rolesInSchool = ['foo'];
@@ -1978,9 +1795,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canDeleteProgramYear()
-     */
     public function testCanDeleteTheirProgramYears(): void
     {
         $rolesInSchool  = ['foo'];
@@ -2020,9 +1834,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canDeleteProgramYear()
-     */
     public function testCanDeleteProgramYearsIfUserCanUpdateProgram(): void
     {
         $rolesInSchool  = ['foo'];
@@ -2075,9 +1886,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canDeleteProgramYear()
-     */
     public function testCanNotDeleteProgramYears(): void
     {
         $rolesInSchool  = ['foo'];
@@ -2139,9 +1947,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canDeleteProgramYear()
-     */
     public function testCanNotDeleteLockedProgramYears(): void
     {
         $programYear = m::mock(ProgramYearInterface::class);
@@ -2153,9 +1958,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canDeleteProgramYear()
-     */
     public function testCanNotDeleteArchivedProgramYears(): void
     {
         $programYear = m::mock(ProgramYearInterface::class);
@@ -2167,9 +1969,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canCreateProgramYear()
-     */
     public function testCanCreateProgramYear(): void
     {
         $programId = 20;
@@ -2197,9 +1996,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateProgramYear($sessionUser, $program));
     }
 
-    /**
-     * @covers ::canCreateProgramYear()
-     */
     public function testCanCreateProgramYearIfUserCanUpdateProgram(): void
     {
         $programId = 20;
@@ -2235,9 +2031,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateProgramYear($sessionUser, $program));
     }
 
-    /**
-     * @covers ::canCreateProgramYear()
-     */
     public function testCanNotCreateProgramYear(): void
     {
         $programId = 20;
@@ -2284,9 +2077,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateProgramYear($sessionUser, $program));
     }
 
-    /**
-     * @covers ::canLockProgramYear()
-     */
     public function testCanLockAllProgramYears(): void
     {
         $rolesInSchool = ['foo'];
@@ -2315,9 +2105,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canLockProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canLockProgramYear()
-     */
     public function testCanLockTheirProgramYears(): void
     {
         $rolesInSchool  = ['foo'];
@@ -2356,9 +2143,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canLockProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canLockProgramYear()
-     */
     public function testCanLockProgramYearsIfUserCanUpdateProgram(): void
     {
         $rolesInSchool  = ['foo'];
@@ -2409,9 +2193,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canLockProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canLockProgramYear()
-     */
     public function testCanNotLockProgramYearIfProgramYearIsArchived(): void
     {
         $programYear = m::mock(ProgramYearInterface::class);
@@ -2422,9 +2203,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canLockProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUnlockProgramYear()
-     */
     public function testCanUnlockAllProgramYears(): void
     {
         $rolesInSchool = ['foo'];
@@ -2453,9 +2231,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUnlockProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUnlockProgramYear()
-     */
     public function testCanUnlockTheirProgramYears(): void
     {
         $rolesInSchool  = ['foo'];
@@ -2494,9 +2269,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUnlockProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUnlockProgramYear()
-     */
     public function testCanUnlockProgramYearsIfUserCanUpdateProgram(): void
     {
         $rolesInSchool  = ['foo'];
@@ -2547,9 +2319,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUnlockProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUnlockProgramYear()
-     */
     public function testCanNotUnlockProgramYearIfProgramYearIsArchived(): void
     {
         $programYear = m::mock(ProgramYearInterface::class);
@@ -2560,9 +2329,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUnlockProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canArchiveProgramYear()
-     */
     public function testCanArchiveAllProgramYears(): void
     {
         $rolesInSchool = ['foo'];
@@ -2590,9 +2356,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canArchiveProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canArchiveProgramYear()
-     */
     public function testCanArchiveTheirProgramYears(): void
     {
         $rolesInSchool  = ['foo'];
@@ -2630,9 +2393,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canArchiveProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canArchiveProgramYear()
-     */
     public function testCanArchiveProgramYearsIfUserCanUpdateProgram(): void
     {
         $rolesInSchool  = ['foo'];
@@ -2682,9 +2442,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canArchiveProgramYear($sessionUser, $programYear));
     }
 
-    /**
-     * @covers ::canUpdateSchoolConfig()
-     */
     public function testCanUpdateSchoolConfig(): void
     {
         $schoolId = 10;
@@ -2705,9 +2462,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateSchoolConfig($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateSchoolConfig()
-     */
     public function testCanNotUpdateSchoolConfig(): void
     {
         $schoolId = 10;
@@ -2728,9 +2482,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateSchoolConfig($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteSchoolConfig()
-     */
     public function testCanDeleteSchoolConfig(): void
     {
         $schoolId = 10;
@@ -2751,9 +2502,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteSchoolConfig($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteSchoolConfig()
-     */
     public function testCanNotDeleteSchoolConfig(): void
     {
         $schoolId = 10;
@@ -2774,9 +2522,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteSchoolConfig($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateSchoolConfig()
-     */
     public function testCanCreateSchoolConfig(): void
     {
         $schoolId = 10;
@@ -2797,9 +2542,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateSchoolConfig($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateSchoolConfig()
-     */
     public function testCanNotCreateSchoolConfig(): void
     {
         $schoolId = 10;
@@ -2820,9 +2562,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateSchoolConfig($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateSchool()
-     */
     public function testCanUpdateSchool(): void
     {
         $schoolId = 10;
@@ -2843,9 +2582,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateSchool($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateSchool()
-     */
     public function testCanNotUpdateSchool(): void
     {
         $schoolId = 10;
@@ -2866,9 +2602,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateSchool($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateCompetency()
-     */
     public function testCanUpdateCompetency(): void
     {
         $schoolId = 10;
@@ -2889,9 +2622,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateCompetency($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateCompetency()
-     */
     public function testCanNotUpdateCompetency(): void
     {
         $schoolId = 10;
@@ -2912,9 +2642,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateCompetency($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteCompetency()
-     */
     public function testCanDeleteCompetency(): void
     {
         $schoolId = 10;
@@ -2935,9 +2662,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteCompetency($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteCompetency()
-     */
     public function testCanNotDeleteCompetency(): void
     {
         $schoolId = 10;
@@ -2958,9 +2682,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteCompetency($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateCompetency()
-     */
     public function testCanCreateCompetency(): void
     {
         $schoolId = 10;
@@ -2981,9 +2702,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateCompetency($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateCompetency()
-     */
     public function testCanNotCreateCompetency(): void
     {
         $schoolId = 10;
@@ -3004,9 +2722,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateCompetency($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateVocabulary()
-     */
     public function testCanUpdateVocabulary(): void
     {
         $schoolId = 10;
@@ -3027,9 +2742,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateVocabulary($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateVocabulary()
-     */
     public function testCanNotUpdateVocabulary(): void
     {
         $schoolId = 10;
@@ -3050,9 +2762,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateVocabulary($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteVocabulary()
-     */
     public function testCanDeleteVocabulary(): void
     {
         $schoolId = 10;
@@ -3073,9 +2782,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteVocabulary($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteVocabulary()
-     */
     public function testCanNotDeleteVocabulary(): void
     {
         $schoolId = 10;
@@ -3096,9 +2802,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteVocabulary($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateVocabulary()
-     */
     public function testCanCreateVocabulary(): void
     {
         $schoolId = 10;
@@ -3119,9 +2822,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateVocabulary($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateVocabulary()
-     */
     public function testCanNotCreateVocabulary(): void
     {
         $schoolId = 10;
@@ -3142,9 +2842,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateVocabulary($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateTerm()
-     */
     public function testCanUpdateTerm(): void
     {
         $schoolId = 10;
@@ -3165,9 +2862,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateTerm($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateTerm()
-     */
     public function testCanNotUpdateTerm(): void
     {
         $schoolId = 10;
@@ -3188,9 +2882,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateTerm($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteTerm()
-     */
     public function testCanDeleteTerm(): void
     {
         $schoolId = 10;
@@ -3211,9 +2902,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteTerm($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteTerm()
-     */
     public function testCanNotDeleteTerm(): void
     {
         $schoolId = 10;
@@ -3234,9 +2922,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteTerm($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateTerm()
-     */
     public function testCanCreateTerm(): void
     {
         $schoolId = 10;
@@ -3257,9 +2942,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateTerm($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateTerm()
-     */
     public function testCanNotCreateTerm(): void
     {
         $schoolId = 10;
@@ -3280,9 +2962,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateTerm($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateInstructorGroup()
-     */
     public function testCanUpdateInstructorGroup(): void
     {
         $schoolId = 10;
@@ -3303,9 +2982,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateInstructorGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateInstructorGroup()
-     */
     public function testCanNotUpdateInstructorGroup(): void
     {
         $schoolId = 10;
@@ -3326,9 +3002,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateInstructorGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteInstructorGroup()
-     */
     public function testCanDeleteInstructorGroup(): void
     {
         $schoolId = 10;
@@ -3349,9 +3022,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteInstructorGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteInstructorGroup()
-     */
     public function testCanNotDeleteInstructorGroup(): void
     {
         $schoolId = 10;
@@ -3372,9 +3042,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteInstructorGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateInstructorGroup()
-     */
     public function testCanCreateInstructorGroup(): void
     {
         $schoolId = 10;
@@ -3395,9 +3062,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateInstructorGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateInstructorGroup()
-     */
     public function testCanNotCreateInstructorGroup(): void
     {
         $schoolId = 10;
@@ -3418,9 +3082,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateInstructorGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateCurriculumInventoryReport()
-     */
     public function testCanUpdateAllCurriculumInventoryReports(): void
     {
         $rolesInSchool = ['foo'];
@@ -3444,9 +3105,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::canUpdateCurriculumInventoryReport()
-     */
     public function testCanUpdateTheirCurriculumInventoryReports(): void
     {
         $rolesInSchool = ['foo'];
@@ -3481,9 +3139,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::canUpdateCurriculumInventoryReport()
-     */
     public function testCanNotUpdateCurriculumInventoryReport(): void
     {
         $rolesInSchool = ['foo'];
@@ -3518,9 +3173,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::canDeleteCurriculumInventoryReport()
-     */
     public function testCanDeleteAllCurriculumInventoryReports(): void
     {
         $rolesInSchool = ['foo'];
@@ -3544,9 +3196,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::canDeleteCurriculumInventoryReport()
-     */
     public function testCanDeleteTheirCurriculumInventoryReports(): void
     {
         $rolesInSchool = ['foo'];
@@ -3581,9 +3230,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::canDeleteCurriculumInventoryReport()
-     */
     public function testCanNotDeleteCurriculumInventoryReport(): void
     {
         $rolesInSchool = ['foo'];
@@ -3618,9 +3264,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::canCreateCurriculumInventoryReport()
-     */
     public function testCanCreateCurriculumInventoryReport(): void
     {
         $schoolId = 10;
@@ -3641,9 +3284,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateCurriculumInventoryReport($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateCurriculumInventoryReport()
-     */
     public function testCanNotCreateCurriculumInventoryReport(): void
     {
         $schoolId = 10;
@@ -3664,9 +3304,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateCurriculumInventoryReport($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateCurriculumInventoryInstitution()
-     */
     public function testCanUpdateCurriculumInventoryInstitution(): void
     {
         $schoolId = 10;
@@ -3687,9 +3324,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateCurriculumInventoryInstitution($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateCurriculumInventoryInstitution()
-     */
     public function testCanNotUpdateCurriculumInventoryInstitution(): void
     {
         $schoolId = 10;
@@ -3710,9 +3344,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateCurriculumInventoryInstitution($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteCurriculumInventoryInstitution()
-     */
     public function testCanDeleteCurriculumInventoryInstitution(): void
     {
         $schoolId = 10;
@@ -3733,9 +3364,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteCurriculumInventoryInstitution($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteCurriculumInventoryInstitution()
-     */
     public function testCanNotDeleteCurriculumInventoryInstitution(): void
     {
         $schoolId = 10;
@@ -3756,9 +3384,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteCurriculumInventoryInstitution($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateCurriculumInventoryInstitution()
-     */
     public function testCanCreateCurriculumInventoryInstitution(): void
     {
         $schoolId = 10;
@@ -3779,9 +3404,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateCurriculumInventoryInstitution($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateCurriculumInventoryInstitution()
-     */
     public function testCanNotCreateCurriculumInventoryInstitution(): void
     {
         $schoolId = 10;
@@ -3802,9 +3424,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateCurriculumInventoryInstitution($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateLearnerGroup()
-     */
     public function testCanUpdateLearnerGroup(): void
     {
         $schoolId = 10;
@@ -3825,9 +3444,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateLearnerGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateLearnerGroup()
-     */
     public function testCanNotUpdateLearnerGroup(): void
     {
         $schoolId = 10;
@@ -3848,9 +3464,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateLearnerGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteLearnerGroup()
-     */
     public function testCanDeleteLearnerGroup(): void
     {
         $schoolId = 10;
@@ -3871,9 +3484,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteLearnerGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteLearnerGroup()
-     */
     public function testCanNotDeleteLearnerGroup(): void
     {
         $schoolId = 10;
@@ -3894,9 +3504,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteLearnerGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateLearnerGroup()
-     */
     public function testCanCreateLearnerGroup(): void
     {
         $schoolId = 10;
@@ -3917,9 +3524,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateLearnerGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateLearnerGroup()
-     */
     public function testCanNotCreateLearnerGroup(): void
     {
         $schoolId = 10;
@@ -3940,9 +3544,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateLearnerGroup($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateUser()
-     */
     public function testCanUpdateUser(): void
     {
         $schoolId = 10;
@@ -3963,9 +3564,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canUpdateUser($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canUpdateUser()
-     */
     public function testCanNotUpdateUser(): void
     {
         $schoolId = 10;
@@ -3986,9 +3584,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canUpdateUser($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteUser()
-     */
     public function testCanDeleteUser(): void
     {
         $schoolId = 10;
@@ -4009,9 +3604,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canDeleteUser($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canDeleteUser()
-     */
     public function testCanNotDeleteUser(): void
     {
         $schoolId = 10;
@@ -4032,9 +3624,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canDeleteUser($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateUser()
-     */
     public function testCanCreateUser(): void
     {
         $schoolId = 10;
@@ -4055,9 +3644,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canCreateUser($sessionUser, $schoolId));
     }
 
-    /**
-     * @covers ::canCreateUser()
-     */
     public function testCanNotCreateUser(): void
     {
         $schoolId = 10;
@@ -4078,10 +3664,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canCreateUser($sessionUser, $schoolId));
     }
 
-
-    /**
-     * @covers ::canViewLearnerGroup()
-     */
     public function testCanViewLearnerGroupIfUseIsInLearnerGroup(): void
     {
         $learnerGroupId = 10;
@@ -4095,10 +3677,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canViewLearnerGroup($sessionUser, $learnerGroupId));
     }
 
-
-    /**
-     * @covers ::canViewLearnerGroup()
-     */
     public function testCanViewLearnerGroupIfUserPerformsNonLearnerFunction(): void
     {
         $learnerGroupId = 10;
@@ -4115,9 +3693,6 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertTrue($this->permissionChecker->canViewLearnerGroup($sessionUser, $learnerGroupId));
     }
 
-    /**
-     * @covers ::canViewLearnerGroup()
-     */
     public function testCanNotViewLearnerGroup(): void
     {
         $learnerGroupId = 10;
@@ -4134,25 +3709,16 @@ class SessionUserPermissionCheckerTest extends TestCase
         $this->assertFalse($this->permissionChecker->canViewLearnerGroup($sessionUser, $learnerGroupId));
     }
 
-    /**
-     * @covers ::canCreateUsersInAnySchool()
-     */
     public function testCanCreateUsersInAnySchool(): void
     {
         $this->markTestIncomplete('This test has not been implemented yet.');
     }
 
-    /**
-     * @covers ::canCreateOrUpdateUsersInAnySchool()
-     */
     public function testCanCreateOrUpdateUsersInAnySchool(): void
     {
         $this->markTestIncomplete('This test has not been implemented yet.');
     }
 
-    /**
-     * @covers ::canCreateCurriculumInventoryReportInAnySchool()
-     */
     public function testCanCreateCurriculumInventoryReportUserInAnySchool(): void
     {
         $this->markTestIncomplete('This test has not been implemented yet.');

--- a/tests/Traits/CohortsEntityTest.php
+++ b/tests/Traits/CohortsEntityTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * @coversDefaultClass \App\Traits\CohortsEntity
+ * @covers \App\Traits\CohortsEntity
  */
 
 class CohortsEntityTest extends TestCase
@@ -30,10 +30,7 @@ class CohortsEntityTest extends TestCase
         unset($this->object);
     }
 
-    /**
-     * @covers ::setCohorts
-     */
-    public function testSetCohorts()
+    public function testSetCohorts(): void
     {
         $collection = new ArrayCollection();
         $collection->add(m::mock(Cohort::class));
@@ -44,10 +41,7 @@ class CohortsEntityTest extends TestCase
         $this->assertEquals($collection, $this->traitObject->getCohorts());
     }
 
-    /**
-     * @covers ::removeCohort
-     */
-    public function testRemoveCohort()
+    public function testRemoveCohort(): void
     {
         $collection = new ArrayCollection();
         $one = m::mock(Cohort::class);
@@ -60,5 +54,26 @@ class CohortsEntityTest extends TestCase
         $cohorts = $this->traitObject->getCohorts();
         $this->assertEquals(1, $cohorts->count());
         $this->assertEquals($two, $cohorts->first());
+    }
+
+    public function testAddCohort(): void
+    {
+        $this->traitObject->setCohorts(new ArrayCollection());
+        $this->assertCount(0, $this->traitObject->getCohorts());
+
+        $one = m::mock(Cohort::class);
+        $this->traitObject->addCohort($one);
+        $this->assertCount(1, $this->traitObject->getCohorts());
+        $this->assertEquals($one, $this->traitObject->getCohorts()->first());
+        // duplicate prevention check
+        $this->traitObject->addCohort($one);
+        $this->assertCount(1, $this->traitObject->getCohorts());
+        $this->assertEquals($one, $this->traitObject->getCohorts()->first());
+
+        $two = m::mock(Cohort::class);
+        $this->traitObject->addCohort($two);
+        $this->assertCount(2, $this->traitObject->getCohorts());
+        $this->assertEquals($one, $this->traitObject->getCohorts()->first());
+        $this->assertEquals($two, $this->traitObject->getCohorts()->last());
     }
 }

--- a/tests/Traits/CompetenciesEntityTest.php
+++ b/tests/Traits/CompetenciesEntityTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * @coversDefaultClass \App\Traits\CompetenciesEntity
+ * @covers \App\Traits\CompetenciesEntity
  */
 
 class CompetenciesEntityTest extends TestCase
@@ -30,10 +30,7 @@ class CompetenciesEntityTest extends TestCase
         unset($this->object);
     }
 
-    /**
-     * @covers ::setCompetencies
-     */
-    public function testSetCompetencies()
+    public function testSetCompetencies(): void
     {
         $collection = new ArrayCollection();
         $collection->add(m::mock(Competency::class));
@@ -44,10 +41,7 @@ class CompetenciesEntityTest extends TestCase
         $this->assertEquals($collection, $this->traitObject->getCompetencies());
     }
 
-    /**
-     * @covers ::removeCompetency
-     */
-    public function testRemoveCompetency()
+    public function testRemoveCompetency(): void
     {
         $collection = new ArrayCollection();
         $one = m::mock(Competency::class);
@@ -60,5 +54,26 @@ class CompetenciesEntityTest extends TestCase
         $competencies = $this->traitObject->getCompetencies();
         $this->assertEquals(1, $competencies->count());
         $this->assertEquals($two, $competencies->first());
+    }
+
+    public function testAddCompetency(): void
+    {
+        $this->traitObject->setCompetencies(new ArrayCollection());
+        $this->assertCount(0, $this->traitObject->getCompetencies());
+
+        $one = m::mock(Competency::class);
+        $this->traitObject->addCompetency($one);
+        $this->assertCount(1, $this->traitObject->getCompetencies());
+        $this->assertEquals($one, $this->traitObject->getCompetencies()->first());
+        // duplicate prevention check
+        $this->traitObject->addCompetency($one);
+        $this->assertCount(1, $this->traitObject->getCompetencies());
+        $this->assertEquals($one, $this->traitObject->getCompetencies()->first());
+
+        $two = m::mock(Competency::class);
+        $this->traitObject->addCompetency($two);
+        $this->assertCount(2, $this->traitObject->getCompetencies());
+        $this->assertEquals($one, $this->traitObject->getCompetencies()->first());
+        $this->assertEquals($two, $this->traitObject->getCompetencies()->last());
     }
 }

--- a/tests/Traits/ConceptsEntityTest.php
+++ b/tests/Traits/ConceptsEntityTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * @coversDefaultClass \App\Traits\ConceptsEntity
+ * @covers \App\Traits\ConceptsEntity
  */
 
 class ConceptsEntityTest extends TestCase
@@ -30,10 +30,7 @@ class ConceptsEntityTest extends TestCase
         unset($this->object);
     }
 
-    /**
-     * @covers ::setConcepts
-     */
-    public function testSetConcepts()
+    public function testSetConcepts(): void
     {
         $collection = new ArrayCollection();
         $collection->add(m::mock(MeshConcept::class));
@@ -44,10 +41,7 @@ class ConceptsEntityTest extends TestCase
         $this->assertEquals($collection, $this->traitObject->getConcepts());
     }
 
-    /**
-     * @covers ::removeConcept
-     */
-    public function testRemoveConcept()
+    public function testRemoveConcept(): void
     {
         $collection = new ArrayCollection();
         $one = m::mock(MeshConcept::class);
@@ -60,5 +54,26 @@ class ConceptsEntityTest extends TestCase
         $concepts = $this->traitObject->getConcepts();
         $this->assertEquals(1, $concepts->count());
         $this->assertEquals($two, $concepts->first());
+    }
+
+    public function testAddConcept(): void
+    {
+        $this->traitObject->setConcepts(new ArrayCollection());
+        $this->assertCount(0, $this->traitObject->getConcepts());
+
+        $one = m::mock(MeshConcept::class);
+        $this->traitObject->addConcept($one);
+        $this->assertCount(1, $this->traitObject->getConcepts());
+        $this->assertEquals($one, $this->traitObject->getConcepts()->first());
+        // duplicate prevention check
+        $this->traitObject->addConcept($one);
+        $this->assertCount(1, $this->traitObject->getConcepts());
+        $this->assertEquals($one, $this->traitObject->getConcepts()->first());
+
+        $two = m::mock(MeshConcept::class);
+        $this->traitObject->addConcept($two);
+        $this->assertCount(2, $this->traitObject->getConcepts());
+        $this->assertEquals($one, $this->traitObject->getConcepts()->first());
+        $this->assertEquals($two, $this->traitObject->getConcepts()->last());
     }
 }

--- a/tests/Traits/CoursesEntityTest.php
+++ b/tests/Traits/CoursesEntityTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * @coversDefaultClass \App\Traits\CoursesEntity
+ * @covers \App\Traits\CoursesEntity
  */
 
 class CoursesEntityTest extends TestCase
@@ -30,10 +30,7 @@ class CoursesEntityTest extends TestCase
         unset($this->object);
     }
 
-    /**
-     * @covers ::setCourses
-     */
-    public function testSetCourses()
+    public function testSetCourses(): void
     {
         $collection = new ArrayCollection();
         $collection->add(m::mock(Course::class));
@@ -44,10 +41,7 @@ class CoursesEntityTest extends TestCase
         $this->assertEquals($collection, $this->traitObject->getCourses());
     }
 
-    /**
-     * @covers ::removeCourse
-     */
-    public function testRemoveCourse()
+    public function testRemoveCourse(): void
     {
         $collection = new ArrayCollection();
         $one = m::mock(Course::class);
@@ -60,5 +54,26 @@ class CoursesEntityTest extends TestCase
         $courses = $this->traitObject->getCourses();
         $this->assertEquals(1, $courses->count());
         $this->assertEquals($two, $courses->first());
+    }
+
+    public function testAddCourse(): void
+    {
+        $this->traitObject->setCourses(new ArrayCollection());
+        $this->assertCount(0, $this->traitObject->getCourses());
+
+        $one = m::mock(Course::class);
+        $this->traitObject->addCourse($one);
+        $this->assertCount(1, $this->traitObject->getCourses());
+        $this->assertEquals($one, $this->traitObject->getCourses()->first());
+        // duplicate prevention check
+        $this->traitObject->addCourse($one);
+        $this->assertCount(1, $this->traitObject->getCourses());
+        $this->assertEquals($one, $this->traitObject->getCourses()->first());
+
+        $two = m::mock(Course::class);
+        $this->traitObject->addCourse($two);
+        $this->assertCount(2, $this->traitObject->getCourses());
+        $this->assertEquals($one, $this->traitObject->getCourses()->first());
+        $this->assertEquals($two, $this->traitObject->getCourses()->last());
     }
 }

--- a/tests/Traits/IlmSessionsEntityTest.php
+++ b/tests/Traits/IlmSessionsEntityTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * @coversDefaultClass \App\Traits\IlmSessionsEntity
+ * @covers \App\Traits\IlmSessionsEntity
  */
 
 class IlmSessionsEntityTest extends TestCase
@@ -30,10 +30,7 @@ class IlmSessionsEntityTest extends TestCase
         unset($this->object);
     }
 
-    /**
-     * @covers ::setIlmSessions
-     */
-    public function testSetIlmSessions()
+    public function testSetIlmSessions(): void
     {
         $collection = new ArrayCollection();
         $collection->add(m::mock(IlmSession::class));
@@ -44,10 +41,7 @@ class IlmSessionsEntityTest extends TestCase
         $this->assertEquals($collection, $this->traitObject->getIlmSessions());
     }
 
-    /**
-     * @covers ::addIlmSession
-     */
-    public function testAddIlmSessions()
+    public function testAddIlmSessions(): void
     {
         $one = m::mock(IlmSession::class);
         $two = m::mock(IlmSession::class);
@@ -60,10 +54,7 @@ class IlmSessionsEntityTest extends TestCase
         $this->assertEquals($two, $this->traitObject->getIlmSessions()->last());
     }
 
-    /**
-     * @covers ::removeIlmSession
-     */
-    public function testRemoveIlmSession()
+    public function testRemoveIlmSession(): void
     {
         $collection = new ArrayCollection();
         $one = m::mock(IlmSession::class);
@@ -76,5 +67,26 @@ class IlmSessionsEntityTest extends TestCase
         $ilmSessions = $this->traitObject->getIlmSessions();
         $this->assertEquals(1, $ilmSessions->count());
         $this->assertEquals($two, $ilmSessions->first());
+    }
+
+    public function testAddIlmSession(): void
+    {
+        $this->traitObject->setIlmSessions(new ArrayCollection());
+        $this->assertCount(0, $this->traitObject->getIlmSessions());
+
+        $one = m::mock(IlmSession::class);
+        $this->traitObject->addIlmSession($one);
+        $this->assertCount(1, $this->traitObject->getIlmSessions());
+        $this->assertEquals($one, $this->traitObject->getIlmSessions()->first());
+        // duplicate prevention check
+        $this->traitObject->addIlmSession($one);
+        $this->assertCount(1, $this->traitObject->getIlmSessions());
+        $this->assertEquals($one, $this->traitObject->getIlmSessions()->first());
+
+        $two = m::mock(IlmSession::class);
+        $this->traitObject->addIlmSession($two);
+        $this->assertCount(2, $this->traitObject->getIlmSessions());
+        $this->assertEquals($one, $this->traitObject->getIlmSessions()->first());
+        $this->assertEquals($two, $this->traitObject->getIlmSessions()->last());
     }
 }

--- a/tests/Traits/LearningMaterialsEntityTest.php
+++ b/tests/Traits/LearningMaterialsEntityTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * @coversDefaultClass \App\Traits\LearningMaterialsEntity
+ * @covers \App\Traits\LearningMaterialsEntity
  */
 
 class LearningMaterialsEntityTest extends TestCase
@@ -30,10 +30,7 @@ class LearningMaterialsEntityTest extends TestCase
         unset($this->object);
     }
 
-    /**
-     * @covers ::setLearningMaterials
-     */
-    public function testSetLearningMaterials()
+    public function testSetLearningMaterials(): void
     {
         $collection = new ArrayCollection();
         $collection->add(m::mock(LearningMaterial::class));
@@ -44,10 +41,7 @@ class LearningMaterialsEntityTest extends TestCase
         $this->assertEquals($collection, $this->traitObject->getLearningMaterials());
     }
 
-    /**
-     * @covers ::removeLearningMaterial
-     */
-    public function testRemoveLearningMaterial()
+    public function testRemoveLearningMaterial(): void
     {
         $collection = new ArrayCollection();
         $one = m::mock(LearningMaterial::class);
@@ -60,5 +54,26 @@ class LearningMaterialsEntityTest extends TestCase
         $learningMaterials = $this->traitObject->getLearningMaterials();
         $this->assertEquals(1, $learningMaterials->count());
         $this->assertEquals($two, $learningMaterials->first());
+    }
+
+    public function testAddLearningMaterial(): void
+    {
+        $this->traitObject->setLearningMaterials(new ArrayCollection());
+        $this->assertCount(0, $this->traitObject->getLearningMaterials());
+
+        $one = m::mock(LearningMaterial::class);
+        $this->traitObject->addLearningMaterial($one);
+        $this->assertCount(1, $this->traitObject->getLearningMaterials());
+        $this->assertEquals($one, $this->traitObject->getLearningMaterials()->first());
+        // duplicate prevention check
+        $this->traitObject->addLearningMaterial($one);
+        $this->assertCount(1, $this->traitObject->getLearningMaterials());
+        $this->assertEquals($one, $this->traitObject->getLearningMaterials()->first());
+
+        $two = m::mock(LearningMaterial::class);
+        $this->traitObject->addLearningMaterial($two);
+        $this->assertCount(2, $this->traitObject->getLearningMaterials());
+        $this->assertEquals($one, $this->traitObject->getLearningMaterials()->first());
+        $this->assertEquals($two, $this->traitObject->getLearningMaterials()->last());
     }
 }

--- a/tests/Traits/ProgramYearsEntityTest.php
+++ b/tests/Traits/ProgramYearsEntityTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * @coversDefaultClass \App\Traits\ProgramYearsEntity
+ * @covers \App\Traits\ProgramYearsEntity
  */
 
 class ProgramYearsEntityTest extends TestCase
@@ -30,10 +30,7 @@ class ProgramYearsEntityTest extends TestCase
         unset($this->object);
     }
 
-    /**
-     * @covers ::setProgramYears
-     */
-    public function testSetProgramYears()
+    public function testSetProgramYears(): void
     {
         $collection = new ArrayCollection();
         $collection->add(m::mock(ProgramYear::class));
@@ -44,10 +41,7 @@ class ProgramYearsEntityTest extends TestCase
         $this->assertEquals($collection, $this->traitObject->getProgramYears());
     }
 
-    /**
-     * @covers ::removeProgramYear
-     */
-    public function testRemoveProgramYear()
+    public function testRemoveProgramYear(): void
     {
         $collection = new ArrayCollection();
         $one = m::mock(ProgramYear::class);
@@ -60,5 +54,26 @@ class ProgramYearsEntityTest extends TestCase
         $programYears = $this->traitObject->getProgramYears();
         $this->assertEquals(1, $programYears->count());
         $this->assertEquals($two, $programYears->first());
+    }
+
+    public function testAddProgramYear(): void
+    {
+        $this->traitObject->setProgramYears(new ArrayCollection());
+        $this->assertCount(0, $this->traitObject->getProgramYears());
+
+        $one = m::mock(ProgramYear::class);
+        $this->traitObject->addProgramYear($one);
+        $this->assertCount(1, $this->traitObject->getProgramYears());
+        $this->assertEquals($one, $this->traitObject->getProgramYears()->first());
+        // duplicate prevention check
+        $this->traitObject->addProgramYear($one);
+        $this->assertCount(1, $this->traitObject->getProgramYears());
+        $this->assertEquals($one, $this->traitObject->getProgramYears()->first());
+
+        $two = m::mock(ProgramYear::class);
+        $this->traitObject->addProgramYear($two);
+        $this->assertCount(2, $this->traitObject->getProgramYears());
+        $this->assertEquals($one, $this->traitObject->getProgramYears()->first());
+        $this->assertEquals($two, $this->traitObject->getProgramYears()->last());
     }
 }

--- a/tests/Traits/ProgramsEntityTest.php
+++ b/tests/Traits/ProgramsEntityTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * @coversDefaultClass \App\Traits\ProgramsEntity
+ * @covers \App\Traits\ProgramsEntity
  */
 
 class ProgramsEntityTest extends TestCase
@@ -30,10 +30,7 @@ class ProgramsEntityTest extends TestCase
         unset($this->object);
     }
 
-    /**
-     * @covers ::setPrograms
-     */
-    public function testSetPrograms()
+    public function testSetPrograms(): void
     {
         $collection = new ArrayCollection();
         $collection->add(m::mock(Program::class));
@@ -44,10 +41,7 @@ class ProgramsEntityTest extends TestCase
         $this->assertEquals($collection, $this->traitObject->getPrograms());
     }
 
-    /**
-     * @covers ::removeProgram
-     */
-    public function testRemoveProgram()
+    public function testRemoveProgram(): void
     {
         $collection = new ArrayCollection();
         $one = m::mock(Program::class);
@@ -60,5 +54,26 @@ class ProgramsEntityTest extends TestCase
         $programs = $this->traitObject->getPrograms();
         $this->assertEquals(1, $programs->count());
         $this->assertEquals($two, $programs->first());
+    }
+
+    public function testAddProgram(): void
+    {
+        $this->traitObject->setPrograms(new ArrayCollection());
+        $this->assertCount(0, $this->traitObject->getPrograms());
+
+        $one = m::mock(Program::class);
+        $this->traitObject->addProgram($one);
+        $this->assertCount(1, $this->traitObject->getPrograms());
+        $this->assertEquals($one, $this->traitObject->getPrograms()->first());
+        // duplicate prevention check
+        $this->traitObject->addProgram($one);
+        $this->assertCount(1, $this->traitObject->getPrograms());
+        $this->assertEquals($one, $this->traitObject->getPrograms()->first());
+
+        $two = m::mock(Program::class);
+        $this->traitObject->addProgram($two);
+        $this->assertCount(2, $this->traitObject->getPrograms());
+        $this->assertEquals($one, $this->traitObject->getPrograms()->first());
+        $this->assertEquals($two, $this->traitObject->getPrograms()->last());
     }
 }

--- a/tests/Traits/UsersEntityTest.php
+++ b/tests/Traits/UsersEntityTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use App\Tests\TestCase;
 
 /**
- * @coversDefaultClass \App\Traits\UsersEntity
+ * @covers \App\Traits\UsersEntity
  */
 
 class UsersEntityTest extends TestCase
@@ -30,10 +30,7 @@ class UsersEntityTest extends TestCase
         unset($this->object);
     }
 
-    /**
-     * @covers ::setUsers
-     */
-    public function testSetUsers()
+    public function testSetUsers(): void
     {
         $collection = new ArrayCollection();
         $collection->add(m::mock(User::class));
@@ -44,10 +41,7 @@ class UsersEntityTest extends TestCase
         $this->assertEquals($collection, $this->traitObject->getUsers());
     }
 
-    /**
-     * @covers ::removeUser
-     */
-    public function testRemoveUser()
+    public function testRemoveUser(): void
     {
         $collection = new ArrayCollection();
         $one = m::mock(User::class);
@@ -60,5 +54,26 @@ class UsersEntityTest extends TestCase
         $users = $this->traitObject->getUsers();
         $this->assertEquals(1, $users->count());
         $this->assertEquals($two, $users->first());
+    }
+
+    public function testAddUser(): void
+    {
+        $this->traitObject->setUsers(new ArrayCollection());
+        $this->assertCount(0, $this->traitObject->getUsers());
+
+        $one = m::mock(User::class);
+        $this->traitObject->addUser($one);
+        $this->assertCount(1, $this->traitObject->getUsers());
+        $this->assertEquals($one, $this->traitObject->getUsers()->first());
+        // duplicate prevention check
+        $this->traitObject->addUser($one);
+        $this->assertCount(1, $this->traitObject->getUsers());
+        $this->assertEquals($one, $this->traitObject->getUsers()->first());
+
+        $two = m::mock(User::class);
+        $this->traitObject->addUser($two);
+        $this->assertCount(2, $this->traitObject->getUsers());
+        $this->assertEquals($one, $this->traitObject->getUsers()->first());
+        $this->assertEquals($two, $this->traitObject->getUsers()->last());
     }
 }


### PR DESCRIPTION
this will give us more accurate numbers in our test coverage report.

for reference, see https://docs.phpunit.de/en/9.6/code-coverage-analysis.html

fill in missing tests while at it, and flag unimplemented methods as "skip from coverage".