### PR TITLE
adds 2024 universe to MeSH importer command, drops support for 2022.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "exercise/htmlpurifier-bundle": "^5.0",
     "firebase/php-jwt": "@stable",
     "flagception/flagception-bundle": "^4.3",
-    "ilios/mesh-parser": "^2.0",
+    "ilios/mesh-parser": "^3.0",
     "jaybizzle/crawler-detect": "^1.2",
     "league/csv": "^9.5",
     "league/flysystem": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7005ca95bae5e03c81b4d9352b986ac",
+    "content-hash": "b8aa4ed6d468b5b439734d4510b16a3a",
     "packages": [
         {
             "name": "async-aws/core",
@@ -3705,24 +3705,27 @@
         },
         {
             "name": "ilios/mesh-parser",
-            "version": "v2.0.2",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ilios/mesh-parser.git",
-                "reference": "b72149c11b050a7d77d5f62f8ffd90cac76cdc88"
+                "reference": "051a015cf6a90d7edd9ae6e3c1d70964f1cfa30c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ilios/mesh-parser/zipball/b72149c11b050a7d77d5f62f8ffd90cac76cdc88",
-                "reference": "b72149c11b050a7d77d5f62f8ffd90cac76cdc88",
+                "url": "https://api.github.com/repos/ilios/mesh-parser/zipball/051a015cf6a90d7edd9ae6e3c1d70964f1cfa30c",
+                "reference": "051a015cf6a90d7edd9ae6e3c1d70964f1cfa30c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "php": ">=8.2"
             },
             "require-dev": {
                 "fakerphp/faker": "@stable",
                 "mockery/mockery": "@stable",
+                "phpstan/phpstan": "^1.10",
                 "phpunit/phpunit": "@stable",
                 "squizlabs/php_codesniffer": "@stable"
             },
@@ -3744,16 +3747,16 @@
                 }
             ],
             "description": "PHP library for extracting MeSH descriptors from XML.",
-            "homepage": "http://iliosproject.org/",
+            "homepage": "https://iliosproject.org/",
             "keywords": [
                 "Ilios",
                 "mesh"
             ],
             "support": {
                 "issues": "https://github.com/ilios/mesh-parser/issues",
-                "source": "https://github.com/ilios/mesh-parser/tree/v2.0.2"
+                "source": "https://github.com/ilios/mesh-parser/tree/v3.0.0"
             },
