### PR TITLE
pre-fix version tag with v.

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -38,6 +38,6 @@ jobs:
         composer config version ${{ env.new_tag }}
         git commit -a -m "Bump Ilios version to ${{ env.new_tag }}"
     - name: Tag Version
-      run: git tag ${{ env.new_tag }} -m "Tagging the ${{ env.new_tag }} ${{ github.event.inputs.releaseType }} release"
+      run: git tag v${{ env.new_tag }} -m "Tagging the ${{ env.new_tag }} ${{ github.event.inputs.releaseType }} release"
     - name: Push Changes
       run: git push --follow-tags


### PR DESCRIPTION
restoring this back to established convention, downstream workflows depend on it.