### PR TITLE
Allow show campus name to be configured by instance

### DIFF
--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -49,6 +49,10 @@ class ConfigController extends AbstractController
             'material_status_enabled'
         ) ?? false;
 
+        $configuration['showLegalName'] = $config->get(
+            'showLegalName'
+        ) ?? false;
+
         return new JsonResponse(['config' => $configuration]);
     }
 }

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -49,8 +49,8 @@ class ConfigController extends AbstractController
             'material_status_enabled'
         ) ?? false;
 
-        $configuration['showLegalName'] = $config->get(
-            'showLegalName'
+        $configuration['showCampusNameOfRecord'] = $config->get(
+            'showCampusNameOfRecord'
         ) ?? false;
 
         return new JsonResponse(['config' => $configuration]);

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -22,6 +22,7 @@ class Config
         'learningMaterialsDisabled',
         'academic_year_crosses_calendar_year_boundaries',
         'material_status_enabled',
+        'showLegalName',
     ];
 
     private const INT_NAMES = [

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -22,7 +22,7 @@ class Config
         'learningMaterialsDisabled',
         'academic_year_crosses_calendar_year_boundaries',
         'material_status_enabled',
-        'showLegalName',
+        'showCampusNameOfRecord',
     ];
 
     private const INT_NAMES = [

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -63,7 +63,7 @@ class ConfigControllerTest extends WebTestCase
                 'searchEnabled' => false,
                 'academicYearCrossesCalendarYearBoundaries' => false,
                 'materialStatusEnabled' => false,
-                'showLegalName' => false,
+                'showCampusNameOfRecord' => false,
             ],
             $data
         );
@@ -99,7 +99,7 @@ class ConfigControllerTest extends WebTestCase
                 'searchEnabled' => false,
                 'academicYearCrossesCalendarYearBoundaries' => true,
                 'materialStatusEnabled' => true,
-                'showLegalName' => true,
+                'showCampusNameOfRecord' => true,
             ],
             $data
         );

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -63,6 +63,7 @@ class ConfigControllerTest extends WebTestCase
                 'searchEnabled' => false,
                 'academicYearCrossesCalendarYearBoundaries' => false,
                 'materialStatusEnabled' => false,
+                'showLegalName' => false,
             ],
             $data
         );
@@ -72,6 +73,7 @@ class ConfigControllerTest extends WebTestCase
     {
         $_SERVER['ILIOS_ACADEMIC_YEAR_CROSSES_CALENDAR_YEAR_BOUNDARIES'] = true;
         $_SERVER['ILIOS_MATERIAL_STATUS_ENABLED'] = true;
+        $_SERVER['ILIOS_SHOW_LEGAL_NAME'] = true;
 
         $this->kernelBrowser->request('GET', '/application/config');
 
@@ -97,6 +99,7 @@ class ConfigControllerTest extends WebTestCase
                 'searchEnabled' => false,
                 'academicYearCrossesCalendarYearBoundaries' => true,
                 'materialStatusEnabled' => true,
+                'showLegalName' => true,
             ],
             $data
         );

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -73,7 +73,7 @@ class ConfigControllerTest extends WebTestCase
     {
         $_SERVER['ILIOS_ACADEMIC_YEAR_CROSSES_CALENDAR_YEAR_BOUNDARIES'] = true;
         $_SERVER['ILIOS_MATERIAL_STATUS_ENABLED'] = true;
-        $_SERVER['ILIOS_SHOW_LEGAL_NAME'] = true;
+        $_SERVER['ILIOS_SHOW_CAMPUS_NAME_OF_RECORD'] = true;
 
         $this->kernelBrowser->request('GET', '/application/config');
 
@@ -106,5 +106,6 @@ class ConfigControllerTest extends WebTestCase
 
         unset($_SERVER['ILIOS_ACADEMIC_YEAR_CROSSES_CALENDAR_YEAR_BOUNDARIES']);
         unset($_SERVER['ILIOS_MATERIAL_STATUS_ENABLED']);
+        unset($_SERVER['ILIOS_SHOW_CAMPUS_NAME_OF_RECORD']);
     }
 }


### PR DESCRIPTION
Sometimes campus policy prevents legal name from being displayed, this configuration will allow us to determine this on the UI and hide that info.

Requires https://github.com/ilios/frontend/pull/7794