### PR TITLE
prevent NULL from being added to previous-indexing list.

### DIFF
--- a/src/Repository/MeshDescriptorRepository.php
+++ b/src/Repository/MeshDescriptorRepository.php
@@ -667,7 +667,9 @@ EOL;
             $descriptor->setUi($arr['id']);
             $descriptor->setName($arr['name']);
             $descriptor->setAnnotation($arr['annotation']);
-            $descriptor->addPreviousIndexing($arr['previousIndexing']);
+            if (!is_null($arr['previousIndexing'])) {
+                $descriptor->addPreviousIndexing($arr['previousIndexing']);
+            }
             foreach ($arr['concepts'] as $arr) {
                 $concept = new Concept();
                 $concept->setUi($arr['id']);


### PR DESCRIPTION
the Descriptor::addPreviousIndexing() method expects a string as an input, it cannot handle NULL.
this puts guard rails around that function call.

fixes #5378 

for reference, see https://github.com/ilios/mesh-parser/commit/87eb37554a3b07c8c955714e3061da914001d6a3#diff-b64ef4fd7da05e3b13283c1ca01fb2cd37cf5b5c43f0f3d47c9f86ad7d2c0401R155