### PR TITLE
correct link description.

### DIFF
--- a/templates/email/teachingreminder.text.twig
+++ b/templates/email/teachingreminder.text.twig
@@ -45,6 +45,6 @@ The learning objectives listed for this course are:
 - {{ objective.title|striptags|trim|raw }}
 {% endfor %}
 
-For a complete review of the session details and its associated learning materials, visit the session details on your Ilios Calendar at {{ base_url }}/courses/{{ offering.session.course.id }}/sessions/{{ offering.session.id }}.
+For a complete review of the session details and its associated learning materials, visit the session details at {{ base_url }}/courses/{{ offering.session.course.id }}/sessions/{{ offering.session.id }}.
 
 If you would like to edit the details of this session and do not have editing rights in Ilios for this course please contact the School of {{ schoolTitle }}'{% if 's' != schoolTitle|lower|last %}s{% endif %} Curriculum Coordinator at {{ adminEmail }}.


### PR DESCRIPTION
the link following the amended text does not link to the calendar, but to the sessions details on the course management screen.

follow-up item to #3469 