### PR TITLE
Make name LDAP properties configurable

### DIFF
--- a/docs/authentication_and_users.md
+++ b/docs/authentication_and_users.md
@@ -43,11 +43,13 @@ sudo -u apache bin/console --env=prod ilios:maintenance:set-config-value ldap_di
 sudo -u apache bin/console --env=prod ilios:maintenance:set-config-value ldap_directory_username_property <your campus value>
 ```
 
-| Property Name| Description| Example Value|
-|---|---|---|
-|  ldap_directory_url  |  URL to connect to your LDAP server including protocol  |  ldaps://directory.campus.edu  |
-|  ldap_directory_user  |  The user we will use to authenticate  |  uid=Ilios,ou=applications,dc=campus,dc=edu  |
-|  ldap_directory_password  |  The bind password for your user  |  123GoLdap!  |
-|  ldap_directory_search_base  |  What scope in the directory we should user for users  |  ou=people,dc=campus,dc=edu  |
-|  ldap_directory_campus_id_property  |  In the returned data for a user what property is unique and can be used to populate the campusId field in Ilios  |  eduIDNumber  |
-|  ldap_directory_username_property  |  In the returned data for a user what property contains the username that links to the **cas**, **ldap**, or **shibboleth** authentication service  |  eduPersonPrincipalName  |
+| Property Name                      | Description                                                                                                                                       | Example Value                              |
+|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
+| ldap_directory_url                 | URL to connect to your LDAP server including protocol                                                                                             | ldaps://directory.campus.edu               |
+| ldap_directory_user                | The user we will use to authenticate                                                                                                              | uid=Ilios,ou=applications,dc=campus,dc=edu |
+| ldap_directory_password            | The bind password for your user                                                                                                                   | 123GoLdap!                                 |
+| ldap_directory_search_base         | What scope in the directory we should user for users                                                                                              | ou=people,dc=campus,dc=edu                 |
+| ldap_directory_campus_id_property  | In the returned data for a user what property is unique and can be used to populate the campusId field in Ilios                                   | eduIDNumber                                |
+| ldap_directory_username_property   | In the returned data for a user what property contains the username that links to the **cas**, **ldap**, or **shibboleth** authentication service | eduPersonPrincipalName                     |
+| ldap_directory_first_name_property | In the returned data for a user what property contains the first name. If this isn't provided it will default to **givenName**                    | givenName                                  |
+| ldap_directory_last_name_property  | In the returned data for a user what property contains the last name. If this isn't provided it will default to **sn**                            | sn                                         |


### PR DESCRIPTION
At UCSF the first and last name can be configured to use the lived name values instead of the default ldap attributes. This change allows ilios to consume those values, but keeps the default of sn/givenName for standard LDAP configs.

I added a note to the class comments, but spelling it out here as well. The `LdapManager` is untestable because the Symphony LDAP class it relies on is marked as final. Because we'd have to mock the query behavior to test this class we can't even create an `LdapFactory` service below this one. Or at least I couldn't figure out how.