-            "time": "2021-02-25T19:33:04+00:00"
+            "time": "2024-02-14T00:04:40+00:00"
         },
         {
             "name": "jaybizzle/crawler-detect",

--- a/src/Command/ImportMeshUniverseCommand.php
+++ b/src/Command/ImportMeshUniverseCommand.php
@@ -34,8 +34,9 @@ class ImportMeshUniverseCommand extends Command
      * @var array
      */
     private const YEARS = [
-        2022 => 'https://nlmpubs.nlm.nih.gov/projects/mesh/2022/xmlmesh/desc2022.xml',
-        2023 => 'ftp://nlmpubs.nlm.nih.gov/online/mesh/MESH_FILES/xmlmesh/desc2023.xml',
+        '2023' => 'https://nlmpubs.nlm.nih.gov/projects/mesh/2023/xmlmesh/desc2023.xml',
+        '2024' => 'https://nlmpubs.nlm.nih.gov/projects/mesh/MESH_FILES/xmlmesh/desc2024.xml',
+
     ];
 
     public function __construct(
@@ -135,7 +136,6 @@ class ImportMeshUniverseCommand extends Command
         $supportedYears = array_keys(self::YEARS);
 
         if ('' !== $year) {
-            $year = (int)$year;
             if (!in_array($year, $supportedYears)) {
                 $this->release();
                 throw new RuntimeException('Given year must be one of: ' . implode(', ', $supportedYears));

--- a/src/Command/ImportMeshUniverseCommand.php
+++ b/src/Command/ImportMeshUniverseCommand.php
@@ -76,7 +76,13 @@ class ImportMeshUniverseCommand extends Command
         $steps = $this->meshIndex->isEnabled() ? 5 : 4;
         $startTime = time();
         $output->writeln('Started MeSH universe import, this will take a while...');
-        $uri = $this->getUri($input);
+        try {
+            $uri = $this->getUri($input);
+        } catch (RuntimeException $e) {
+            $output->writeln("<error>{$e->getMessage()}</error>");
+            $this->release();
+            return Command::FAILURE;
+        }
         $output->writeln("1/{$steps}: Parsing MeSH XML retrieved from {$uri}.");
         $descriptorSet = $this->parser->parse($uri);
         $descriptorIds = $descriptorSet->getDescriptorUis();
@@ -143,7 +149,6 @@ class ImportMeshUniverseCommand extends Command
         }
 
         // SOL
-        $this->release();
-        throw new RuntimeException('Given year must be one of: ' . implode(', ', $supportedYears));
+        throw new RuntimeException('Given year must be one of: ' . implode(', ', $supportedYears) . '.');
     }
 }

--- a/src/Command/ImportMeshUniverseCommand.php
+++ b/src/Command/ImportMeshUniverseCommand.php
@@ -30,13 +30,9 @@ class ImportMeshUniverseCommand extends Command
 {
     use LockableTrait;
 
-    /**
-     * @var array
-     */
     private const YEARS = [
         '2023' => 'https://nlmpubs.nlm.nih.gov/projects/mesh/2023/xmlmesh/desc2023.xml',
         '2024' => 'https://nlmpubs.nlm.nih.gov/projects/mesh/MESH_FILES/xmlmesh/desc2024.xml',
-
     ];
 
     public function __construct(
@@ -135,17 +131,19 @@ class ImportMeshUniverseCommand extends Command
 
         $supportedYears = array_keys(self::YEARS);
 
-        if ('' !== $year) {
-            if (!in_array($year, $supportedYears)) {
-                $this->release();
-                throw new RuntimeException('Given year must be one of: ' . implode(', ', $supportedYears));
-            }
+        // if no year is given as input, then grab the most recent year on file and return its URL.
+        if (!$year) {
+            rsort($supportedYears);
+            return self::YEARS[$supportedYears[0]];
+        }
 
+        // if a year was given as input, then return its URL on file.
+        if (array_key_exists($year, self::YEARS)) {
             return self::YEARS[$year];
         }
 
-        rsort($supportedYears);
-
-        return self::YEARS[$supportedYears[0]];
+        // SOL
+        $this->release();
+        throw new RuntimeException('Given year must be one of: ' . implode(', ', $supportedYears));
     }
 }

--- a/tests/Command/ImportMeshUniverseCommandTest.php
+++ b/tests/Command/ImportMeshUniverseCommandTest.php
@@ -155,7 +155,6 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     public function testInvalidGivenYear(): void
     {
         $year = '1906';
-        $this->expectExceptionMessage('Given year must be one of: 2023, 2024');
         $this->meshIndex->shouldReceive('isEnabled');
 
         $this->commandTester->execute(
@@ -163,6 +162,10 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
                 '--year' => $year,
             ]
         );
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Given year must be one of: 2023, 2024.', $output);
+
         $this->descriptorRepository->shouldNotHaveReceived('clearExistingData');
         $this->descriptorRepository->shouldNotHaveReceived('findDTOsBy');
         $this->descriptorRepository->shouldNotHaveReceived('upsertMeshUniverse');

--- a/tests/Command/ImportMeshUniverseCommandTest.php
+++ b/tests/Command/ImportMeshUniverseCommandTest.php
@@ -58,7 +58,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     public function testNoArgs(): void
     {
         $this->mockHappyPath();
-        $url = 'ftp://nlmpubs.nlm.nih.gov/online/mesh/MESH_FILES/xmlmesh/desc2023.xml';
+        $url = 'https://nlmpubs.nlm.nih.gov/projects/mesh/MESH_FILES/xmlmesh/desc2024.xml';
         $this->meshParser
             ->shouldReceive('parse')
             ->withArgs([$url])
@@ -117,7 +117,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         $this->mockHappyPath();
 
         $year = '2023';
-        $url = "ftp://nlmpubs.nlm.nih.gov/online/mesh/MESH_FILES/xmlmesh/desc2023.xml";
+        $url = "https://nlmpubs.nlm.nih.gov/projects/mesh/2023/xmlmesh/desc2023.xml";
         $this->meshParser
             ->shouldReceive('parse')
             ->withArgs([$url])
@@ -132,12 +132,12 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
         $this->assertStringContainsString("1/4: Parsing MeSH XML retrieved from {$url}.", $output);
     }
 
-    public function testYear2022(): void
+    public function testYear2024(): void
     {
         $this->mockHappyPath();
 
-        $year = '2022';
-        $url = "https://nlmpubs.nlm.nih.gov/projects/mesh/2022/xmlmesh/desc2022.xml";
+        $year = '2024';
+        $url = "https://nlmpubs.nlm.nih.gov/projects/mesh/MESH_FILES/xmlmesh/desc2024.xml";
         $this->meshParser
             ->shouldReceive('parse')
             ->withArgs([$url])
@@ -155,7 +155,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
     public function testInvalidGivenYear(): void
     {
         $year = '1906';
-        $this->expectExceptionMessage('Given year must be one of: 2022, 2023');
+        $this->expectExceptionMessage('Given year must be one of: 2023, 2024');
         $this->meshIndex->shouldReceive('isEnabled');
 
         $this->commandTester->execute(
@@ -185,7 +185,7 @@ class ImportMeshUniverseCommandTest extends KernelTestCase
             ->shouldReceive('index')->with([$descriptor])
             ->once()->andReturn(true);
 
-        $url = 'ftp://nlmpubs.nlm.nih.gov/online/mesh/MESH_FILES/xmlmesh/desc2023.xml';
+        $url = 'https://nlmpubs.nlm.nih.gov/projects/mesh/MESH_FILES/xmlmesh/desc2024.xml';
         $this->meshParser
             ->shouldReceive('parse')
             ->withArgs([$url])

--- a/tests/Service/MeshDescriptorSetTransmogrifierTest.php
+++ b/tests/Service/MeshDescriptorSetTransmogrifierTest.php
@@ -83,12 +83,35 @@ class MeshDescriptorSetTransmogrifierTest extends TestCase
 
         $term1 = new Term();
         $term1->setUi('T01');
+        $term1->setName('Term 1');
+        $term1->setLexicalTag('ABB');
+        $term1->setConceptPreferred(true);
+        $term1->setRecordPreferred(false);
+        $term1->setPermuted(false);
+
         $term2 = new Term();
         $term2->setUi('T02');
+        $term2->setName('Term 2');
+        $term2->setLexicalTag('ABX');
+        $term2->setConceptPreferred(false);
+        $term2->setRecordPreferred(true);
+        $term2->setPermuted(true);
+
         $term3 = new Term();
         $term3->setUi('T03');
+        $term3->setName('Term 3');
+        $term3->setLexicalTag('ACR');
+        $term3->setConceptPreferred(false);
+        $term3->setRecordPreferred(true);
+        $term3->setPermuted(true);
+
         $term4 = new Term();
         $term4->setUi('T04');
+        $term4->setName('Term 4');
+        $term4->setLexicalTag('NAM');
+        $term4->setConceptPreferred(false);
+        $term4->setRecordPreferred(true);
+        $term4->setPermuted(true);
 
         $concept1->addTerm($term1);
         $concept2->addTerm($term2);
@@ -134,16 +157,16 @@ class MeshDescriptorSetTransmogrifierTest extends TestCase
         $this->assertEquals(['D02', 'M03'], $data['insert']['mesh_descriptor_x_concept'][2]);
 
         $this->assertEquals(4, count($data['insert']['mesh_term']));
-        $this->assertEquals($term1, $data['insert']['mesh_term']['d4df230358e7ddc53cc73a03ebb2bc0d']);
-        $this->assertEquals($term2, $data['insert']['mesh_term']['9806b2bc48e2b405f0fc7229d4c90d6c']);
-        $this->assertEquals($term3, $data['insert']['mesh_term']['7fe11936da217dd700133a92afc30479']);
-        $this->assertEquals($term4, $data['insert']['mesh_term']['08bdb77fb1283be4c8856fb919d5a1c3']);
+        $this->assertEquals($term1, $data['insert']['mesh_term']['f2f897155cc34c82854374c95aa7265c']);
+        $this->assertEquals($term2, $data['insert']['mesh_term']['5edc2ddc166bdb35f40a5d5588bec92b']);
+        $this->assertEquals($term3, $data['insert']['mesh_term']['02184148ab7c834193206aef1689eea7']);
+        $this->assertEquals($term4, $data['insert']['mesh_term']['ea9ae8ecee1f8a46784000abdcd0228a']);
 
         $this->assertEquals(4, count($data['insert']['mesh_concept_x_term']));
-        $this->assertEquals(['M01', 'd4df230358e7ddc53cc73a03ebb2bc0d'], $data['insert']['mesh_concept_x_term'][0]);
-        $this->assertEquals(['M02', '9806b2bc48e2b405f0fc7229d4c90d6c'], $data['insert']['mesh_concept_x_term'][1]);
-        $this->assertEquals(['M03', '7fe11936da217dd700133a92afc30479'], $data['insert']['mesh_concept_x_term'][2]);
-        $this->assertEquals(['M03', '08bdb77fb1283be4c8856fb919d5a1c3'], $data['insert']['mesh_concept_x_term'][3]);
+        $this->assertEquals(['M01', 'f2f897155cc34c82854374c95aa7265c'], $data['insert']['mesh_concept_x_term'][0]);
+        $this->assertEquals(['M02', '5edc2ddc166bdb35f40a5d5588bec92b'], $data['insert']['mesh_concept_x_term'][1]);
+        $this->assertEquals(['M03', '02184148ab7c834193206aef1689eea7'], $data['insert']['mesh_concept_x_term'][2]);
+        $this->assertEquals(['M03', 'ea9ae8ecee1f8a46784000abdcd0228a'], $data['insert']['mesh_concept_x_term'][3]);
 
         $this->assertEquals(2, count($data['insert']['mesh_previous_indexing']));
         $this->assertEquals('Bar', $data['insert']['mesh_previous_indexing']['D01']);


### PR DESCRIPTION
the MeSH descriptors for 2024 are out, let's pull them in. 

no schema changes to the DTD again this year.

see https://www.nlm.nih.gov/databases/download/mesh.html for details and data.