### PR TITLE
Streamline release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  categories:
+    - title: What's Changed
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,3 +3,9 @@ changelog:
     - title: What's Changed
       labels:
         - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,6 +1,6 @@
 name: Release Notes
 
-on: 
+on:
   push:
     tags:
     - '*'
@@ -25,16 +25,8 @@ jobs:
         echo ${NEW_TAG}
         echo ::set-output name=tag::${NEW_TAG}
     - uses: actions/setup-node@v4
-    - name: Generate Release Notes
-      id: notes
-      run: |
-        NOTES=$(npx generate-github-release-notes ilios ilios ${{ steps.previousTag.outputs.tag }} ${{steps.nextTag.outputs.tag}})
-        echo ${NOTES}
-        # remove line breaks from notes so they can be passed around
-        NOTES="${NOTES//$'\n'/'%0A'}"
-        echo "::set-output name=releaseNotes::$NOTES"
     - uses: ncipollo/release-action@v1
       with:
         name: Ilios ${{steps.nextTag.outputs.tag}}
-        body: ${{steps.notes.outputs.releaseNotes}}
         token: ${{ secrets.ZORGBORT_TOKEN }}
+        generateReleaseNotes: true

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,4 +1,4 @@
-name: Release Notes
+name: Create Release
 
 on:
   push:


### PR DESCRIPTION
> The fastest way to a developer's heart is through removal of their code from the project.

— Mark Twain

This removes https://github.com/jrjohnson/generate-github-release-notes from our CI pipeline. Instead, GH's release note generation tools are used.

Please see https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes and https://github.com/ncipollo/release-action?tab=readme-ov-file#release-action for reference.