### PR TITLE
Improve the consume-messages container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -49,13 +49,15 @@ services:
   messages:
     build:
       context: .
-      target: consume-messages-dev
+      target: consume-messages
     environment:
       - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=8.0
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_SEARCH_HOSTS=opensearch:9200
       - ILIOS_REDIS_URL=redis://redis
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/ilios-storage
+    restart: always
+    command: [ "--time-limit", "3600", "-vv"]
     depends_on:
         - db
         - opensearch

--- a/docker/messages-entrypoint
+++ b/docker/messages-entrypoint
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+/srv/app/bin/console ilios:wait-for-database
+/srv/app/bin/console ilios:wait-for-index
+
+# use exec so the process is the container's PID 1 which will allow
+# signals (Kill, Quit, Term) to be passed to the process.
+# Also pass all arguments into it
+exec /srv/app/bin/console messenger:consume async "$@"


### PR DESCRIPTION
Our messages container wasn't gracefully shutting down because we were using the shell form of ENTRYPOINT which executes the process in bash, but doesn't pass any signals into it. This resulted in not responding to the docker stop command correctly.
By moving the delays into a script and using the exec form of entrypoint we make the message consumer process the first process on the container and it gets passed signals.

PHP requires the pcntl extension to be enabled to listen for any signals so I've added that as well.

We were also relying on the HEALTHCHECK from the php-bash container which checks for running fpm so our container was showing up as unhealthy. We can just rely on the default by removing it which should be fine because it's the only process on the image.

Lastly by using the exec form of the entrypoint we can pass arguments into the container which are read by the consume messages command and remove the dev containers and just send additional logging as a parameter.

Note: this still doesn't actually work 😢 because Symfony messages doesn't yet respond to SIGQUIT which is used in the php-fpm base image. That PR has been merged and will be in 7.1 (due in May).