### PR TITLE
Fix sonarqube configuration

### DIFF
--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -18,4 +18,6 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarqube.ucsf.edu
-          SONAR_PROJECT_KEY: ilios_ilios_99baf4a1-99a4-4d9a-adb9-2c1253c22751
+        with:
+          args: >
+            -Dsonar.projectKey=ilios_ilios_99baf4a1-99a4-4d9a-adb9-2c1253c22751


### PR DESCRIPTION
The project key can't go in an environmental file, it has to be passed into the command. Let's try it this way.