### PR TITLE
Lint for trailing comma in multi line arrays

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,6 +12,7 @@
     <rule ref="Generic.PHP.RequireStrictTypes"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
+    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma" />
 
     <file>bin/</file>
     <file>config/</file>

--- a/src/Classes/CurrentSession.php
+++ b/src/Classes/CurrentSession.php
@@ -15,7 +15,7 @@ use OpenApi\Attributes as OA;
             "userId",
             description: "The user ID",
             type: "string"
-        )
+        ),
     ]
 )]
 class CurrentSession

--- a/src/Classes/JsonApiData.php
+++ b/src/Classes/JsonApiData.php
@@ -34,7 +34,7 @@ class JsonApiData
     {
         return [
             'data' => $this->data,
-            'included' => $this->includes
+            'included' => $this->includes,
         ];
     }
 
@@ -50,25 +50,25 @@ class JsonApiData
             $value = $related['value'];
             if (is_null($value)) {
                 $data['relationships'][$name] = [
-                    'data' => null
+                    'data' => null,
                 ];
             } elseif (is_array($value)) {
                 $relatedData = [];
                 foreach ($value as $id) {
                     $relatedData[] = [
                         'type' => $related['type'],
-                        'id' => (string) $id
+                        'id' => (string) $id,
                     ];
                 }
                 $data['relationships'][$name] = [
-                    'data' => $relatedData
+                    'data' => $relatedData,
                 ];
             } else {
                 $data['relationships'][$name] = [
                     'data' => [
                         'type' => $related['type'],
-                        'id' => (string) $value
-                    ]
+                        'id' => (string) $value,
+                    ],
                 ];
             }
         }

--- a/src/Classes/OpenSearchBase.php
+++ b/src/Classes/OpenSearchBase.php
@@ -148,7 +148,7 @@ class OpenSearchBase
         $results = [
             'took' => 0,
             'errors' => false,
-            'items' => []
+            'items' => [],
         ];
 
         foreach ($chunks as $chunk) {
@@ -156,7 +156,7 @@ class OpenSearchBase
             foreach ($chunk as $item) {
                 $body[] = ['index' => [
                     '_index' => $index,
-                    '_id' => $item['id']
+                    '_id' => $item['id'],
                 ]];
                 $body[] = $item;
             }

--- a/src/Classes/SchoolEvent.php
+++ b/src/Classes/SchoolEvent.php
@@ -204,7 +204,7 @@ use OpenApi\Attributes as OA;
             description: "Course vocabulary terms",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 

--- a/src/Classes/SessionUser.php
+++ b/src/Classes/SessionUser.php
@@ -434,7 +434,7 @@ class SessionUser implements SessionUserInterface
             UserRoles::COURSE_DIRECTOR,
             UserRoles::COURSE_ADMINISTRATOR,
             UserRoles::SESSION_ADMINISTRATOR,
-            UserRoles::COURSE_INSTRUCTOR
+            UserRoles::COURSE_INSTRUCTOR,
         ]
     ): array {
         $rhett = [];

--- a/src/Classes/SessionUserInterface.php
+++ b/src/Classes/SessionUserInterface.php
@@ -86,7 +86,7 @@ interface SessionUserInterface extends PasswordAuthenticatedUserInterface, UserI
             UserRoles::COURSE_DIRECTOR,
             UserRoles::COURSE_ADMINISTRATOR,
             UserRoles::SESSION_ADMINISTRATOR,
-            UserRoles::COURSE_INSTRUCTOR
+            UserRoles::COURSE_INSTRUCTOR,
         ]
     ): array;
     public function isAdministeringSessionInCourse(int $courseId): bool;

--- a/src/Classes/UserMaterial.php
+++ b/src/Classes/UserMaterial.php
@@ -146,7 +146,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             "isBlanked",
             description: "Is blanked",
             type: "boolean"
-        )
+        ),
     ]
 )]
 class UserMaterial

--- a/src/Command/AddDirectoryUserCommand.php
+++ b/src/Command/AddDirectoryUserCommand.php
@@ -87,8 +87,8 @@ class AddDirectoryUserCommand extends Command
                     $userRecord['lastName'],
                     $userRecord['email'],
                     $userRecord['username'],
-                    $userRecord['telephoneNumber']
-                ]
+                    $userRecord['telephoneNumber'],
+                ],
             ])
         ;
         $table->render();

--- a/src/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Command/AddNewStudentsToSchoolCommand.php
@@ -94,7 +94,7 @@ class AddNewStudentsToSchoolCommand extends Command
             $arr['campusId'],
             $arr['firstName'],
             $arr['lastName'],
-            $arr['email']
+            $arr['email'],
         ], $newStudents);
         $table = new Table($output);
         $table->setHeaders(['Campus ID', 'First', 'Last', 'Email'])->setRows($rows);

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -114,7 +114,7 @@ class AddUserCommand extends Command
                 $input->getOption('isRoot'),
                 FILTER_VALIDATE_BOOLEAN,
                 FILTER_NULL_ON_FAILURE
-            ) : null
+            ) : null,
         ];
 
         $userRecord = $this->fillUserRecord($userRecord, $input, $output);
@@ -144,7 +144,7 @@ class AddUserCommand extends Command
                     $userRecord['username'],
                     $userRecord['telephoneNumber'],
                     $userRecord['isRoot'] ? 'yes' : 'no',
-                ]
+                ],
             ])
         ;
         $table->render();

--- a/src/Command/AuditLogExportCommand.php
+++ b/src/Command/AuditLogExportCommand.php
@@ -84,7 +84,7 @@ class AuditLogExportCommand extends Command
                 $dt->format('c'),
                 $arr['objectId'],
                 $arr['objectClass'],
-                $arr['valuesChanged']
+                $arr['valuesChanged'],
             ];
         }, $this->auditLogRepository->findInRange($from, $to));
 

--- a/src/Command/CleanupStringsCommand.php
+++ b/src/Command/CleanupStringsCommand.php
@@ -161,7 +161,7 @@ class CleanupStringsCommand extends Command
         $objectiveManagers = [
             $this->sessionObjectiveRepository,
             $this->courseObjectiveRepository,
-            $this->programYearObjectiveRepository
+            $this->programYearObjectiveRepository,
         ];
 
         foreach ($objectiveManagers as $objectiveManager) {

--- a/src/Command/FindUserCommand.php
+++ b/src/Command/FindUserCommand.php
@@ -54,7 +54,7 @@ class FindUserCommand extends Command
             $arr['firstName'],
             $arr['lastName'],
             $arr['email'],
-            $arr['telephoneNumber']
+            $arr['telephoneNumber'],
         ], $userRecords);
         $table = new Table($output);
         $table

--- a/src/Command/GenerateCurriculumInventoryVerificationPreviewCommand.php
+++ b/src/Command/GenerateCurriculumInventoryVerificationPreviewCommand.php
@@ -107,7 +107,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
             'Item Code',
             'Instructional Method',
             'Number of Events Featuring This as the Primary Method',
-            'Number of Non-Primary Occurrences if This Method'
+            'Number of Non-Primary Occurrences if This Method',
             ]);
         $table->addRows($data);
         $table->addRow(new TableSeparator());
@@ -118,7 +118,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
             '',
             '<options=bold>TOTAL</>',
             "<options=bold>{$primaryMethodTotal}</>",
-            "<options=bold>{$nonPrimaryMethodTotal}</>"
+            "<options=bold>{$nonPrimaryMethodTotal}</>",
         ];
         $table->addRow($summaryRow);
         $table->render();
@@ -135,7 +135,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
             'Item Code',
             'Assessment Method(s)',
             'Number of Summative Assessments',
-            'Number of Formative Assessments'
+            'Number of Formative Assessments',
         ]);
         $table->addRows($data);
         $table->addRow(new TableSeparator());
@@ -146,7 +146,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
             '',
             '<options=bold>TOTAL</>',
             "<options=bold>{$summativeAssessmentsTotal}</>",
-            "<options=bold>{$formativeAssessmentsTotal}</>"
+            "<options=bold>{$formativeAssessmentsTotal}</>",
         ];
         $table->addRow($summaryRow);
         $table->render();
@@ -171,7 +171,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
             $rows[] = [
                 'n/a',
                 trim(strip_tags($expectation['title'])),
-                implode("\n", $expectation['pcrs'])
+                implode("\n", $expectation['pcrs']),
             ];
         };
 
@@ -204,9 +204,9 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
             [
                 new TableCell('Non-clerkship Sequence Blocks', ['rowspan' => 2]),
                 new TableCell('Academic Level', ['rowspan' => 2]),
-                new TableCell('Number of Formal Instructional Hours Per Course', ['colspan' => count($titles) + 1])
+                new TableCell('Number of Formal Instructional Hours Per Course', ['colspan' => count($titles) + 1]),
             ],
-            array_merge($titles, ['Total'])
+            array_merge($titles, ['Total']),
         ]);
 
         foreach ($data['rows'] as $clerkship) {
@@ -260,7 +260,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
             'Non-Clerkship Sequence Blocks',
             'Academic Level',
             'Total Weeks',
-            'Average Hours of Instruction Per Week'
+            'Average Hours of Instruction Per Week',
             ]);
         $table->setRows($data);
         $table->render();
@@ -275,7 +275,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
                 'Clerkship Sequence Blocks',
                 'Academic Level',
                 'Total Weeks',
-                'Average Hours of Instruction Per Week'
+                'Average Hours of Instruction Per Week',
             ]);
         $table->setRows($data);
         $table->render();
@@ -295,7 +295,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
                 new TableCell('Narrative Asmt.', ['rowspan' => 2]),
                 new TableCell('Included in Grade', ['colspan' => count($data['methods']) + 1 ]),
             ],
-            array_merge(['Number of Exams'], $data['methods'])
+            array_merge(['Number of Exams'], $data['methods']),
         ]);
 
         foreach ($data['rows'] as $row) {
@@ -325,7 +325,7 @@ class GenerateCurriculumInventoryVerificationPreviewCommand extends Command
                 new TableCell('Narrative Asmt.', ['rowspan' => 2]),
                 new TableCell('Included in Grade', ['colspan' => count($data['methods']) ]),
             ],
-            $data['methods']
+            $data['methods'],
         ]);
 
         foreach ($data['rows'] as $row) {

--- a/src/Command/GenerateEndpointTestCommand.php
+++ b/src/Command/GenerateEndpointTestCommand.php
@@ -58,7 +58,7 @@ class GenerateEndpointTestCommand extends Command
 
         $mapProperties = fn(ReflectionProperty $property) => [
             'name' => $property->getName(),
-            'type' => $this->entityMetadata->getTypeOfProperty($property)
+            'type' => $this->entityMetadata->getTypeOfProperty($property),
         ];
 
         $writableProperties = $this->entityMetadata->extractWritableProperties($reflection);

--- a/src/Command/ImportDefaultDataCommand.php
+++ b/src/Command/ImportDefaultDataCommand.php
@@ -187,7 +187,7 @@ class ImportDefaultDataCommand extends Command
         } catch (Exception $e) {
             $io->error([
                 'An error occurred during data import:',
-                $e->getMessage()
+                $e->getMessage(),
             ]);
             $this->release();
             return Command::FAILURE;

--- a/src/Command/ListRootUsersCommand.php
+++ b/src/Command/ListRootUsersCommand.php
@@ -43,7 +43,7 @@ class ListRootUsersCommand extends Command
             $dto->lastName,
             $dto->email,
             $dto->phone,
-            ($dto->enabled ? 'Yes' : 'No')
+            ($dto->enabled ? 'Yes' : 'No'),
         ], $users);
 
         $table = new Table($output);

--- a/src/Command/SendTeachingRemindersCommand.php
+++ b/src/Command/SendTeachingRemindersCommand.php
@@ -157,7 +157,7 @@ class SendTeachingRemindersCommand extends Command
                     'base_url' => $baseUrl,
                     'instructor' => $instructor,
                     'offering' => $offering,
-                    'timezone' => $timezone
+                    'timezone' => $timezone,
                 ]);
                 $email = $instructor->getPreferredEmail();
                 if (empty($email)) {

--- a/src/Command/SetupAuthenticationCommand.php
+++ b/src/Command/SetupAuthenticationCommand.php
@@ -77,14 +77,14 @@ class SetupAuthenticationCommand extends Command
     protected function setupForm(): array
     {
         return [
-            'authentication_type' => 'form'
+            'authentication_type' => 'form',
         ];
     }
 
     protected function setupCas(InputInterface $input, OutputInterface $output): array
     {
         $parameters = [
-            'authentication_type' => 'cas'
+            'authentication_type' => 'cas',
         ];
         $helper = $this->getHelper('question');
         $question = new Question('What is the url for you CAS server?: ');
@@ -109,7 +109,7 @@ class SetupAuthenticationCommand extends Command
     protected function setupLdap(InputInterface $input, OutputInterface $output): array
     {
         $parameters = [
-            'authentication_type' => 'ldap'
+            'authentication_type' => 'ldap',
         ];
         $helper = $this->getHelper('question');
         $question = new Question('What is the url for you LDAP server? ');
@@ -130,7 +130,7 @@ class SetupAuthenticationCommand extends Command
     protected function setupShib(InputInterface $input, OutputInterface $output): array
     {
         $parameters = [
-            'authentication_type' => 'shibboleth'
+            'authentication_type' => 'shibboleth',
         ];
         $helper = $this->getHelper('question');
         $question = new Question(

--- a/src/Command/SyncUserCommand.php
+++ b/src/Command/SyncUserCommand.php
@@ -82,7 +82,7 @@ class SyncUserCommand extends Command
                     $user->getDisplayName(),
                     $user->getPronouns(),
                     $user->getEmail(),
-                    $user->getPhone()
+                    $user->getPhone(),
                 ],
                 [
                     'Directory User',
@@ -93,7 +93,7 @@ class SyncUserCommand extends Command
                     $userRecord['pronouns'],
                     $userRecord['email'],
                     $userRecord['telephoneNumber'],
-                ]
+                ],
             ])
         ;
         $table->render();

--- a/src/Command/UpdateFrontendCommand.php
+++ b/src/Command/UpdateFrontendCommand.php
@@ -255,7 +255,7 @@ class UpdateFrontendCommand extends Command implements CacheWarmerInterface
     ): void {
         $parts = [
             $archiveDir,
-            $key
+            $key,
         ];
         $archivePath = join(DIRECTORY_SEPARATOR, $parts);
         $version = explode(':', $key)[1];

--- a/src/Command/ValidateLearningMaterialPathsCommand.php
+++ b/src/Command/ValidateLearningMaterialPathsCommand.php
@@ -54,7 +54,7 @@ class ValidateLearningMaterialPathsCommand extends Command
                 } else {
                     $broken[] = [
                         'id' => $lm->getId(),
-                        'path' => $lm->getRelativePath()
+                        'path' => $lm->getRelativePath(),
                     ];
                 }
                 $progress->advance();
@@ -71,7 +71,7 @@ class ValidateLearningMaterialPathsCommand extends Command
             $output->writeln($msg);
             $rows = array_map(fn($arr) => [
                 $arr['id'],
-                $arr['path']
+                $arr['path'],
             ], $broken);
             $table = new Table($output);
             $table

--- a/src/Composer/MigrateParameters.php
+++ b/src/Composer/MigrateParameters.php
@@ -23,7 +23,7 @@ class MigrateParameters
         'mailer_user',
         'mailer_password',
         'locale',
-        'secret'
+        'secret',
     ];
     public static function migrate(Event $event)
     {

--- a/src/Controller/API/AamcMethods.php
+++ b/src/Controller/API/AamcMethods.php
@@ -38,7 +38,7 @@ class AamcMethods extends AbstractApiController
         summary: 'Fetch a single AAMC method.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -52,12 +52,12 @@ class AamcMethods extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AamcMethodDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -113,7 +113,7 @@ class AamcMethods extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -127,11 +127,11 @@ class AamcMethods extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AamcMethodDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -157,13 +157,13 @@ class AamcMethods extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: AamcMethodDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -177,13 +177,13 @@ class AamcMethods extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AamcMethodDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -213,14 +213,14 @@ class AamcMethods extends AbstractApiController
                         'aamcMethod',
                         ref: new Model(type: AamcMethodDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -231,7 +231,7 @@ class AamcMethods extends AbstractApiController
                         new OA\Property(
                             'aamcMethod',
                             ref: new Model(type: AamcMethodDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -244,14 +244,14 @@ class AamcMethods extends AbstractApiController
                         new OA\Property(
                             'aamcMethod',
                             ref: new Model(type: AamcMethodDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -293,7 +293,7 @@ class AamcMethods extends AbstractApiController
         summary: 'Delete an AAMC method.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -302,7 +302,7 @@ class AamcMethods extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/AamcPcrses.php
+++ b/src/Controller/API/AamcPcrses.php
@@ -37,7 +37,7 @@ class AamcPcrses extends AbstractApiController
         summary: 'Fetch a single AAMC PCRS.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path', schema: new OA\Schema(type: 'integer'))
+            new OA\Parameter(name: 'id', description: 'id', in: 'path', schema: new OA\Schema(type: 'integer')),
         ],
         responses: [
             new OA\Response(
@@ -51,12 +51,12 @@ class AamcPcrses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AamcPcrsDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
 
@@ -113,7 +113,7 @@ class AamcPcrses extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -127,11 +127,11 @@ class AamcPcrses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AamcPcrsDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -157,13 +157,13 @@ class AamcPcrses extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: AamcPcrsDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -177,13 +177,13 @@ class AamcPcrses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AamcPcrsDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -213,14 +213,14 @@ class AamcPcrses extends AbstractApiController
                         'aamcPcrs',
                         ref: new Model(type: AamcPcrsDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -231,7 +231,7 @@ class AamcPcrses extends AbstractApiController
                         new OA\Property(
                             'aamcPcrs',
                             ref: new Model(type: AamcPcrsDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -244,14 +244,14 @@ class AamcPcrses extends AbstractApiController
                         new OA\Property(
                             'aamcPcrs',
                             ref: new Model(type: AamcPcrsDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -293,7 +293,7 @@ class AamcPcrses extends AbstractApiController
         summary: 'Delete an AAMC PCRS.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -302,7 +302,7 @@ class AamcPcrses extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/AamcResourceTypes.php
+++ b/src/Controller/API/AamcResourceTypes.php
@@ -38,7 +38,7 @@ class AamcResourceTypes extends AbstractApiController
         summary: 'Fetch a single AAMC resource type.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -52,12 +52,12 @@ class AamcResourceTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AamcResourceTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -113,7 +113,7 @@ class AamcResourceTypes extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -127,11 +127,11 @@ class AamcResourceTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AamcResourceTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -157,13 +157,13 @@ class AamcResourceTypes extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: AamcResourceTypeDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -177,13 +177,13 @@ class AamcResourceTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AamcResourceTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -213,14 +213,14 @@ class AamcResourceTypes extends AbstractApiController
                         'aamcResourceType',
                         ref: new Model(type: AamcResourceTypeDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -231,7 +231,7 @@ class AamcResourceTypes extends AbstractApiController
                         new OA\Property(
                             'aamcResourceType',
                             ref: new Model(type: AamcResourceTypeDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -244,14 +244,14 @@ class AamcResourceTypes extends AbstractApiController
                         new OA\Property(
                             'aamcResourceType',
                             ref: new Model(type: AamcResourceTypeDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -293,7 +293,7 @@ class AamcResourceTypes extends AbstractApiController
         summary: 'Delete an AAMC resource type.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -302,7 +302,7 @@ class AamcResourceTypes extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/AcademicYears.php
+++ b/src/Controller/API/AcademicYears.php
@@ -27,7 +27,7 @@ class AcademicYears
         summary: 'Fetch a single academic years.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -41,16 +41,16 @@ class AcademicYears
                             items: new OA\Items(
                                 properties: [
                                     new OA\Property("id", type: "string"),
-                                    new OA\Property("title", type: "string")
+                                    new OA\Property("title", type: "string"),
                                 ],
                                 type: "object"
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -76,7 +76,7 @@ class AcademicYears
                     $builder->extractJsonApiSideLoadFields(
                         $request->query->has('include') ? $request->query->all()['include'] : null
                     ),
-                'singleItem' => true
+                'singleItem' => true,
             ]);
             return new Response(
                 $json,
@@ -115,15 +115,15 @@ class AcademicYears
                             items: new OA\Items(
                                 properties: [
                                     new OA\Property("id", type: "string"),
-                                    new OA\Property("title", type: "string")
+                                    new OA\Property("title", type: "string"),
                                 ],
                                 type: "object"
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -142,7 +142,7 @@ class AcademicYears
                     $builder->extractJsonApiSideLoadFields(
                         $request->query->has('include') ? $request->query->all()['include'] : null
                     ),
-                'singleItem' => false
+                'singleItem' => false,
             ]);
             return new Response(
                 $json,

--- a/src/Controller/API/AlertChangeTypes.php
+++ b/src/Controller/API/AlertChangeTypes.php
@@ -34,7 +34,7 @@ class AlertChangeTypes extends AbstractApiController
         summary: 'Fetch a single alert change type.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class AlertChangeTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AlertChangeTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class AlertChangeTypes extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class AlertChangeTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AlertChangeTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,7 +153,7 @@ class AlertChangeTypes extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: AlertChangeTypeDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
@@ -173,13 +173,13 @@ class AlertChangeTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AlertChangeTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class AlertChangeTypes extends AbstractApiController
                         'alertChangeType',
                         ref: new Model(type: AlertChangeTypeDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class AlertChangeTypes extends AbstractApiController
                         new OA\Property(
                             'alertChangeType',
                             ref: new Model(type: AlertChangeTypeDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class AlertChangeTypes extends AbstractApiController
                         new OA\Property(
                             'alertChangeType',
                             ref: new Model(type: AlertChangeTypeDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class AlertChangeTypes extends AbstractApiController
         summary: 'Delete an alert change type.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class AlertChangeTypes extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/Alerts.php
+++ b/src/Controller/API/Alerts.php
@@ -34,7 +34,7 @@ class Alerts extends AbstractApiController
         summary: 'Fetch a single alert.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class Alerts extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AlertDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class Alerts extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class Alerts extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AlertDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class Alerts extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: AlertDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class Alerts extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AlertDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class Alerts extends AbstractApiController
                         'alert',
                         ref: new Model(type: AlertDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class Alerts extends AbstractApiController
                         new OA\Property(
                             'alert',
                             ref: new Model(type: AlertDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class Alerts extends AbstractApiController
                         new OA\Property(
                             'alert',
                             ref: new Model(type: AlertDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class Alerts extends AbstractApiController
         summary: 'Delete an alert.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class Alerts extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/ApplicationConfigs.php
+++ b/src/Controller/API/ApplicationConfigs.php
@@ -40,7 +40,7 @@ class ApplicationConfigs extends AbstractApiController
         summary: 'Fetch a single application configuration item.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -54,12 +54,12 @@ class ApplicationConfigs extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ApplicationConfigDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -116,7 +116,7 @@ class ApplicationConfigs extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -130,11 +130,11 @@ class ApplicationConfigs extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ApplicationConfigDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -161,13 +161,13 @@ class ApplicationConfigs extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: ApplicationConfigDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -181,13 +181,13 @@ class ApplicationConfigs extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ApplicationConfigDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -217,14 +217,14 @@ class ApplicationConfigs extends AbstractApiController
                         'applicationConfig',
                         ref: new Model(type: ApplicationConfigDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -235,7 +235,7 @@ class ApplicationConfigs extends AbstractApiController
                         new OA\Property(
                             'applicationConfig',
                             ref: new Model(type: ApplicationConfigDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -248,14 +248,14 @@ class ApplicationConfigs extends AbstractApiController
                         new OA\Property(
                             'applicationConfig',
                             ref: new Model(type: ApplicationConfigDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -297,7 +297,7 @@ class ApplicationConfigs extends AbstractApiController
         summary: 'Delete an application configuration item.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -306,7 +306,7 @@ class ApplicationConfigs extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/AssessmentOptions.php
+++ b/src/Controller/API/AssessmentOptions.php
@@ -38,7 +38,7 @@ class AssessmentOptions extends AbstractApiController
         summary: 'Fetch a single assessment option.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -52,12 +52,12 @@ class AssessmentOptions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AssessmentOptionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -113,7 +113,7 @@ class AssessmentOptions extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -127,11 +127,11 @@ class AssessmentOptions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AssessmentOptionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -157,13 +157,13 @@ class AssessmentOptions extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: AssessmentOptionDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -177,13 +177,13 @@ class AssessmentOptions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: AssessmentOptionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -213,14 +213,14 @@ class AssessmentOptions extends AbstractApiController
                         'assessmentOption',
                         ref: new Model(type: AssessmentOptionDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -231,7 +231,7 @@ class AssessmentOptions extends AbstractApiController
                         new OA\Property(
                             'assessmentOption',
                             ref: new Model(type: AssessmentOptionDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -244,14 +244,14 @@ class AssessmentOptions extends AbstractApiController
                         new OA\Property(
                             'assessmentOption',
                             ref: new Model(type: AssessmentOptionDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -293,7 +293,7 @@ class AssessmentOptions extends AbstractApiController
         summary: 'Delete an assessment option.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -302,7 +302,7 @@ class AssessmentOptions extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/Authentications.php
+++ b/src/Controller/API/Authentications.php
@@ -55,7 +55,7 @@ class Authentications
         summary: 'Fetch a single authentication record.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'user id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'user id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -69,12 +69,12 @@ class Authentications
                             items: new OA\Items(
                                 ref: new Model(type: AuthenticationDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(string $version, int $id, ApiResponseBuilder $builder, Request $request): Response
@@ -107,17 +107,17 @@ class Authentications
                             properties: [
                                 new OA\Property("user", type: "integer"),
                                 new OA\Property("username", type: "string"),
-                                new OA\Property("password", type: "string")
+                                new OA\Property("password", type: "string"),
                             ],
                             type: "object"
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -131,13 +131,13 @@ class Authentications
                             items: new OA\Items(
                                 ref: new Model(type: AuthenticationDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -237,7 +237,7 @@ class Authentications
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -251,11 +251,11 @@ class Authentications
                             items: new OA\Items(
                                 ref: new Model(type: AuthenticationDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -301,18 +301,18 @@ class Authentications
                             properties: [
                                 new OA\Property("user", type: "integer"),
                                 new OA\Property("username", type: "string"),
-                                new OA\Property("password", type: "string")
+                                new OA\Property("password", type: "string"),
                             ],
                             type: "object"
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'user id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'user id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -323,7 +323,7 @@ class Authentications
                         new OA\Property(
                             'authentication',
                             ref: new Model(type: AuthenticationDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -336,14 +336,14 @@ class Authentications
                         new OA\Property(
                             'authentication',
                             ref: new Model(type: AuthenticationDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -454,7 +454,7 @@ class Authentications
         summary: 'Delete an authentication record.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'user id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'user id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -463,7 +463,7 @@ class Authentications
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/Cohorts.php
+++ b/src/Controller/API/Cohorts.php
@@ -40,7 +40,7 @@ class Cohorts extends AbstractApiController
         summary: 'Fetch a single cohort.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -54,12 +54,12 @@ class Cohorts extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CohortDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -115,7 +115,7 @@ class Cohorts extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -129,11 +129,11 @@ class Cohorts extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CohortDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -164,14 +164,14 @@ class Cohorts extends AbstractApiController
                         'cohort',
                         ref: new Model(type: CohortDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -182,14 +182,14 @@ class Cohorts extends AbstractApiController
                         new OA\Property(
                             'cohort',
                             ref: new Model(type: CohortDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(

--- a/src/Controller/API/Competencies.php
+++ b/src/Controller/API/Competencies.php
@@ -34,7 +34,7 @@ class Competencies extends AbstractApiController
         summary: 'Fetch a single competency.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class Competencies extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CompetencyDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class Competencies extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class Competencies extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CompetencyDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class Competencies extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CompetencyDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class Competencies extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CompetencyDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class Competencies extends AbstractApiController
                         'competency',
                         ref: new Model(type: CompetencyDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class Competencies extends AbstractApiController
                         new OA\Property(
                             'competency',
                             ref: new Model(type: CompetencyDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class Competencies extends AbstractApiController
                         new OA\Property(
                             'competency',
                             ref: new Model(type: CompetencyDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class Competencies extends AbstractApiController
         summary: 'Delete a competencies.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class Competencies extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/CourseClerkshipTypes.php
+++ b/src/Controller/API/CourseClerkshipTypes.php
@@ -40,7 +40,7 @@ class CourseClerkshipTypes extends AbstractApiController
         summary: 'Fetch a single course clerkship type.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -54,12 +54,12 @@ class CourseClerkshipTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseClerkshipTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -115,7 +115,7 @@ class CourseClerkshipTypes extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -129,11 +129,11 @@ class CourseClerkshipTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseClerkshipTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -159,13 +159,13 @@ class CourseClerkshipTypes extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CourseClerkshipTypeDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -179,13 +179,13 @@ class CourseClerkshipTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseClerkshipTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -215,14 +215,14 @@ class CourseClerkshipTypes extends AbstractApiController
                         'courseClerkshipType',
                         ref: new Model(type: CourseClerkshipTypeDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -233,7 +233,7 @@ class CourseClerkshipTypes extends AbstractApiController
                         new OA\Property(
                             'courseClerkshipType',
                             ref: new Model(type: CourseClerkshipTypeDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -246,14 +246,14 @@ class CourseClerkshipTypes extends AbstractApiController
                         new OA\Property(
                             'courseClerkshipType',
                             ref: new Model(type: CourseClerkshipTypeDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -295,7 +295,7 @@ class CourseClerkshipTypes extends AbstractApiController
         summary: 'Delete a course clerkship type.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -304,7 +304,7 @@ class CourseClerkshipTypes extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/CourseLearningMaterials.php
+++ b/src/Controller/API/CourseLearningMaterials.php
@@ -34,7 +34,7 @@ class CourseLearningMaterials extends AbstractApiController
         summary: 'Fetch a single course learning material.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class CourseLearningMaterials extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseLearningMaterialDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class CourseLearningMaterials extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class CourseLearningMaterials extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseLearningMaterialDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class CourseLearningMaterials extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CourseLearningMaterialDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class CourseLearningMaterials extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseLearningMaterialDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class CourseLearningMaterials extends AbstractApiController
                         'courseLearningMaterial',
                         ref: new Model(type: CourseLearningMaterialDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class CourseLearningMaterials extends AbstractApiController
                         new OA\Property(
                             'courseLearningMaterial',
                             ref: new Model(type: CourseLearningMaterialDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class CourseLearningMaterials extends AbstractApiController
                         new OA\Property(
                             'courseLearningMaterial',
                             ref: new Model(type: CourseLearningMaterialDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class CourseLearningMaterials extends AbstractApiController
         summary: 'Delete a course learning material.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class CourseLearningMaterials extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/CourseObjectives.php
+++ b/src/Controller/API/CourseObjectives.php
@@ -34,7 +34,7 @@ class CourseObjectives extends AbstractApiController
         summary: 'Fetch a single course objective.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class CourseObjectives extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseObjectiveDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class CourseObjectives extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class CourseObjectives extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseObjectiveDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class CourseObjectives extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CourseObjectiveDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class CourseObjectives extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseObjectiveDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class CourseObjectives extends AbstractApiController
                         'courseObjective',
                         ref: new Model(type: CourseObjectiveDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class CourseObjectives extends AbstractApiController
                         new OA\Property(
                             'courseObjective',
                             ref: new Model(type: CourseObjectiveDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class CourseObjectives extends AbstractApiController
                         new OA\Property(
                             'courseObjective',
                             ref: new Model(type: CourseObjectiveDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class CourseObjectives extends AbstractApiController
         summary: 'Delete a course objective.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class CourseObjectives extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/Courses.php
+++ b/src/Controller/API/Courses.php
@@ -47,7 +47,7 @@ class Courses extends AbstractApiController
         summary: 'Fetch a single course.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -61,12 +61,12 @@ class Courses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -137,7 +137,7 @@ class Courses extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -151,11 +151,11 @@ class Courses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -228,13 +228,13 @@ class Courses extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CourseDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -248,13 +248,13 @@ class Courses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -283,14 +283,14 @@ class Courses extends AbstractApiController
                         'course',
                         ref: new Model(type: CourseDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -301,7 +301,7 @@ class Courses extends AbstractApiController
                         new OA\Property(
                             'course',
                             ref: new Model(type: CourseDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -314,14 +314,14 @@ class Courses extends AbstractApiController
                         new OA\Property(
                             'course',
                             ref: new Model(type: CourseDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -376,7 +376,7 @@ class Courses extends AbstractApiController
         summary: 'Delete a course.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -385,7 +385,7 @@ class Courses extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(
@@ -452,7 +452,7 @@ class Courses extends AbstractApiController
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -466,13 +466,13 @@ class Courses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CourseDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function rolloverAction(

--- a/src/Controller/API/CurrentSessionController.php
+++ b/src/Controller/API/CurrentSessionController.php
@@ -43,12 +43,12 @@ class CurrentSessionController extends AbstractController
                         new OA\Property(
                             'userId',
                             type: 'string',
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getCurrentSession(

--- a/src/Controller/API/CurriculumInventoryAcademicLevels.php
+++ b/src/Controller/API/CurriculumInventoryAcademicLevels.php
@@ -34,7 +34,7 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
         summary: 'Fetch a single curriculum inventory academic level.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryAcademicLevelDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryAcademicLevelDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CurriculumInventoryAcademicLevelDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryAcademicLevelDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
                         'curriculumInventoryAcademicLevel',
                         ref: new Model(type: CurriculumInventoryAcademicLevelDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
                         new OA\Property(
                             'curriculumInventoryAcademicLevel',
                             ref: new Model(type: CurriculumInventoryAcademicLevelDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
                         new OA\Property(
                             'curriculumInventoryAcademicLevel',
                             ref: new Model(type: CurriculumInventoryAcademicLevelDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
         summary: 'Delete a curriculum inventory academic level.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class CurriculumInventoryAcademicLevels extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/CurriculumInventoryExports.php
+++ b/src/Controller/API/CurriculumInventoryExports.php
@@ -55,13 +55,13 @@ class CurriculumInventoryExports extends AbstractApiController
                         'curriculumInventoryExports',
                         ref: new Model(type: CurriculumInventoryExportDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -75,13 +75,13 @@ class CurriculumInventoryExports extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryExportDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(

--- a/src/Controller/API/CurriculumInventoryInstitutions.php
+++ b/src/Controller/API/CurriculumInventoryInstitutions.php
@@ -34,7 +34,7 @@ class CurriculumInventoryInstitutions extends AbstractApiController
         summary: 'Fetch a single curriculum inventory institution.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class CurriculumInventoryInstitutions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryInstitutionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class CurriculumInventoryInstitutions extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class CurriculumInventoryInstitutions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryInstitutionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class CurriculumInventoryInstitutions extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CurriculumInventoryInstitutionDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class CurriculumInventoryInstitutions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryInstitutionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class CurriculumInventoryInstitutions extends AbstractApiController
                         'curriculumInventoryInstitution',
                         ref: new Model(type: CurriculumInventoryInstitutionDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class CurriculumInventoryInstitutions extends AbstractApiController
                         new OA\Property(
                             'curriculumInventoryInstitution',
                             ref: new Model(type: CurriculumInventoryInstitutionDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class CurriculumInventoryInstitutions extends AbstractApiController
                         new OA\Property(
                             'curriculumInventoryInstitution',
                             ref: new Model(type: CurriculumInventoryInstitutionDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class CurriculumInventoryInstitutions extends AbstractApiController
         summary: 'Delete a curriculum inventory institution.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class CurriculumInventoryInstitutions extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/CurriculumInventoryReports.php
+++ b/src/Controller/API/CurriculumInventoryReports.php
@@ -52,7 +52,7 @@ class CurriculumInventoryReports extends AbstractApiController
         summary: 'Fetch a single curriculum inventory report.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -66,12 +66,12 @@ class CurriculumInventoryReports extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryReportDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -127,7 +127,7 @@ class CurriculumInventoryReports extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -141,11 +141,11 @@ class CurriculumInventoryReports extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryReportDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -176,7 +176,7 @@ class CurriculumInventoryReports extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CurriculumInventoryReportDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
@@ -196,13 +196,13 @@ class CurriculumInventoryReports extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryReportDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -264,14 +264,14 @@ class CurriculumInventoryReports extends AbstractApiController
                         'curriculumInventoryReport',
                         ref: new Model(type: CurriculumInventoryReportDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -282,7 +282,7 @@ class CurriculumInventoryReports extends AbstractApiController
                         new OA\Property(
                             'curriculumInventoryReport',
                             ref: new Model(type: CurriculumInventoryReportDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -295,14 +295,14 @@ class CurriculumInventoryReports extends AbstractApiController
                         new OA\Property(
                             'curriculumInventoryReport',
                             ref: new Model(type: CurriculumInventoryReportDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -342,7 +342,7 @@ class CurriculumInventoryReports extends AbstractApiController
         summary: 'Delete a curriculum inventory report.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -351,7 +351,7 @@ class CurriculumInventoryReports extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(
@@ -397,7 +397,7 @@ class CurriculumInventoryReports extends AbstractApiController
                             'program',
                             description: 'Program ID',
                             type: 'string',
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -405,7 +405,7 @@ class CurriculumInventoryReports extends AbstractApiController
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -419,13 +419,13 @@ class CurriculumInventoryReports extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventoryReportDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function rollover(
@@ -491,7 +491,7 @@ class CurriculumInventoryReports extends AbstractApiController
         summary: 'Fetch verification preview data for a given report.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -502,12 +502,12 @@ class CurriculumInventoryReports extends AbstractApiController
                         new OA\Property(
                             'preview',
                             type: 'object',
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function verificationPreview(

--- a/src/Controller/API/CurriculumInventorySequenceBlocks.php
+++ b/src/Controller/API/CurriculumInventorySequenceBlocks.php
@@ -44,7 +44,7 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
         summary: 'Fetch a single curriculum inventory sequence block.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -58,12 +58,12 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventorySequenceBlockDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -119,7 +119,7 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -133,11 +133,11 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventorySequenceBlockDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -163,13 +163,13 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CurriculumInventorySequenceBlockDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -183,13 +183,13 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventorySequenceBlockDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -235,14 +235,14 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
                         'curriculumInventorySequenceBlock',
                         ref: new Model(type: CurriculumInventorySequenceBlockDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -253,7 +253,7 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
                         new OA\Property(
                             'curriculumInventorySequenceBlock',
                             ref: new Model(type: CurriculumInventorySequenceBlockDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -266,14 +266,14 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
                         new OA\Property(
                             'curriculumInventorySequenceBlock',
                             ref: new Model(type: CurriculumInventorySequenceBlockDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -329,7 +329,7 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
         summary: 'Delete a curriculum inventory sequence block.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -338,7 +338,7 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/CurriculumInventorySequences.php
+++ b/src/Controller/API/CurriculumInventorySequences.php
@@ -34,7 +34,7 @@ class CurriculumInventorySequences extends AbstractApiController
         summary: 'Fetch a single curriculum inventory sequence.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class CurriculumInventorySequences extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventorySequenceDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class CurriculumInventorySequences extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class CurriculumInventorySequences extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventorySequenceDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class CurriculumInventorySequences extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: CurriculumInventorySequenceDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class CurriculumInventorySequences extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: CurriculumInventorySequenceDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class CurriculumInventorySequences extends AbstractApiController
                         'curriculumInventorySequence',
                         ref: new Model(type: CurriculumInventorySequenceDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class CurriculumInventorySequences extends AbstractApiController
                         new OA\Property(
                             'curriculumInventorySequence',
                             ref: new Model(type: CurriculumInventorySequenceDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class CurriculumInventorySequences extends AbstractApiController
                         new OA\Property(
                             'curriculumInventorySequence',
                             ref: new Model(type: CurriculumInventorySequenceDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class CurriculumInventorySequences extends AbstractApiController
         summary: 'Delete a curriculum inventory sequence.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class CurriculumInventorySequences extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/GraphQL.php
+++ b/src/Controller/API/GraphQL.php
@@ -30,7 +30,7 @@ class GraphQL
             'fields' => $types,
         ]);
         $schema = new Schema([
-            'query' => $queryType
+            'query' => $queryType,
         ]);
         $input = json_decode($request->getContent() ?: '', true);
         $variableValues = array_key_exists('variables', $input) ? $input['variables'] : null;

--- a/src/Controller/API/IlmSessions.php
+++ b/src/Controller/API/IlmSessions.php
@@ -34,7 +34,7 @@ class IlmSessions extends AbstractApiController
         summary: 'Fetch a single ILM session.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class IlmSessions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: IlmSessionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class IlmSessions extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class IlmSessions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: IlmSessionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class IlmSessions extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: IlmSessionDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class IlmSessions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: IlmSessionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class IlmSessions extends AbstractApiController
                         'ilmSession',
                         ref: new Model(type: IlmSessionDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class IlmSessions extends AbstractApiController
                         new OA\Property(
                             'ilmSession',
                             ref: new Model(type: IlmSessionDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class IlmSessions extends AbstractApiController
                         new OA\Property(
                             'ilmSession',
                             ref: new Model(type: IlmSessionDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class IlmSessions extends AbstractApiController
         summary: 'Delete an ILM session.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class IlmSessions extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/IngestionExceptions.php
+++ b/src/Controller/API/IngestionExceptions.php
@@ -32,7 +32,7 @@ class IngestionExceptions extends AbstractApiController
         summary: 'Fetch a single ingestion exception.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -46,12 +46,12 @@ class IngestionExceptions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: IngestionExceptionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -107,7 +107,7 @@ class IngestionExceptions extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -121,11 +121,11 @@ class IngestionExceptions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: IngestionExceptionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(

--- a/src/Controller/API/InstructorGroups.php
+++ b/src/Controller/API/InstructorGroups.php
@@ -34,7 +34,7 @@ class InstructorGroups extends AbstractApiController
         summary: 'Fetch a single instructor group.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class InstructorGroups extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: InstructorGroupDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class InstructorGroups extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class InstructorGroups extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: InstructorGroupDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class InstructorGroups extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: InstructorGroupDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class InstructorGroups extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: InstructorGroupDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class InstructorGroups extends AbstractApiController
                         'instructorGroup',
                         ref: new Model(type: InstructorGroupDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class InstructorGroups extends AbstractApiController
                         new OA\Property(
                             'instructorGroup',
                             ref: new Model(type: InstructorGroupDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class InstructorGroups extends AbstractApiController
                         new OA\Property(
                             'instructorGroup',
                             ref: new Model(type: InstructorGroupDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,12 +286,12 @@ class InstructorGroups extends AbstractApiController
         summary: 'Delete an instructor group.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function delete(

--- a/src/Controller/API/LearnerGroups.php
+++ b/src/Controller/API/LearnerGroups.php
@@ -34,7 +34,7 @@ class LearnerGroups extends AbstractApiController
         summary: 'Fetch a single learner group.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class LearnerGroups extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: LearnerGroupDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class LearnerGroups extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class LearnerGroups extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: LearnerGroupDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class LearnerGroups extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: LearnerGroupDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class LearnerGroups extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: LearnerGroupDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class LearnerGroups extends AbstractApiController
                         'learnerGroup',
                         ref: new Model(type: LearnerGroupDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class LearnerGroups extends AbstractApiController
                         new OA\Property(
                             'learnerGroup',
                             ref: new Model(type: LearnerGroupDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class LearnerGroups extends AbstractApiController
                         new OA\Property(
                             'learnerGroup',
                             ref: new Model(type: LearnerGroupDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class LearnerGroups extends AbstractApiController
         summary: 'Delete a learner group.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class LearnerGroups extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/LearningMaterialStatuses.php
+++ b/src/Controller/API/LearningMaterialStatuses.php
@@ -34,7 +34,7 @@ class LearningMaterialStatuses extends AbstractApiController
         summary: 'Fetch a single learning material status.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class LearningMaterialStatuses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: LearningMaterialStatusDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class LearningMaterialStatuses extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class LearningMaterialStatuses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: LearningMaterialStatusDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class LearningMaterialStatuses extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: LearningMaterialStatusDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class LearningMaterialStatuses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: LearningMaterialStatusDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class LearningMaterialStatuses extends AbstractApiController
                         'learningMaterialStatus',
                         ref: new Model(type: LearningMaterialStatusDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class LearningMaterialStatuses extends AbstractApiController
                         new OA\Property(
                             'learningMaterialStatus',
                             ref: new Model(type: LearningMaterialStatusDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class LearningMaterialStatuses extends AbstractApiController
                         new OA\Property(
                             'learningMaterialStatus',
                             ref: new Model(type: LearningMaterialStatusDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class LearningMaterialStatuses extends AbstractApiController
         summary: 'Delete a learning material status.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class LearningMaterialStatuses extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/LearningMaterialUserRoles.php
+++ b/src/Controller/API/LearningMaterialUserRoles.php
@@ -34,7 +34,7 @@ class LearningMaterialUserRoles extends AbstractApiController
         summary: 'Fetch a single learning material user role.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class LearningMaterialUserRoles extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: LearningMaterialUserRoleDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class LearningMaterialUserRoles extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class LearningMaterialUserRoles extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: LearningMaterialUserRoleDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class LearningMaterialUserRoles extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: LearningMaterialUserRoleDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class LearningMaterialUserRoles extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: LearningMaterialUserRoleDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class LearningMaterialUserRoles extends AbstractApiController
                         'learningMaterialUserRole',
                         ref: new Model(type: LearningMaterialUserRoleDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class LearningMaterialUserRoles extends AbstractApiController
                         new OA\Property(
                             'learningMaterialUserRole',
                             ref: new Model(type: LearningMaterialUserRoleDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class LearningMaterialUserRoles extends AbstractApiController
                         new OA\Property(
                             'learningMaterialUserRole',
                             ref: new Model(type: LearningMaterialUserRoleDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class LearningMaterialUserRoles extends AbstractApiController
         summary: 'Delete a learning material user role.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class LearningMaterialUserRoles extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/LearningMaterials.php
+++ b/src/Controller/API/LearningMaterials.php
@@ -64,7 +64,7 @@ class LearningMaterials
         summary: 'Fetch a single learning material.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -78,12 +78,12 @@ class LearningMaterials
                             items: new OA\Items(
                                 ref: new Model(type: LearningMaterialDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -162,7 +162,7 @@ class LearningMaterials
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -176,11 +176,11 @@ class LearningMaterials
                             items: new OA\Items(
                                 ref: new Model(type: LearningMaterialDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -248,13 +248,13 @@ class LearningMaterials
                         items: new OA\Items(
                             ref: new Model(type: LearningMaterialDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -268,13 +268,13 @@ class LearningMaterials
                             items: new OA\Items(
                                 ref: new Model(type: LearningMaterialDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -372,14 +372,14 @@ class LearningMaterials
                         'learningMaterial',
                         ref: new Model(type: LearningMaterialDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -390,7 +390,7 @@ class LearningMaterials
                         new OA\Property(
                             'learningMaterial',
                             ref: new Model(type: LearningMaterialDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -403,14 +403,14 @@ class LearningMaterials
                         new OA\Property(
                             'learningMaterial',
                             ref: new Model(type: LearningMaterialDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -522,7 +522,7 @@ class LearningMaterials
         summary: 'Delete a learning material.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -531,7 +531,7 @@ class LearningMaterials
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/MeshConcepts.php
+++ b/src/Controller/API/MeshConcepts.php
@@ -32,7 +32,7 @@ class MeshConcepts extends AbstractApiController
         summary: 'Fetch a single MeSH concept.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -46,12 +46,12 @@ class MeshConcepts extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshConceptDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -107,7 +107,7 @@ class MeshConcepts extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -121,11 +121,11 @@ class MeshConcepts extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshConceptDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(

--- a/src/Controller/API/MeshDescriptors.php
+++ b/src/Controller/API/MeshDescriptors.php
@@ -35,7 +35,7 @@ class MeshDescriptors extends AbstractApiController
         summary: 'Fetch a single MeSH descriptor.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -49,12 +49,12 @@ class MeshDescriptors extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshDescriptorDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -115,7 +115,7 @@ class MeshDescriptors extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -129,11 +129,11 @@ class MeshDescriptors extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshDescriptorDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(

--- a/src/Controller/API/MeshPreviousIndexings.php
+++ b/src/Controller/API/MeshPreviousIndexings.php
@@ -32,7 +32,7 @@ class MeshPreviousIndexings extends AbstractApiController
         summary: 'Fetch a single MeSH previous indexing.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -46,12 +46,12 @@ class MeshPreviousIndexings extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshPreviousIndexingDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -107,7 +107,7 @@ class MeshPreviousIndexings extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -121,11 +121,11 @@ class MeshPreviousIndexings extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshPreviousIndexingDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(

--- a/src/Controller/API/MeshQualifiers.php
+++ b/src/Controller/API/MeshQualifiers.php
@@ -32,7 +32,7 @@ class MeshQualifiers extends AbstractApiController
         summary: 'Fetch a single MeSH qualifier.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -46,12 +46,12 @@ class MeshQualifiers extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshQualifierDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -107,7 +107,7 @@ class MeshQualifiers extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -121,11 +121,11 @@ class MeshQualifiers extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshQualifierDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(

--- a/src/Controller/API/MeshTerms.php
+++ b/src/Controller/API/MeshTerms.php
@@ -32,7 +32,7 @@ class MeshTerms extends AbstractApiController
         summary: 'Fetch a single MeSH term.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -46,12 +46,12 @@ class MeshTerms extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshTermDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -107,7 +107,7 @@ class MeshTerms extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -121,11 +121,11 @@ class MeshTerms extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshTermDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(

--- a/src/Controller/API/MeshTrees.php
+++ b/src/Controller/API/MeshTrees.php
@@ -32,7 +32,7 @@ class MeshTrees extends AbstractApiController
         summary: 'Fetch a single MeSH tree.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -46,12 +46,12 @@ class MeshTrees extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshTreeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -107,7 +107,7 @@ class MeshTrees extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -121,11 +121,11 @@ class MeshTrees extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: MeshTreeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(

--- a/src/Controller/API/Offerings.php
+++ b/src/Controller/API/Offerings.php
@@ -50,7 +50,7 @@ class Offerings extends AbstractApiController
         summary: 'Fetch a single offering.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -64,12 +64,12 @@ class Offerings extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: OfferingDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -125,7 +125,7 @@ class Offerings extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -139,11 +139,11 @@ class Offerings extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: OfferingDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -169,13 +169,13 @@ class Offerings extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: OfferingDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -189,13 +189,13 @@ class Offerings extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: OfferingDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -250,14 +250,14 @@ class Offerings extends AbstractApiController
                         'offering',
                         ref: new Model(type: OfferingDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -268,7 +268,7 @@ class Offerings extends AbstractApiController
                         new OA\Property(
                             'offering',
                             ref: new Model(type: OfferingDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -281,14 +281,14 @@ class Offerings extends AbstractApiController
                         new OA\Property(
                             'offering',
                             ref: new Model(type: OfferingDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -392,7 +392,7 @@ class Offerings extends AbstractApiController
         summary: 'Delete an offering.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -401,7 +401,7 @@ class Offerings extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/PendingUserUpdates.php
+++ b/src/Controller/API/PendingUserUpdates.php
@@ -34,7 +34,7 @@ class PendingUserUpdates extends AbstractApiController
         summary: 'Fetch a single pending user update.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class PendingUserUpdates extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: PendingUserUpdateDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class PendingUserUpdates extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class PendingUserUpdates extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: PendingUserUpdateDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class PendingUserUpdates extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: PendingUserUpdateDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class PendingUserUpdates extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: PendingUserUpdateDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class PendingUserUpdates extends AbstractApiController
                         'pendingUserUpdate',
                         ref: new Model(type: PendingUserUpdateDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class PendingUserUpdates extends AbstractApiController
                         new OA\Property(
                             'pendingUserUpdate',
                             ref: new Model(type: PendingUserUpdateDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class PendingUserUpdates extends AbstractApiController
                         new OA\Property(
                             'pendingUserUpdate',
                             ref: new Model(type: PendingUserUpdateDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class PendingUserUpdates extends AbstractApiController
         summary: 'Delete a pending user update.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class PendingUserUpdates extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/ProgramYearObjectives.php
+++ b/src/Controller/API/ProgramYearObjectives.php
@@ -34,7 +34,7 @@ class ProgramYearObjectives extends AbstractApiController
         summary: 'Fetch a single program year objective.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class ProgramYearObjectives extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ProgramYearObjectiveDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class ProgramYearObjectives extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class ProgramYearObjectives extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ProgramYearObjectiveDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class ProgramYearObjectives extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: ProgramYearObjectiveDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class ProgramYearObjectives extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ProgramYearObjectiveDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class ProgramYearObjectives extends AbstractApiController
                         'programYearObjective',
                         ref: new Model(type: ProgramYearObjectiveDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class ProgramYearObjectives extends AbstractApiController
                         new OA\Property(
                             'programYearObjective',
                             ref: new Model(type: ProgramYearObjectiveDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class ProgramYearObjectives extends AbstractApiController
                         new OA\Property(
                             'programYearObjective',
                             ref: new Model(type: ProgramYearObjectiveDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class ProgramYearObjectives extends AbstractApiController
         summary: 'Delete a program year objective.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class ProgramYearObjectives extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/ProgramYears.php
+++ b/src/Controller/API/ProgramYears.php
@@ -48,7 +48,7 @@ class ProgramYears extends AbstractApiController
         summary: 'Fetch a single program year.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -62,12 +62,12 @@ class ProgramYears extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ProgramYearDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -123,7 +123,7 @@ class ProgramYears extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -137,11 +137,11 @@ class ProgramYears extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ProgramYearDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -167,13 +167,13 @@ class ProgramYears extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: ProgramYearDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -187,13 +187,13 @@ class ProgramYears extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ProgramYearDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -245,14 +245,14 @@ class ProgramYears extends AbstractApiController
                         'programYear',
                         ref: new Model(type: ProgramYearDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -263,7 +263,7 @@ class ProgramYears extends AbstractApiController
                         new OA\Property(
                             'programYear',
                             ref: new Model(type: ProgramYearDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -276,14 +276,14 @@ class ProgramYears extends AbstractApiController
                         new OA\Property(
                             'programYear',
                             ref: new Model(type: ProgramYearDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -357,7 +357,7 @@ class ProgramYears extends AbstractApiController
         summary: 'Delete a program year.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -366,7 +366,7 @@ class ProgramYears extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(
@@ -386,13 +386,13 @@ class ProgramYears extends AbstractApiController
         summary: 'Download the objective mapping as CSV.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
                 response: '200',
                 description: 'A CSV file containing the objective mapping.'
-            )
+            ),
         ]
     )]
     public function downloadCourseObjectivesReport(

--- a/src/Controller/API/Programs.php
+++ b/src/Controller/API/Programs.php
@@ -34,7 +34,7 @@ class Programs extends AbstractApiController
         summary: 'Fetch a single program.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class Programs extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ProgramDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class Programs extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class Programs extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ProgramDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class Programs extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: ProgramDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class Programs extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ProgramDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class Programs extends AbstractApiController
                         'program',
                         ref: new Model(type: ProgramDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class Programs extends AbstractApiController
                         new OA\Property(
                             'program',
                             ref: new Model(type: ProgramDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class Programs extends AbstractApiController
                         new OA\Property(
                             'program',
                             ref: new Model(type: ProgramDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class Programs extends AbstractApiController
         summary: 'Delete a program.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class Programs extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/Reports.php
+++ b/src/Controller/API/Reports.php
@@ -38,7 +38,7 @@ class Reports extends AbstractApiController
         summary: 'Fetch a single report.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -52,12 +52,12 @@ class Reports extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ReportDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -114,7 +114,7 @@ class Reports extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -128,11 +128,11 @@ class Reports extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ReportDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -159,13 +159,13 @@ class Reports extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: ReportDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -179,13 +179,13 @@ class Reports extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: ReportDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -215,14 +215,14 @@ class Reports extends AbstractApiController
                         'report',
                         ref: new Model(type: ReportDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -233,7 +233,7 @@ class Reports extends AbstractApiController
                         new OA\Property(
                             'report',
                             ref: new Model(type: ReportDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -246,14 +246,14 @@ class Reports extends AbstractApiController
                         new OA\Property(
                             'report',
                             ref: new Model(type: ReportDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -295,7 +295,7 @@ class Reports extends AbstractApiController
         summary: 'Delete a report.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -304,7 +304,7 @@ class Reports extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/SchoolConfigs.php
+++ b/src/Controller/API/SchoolConfigs.php
@@ -34,7 +34,7 @@ class SchoolConfigs extends AbstractApiController
         summary: 'Fetch a single school configuration item.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class SchoolConfigs extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SchoolConfigDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class SchoolConfigs extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class SchoolConfigs extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SchoolConfigDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class SchoolConfigs extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: SchoolConfigDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class SchoolConfigs extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SchoolConfigDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class SchoolConfigs extends AbstractApiController
                         'schoolConfig',
                         ref: new Model(type: SchoolConfigDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class SchoolConfigs extends AbstractApiController
                         new OA\Property(
                             'schoolConfig',
                             ref: new Model(type: SchoolConfigDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class SchoolConfigs extends AbstractApiController
                         new OA\Property(
                             'schoolConfig',
                             ref: new Model(type: SchoolConfigDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class SchoolConfigs extends AbstractApiController
         summary: 'Delete a session configuration item.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class SchoolConfigs extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/SchooleventController.php
+++ b/src/Controller/API/SchooleventController.php
@@ -59,7 +59,7 @@ class SchooleventController extends AbstractController
                 in: 'query',
                 required: false,
                 schema: new OA\Schema(type: 'string', format: 'date-time')
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -73,13 +73,13 @@ class SchooleventController extends AbstractController
                             items: new OA\Items(
                                 ref: new Model(type: SchoolEvent::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function getEvents(

--- a/src/Controller/API/Schools.php
+++ b/src/Controller/API/Schools.php
@@ -38,7 +38,7 @@ class Schools extends AbstractApiController
         summary: 'Fetch a single school.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -52,12 +52,12 @@ class Schools extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SchoolDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -113,7 +113,7 @@ class Schools extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -127,11 +127,11 @@ class Schools extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SchoolDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -157,13 +157,13 @@ class Schools extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: SchoolDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -177,13 +177,13 @@ class Schools extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SchoolDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -213,14 +213,14 @@ class Schools extends AbstractApiController
                         'school',
                         ref: new Model(type: SchoolDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -231,7 +231,7 @@ class Schools extends AbstractApiController
                         new OA\Property(
                             'school',
                             ref: new Model(type: SchoolDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -244,14 +244,14 @@ class Schools extends AbstractApiController
                         new OA\Property(
                             'school',
                             ref: new Model(type: SchoolDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -291,7 +291,7 @@ class Schools extends AbstractApiController
         summary: 'Delete a school.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -300,7 +300,7 @@ class Schools extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/SessionLearningMaterials.php
+++ b/src/Controller/API/SessionLearningMaterials.php
@@ -38,7 +38,7 @@ class SessionLearningMaterials extends AbstractApiController
         summary: 'Fetch a single session learning material.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -52,12 +52,12 @@ class SessionLearningMaterials extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionLearningMaterialDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -130,7 +130,7 @@ class SessionLearningMaterials extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -144,11 +144,11 @@ class SessionLearningMaterials extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionLearningMaterialDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -200,13 +200,13 @@ class SessionLearningMaterials extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: SessionLearningMaterialDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -220,13 +220,13 @@ class SessionLearningMaterials extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionLearningMaterialDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -255,14 +255,14 @@ class SessionLearningMaterials extends AbstractApiController
                         'sessionLearningMaterial',
                         ref: new Model(type: SessionLearningMaterialDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -273,7 +273,7 @@ class SessionLearningMaterials extends AbstractApiController
                         new OA\Property(
                             'sessionLearningMaterial',
                             ref: new Model(type: SessionLearningMaterialDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -286,14 +286,14 @@ class SessionLearningMaterials extends AbstractApiController
                         new OA\Property(
                             'sessionLearningMaterial',
                             ref: new Model(type: SessionLearningMaterialDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -333,7 +333,7 @@ class SessionLearningMaterials extends AbstractApiController
         summary: 'Delete a session learning material.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -342,7 +342,7 @@ class SessionLearningMaterials extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/SessionObjectives.php
+++ b/src/Controller/API/SessionObjectives.php
@@ -34,7 +34,7 @@ class SessionObjectives extends AbstractApiController
         summary: 'Fetch a single session objective.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class SessionObjectives extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionObjectiveDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class SessionObjectives extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class SessionObjectives extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionObjectiveDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class SessionObjectives extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: SessionObjectiveDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class SessionObjectives extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionObjectiveDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class SessionObjectives extends AbstractApiController
                         'sessionObjective',
                         ref: new Model(type: SessionObjectiveDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class SessionObjectives extends AbstractApiController
                         new OA\Property(
                             'sessionObjective',
                             ref: new Model(type: SessionObjectiveDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class SessionObjectives extends AbstractApiController
                         new OA\Property(
                             'sessionObjective',
                             ref: new Model(type: SessionObjectiveDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class SessionObjectives extends AbstractApiController
         summary: 'Delete a session objective.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class SessionObjectives extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/SessionTypes.php
+++ b/src/Controller/API/SessionTypes.php
@@ -34,7 +34,7 @@ class SessionTypes extends AbstractApiController
         summary: 'Fetch a single session type.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class SessionTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class SessionTypes extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class SessionTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class SessionTypes extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: SessionTypeDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class SessionTypes extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionTypeDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class SessionTypes extends AbstractApiController
                         'sessionType',
                         ref: new Model(type: SessionTypeDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class SessionTypes extends AbstractApiController
                         new OA\Property(
                             'sessionType',
                             ref: new Model(type: SessionTypeDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class SessionTypes extends AbstractApiController
                         new OA\Property(
                             'sessionType',
                             ref: new Model(type: SessionTypeDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class SessionTypes extends AbstractApiController
         summary: 'Delete a session terms.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class SessionTypes extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/Sessions.php
+++ b/src/Controller/API/Sessions.php
@@ -36,7 +36,7 @@ class Sessions extends AbstractApiController
         summary: 'Fetch a single session.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -50,12 +50,12 @@ class Sessions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -118,7 +118,7 @@ class Sessions extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -132,11 +132,11 @@ class Sessions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -184,13 +184,13 @@ class Sessions extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: SessionDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -204,13 +204,13 @@ class Sessions extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: SessionDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -239,14 +239,14 @@ class Sessions extends AbstractApiController
                         'session',
                         ref: new Model(type: SessionDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -257,7 +257,7 @@ class Sessions extends AbstractApiController
                         new OA\Property(
                             'session',
                             ref: new Model(type: SessionDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -270,14 +270,14 @@ class Sessions extends AbstractApiController
                         new OA\Property(
                             'session',
                             ref: new Model(type: SessionDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -317,7 +317,7 @@ class Sessions extends AbstractApiController
         summary: 'Delete a session.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -326,7 +326,7 @@ class Sessions extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/Terms.php
+++ b/src/Controller/API/Terms.php
@@ -34,7 +34,7 @@ class Terms extends AbstractApiController
         summary: 'Fetch a single vocabulary term.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class Terms extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: TermDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class Terms extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class Terms extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: TermDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class Terms extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: TermDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class Terms extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: TermDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class Terms extends AbstractApiController
                         'term',
                         ref: new Model(type: TermDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class Terms extends AbstractApiController
                         new OA\Property(
                             'term',
                             ref: new Model(type: TermDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class Terms extends AbstractApiController
                         new OA\Property(
                             'term',
                             ref: new Model(type: TermDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,7 +286,7 @@ class Terms extends AbstractApiController
         summary: 'Delete a vocabulary term.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -295,7 +295,7 @@ class Terms extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/UserRoles.php
+++ b/src/Controller/API/UserRoles.php
@@ -34,7 +34,7 @@ class UserRoles extends AbstractApiController
         summary: 'Fetch a single user role.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class UserRoles extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: UserRoleDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class UserRoles extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class UserRoles extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: UserRoleDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class UserRoles extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: UserRoleDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class UserRoles extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: UserRoleDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class UserRoles extends AbstractApiController
                         'userRole',
                         ref: new Model(type: UserRoleDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class UserRoles extends AbstractApiController
                         new OA\Property(
                             'userRole',
                             ref: new Model(type: UserRoleDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class UserRoles extends AbstractApiController
                         new OA\Property(
                             'userRole',
                             ref: new Model(type: UserRoleDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,12 +286,12 @@ class UserRoles extends AbstractApiController
         summary: 'Delete a user role.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function delete(

--- a/src/Controller/API/UserSessionMaterialStatuses.php
+++ b/src/Controller/API/UserSessionMaterialStatuses.php
@@ -40,7 +40,7 @@ class UserSessionMaterialStatuses extends AbstractApiController
         summary: 'Fetch a single user session learning material.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -54,12 +54,12 @@ class UserSessionMaterialStatuses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: UserSessionMaterialStatusDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -116,7 +116,7 @@ class UserSessionMaterialStatuses extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -130,11 +130,11 @@ class UserSessionMaterialStatuses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: UserSessionMaterialStatusDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -161,13 +161,13 @@ class UserSessionMaterialStatuses extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: UserSessionMaterialStatusDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -181,13 +181,13 @@ class UserSessionMaterialStatuses extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: UserSessionMaterialStatusDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -217,14 +217,14 @@ class UserSessionMaterialStatuses extends AbstractApiController
                         'userSessionMaterialStatuses',
                         ref: new Model(type: UserSessionMaterialStatusDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -235,7 +235,7 @@ class UserSessionMaterialStatuses extends AbstractApiController
                         new OA\Property(
                             'userSessionMaterialStatuses',
                             ref: new Model(type: UserSessionMaterialStatusDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -248,14 +248,14 @@ class UserSessionMaterialStatuses extends AbstractApiController
                         new OA\Property(
                             'userSessionMaterialStatuses',
                             ref: new Model(type: UserSessionMaterialStatusDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -297,7 +297,7 @@ class UserSessionMaterialStatuses extends AbstractApiController
         summary: 'Delete a user session learning material.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -306,7 +306,7 @@ class UserSessionMaterialStatuses extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/UsereventController.php
+++ b/src/Controller/API/UsereventController.php
@@ -59,7 +59,7 @@ class UsereventController extends AbstractController
                 in: 'query',
                 required: false,
                 schema: new OA\Schema(type: 'string', format: 'date-time')
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -73,13 +73,13 @@ class UsereventController extends AbstractController
                             items: new OA\Items(
                                 ref: new Model(type: UserEvent::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function getEvents(

--- a/src/Controller/API/UsermaterialController.php
+++ b/src/Controller/API/UsermaterialController.php
@@ -74,13 +74,13 @@ class UsermaterialController extends AbstractController
                             items: new OA\Items(
                                 ref: new Model(type: UserMaterial::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function getMaterials(

--- a/src/Controller/API/Users.php
+++ b/src/Controller/API/Users.php
@@ -53,7 +53,7 @@ class Users extends AbstractApiController
         summary: 'Fetch a single user.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -67,12 +67,12 @@ class Users extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: UserDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -136,7 +136,7 @@ class Users extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -150,11 +150,11 @@ class Users extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: UserDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -209,13 +209,13 @@ class Users extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: UserDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -229,13 +229,13 @@ class Users extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: UserDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -294,14 +294,14 @@ class Users extends AbstractApiController
                         'user',
                         ref: new Model(type: UserDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -312,7 +312,7 @@ class Users extends AbstractApiController
                         new OA\Property(
                             'user',
                             ref: new Model(type: UserDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -325,14 +325,14 @@ class Users extends AbstractApiController
                         new OA\Property(
                             'user',
                             ref: new Model(type: UserDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -414,7 +414,7 @@ class Users extends AbstractApiController
         summary: 'Delete a user.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
@@ -423,7 +423,7 @@ class Users extends AbstractApiController
             new OA\Response(
                 response: '500',
                 description: 'Deletion failed (usually caused by non-cascading relationships).'
-            )
+            ),
         ]
     )]
     public function delete(

--- a/src/Controller/API/Vocabularies.php
+++ b/src/Controller/API/Vocabularies.php
@@ -34,7 +34,7 @@ class Vocabularies extends AbstractApiController
         summary: 'Fetch a single vocabulary.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -48,12 +48,12 @@ class Vocabularies extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: VocabularyDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
-            new OA\Response(response: '404', description: 'Not found.')
+            new OA\Response(response: '404', description: 'Not found.'),
         ]
     )]
     public function getOne(
@@ -109,7 +109,7 @@ class Vocabularies extends AbstractApiController
                     items: new OA\Items(type: 'string'),
                 ),
                 style: "deepObject"
-            )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -123,11 +123,11 @@ class Vocabularies extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: VocabularyDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
-            )
+            ),
         ]
     )]
     public function getAll(
@@ -153,13 +153,13 @@ class Vocabularies extends AbstractApiController
                         items: new OA\Items(
                             ref: new Model(type: VocabularyDTO::class)
                         )
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
-            new OA\Parameter(name: 'version', description: 'API Version', in: 'path')
+            new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -173,13 +173,13 @@ class Vocabularies extends AbstractApiController
                             items: new OA\Items(
                                 ref: new Model(type: VocabularyDTO::class)
                             )
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
-            new OA\Response(response: '403', description: 'Access Denied.')
+            new OA\Response(response: '403', description: 'Access Denied.'),
         ]
     )]
     public function post(
@@ -208,14 +208,14 @@ class Vocabularies extends AbstractApiController
                         'vocabulary',
                         ref: new Model(type: VocabularyDTO::class),
                         type: 'object'
-                    )
+                    ),
                 ],
                 type: 'object',
             )
         ),
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(
@@ -226,7 +226,7 @@ class Vocabularies extends AbstractApiController
                         new OA\Property(
                             'vocabulary',
                             ref: new Model(type: VocabularyDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
@@ -239,14 +239,14 @@ class Vocabularies extends AbstractApiController
                         new OA\Property(
                             'vocabulary',
                             ref: new Model(type: VocabularyDTO::class)
-                        )
+                        ),
                     ],
                     type: 'object'
                 )
             ),
             new OA\Response(response: '400', description: 'Bad Request Data.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function put(
@@ -286,12 +286,12 @@ class Vocabularies extends AbstractApiController
         summary: 'Delete a vocabulary.',
         parameters: [
             new OA\Parameter(name: 'version', description: 'API Version', in: 'path'),
-            new OA\Parameter(name: 'id', description: 'id', in: 'path')
+            new OA\Parameter(name: 'id', description: 'id', in: 'path'),
         ],
         responses: [
             new OA\Response(response: '204', description: 'Deleted.'),
             new OA\Response(response: '403', description: 'Access Denied.'),
-            new OA\Response(response: '404', description: 'Not Found.')
+            new OA\Response(response: '404', description: 'Not Found.'),
         ]
     )]
     public function delete(

--- a/src/Controller/DownloadController.php
+++ b/src/Controller/DownloadController.php
@@ -60,7 +60,7 @@ class DownloadController extends AbstractController
 
         $headers = [
             'Content-Type' => $learningMaterial->getMimetype(),
-            'Content-Disposition' => 'attachment; filename="' . $learningMaterial->getFilename() . '"'
+            'Content-Disposition' => 'attachment; filename="' . $learningMaterial->getFilename() . '"',
         ];
 
         // d/l PDFs inline if requested so.

--- a/src/Controller/ExceptionController.php
+++ b/src/Controller/ExceptionController.php
@@ -36,7 +36,7 @@ class ExceptionController
 
         $json = json_encode([
             'code' => $code,
-            'message' => $safeMessage
+            'message' => $safeMessage,
         ]);
         $response->setContent($json);
         $response->headers->set('Content-Type', 'application/json');

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -175,7 +175,7 @@ class IndexController extends AbstractController
             'styles' => $styles,
             'noScripts' => $noScripts,
             'divs' => $divs,
-            'errorCaptureEnabled' => $this->config->get('errorCaptureEnabled')
+            'errorCaptureEnabled' => $this->config->get('errorCaptureEnabled'),
         ];
     }
 

--- a/src/Controller/UploadController.php
+++ b/src/Controller/UploadController.php
@@ -32,7 +32,7 @@ class UploadController extends AbstractController
         if (is_null($uploadedFile)) {
             return new JsonResponse([
                 'errors' => 'Unable to find file in the request. ' .
-                            'The uploaded file may have exceeded the maximum allowed size'
+                            'The uploaded file may have exceeded the maximum allowed size',
             ], JsonResponse::HTTP_BAD_REQUEST);
         }
         if (!$uploadedFile->isValid()) {
@@ -41,7 +41,7 @@ class UploadController extends AbstractController
         $hash = $iliosFileSystem->storeUploadedTemporaryFile($uploadedFile);
         $response = [
             'filename' => $uploadedFile->getClientOriginalName(),
-            'fileHash' => $hash
+            'fileHash' => $hash,
         ];
         return new JsonResponse($response, JsonResponse::HTTP_OK);
     }

--- a/src/Entity/DTO/AamcMethodDTO.php
+++ b/src/Entity/DTO/AamcMethodDTO.php
@@ -32,7 +32,7 @@ use OpenApi\Attributes as OA;
             description: "Session types",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class AamcMethodDTO

--- a/src/Entity/DTO/AamcPcrsDTO.php
+++ b/src/Entity/DTO/AamcPcrsDTO.php
@@ -27,7 +27,7 @@ use OpenApi\Attributes as OA;
             description: "Competencies",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class AamcPcrsDTO

--- a/src/Entity/DTO/AamcResourceTypeDTO.php
+++ b/src/Entity/DTO/AamcResourceTypeDTO.php
@@ -32,7 +32,7 @@ use OpenApi\Attributes as OA;
             description: "Vocabulary terms",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class AamcResourceTypeDTO

--- a/src/Entity/DTO/AlertChangeTypeDTO.php
+++ b/src/Entity/DTO/AlertChangeTypeDTO.php
@@ -26,7 +26,7 @@ use OpenApi\Attributes as OA;
             description: "Alerts",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class AlertChangeTypeDTO

--- a/src/Entity/DTO/AlertDTO.php
+++ b/src/Entity/DTO/AlertDTO.php
@@ -53,7 +53,7 @@ use OpenApi\Attributes as OA;
             description: "Recipient schools",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class AlertDTO

--- a/src/Entity/DTO/AssessmentOptionDTO.php
+++ b/src/Entity/DTO/AssessmentOptionDTO.php
@@ -27,7 +27,7 @@ use OpenApi\Attributes as OA;
             description: "Session types",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class AssessmentOptionDTO

--- a/src/Entity/DTO/AuthenticationDTO.php
+++ b/src/Entity/DTO/AuthenticationDTO.php
@@ -20,7 +20,7 @@ use OpenApi\Attributes as OA;
             "username",
             description: "Username",
             type: "string"
-        )
+        ),
     ]
 )]
 class AuthenticationDTO

--- a/src/Entity/DTO/CohortDTO.php
+++ b/src/Entity/DTO/CohortDTO.php
@@ -45,7 +45,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Users",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('schools', 'array<integer>')]

--- a/src/Entity/DTO/CurriculumInventoryAcademicLevelDTO.php
+++ b/src/Entity/DTO/CurriculumInventoryAcademicLevelDTO.php
@@ -49,7 +49,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Ending sequence blocks",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class CurriculumInventoryAcademicLevelDTO

--- a/src/Entity/DTO/CurriculumInventoryExportDTO.php
+++ b/src/Entity/DTO/CurriculumInventoryExportDTO.php
@@ -34,7 +34,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Created at",
             type: "string",
             format: "date-time"
-        )
+        ),
     ]
 )]
 class CurriculumInventoryExportDTO

--- a/src/Entity/DTO/IlmSessionDTO.php
+++ b/src/Entity/DTO/IlmSessionDTO.php
@@ -58,7 +58,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Learners",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('courses', 'array<integer>')]

--- a/src/Entity/DTO/IngestionExceptionDTO.php
+++ b/src/Entity/DTO/IngestionExceptionDTO.php
@@ -25,7 +25,7 @@ use OpenApi\Attributes as OA;
             "user",
             description: "User",
             type: "integer"
-        )
+        ),
     ]
 )]
 class IngestionExceptionDTO

--- a/src/Entity/DTO/LearnerGroupDTO.php
+++ b/src/Entity/DTO/LearnerGroupDTO.php
@@ -93,7 +93,7 @@ use OpenApi\Attributes as OA;
             description: "Instructors",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('cohorts', 'array<integer>')]

--- a/src/Entity/DTO/MeshConceptDTO.php
+++ b/src/Entity/DTO/MeshConceptDTO.php
@@ -66,7 +66,7 @@ use OpenApi\Attributes as OA;
             description: "MeSH descriptors",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class MeshConceptDTO

--- a/src/Entity/DTO/MeshDescriptorDTO.php
+++ b/src/Entity/DTO/MeshDescriptorDTO.php
@@ -109,7 +109,7 @@ use OpenApi\Attributes as OA;
             description: "Course learning materials",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('learningMaterials', 'array<integer>')]

--- a/src/Entity/DTO/MeshPreviousIndexingDTO.php
+++ b/src/Entity/DTO/MeshPreviousIndexingDTO.php
@@ -26,7 +26,7 @@ use OpenApi\Attributes as OA;
             "descriptor",
             description: "MeSH descriptor",
             type: "string"
-        )
+        ),
     ]
 )]
 class MeshPreviousIndexingDTO

--- a/src/Entity/DTO/MeshQualifierDTO.php
+++ b/src/Entity/DTO/MeshQualifierDTO.php
@@ -40,7 +40,7 @@ use OpenApi\Attributes as OA;
             description: "MeSH descriptors",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class MeshQualifierDTO

--- a/src/Entity/DTO/MeshTermDTO.php
+++ b/src/Entity/DTO/MeshTermDTO.php
@@ -65,7 +65,7 @@ use OpenApi\Attributes as OA;
             description: "MeSH concepts",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class MeshTermDTO

--- a/src/Entity/DTO/MeshTreeDTO.php
+++ b/src/Entity/DTO/MeshTreeDTO.php
@@ -26,7 +26,7 @@ use OpenApi\Attributes as OA;
             "descriptor",
             description: "MeSH descriptor",
             type: "string"
-        )
+        ),
     ]
 )]
 class MeshTreeDTO

--- a/src/Entity/DTO/OfferingDTO.php
+++ b/src/Entity/DTO/OfferingDTO.php
@@ -80,7 +80,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Instructors",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('sessions', 'array<integer>')]

--- a/src/Entity/DTO/PendingUserUpdateDTO.php
+++ b/src/Entity/DTO/PendingUserUpdateDTO.php
@@ -35,7 +35,7 @@ use OpenApi\Attributes as OA;
             "user",
             description: "User",
             type: "integer"
-        )
+        ),
     ]
 )]
 class PendingUserUpdateDTO

--- a/src/Entity/DTO/ProgramYearDTO.php
+++ b/src/Entity/DTO/ProgramYearDTO.php
@@ -66,7 +66,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Program year objectives",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('courses', 'array<integer>')]

--- a/src/Entity/DTO/ProgramYearObjectiveDTO.php
+++ b/src/Entity/DTO/ProgramYearObjectiveDTO.php
@@ -71,7 +71,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Descendants",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class ProgramYearObjectiveDTO

--- a/src/Entity/DTO/ReportDTO.php
+++ b/src/Entity/DTO/ReportDTO.php
@@ -53,7 +53,7 @@ use OpenApi\Attributes as OA;
             "user",
             description: "User",
             type: "integer"
-        )
+        ),
     ]
 )]
 class ReportDTO

--- a/src/Entity/DTO/SchoolConfigDTO.php
+++ b/src/Entity/DTO/SchoolConfigDTO.php
@@ -30,7 +30,7 @@ use OpenApi\Attributes as OA;
             "school",
             description: "School",
             type: "integer"
-        )
+        ),
     ]
 )]
 class SchoolConfigDTO

--- a/src/Entity/DTO/SchoolDTO.php
+++ b/src/Entity/DTO/SchoolDTO.php
@@ -36,7 +36,7 @@ use OpenApi\Attributes as OA;
             "changeAlertRecipients",
             description: "Change alert recipients",
             type: "string"
-        )
+        ),
     ]
 )]
 class SchoolDTO

--- a/src/Entity/DTO/SessionObjectiveDTO.php
+++ b/src/Entity/DTO/SessionObjectiveDTO.php
@@ -61,7 +61,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Descendants",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('courses', 'array<integer>')]

--- a/src/Entity/DTO/SessionTypeDTO.php
+++ b/src/Entity/DTO/SessionTypeDTO.php
@@ -58,7 +58,7 @@ use OpenApi\Attributes as OA;
             description: "Sessions",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('courses', 'array<integer>')]

--- a/src/Entity/DTO/TermDTO.php
+++ b/src/Entity/DTO/TermDTO.php
@@ -90,7 +90,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Program year objectives",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('sessionTypes', 'array<integer>')]

--- a/src/Entity/DTO/UserDTO.php
+++ b/src/Entity/DTO/UserDTO.php
@@ -250,7 +250,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
             description: "Audit logs",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 #[IA\FilterableBy('roles', 'array<integer>')]

--- a/src/Entity/DTO/UserRoleDTO.php
+++ b/src/Entity/DTO/UserRoleDTO.php
@@ -20,7 +20,7 @@ use OpenApi\Attributes as OA;
             "title",
             description: "Title",
             type: "string"
-        )
+        ),
     ]
 )]
 class UserRoleDTO

--- a/src/Entity/DTO/VocabularyDTO.php
+++ b/src/Entity/DTO/VocabularyDTO.php
@@ -37,7 +37,7 @@ use OpenApi\Attributes as OA;
             description: "Vocabulary terms",
             type: "array",
             items: new OA\Items(type: "string")
-        )
+        ),
     ]
 )]
 class VocabularyDTO

--- a/src/EventListener/LogEntityChanges.php
+++ b/src/EventListener/LogEntityChanges.php
@@ -43,7 +43,7 @@ class LogEntityChanges
                     $updates[$entity::class] = [
                         'entity' => $entity,
                         'action' => $action,
-                        'changes' => array_keys($changes)
+                        'changes' => array_keys($changes),
                     ];
                 }
             }
@@ -60,7 +60,7 @@ class LogEntityChanges
                     $updates[$entityClass] = [
                         'entity' => $entity,
                         'action' => 'update',
-                        'changes' => []
+                        'changes' => [],
                     ];
                 }
                 $ref = new ReflectionClass($change);
@@ -78,7 +78,7 @@ class LogEntityChanges
                     $updates[$entityClass] = [
                         'entity' => $entity,
                         'action' => 'update',
-                        'changes' => []
+                        'changes' => [],
                     ];
                 }
                 $ref = new ReflectionClass($change);

--- a/src/EventSubscriber/RedirectInsecureConnections.php
+++ b/src/EventSubscriber/RedirectInsecureConnections.php
@@ -25,7 +25,7 @@ class RedirectInsecureConnections implements EventSubscriberInterface
         return [
             KernelEvents::REQUEST => [
                 ['checkAndRedirect', 10],
-            ]
+            ],
         ];
     }
 

--- a/src/Monitor/RequiredENV.php
+++ b/src/Monitor/RequiredENV.php
@@ -15,7 +15,7 @@ class RequiredENV implements CheckInterface
         'ILIOS_DATABASE_URL',
         'ILIOS_LOCALE',
         'ILIOS_SECRET',
-        'MAILER_DSN'
+        'MAILER_DSN',
     ];
     private const INSTRUCTIONS_URL = 'https://github.com/ilios/ilios/blob/master/docs/env_vars_and_config.md';
     private const UPDATE_URL = 'https://github.com/ilios/ilios/blob/master/docs/update.md';

--- a/src/RelationshipVoter/IliosFileSystem.php
+++ b/src/RelationshipVoter/IliosFileSystem.php
@@ -18,7 +18,7 @@ class IliosFileSystem extends AbstractVoter
             $permissionChecker,
             FileSystem::class,
             [
-                VoterPermissions::CREATE_TEMPORARY_FILE
+                VoterPermissions::CREATE_TEMPORARY_FILE,
             ]
         );
     }

--- a/src/Repository/AlertRepository.php
+++ b/src/Repository/AlertRepository.php
@@ -47,7 +47,7 @@ class AlertRepository extends ServiceEntityRepository implements DTORepositoryIn
             [
                 'changeTypes',
                 'instigators',
-                'recipients'
+                'recipients',
             ],
         );
 

--- a/src/Repository/CohortRepository.php
+++ b/src/Repository/CohortRepository.php
@@ -62,7 +62,7 @@ class CohortRepository extends ServiceEntityRepository implements DTORepositoryI
             [
                 'courses',
                 'learnerGroups',
-                'users'
+                'users',
             ],
         );
 

--- a/src/Repository/CompetencyRepository.php
+++ b/src/Repository/CompetencyRepository.php
@@ -66,7 +66,7 @@ class CompetencyRepository extends ServiceEntityRepository implements
                 'programYearObjectives',
                 'children',
                 'aamcPcrses',
-                'programYears'
+                'programYears',
             ],
         );
 

--- a/src/Repository/CourseClerkshipTypeRepository.php
+++ b/src/Repository/CourseClerkshipTypeRepository.php
@@ -49,7 +49,7 @@ class CourseClerkshipTypeRepository extends ServiceEntityRepository implements
         $dtos = $this->attachRelatedToDtos(
             $dtos,
             [
-                'courses'
+                'courses',
             ],
         );
 

--- a/src/Repository/CourseLearningMaterialRepository.php
+++ b/src/Repository/CourseLearningMaterialRepository.php
@@ -75,7 +75,7 @@ class CourseLearningMaterialRepository extends ServiceEntityRepository implement
         $dtos = $this->attachRelatedToDtos(
             $dtos,
             [
-                'meshDescriptors'
+                'meshDescriptors',
             ],
         );
 

--- a/src/Repository/CourseObjectiveRepository.php
+++ b/src/Repository/CourseObjectiveRepository.php
@@ -82,7 +82,7 @@ class CourseObjectiveRepository extends ServiceEntityRepository implements DTORe
                 'programYearObjectives',
                 'sessionObjectives',
                 'meshDescriptors',
-                'descendants'
+                'descendants',
             ],
         );
 

--- a/src/Repository/IlmSessionRepository.php
+++ b/src/Repository/IlmSessionRepository.php
@@ -83,7 +83,7 @@ class IlmSessionRepository extends ServiceEntityRepository implements DTOReposit
             'learners',
             'learnerGroups',
             'instructors',
-            'instructorGroups'
+            'instructorGroups',
         ];
         foreach ($related as $rel) {
             if (array_key_exists($rel, $criteria)) {

--- a/src/Repository/MeshDescriptorRepository.php
+++ b/src/Repository/MeshDescriptorRepository.php
@@ -473,7 +473,7 @@ EOL;
                     'annotation' => $descriptor->getAnnotation(),
                     'updated_at' => $now,
                 ], [
-                    'mesh_descriptor_uid' => $descriptor->getUi()
+                    'mesh_descriptor_uid' => $descriptor->getUi(),
                 ], [
                     PDO::PARAM_STR,
                     PDO::PARAM_STR,
@@ -491,7 +491,7 @@ EOL;
                     PDO::PARAM_STR,
                     PDO::PARAM_STR,
                     'datetime',
-                    'datetime'
+                    'datetime',
                 ]);
             }
             /* @var Concept $concept */
@@ -513,7 +513,7 @@ EOL;
                     PDO::PARAM_STR,
                     PDO::PARAM_STR,
                     'datetime',
-                    'datetime'
+                    'datetime',
                 ]);
             }
             /* @var Term $term */

--- a/src/Repository/OfferingRepository.php
+++ b/src/Repository/OfferingRepository.php
@@ -142,7 +142,7 @@ class OfferingRepository extends ServiceEntityRepository implements DTORepositor
             'learnerGroups',
             'instructorGroups',
             'learners',
-            'instructors'
+            'instructors',
         ];
         foreach ($related as $rel) {
             if (array_key_exists($rel, $criteria)) {

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1168,7 +1168,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             if (!array_key_exists($arr['id'], $sessions)) {
                 $sessions[$arr['id']] = [
                     'firstOfferingDate' => $arr['startDate'],
-                    'instructors' => []
+                    'instructors' => [],
                 ];
             }
             if ($arr['startDate'] < $sessions[$arr['id']]['firstOfferingDate']) {
@@ -1182,7 +1182,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             if (!array_key_exists($arr['id'], $sessions)) {
                 $sessions[$arr['id']] = [
                     'firstOfferingDate' => $arr['dueDate'],
-                    'instructors' => []
+                    'instructors' => [],
                 ];
             }
             if ($arr['dueDate'] < $sessions[$arr['id']]['firstOfferingDate']) {
@@ -1737,15 +1737,15 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             [['ilm' => 'u.instructorIlmSessions'], CalendarEventUserContext::INSTRUCTOR],
             [
                 ['dc' => 'u.directedCourses', 'sess' => 'dc.sessions', 'ilm' => 'sess.ilmSession'],
-                CalendarEventUserContext::COURSE_DIRECTOR
+                CalendarEventUserContext::COURSE_DIRECTOR,
             ],
             [
                 ['ac' => 'u.administeredCourses', 'sess' => 'ac.sessions', 'ilm' => 'sess.ilmSession'],
-                CalendarEventUserContext::COURSE_ADMINISTRATOR
+                CalendarEventUserContext::COURSE_ADMINISTRATOR,
             ],
             [
                 ['sess' => 'u.administeredSessions', 'ilm' => 'sess.ilmSession'],
-                CalendarEventUserContext::SESSION_ADMINISTRATOR
+                CalendarEventUserContext::SESSION_ADMINISTRATOR,
             ],
         ];
     }
@@ -1759,15 +1759,15 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             [['o' => 'u.instructedOfferings'], CalendarEventUserContext::INSTRUCTOR],
             [
                 ['dc' => 'u.directedCourses', 'dcs' => 'dc.sessions', 'o' => 'dcs.offerings'],
-                CalendarEventUserContext::COURSE_DIRECTOR
+                CalendarEventUserContext::COURSE_DIRECTOR,
             ],
             [
                 ['ac' => 'u.administeredCourses', 'acs' => 'ac.sessions', 'o' => 'acs.offerings'],
-                CalendarEventUserContext::COURSE_ADMINISTRATOR
+                CalendarEventUserContext::COURSE_ADMINISTRATOR,
             ],
             [
                 ['sess' => 'u.administeredSessions', 'o' => 'sess.offerings'],
-                CalendarEventUserContext::SESSION_ADMINISTRATOR
+                CalendarEventUserContext::SESSION_ADMINISTRATOR,
             ],
 
         ];

--- a/src/Service/ApiRequestParser.php
+++ b/src/Service/ApiRequestParser.php
@@ -27,7 +27,7 @@ class ApiRequestParser
             'offset' => $request->query->has('offset') ? (int) $request->query->all()['offset'] : null,
             'limit' => $request->query->has('limit') ? (int) $request->query->all()['limit'] : null,
             'orderBy' => $request->query->has('order_by') ? $request->query->all()['order_by'] : null,
-            'criteria' => []
+            'criteria' => [],
         ];
 
 

--- a/src/Service/ApiResponseBuilder.php
+++ b/src/Service/ApiResponseBuilder.php
@@ -127,7 +127,7 @@ class ApiResponseBuilder
     {
         $json = $this->serializer->serialize($data, 'json-api', [
             'sideLoadFields' => $this->extractJsonApiSideLoadFields($include),
-            'singleItem' => $singleItem
+            'singleItem' => $singleItem,
         ]);
         return new Response(
             $json,

--- a/src/Service/CasAuthentication.php
+++ b/src/Service/CasAuthentication.php
@@ -130,7 +130,7 @@ class CasAuthentication implements AuthenticationInterface
         $logoutUrl = $this->casManager->getLogoutUrl();
         $response =  new JsonResponse([
             'status' => 'redirect',
-            'logoutUrl' => $logoutUrl
+            'logoutUrl' => $logoutUrl,
         ], JsonResponse::HTTP_OK);
         $response->headers->clearCookie(self::JWT_COOKIE);
 

--- a/src/Service/ChangeAlertHandler.php
+++ b/src/Service/ChangeAlertHandler.php
@@ -109,7 +109,7 @@ class ChangeAlertHandler
         $alert = $this->alertRepository->findOneBy([
             'dispatched' => false,
             'tableName' => 'offering',
-            'tableRowId' => $offering->getId()
+            'tableRowId' => $offering->getId(),
         ]);
 
         if (! $alert) {

--- a/src/Service/CurriculumInventory/Export/XmlPrinter.php
+++ b/src/Service/CurriculumInventory/Export/XmlPrinter.php
@@ -329,7 +329,7 @@ class XmlPrinter
             $topLevelSequenceBlocks,
             [
                 'App\Entity\CurriculumInventorySequenceBlock',
-                'compareSequenceBlocksWithDefaultStrategy'
+                'compareSequenceBlocksWithDefaultStrategy',
             ]
         );
         foreach ($topLevelSequenceBlocks as $block) {

--- a/src/Service/FilesystemFactory.php
+++ b/src/Service/FilesystemFactory.php
@@ -115,7 +115,7 @@ class FilesystemFactory
             ],
             'region' => $matches[5],
             'version' => 'latest',
-            'bucket' => $matches[4]
+            'bucket' => $matches[4],
         ];
     }
 }

--- a/src/Service/FormAuthentication.php
+++ b/src/Service/FormAuthentication.php
@@ -88,7 +88,7 @@ class FormAuthentication implements AuthenticationInterface
     public function logout(Request $request): JsonResponse
     {
         return new JsonResponse([
-            'status' => 'success'
+            'status' => 'success',
         ], JsonResponse::HTTP_OK);
     }
 

--- a/src/Service/GraphQL/DeferredBuffer.php
+++ b/src/Service/GraphQL/DeferredBuffer.php
@@ -62,7 +62,7 @@ class DeferredBuffer
             $ref = $this->dtoInfo->getRefForType($type);
             $idField = $this->entityMetadata->extractId($ref);
             $values = $repository->findDTOsBy([
-                "{$idField}" => $uncachedIds
+                "{$idField}" => $uncachedIds,
             ]);
             foreach ($values as $dto) {
                 $this->cachedValues[$type][$dto->{$idField}] = $dto;

--- a/src/Service/GraphQL/TypeRegistry.php
+++ b/src/Service/GraphQL/TypeRegistry.php
@@ -54,7 +54,7 @@ class TypeRegistry
             'resolve' => $this->typeResolver,
             'extensions' => [
                 'dtoClassName' => $name,
-            ]
+            ],
         ];
 
         if ($includeArgs) {

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -39,7 +39,7 @@ class Curriculum extends OpenSearchBase
                 'completion' => [
                     'field' => "{$field}.cmp",
                     'skip_duplicates' => true,
-                ]
+                ],
             ];
 
             return $carry;
@@ -58,8 +58,8 @@ class Curriculum extends OpenSearchBase
                     'school',
                 ],
                 'sort' => '_score',
-                'size' => 1000
-            ]
+                'size' => 1000,
+            ],
         ];
 
         if (!$onlySuggest) {
@@ -120,9 +120,9 @@ class Curriculum extends OpenSearchBase
             'index' => self::INDEX,
             'body' => [
                 'query' => [
-                    'term' => ['courseId' => $id]
-                ]
-            ]
+                    'term' => ['courseId' => $id],
+                ],
+            ],
         ]);
 
         return !count($result['failures']);
@@ -135,7 +135,7 @@ class Curriculum extends OpenSearchBase
     {
         $result = $this->doDelete([
             'index' => self::INDEX,
-            'id' => self::SESSION_ID_PREFIX . $id
+            'id' => self::SESSION_ID_PREFIX . $id,
         ]);
 
         return $result['result'] === 'deleted';
@@ -153,14 +153,14 @@ class Curriculum extends OpenSearchBase
                 'body' => [
                     'query' => [
                         'terms' => [
-                            'learningMaterialId' => $learningMaterialIds
-                        ]
+                            'learningMaterialId' => $learningMaterialIds,
+                        ],
                     ],
                     "_source" => [
                         'learningMaterialId',
                         'material.content',
-                    ]
-                ]
+                    ],
+                ],
             ];
             $results = $this->doSearch($params);
 
@@ -278,7 +278,7 @@ class Curriculum extends OpenSearchBase
          * but we wrap it in a should block so they don't all have to match
          */
         $must = ['bool' => [
-            'should' => $mustMatch
+            'should' => $mustMatch,
         ]];
 
         /**
@@ -304,7 +304,7 @@ class Curriculum extends OpenSearchBase
             'bool' => [
                 'must' => $must,
                 'should' => $should,
-            ]
+            ],
         ];
     }
 
@@ -394,7 +394,7 @@ class Curriculum extends OpenSearchBase
 
         return [
             'autocomplete' => $autocompleteSuggestions,
-            'courses' => $courses
+            'courses' => $courses,
         ];
     }
 
@@ -416,7 +416,7 @@ class Curriculum extends OpenSearchBase
                 'raw' => [
                     'type' => 'text',
                     'analyzer' => 'keyword',
-                ]
+                ],
             ],
         ];
         $txtTypeFieldWithCompletion = $txtTypeField;
@@ -441,8 +441,8 @@ class Curriculum extends OpenSearchBase
                         'type' => 'keyword',
                         'fields' => [
                             'cmp' => [
-                                'type' => 'completion'
-                            ]
+                                'type' => 'completion',
+                            ],
                         ],
                     ],
                     'courseYear' => [
@@ -463,7 +463,7 @@ class Curriculum extends OpenSearchBase
                                 // we have to override the analyzer here because the default strips
                                 // out numbers and mesh ids are mostly numbers
                                 'analyzer' => 'standard',
-                            ]
+                            ],
                         ],
                     ],
                     'courseMeshDescriptorNames' => $txtTypeFieldWithCompletion,
@@ -477,8 +477,8 @@ class Curriculum extends OpenSearchBase
                         'type' => 'keyword',
                         'fields' => [
                             'cmp' => [
-                                'type' => 'completion'
-                            ]
+                                'type' => 'completion',
+                            ],
                         ],
                     ],
                     'sessionTerms' => $txtTypeFieldWithCompletion,
@@ -495,13 +495,13 @@ class Curriculum extends OpenSearchBase
                                 // we have to override the analyzer here because the default strips
                                 // out numbers and mesh ids are mostly numbers
                                 'analyzer' => 'standard',
-                            ]
+                            ],
                         ],
                     ],
                     'sessionMeshDescriptorNames' => $txtTypeFieldWithCompletion,
                     'sessionMeshDescriptorAnnotations' => $txtTypeField,
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
@@ -526,7 +526,7 @@ class Curriculum extends OpenSearchBase
                     'max_gram' => 15,
                     'token_chars' => [
                         'letter',
-                        'digit'
+                        'digit',
                     ],
                 ],
             ],

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -48,7 +48,7 @@ class LearningMaterials extends OpenSearchBase
             foreach ($this->extractLearningMaterialData($lm) as $data) {
                 $materials[] = [
                     'id' => $lm->id,
-                    'data' => $data
+                    'data' => $data,
                 ];
             }
             return $materials;
@@ -61,7 +61,7 @@ class LearningMaterials extends OpenSearchBase
                 'body' => [
                     'learningMaterialId' => $arr['id'],
                     'data' => $arr['data'],
-                ]
+                ],
             ];
             return $this->client->index($params);
         }, $extractedMaterials);
@@ -80,9 +80,9 @@ class LearningMaterials extends OpenSearchBase
             'index' => self::INDEX,
             'body' => [
                 'query' => [
-                    'term' => ['learningMaterialId' => $id]
-                ]
-            ]
+                    'term' => ['learningMaterialId' => $id],
+                ],
+            ],
         ]);
 
         return !count($result['failures']);
@@ -110,7 +110,7 @@ class LearningMaterials extends OpenSearchBase
         $encodedData = base64_encode($data);
         if (strlen($encodedData) < $this->uploadLimit) {
             return [
-                $encodedData
+                $encodedData,
             ];
         }
 
@@ -130,13 +130,13 @@ class LearningMaterials extends OpenSearchBase
                 ],
                 'properties' => [
                     'learningMaterialId' => [
-                        'type' => 'integer'
+                        'type' => 'integer',
                     ],
                     'material' => [
-                        'type' => 'object'
+                        'type' => 'object',
                     ],
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
@@ -151,10 +151,10 @@ class LearningMaterials extends OpenSearchBase
                         'attachment' => [
                             'field' => 'data',
                             'target_field' => 'material',
-                        ]
-                    ]
-                ]
-            ]
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/src/Service/Index/Manager.php
+++ b/src/Service/Index/Manager.php
@@ -34,21 +34,21 @@ class Manager extends OpenSearchBase
 
         $this->client->indices()->create([
             'index' => Users::INDEX,
-            'body' => Users::getMapping()
+            'body' => Users::getMapping(),
         ]);
         $this->client->indices()->create([
             'index' => Mesh::INDEX,
-            'body' => Mesh::getMapping()
+            'body' => Mesh::getMapping(),
         ]);
         $this->client->indices()->create([
             'index' => Curriculum::INDEX,
-            'body' => Curriculum::getMapping()
+            'body' => Curriculum::getMapping(),
         ]);
 
         $this->client->ingest()->putPipeline(LearningMaterials::getPipeline());
         $this->client->indices()->create([
             'index' => LearningMaterials::INDEX,
-            'body' => LearningMaterials::getMapping()
+            'body' => LearningMaterials::getMapping(),
         ]);
     }
 

--- a/src/Service/Index/Mesh.php
+++ b/src/Service/Index/Mesh.php
@@ -25,12 +25,12 @@ class Mesh extends OpenSearchBase
                 'query' => [
                     'query_string' => [
                         'query' => "*{$query}*",
-                    ]
+                    ],
                 ],
                 "_source" => [
-                    '_id'
-                ]
-            ]
+                    '_id',
+                ],
+            ],
         ];
         $results = $this->doSearch($params);
         return array_map(fn(array $arr) => $arr['_id'], $results['hits']['hits']);

--- a/src/Service/Index/Users.php
+++ b/src/Service/Index/Users.php
@@ -80,7 +80,7 @@ class Users extends OpenSearchBase
                 'completion' => [
                     'field' => "{$field}",
                     'skip_duplicates' => true,
-                ]
+                ],
             ];
 
             return $carry;
@@ -102,8 +102,8 @@ class Users extends OpenSearchBase
                     'email',
                     'enabled',
                 ],
-                'sort' => '_score'
-            ]
+                'sort' => '_score',
+            ],
         ];
 
         if (!$onlySuggest) {
@@ -125,8 +125,8 @@ class Users extends OpenSearchBase
                         'campusId^5',
                         'email',
                         'email.email^5',
-                    ]
-                ]
+                    ],
+                ],
             ];
         }
 
@@ -146,7 +146,7 @@ class Users extends OpenSearchBase
 
         return [
             'autocomplete' => $autocompleteSuggestions,
-            'users' => $users
+            'users' => $users,
         ];
     }
     public static function getMapping(): array
@@ -173,7 +173,7 @@ class Users extends OpenSearchBase
                         'fields' => [
                             'raw' => [
                                 'type' => 'keyword',
-                            ]
+                            ],
                         ],
                     ],
                     'middleName' => [
@@ -183,7 +183,7 @@ class Users extends OpenSearchBase
                         'fields' => [
                             'raw' => [
                                 'type' => 'keyword',
-                            ]
+                            ],
                         ],
                     ],
                     'lastName' => [
@@ -193,7 +193,7 @@ class Users extends OpenSearchBase
                         'fields' => [
                             'raw' => [
                                 'type' => 'keyword',
-                            ]
+                            ],
                         ],
                     ],
                     'displayName' => [
@@ -205,15 +205,15 @@ class Users extends OpenSearchBase
                                 'type' => 'keyword',
                             ],
                             'cmp' => [
-                                'type' => 'completion'
+                                'type' => 'completion',
                             ],
                         ],
                     ],
                     'fullName' => [
-                        'type' => 'completion'
+                        'type' => 'completion',
                     ],
                     'fullNameLastFirst' => [
-                        'type' => 'completion'
+                        'type' => 'completion',
                     ],
                     'username' => [
                         'type' => 'text',
@@ -224,7 +224,7 @@ class Users extends OpenSearchBase
                                 'type' => 'keyword',
                             ],
                             'cmp' => [
-                                'type' => 'completion'
+                                'type' => 'completion',
                             ],
                         ],
                     ],
@@ -232,8 +232,8 @@ class Users extends OpenSearchBase
                         'type' => 'keyword',
                         'fields' => [
                             'cmp' => [
-                                'type' => 'completion'
-                            ]
+                                'type' => 'completion',
+                            ],
                         ],
                     ],
                     'email' => [
@@ -247,14 +247,14 @@ class Users extends OpenSearchBase
                             'email' => [
                                 'type' => 'text',
                                 'analyzer' => 'email_address',
-                            ]
+                            ],
                         ],
                     ],
                     'enabled' => [
                         'type' => 'boolean',
                     ],
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
@@ -284,7 +284,7 @@ class Users extends OpenSearchBase
                     'max_gram' => 15,
                     'token_chars' => [
                         'letter',
-                        'digit'
+                        'digit',
                     ],
                 ],
             ],

--- a/src/Service/LdapAuthentication.php
+++ b/src/Service/LdapAuthentication.php
@@ -100,7 +100,7 @@ class LdapAuthentication implements AuthenticationInterface
     public function logout(Request $request): JsonResponse
     {
         return new JsonResponse([
-            'status' => 'success'
+            'status' => 'success',
         ], JsonResponse::HTTP_OK);
     }
 

--- a/src/Service/LoggerQueue.php
+++ b/src/Service/LoggerQueue.php
@@ -30,7 +30,7 @@ class LoggerQueue
             'className' => $className,
             //deleted entities lose their ID before they can be logged so we must record it here
             'id' => (string)$entity,
-            'changes' => $changes
+            'changes' => $changes,
         ];
     }
 

--- a/src/Service/SerializerFactory.php
+++ b/src/Service/SerializerFactory.php
@@ -49,7 +49,7 @@ class SerializerFactory
             ],
             [
                 $jsonApiEncoder,
-                $jsonEncoder
+                $jsonEncoder,
             ]
         );
 

--- a/src/Service/ShibbolethAuthentication.php
+++ b/src/Service/ShibbolethAuthentication.php
@@ -78,7 +78,7 @@ class ShibbolethAuthentication implements AuthenticationInterface
                 'Shib-Session-ID',
                 'Shib-Authentication-Instant',
                 'Shib-Authentication-Method',
-                'Shib-Session-Index'
+                'Shib-Session-Index',
             ];
             foreach ($shibProperties as $key) {
                 $logVars[$key] = $request->server->get($key);
@@ -126,7 +126,7 @@ class ShibbolethAuthentication implements AuthenticationInterface
         }
         return new JsonResponse([
             'status' => 'redirect',
-            'logoutUrl' => $logoutUrl
+            'logoutUrl' => $logoutUrl,
 
         ], JsonResponse::HTTP_OK);
     }

--- a/tests/Classes/SessionUserTest.php
+++ b/tests/Classes/SessionUserTest.php
@@ -480,7 +480,7 @@ class SessionUserTest extends TestCase
         $roles = [UserRoles::COURSE_DIRECTOR,
             UserRoles::COURSE_ADMINISTRATOR,
             UserRoles::SESSION_ADMINISTRATOR,
-            UserRoles::COURSE_INSTRUCTOR
+            UserRoles::COURSE_INSTRUCTOR,
         ];
         $this->userRepository
             ->shouldReceive('getDirectedCourseAndSchoolIds')

--- a/tests/Command/AddDirectoryUserCommandTest.php
+++ b/tests/Command/AddDirectoryUserCommandTest.php
@@ -102,7 +102,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
             'email' => 'email',
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
-            'username' => 'abc123'
+            'username' => 'abc123',
         ];
         $this->directory->shouldReceive('findByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
         $this->commandTester->setInputs(['Yes']);
@@ -133,7 +133,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
         $this->expectException(Exception::class);
         $this->commandTester->execute([
             'campusId' => '1',
-            'schoolId' => '1'
+            'schoolId' => '1',
         ]);
     }
 
@@ -144,7 +144,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
         $this->expectException(Exception::class);
         $this->commandTester->execute([
             'campusId' => '1',
-            'schoolId' => '1'
+            'schoolId' => '1',
         ]);
     }
 
@@ -152,7 +152,7 @@ class AddDirectoryUserCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'schoolId' => '1'
+            'schoolId' => '1',
         ]);
     }
 

--- a/tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -178,7 +178,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
         $this->expectException(Exception::class);
         $this->commandTester->execute([
             'filter' => 'FILTER',
-            'schoolId' => '1'
+            'schoolId' => '1',
         ]);
     }
 
@@ -186,7 +186,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'schoolId' => '1'
+            'schoolId' => '1',
         ]);
     }
 

--- a/tests/Command/AddRootUserCommandTest.php
+++ b/tests/Command/AddRootUserCommandTest.php
@@ -61,7 +61,7 @@ class AddRootUserCommandTest extends KernelTestCase
         $user->shouldReceive('setRoot');
 
         $this->commandTester->execute([
-            'userId' => $userId
+            'userId' => $userId,
         ]);
 
         $this->userRepository->shouldHaveReceived('update', [ $user, true, true ]);
@@ -91,7 +91,7 @@ class AddRootUserCommandTest extends KernelTestCase
 
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'userId' => $userId
+            'userId' => $userId,
         ]);
     }
 }

--- a/tests/Command/AuditLogExportCommandTest.php
+++ b/tests/Command/AuditLogExportCommandTest.php
@@ -118,7 +118,7 @@ class AuditLogExportCommandTest extends KernelTestCase
                     'objectId' => '20',
                     'valuesChanged' => 'phone',
                     'objectClass' => 'FooBar',
-                ]
+                ],
             ]);
 
         $this->logger->shouldReceive('info');
@@ -161,7 +161,7 @@ class AuditLogExportCommandTest extends KernelTestCase
                     'objectId' => '21',
                     'valuesChanged' => 'email',
                     'objectClass' => 'Baz',
-                ]
+                ],
             ]);
         $this->auditLogRepository->shouldReceive('deleteInRange')->once();
 

--- a/tests/Command/ChangePasswordCommandTest.php
+++ b/tests/Command/ChangePasswordCommandTest.php
@@ -120,7 +120,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
 
@@ -136,7 +136,7 @@ class ChangePasswordCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
     }
 

--- a/tests/Command/ChangeUsernameCommandTest.php
+++ b/tests/Command/ChangeUsernameCommandTest.php
@@ -71,7 +71,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
 
@@ -98,7 +98,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
 
@@ -119,7 +119,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
 
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
     }
 
@@ -133,7 +133,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
 
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
     }
 
@@ -147,7 +147,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
 
         $this->expectException(RuntimeException::class);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
     }
 
@@ -167,7 +167,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
 
@@ -194,7 +194,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
 
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
 
@@ -210,7 +210,7 @@ class ChangeUsernameCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
     }
 

--- a/tests/Command/CleanupStringsCommandTest.php
+++ b/tests/Command/CleanupStringsCommandTest.php
@@ -145,7 +145,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->times(3);
         $this->em->shouldReceive('clear')->times(3);
         $this->commandTester->execute([
-            '--objective-title' => true
+            '--objective-title' => true,
         ]);
 
 
@@ -197,7 +197,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->times(3);
         $this->em->shouldReceive('clear')->times(3);
         $this->commandTester->execute([
-            '--objective-title-blankspace' => true
+            '--objective-title-blankspace' => true,
         ]);
 
 
@@ -226,7 +226,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute([
-            '--learningmaterial-description' => true
+            '--learningmaterial-description' => true,
         ]);
 
 
@@ -269,7 +269,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->twice();
         $this->em->shouldReceive('clear')->twice();
         $this->commandTester->execute([
-            '--learningmaterial-note' => true
+            '--learningmaterial-note' => true,
         ]);
 
 
@@ -304,7 +304,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute([
-            '--session-description' => true
+            '--session-description' => true,
         ]);
 
 
@@ -334,7 +334,7 @@ class CleanupStringsCommandTest extends KernelTestCase
         $this->em->shouldReceive('flush')->once();
         $this->em->shouldReceive('clear')->once();
         $this->commandTester->execute([
-            '--session-description' => true
+            '--session-description' => true,
         ]);
 
 

--- a/tests/Command/CreateUserTokenCommandTest.php
+++ b/tests/Command/CreateUserTokenCommandTest.php
@@ -61,7 +61,7 @@ class CreateUserTokenCommandTest extends KernelTestCase
         $this->jwtManager->shouldReceive('createJwtFromUserId')->with(1, 'PT8H')->andReturn('123JWT');
 
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
 
@@ -79,7 +79,7 @@ class CreateUserTokenCommandTest extends KernelTestCase
         $this->jwtManager->shouldReceive('createJwtFromUserId')->with(1, '108Franks')->andReturn('123JWT');
         $this->commandTester->execute([
             'userId' => '1',
-            '--ttl' => '108Franks'
+            '--ttl' => '108Franks',
         ]);
 
 
@@ -95,7 +95,7 @@ class CreateUserTokenCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
     }
 

--- a/tests/Command/ExportMeshUniverseCommandTest.php
+++ b/tests/Command/ExportMeshUniverseCommandTest.php
@@ -60,7 +60,7 @@ class ExportMeshUniverseCommandTest extends KernelTestCase
                 'An ionophorous, polyether antibiotic from Streptomyces chartreusensis.',
                 '4-Benzoxazolecarboxylic acid, ...',
                 '37H9VM9WZL',
-            ]
+            ],
         ];
         $meshConceptHeader = [
             'mesh_concept_uid',
@@ -138,7 +138,7 @@ class ExportMeshUniverseCommandTest extends KernelTestCase
             );
 
         $meshTermData = [
-            ['T000002', 'Calcimycin', 'NON', true, true, false, 1]
+            ['T000002', 'Calcimycin', 'NON', true, true, false, 1],
         ];
         $meshTermHeader = [
             'mesh_term_uid',

--- a/tests/Command/FindUserCommandTest.php
+++ b/tests/Command/FindUserCommandTest.php
@@ -59,7 +59,7 @@ class FindUserCommandTest extends KernelTestCase
         $this->directory->shouldReceive('find')->with(['a', 'b'])->andReturn([$fakeDirectoryUser]);
 
         $this->commandTester->execute([
-            'searchTerms' => ['a', 'b']
+            'searchTerms' => ['a', 'b'],
         ]);
 
 

--- a/tests/Command/ImportDefaultDataCommandTest.php
+++ b/tests/Command/ImportDefaultDataCommandTest.php
@@ -162,7 +162,7 @@ class ImportDefaultDataCommandTest extends KernelTestCase
                 [
                     $this->learningMaterialUserRoleRepository,
                     DefaultDataImporter::LEARNING_MATERIAL_USER_ROLE,
-                    []
+                    [],
                 ]
             )
             ->andReturn([]);
@@ -177,7 +177,7 @@ class ImportDefaultDataCommandTest extends KernelTestCase
                 [
                     $this->curriculumInventoryInstitutionRepository,
                     DefaultDataImporter::CURRICULUM_INVENTORY_INSTITUTION,
-                    []
+                    [],
                 ]
             )
             ->andReturn([]);

--- a/tests/Command/InstallFirstUserCommandTest.php
+++ b/tests/Command/InstallFirstUserCommandTest.php
@@ -88,7 +88,7 @@ class InstallFirstUserCommandTest extends KernelTestCase
         $this->schoolRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            '--school' => '1'
+            '--school' => '1',
         ]);
     }
 
@@ -98,7 +98,7 @@ class InstallFirstUserCommandTest extends KernelTestCase
         $this->schoolRepository->shouldReceive('findBy')->with([], ['title' => 'ASC'])->andReturn([]);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            '--school' => '1'
+            '--school' => '1',
         ]);
     }
 

--- a/tests/Command/InvalidateUserTokenCommandTest.php
+++ b/tests/Command/InvalidateUserTokenCommandTest.php
@@ -68,7 +68,7 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn($user);
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -100,7 +100,7 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
         $this->authenticationRepository->shouldReceive('create')->andReturn($authentication);
         $this->authenticationRepository->shouldReceive('update')->with($authentication);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -115,7 +115,7 @@ class InvalidateUserTokenCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
     }
 

--- a/tests/Command/ListSchoolConfigValuesCommandTest.php
+++ b/tests/Command/ListSchoolConfigValuesCommandTest.php
@@ -66,7 +66,7 @@ class ListSchoolConfigValuesCommandTest extends KernelTestCase
             ->andReturn([$mockConfig]);
 
         $this->commandTester->execute([
-            'school' => '1'
+            'school' => '1',
         ]);
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(

--- a/tests/Command/ListServiceTokensCommandTest.php
+++ b/tests/Command/ListServiceTokensCommandTest.php
@@ -66,7 +66,7 @@ class ListServiceTokensCommandTest extends KernelTestCase
         $serviceToken1->shouldReceive('getExpiresAt')->andReturn($expiresAt1);
         $serviceToken2->shouldReceive('getExpiresAt')->andReturn($expiresAt2);
         $this->serviceTokenRepository->shouldReceive('findBy')->andReturn([
-            $serviceToken1, $serviceToken2
+            $serviceToken1, $serviceToken2,
         ]);
         $this->commandTester->execute([]);
         $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());

--- a/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
+++ b/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
@@ -88,7 +88,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
         $this->commandTester->setInputs(['Yes']);
 
         $this->commandTester->execute([
-            'pathToIlios2' => __DIR__ . '/'
+            'pathToIlios2' => __DIR__ . '/',
         ]);
 
 
@@ -117,7 +117,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
 
         $this->commandTester->setInputs(['Yes']);
         $this->commandTester->execute([
-            'pathToIlios2' => 'path'
+            'pathToIlios2' => 'path',
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -136,7 +136,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
         $this->symfonyFileSystem->shouldReceive('exists')->with('badpath')->andReturn(false);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'pathToIlios2' => 'badpath'
+            'pathToIlios2' => 'badpath',
         ]);
     }
 

--- a/tests/Command/RemoveRootUserCommandTest.php
+++ b/tests/Command/RemoveRootUserCommandTest.php
@@ -61,7 +61,7 @@ class RemoveRootUserCommandTest extends KernelTestCase
         $user->shouldReceive('setRoot');
 
         $this->commandTester->execute([
-            'userId' => $userId
+            'userId' => $userId,
         ]);
 
         $this->userRepository->shouldHaveReceived('update', [ $user, true, true ]);
@@ -91,7 +91,7 @@ class RemoveRootUserCommandTest extends KernelTestCase
 
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'userId' => $userId
+            'userId' => $userId,
         ]);
     }
 }

--- a/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
+++ b/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
@@ -88,7 +88,7 @@ class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
         $options = [
             'name' => 'foo',
             'description' => 'lorem ipsum',
-            'year' => 2016
+            'year' => 2016,
         ];
 
         $reportId  = 1;

--- a/tests/Command/SendChangeAlertsCommandTest.php
+++ b/tests/Command/SendChangeAlertsCommandTest.php
@@ -401,7 +401,7 @@ class SendChangeAlertsCommandTest extends KernelTestCase
         $logB->setCreatedAt(new DateTime('2015-09-20 15:20:15', new DateTimeZone('UTC')));
 
         return [
-            [ $alert , $offering, [ $logA, $logB ]]
+            [ $alert , $offering, [ $logA, $logB ]],
         ];
     }
 

--- a/tests/Command/SendTeachingRemindersCommandTest.php
+++ b/tests/Command/SendTeachingRemindersCommandTest.php
@@ -437,7 +437,7 @@ class SendTeachingRemindersCommandTest extends KernelTestCase
         $this->commandTester->execute([
             'sender' => 'not an email',
             'base_url' => 'http://foobar.com',
-            '--days' => -1
+            '--days' => -1,
         ]);
 
         $output = $this->commandTester->getDisplay();

--- a/tests/Command/SyncFormerStudentsCommandTest.php
+++ b/tests/Command/SyncFormerStudentsCommandTest.php
@@ -105,7 +105,7 @@ class SyncFormerStudentsCommandTest extends KernelTestCase
 
         $this->commandTester->setInputs(['Yes']);
         $this->commandTester->execute([
-            'filter' => 'FILTER'
+            'filter' => 'FILTER',
         ]);
 
         $output = $this->commandTester->getDisplay();

--- a/tests/Command/SyncStudentStatusCommandTest.php
+++ b/tests/Command/SyncStudentStatusCommandTest.php
@@ -93,7 +93,7 @@ class SyncStudentStatusCommandTest extends KernelTestCase
 
         $this->commandTester->setInputs(['Yes']);
         $this->commandTester->execute([
-            'filter' => 'FILTER'
+            'filter' => 'FILTER',
         ]);
 
         $output = $this->commandTester->getDisplay();

--- a/tests/Command/SyncUserCommandTest.php
+++ b/tests/Command/SyncUserCommandTest.php
@@ -104,13 +104,13 @@ class SyncUserCommandTest extends KernelTestCase
             'pronouns' => 'pronouns',
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
-            'username' => 'username'
+            'username' => 'username',
         ];
         $this->directory->shouldReceive('findByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
         $this->commandTester->setInputs(['Yes']);
 
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -168,13 +168,13 @@ class SyncUserCommandTest extends KernelTestCase
             'pronouns' => 'pronouns',
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
-            'username' => 'username'
+            'username' => 'username',
         ];
         $this->directory->shouldReceive('findByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
         $this->commandTester->setInputs(['Yes']);
 
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -235,13 +235,13 @@ class SyncUserCommandTest extends KernelTestCase
             'pronouns' => null,
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
-            'username' => 'username'
+            'username' => 'username',
         ];
         $this->directory->shouldReceive('findByCampusId')->with('abc')->andReturn($fakeDirectoryUser);
         $this->commandTester->setInputs(['Yes']);
 
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -267,7 +267,7 @@ class SyncUserCommandTest extends KernelTestCase
         $this->userRepository->shouldReceive('findOneBy')->with(['id' => 1])->andReturn(null);
         $this->expectException(Exception::class);
         $this->commandTester->execute([
-            'userId' => '1'
+            'userId' => '1',
         ]);
     }
 

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -72,7 +72,7 @@ class AuthControllerTest extends WebTestCase
     {
         $this->kernelBrowser->request('POST', '/auth/login', [], [], [], json_encode([
             'username' => 'newuser',
-            'password' => 'newuserpass'
+            'password' => 'newuserpass',
         ]));
 
         $response = $this->kernelBrowser->getResponse();
@@ -93,7 +93,7 @@ class AuthControllerTest extends WebTestCase
     {
         $this->kernelBrowser->request('POST', '/auth/login', [], [], [], json_encode([
             'username' => 'NEWUSER',
-            'password' => 'newuserpass'
+            'password' => 'newuserpass',
         ]));
         $response = $this->kernelBrowser->getResponse();
 
@@ -112,7 +112,7 @@ class AuthControllerTest extends WebTestCase
     {
         $this->kernelBrowser->request('POST', '/auth/login', [], [], [], json_encode([
             'username' => 'newuser',
-            'password' => 'wrongnewuserpass'
+            'password' => 'wrongnewuserpass',
         ]));
 
         $response = $this->kernelBrowser->getResponse();

--- a/tests/Controller/CurriculumInventoryDownloadControllerTest.php
+++ b/tests/Controller/CurriculumInventoryDownloadControllerTest.php
@@ -77,7 +77,7 @@ class CurriculumInventoryDownloadControllerTest extends WebTestCase
                     'app_api_curriculuminventoryreports_getone',
                     [
                         'version' => $this->apiVersion,
-                        'id' => $curriculumInventoryExport['report']
+                        'id' => $curriculumInventoryExport['report'],
                     ]
                 ),
                 null,

--- a/tests/Controller/ErrorControllerTest.php
+++ b/tests/Controller/ErrorControllerTest.php
@@ -43,7 +43,7 @@ class ErrorControllerTest extends WebTestCase
     {
         $data = [
             'mainMessage' => 'dev/null',
-            'stack' => 'lorem ipsum'
+            'stack' => 'lorem ipsum',
         ];
         $this->makeJsonRequest(
             $this->kernelBrowser,
@@ -61,7 +61,7 @@ class ErrorControllerTest extends WebTestCase
     {
         $data = [
             'mainMessage' => 'lorem ipsum',
-            'stack' => 'dev/null'
+            'stack' => 'dev/null',
         ];
         $this->makeJsonRequest(
             $this->kernelBrowser,
@@ -78,7 +78,7 @@ class ErrorControllerTest extends WebTestCase
     {
         $data = [
             'mainMessage' => 'lorem ipsum',
-            'stack' => 'dev/null'
+            'stack' => 'dev/null',
         ];
         $this->makeJsonRequest(
             $this->kernelBrowser,

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -74,11 +74,11 @@ class SearchControllerTest extends TestCase
                         [
                             'id' => 11,
                             'title' => 'This Session',
-                            'matchedIn' => []
-                        ]
-                    ]
-                ]
-            ]
+                            'matchedIn' => [],
+                        ],
+                    ],
+                ],
+            ],
         ];
         $this->mockTokenStorage
             ->shouldReceive('getToken')
@@ -116,8 +116,8 @@ class SearchControllerTest extends TestCase
             ],
             'courses' => [
                 [
-                ]
-            ]
+                ],
+            ],
         ];
         $this->mockTokenStorage
             ->shouldReceive('getToken')
@@ -151,7 +151,7 @@ class SearchControllerTest extends TestCase
               'one',
               'two',
             ],
-            'courses' => []
+            'courses' => [],
         ];
 
         $this->mockTokenStorage
@@ -206,8 +206,8 @@ class SearchControllerTest extends TestCase
             'users' => [
                 [
                     'id' => 1,
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->mockTokenStorage
@@ -247,8 +247,8 @@ class SearchControllerTest extends TestCase
             'users' => [
                 [
                     'id' => 1,
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->mockTokenStorage
@@ -283,7 +283,7 @@ class SearchControllerTest extends TestCase
                 'one',
                 'two',
             ],
-            'courses' => []
+            'courses' => [],
         ];
 
         $this->mockTokenStorage
@@ -319,7 +319,7 @@ class SearchControllerTest extends TestCase
         $searchTerm = 'jasper & jackson';
         $result = [
             'autocomplete' => [],
-            'courses' => []
+            'courses' => [],
         ];
 
         $this->mockTokenStorage

--- a/tests/DataLoader/AamcMethodData.php
+++ b/tests/DataLoader/AamcMethodData.php
@@ -35,7 +35,7 @@ class AamcMethodData extends AbstractDataLoader
             'id' => 'FK',
             'description' => 'method description',
             'sessionTypes' => ['1'],
-            'active' => true
+            'active' => true,
         ];
     }
 

--- a/tests/DataLoader/AamcPcrsData.php
+++ b/tests/DataLoader/AamcPcrsData.php
@@ -14,12 +14,12 @@ class AamcPcrsData extends AbstractDataLoader
         $arr[] = [
             'id' => 'aamc-pcrs-comp-c0101',
             'description' => 'first description',
-            'competencies' => [1,2]
+            'competencies' => [1,2],
         ];
         $arr[] = [
             'id' => 'aamc-pcrs-comp-c0102',
             'description' => 'second description',
-            'competencies' => [2,3]
+            'competencies' => [2,3],
         ];
 
         return $arr;
@@ -30,7 +30,7 @@ class AamcPcrsData extends AbstractDataLoader
         return [
             'id' => 'fk-',
             'description' => 'some other description',
-            'competencies' => [1]
+            'competencies' => [1],
         ];
     }
 
@@ -38,7 +38,7 @@ class AamcPcrsData extends AbstractDataLoader
     {
         return [
             'id' => 'key',
-            'competencies' => [454098430958]
+            'competencies' => [454098430958],
         ];
     }
 

--- a/tests/DataLoader/AbstractDataLoader.php
+++ b/tests/DataLoader/AbstractDataLoader.php
@@ -147,7 +147,7 @@ abstract class AbstractDataLoader implements DataLoaderInterface
             'id' => $id,
             'type' => $type,
             'attributes' => $attributes,
-            'relationships' => $relationships
+            'relationships' => $relationships,
         ];
     }
 

--- a/tests/DataLoader/AlertChangeTypeData.php
+++ b/tests/DataLoader/AlertChangeTypeData.php
@@ -16,49 +16,49 @@ class AlertChangeTypeData extends AbstractDataLoader
         $arr[] = [
             'id' => AlertChangeTypeInterface::CHANGE_TYPE_TIME,
             'title' => 'first title',
-            'alerts' => ['1', '2']
+            'alerts' => ['1', '2'],
         ];
 
         $arr[] = [
             'id' => AlertChangeTypeInterface::CHANGE_TYPE_LOCATION,
             'title' => 'second title',
-            'alerts' => []
+            'alerts' => [],
         ];
 
         $arr[] = [
             'id' => AlertChangeTypeInterface::CHANGE_TYPE_LEARNING_MATERIAL,
             'title' => 'third title',
-            'alerts' => []
+            'alerts' => [],
         ];
 
         $arr[] = [
             'id' => AlertChangeTypeInterface::CHANGE_TYPE_INSTRUCTOR,
             'title' => 'fourth title',
-            'alerts' => []
+            'alerts' => [],
         ];
 
         $arr[] = [
             'id' => AlertChangeTypeInterface::CHANGE_TYPE_COURSE_DIRECTOR,
             'title' => 'fifth title',
-            'alerts' => []
+            'alerts' => [],
         ];
 
         $arr[] = [
             'id' => AlertChangeTypeInterface::CHANGE_TYPE_LEARNER_GROUP,
             'title' => 'sixth title',
-            'alerts' => []
+            'alerts' => [],
         ];
 
         $arr[] = [
             'id' => AlertChangeTypeInterface::CHANGE_TYPE_NEW_OFFERING,
             'title' => 'seventh title',
-            'alerts' => []
+            'alerts' => [],
         ];
 
         $arr[] = [
             'id' => AlertChangeTypeInterface::CHANGE_TYPE_SESSION_PUBLISH,
             'title' => 'eighth title',
-            'alerts' => []
+            'alerts' => [],
         ];
 
         return $arr;
@@ -69,7 +69,7 @@ class AlertChangeTypeData extends AbstractDataLoader
         return [
             'id' => 9,
             'title' => 'ninth title',
-            'alerts' => ['1']
+            'alerts' => ['1'],
         ];
     }
 
@@ -77,7 +77,7 @@ class AlertChangeTypeData extends AbstractDataLoader
     {
         return [
             'id' => 'something',
-            'alerts' => [424524]
+            'alerts' => [424524],
         ];
     }
 

--- a/tests/DataLoader/AlertData.php
+++ b/tests/DataLoader/AlertData.php
@@ -18,7 +18,7 @@ class AlertData extends AbstractDataLoader
             'dispatched' => true,
             'changeTypes' => ['1'],
             'instigators' => ['1', '2'],
-            'recipients' => ['1', '2']
+            'recipients' => ['1', '2'],
         ];
         $arr[] = [
             'id' => 2,
@@ -28,7 +28,7 @@ class AlertData extends AbstractDataLoader
             'dispatched' => true,
             'changeTypes' => ['1'],
             'instigators' => ['2'],
-            'recipients' => []
+            'recipients' => [],
         ];
         $arr[] = [
             'id' => 3,
@@ -37,7 +37,7 @@ class AlertData extends AbstractDataLoader
             'dispatched' => false,
             'changeTypes' => [],
             'instigators' => [],
-            'recipients' => ['2']
+            'recipients' => ['2'],
         ];
 
         return $arr;
@@ -52,7 +52,7 @@ class AlertData extends AbstractDataLoader
             'dispatched' => true,
             'changeTypes' => ['1'],
             'instigators' => ['1'],
-            'recipients' => ['1']
+            'recipients' => ['1'],
         ];
     }
 
@@ -62,7 +62,7 @@ class AlertData extends AbstractDataLoader
             'id' => 'string',
             'changeTypes' => [232452],
             'instigators' => [3234],
-            'recipients' => [32434]
+            'recipients' => [32434],
         ];
     }
 

--- a/tests/DataLoader/ApplicationConfigData.php
+++ b/tests/DataLoader/ApplicationConfigData.php
@@ -29,7 +29,7 @@ class ApplicationConfigData extends AbstractDataLoader
         $arr[] = [
             'id' => 4,
             'name' => 'institution_domain',
-            'value' => 'test.edu'
+            'value' => 'test.edu',
         ];
 
         return $arr;
@@ -60,7 +60,7 @@ class ApplicationConfigData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'id' => 'dsfdsaf'
+            'id' => 'dsfdsaf',
         ];
     }
 

--- a/tests/DataLoader/AssessmentOptionData.php
+++ b/tests/DataLoader/AssessmentOptionData.php
@@ -15,13 +15,13 @@ class AssessmentOptionData extends AbstractDataLoader
         $arr[] = [
             'id' => 1,
             'name' => 'first option',
-            'sessionTypes' => [1]
+            'sessionTypes' => [1],
         ];
 
         $arr[] = [
             'id' => 2,
             'name' => 'second option',
-            'sessionTypes' => [2]
+            'sessionTypes' => [2],
         ];
         return $arr;
     }
@@ -31,7 +31,7 @@ class AssessmentOptionData extends AbstractDataLoader
         return [
             'id' => 3,
             'name' => 'third option',
-            'sessionTypes' => []
+            'sessionTypes' => [],
         ];
     }
 

--- a/tests/DataLoader/AuthenticationData.php
+++ b/tests/DataLoader/AuthenticationData.php
@@ -23,7 +23,7 @@ class AuthenticationData extends AbstractDataLoader
         $arr[] = [
             'user' => 2,
             'username' => 'newuser',
-            'password' => 'newuserpass'
+            'password' => 'newuserpass',
         ];
 
         $arr[] = [
@@ -40,7 +40,7 @@ class AuthenticationData extends AbstractDataLoader
         return [
             'user' => 4,
             'username' => 'createduser',
-            'password' => 'newpass'
+            'password' => 'newpass',
         ];
     }
 

--- a/tests/DataLoader/CohortData.php
+++ b/tests/DataLoader/CohortData.php
@@ -18,7 +18,7 @@ class CohortData extends AbstractDataLoader
             'programYear' => 1,
             'courses' => ['1', '2'],
             'learnerGroups' => ['1', '3', '4', '5'],
-            'users' => ['1', '2']
+            'users' => ['1', '2'],
         ];
 
         $arr[] = [
@@ -27,7 +27,7 @@ class CohortData extends AbstractDataLoader
             'programYear' => 2,
             'courses' => ["3"],
             'learnerGroups' => ['2'],
-            'users' => []
+            'users' => [],
         ];
 
         $arr[] = [
@@ -36,7 +36,7 @@ class CohortData extends AbstractDataLoader
             'programYear' => 3,
             'courses' => ["4", "5"],
             'learnerGroups' => [],
-            'users' => []
+            'users' => [],
         ];
 
         $arr[] = [
@@ -45,7 +45,7 @@ class CohortData extends AbstractDataLoader
             'programYear' => 4,
             'courses' => [],
             'learnerGroups' => [],
-            'users' => []
+            'users' => [],
         ];
 
         $arr[] = [
@@ -54,7 +54,7 @@ class CohortData extends AbstractDataLoader
             'programYear' => 5,
             'courses' => [],
             'learnerGroups' => [],
-            'users' => []
+            'users' => [],
         ];
 
 
@@ -69,7 +69,7 @@ class CohortData extends AbstractDataLoader
             'programYear' => "5",
             'courses' => ['1'],
             'learnerGroups' => [],
-            'users' => ['1']
+            'users' => ['1'],
         ];
     }
 
@@ -78,7 +78,7 @@ class CohortData extends AbstractDataLoader
         return [
             'id' => 'string',
             'title' => null,
-            'programYear' => null
+            'programYear' => null,
         ];
     }
 

--- a/tests/DataLoader/CompetencyData.php
+++ b/tests/DataLoader/CompetencyData.php
@@ -69,7 +69,7 @@ class CompetencyData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'school' => 11
+            'school' => 11,
         ];
     }
 

--- a/tests/DataLoader/CourseClerkshipTypeData.php
+++ b/tests/DataLoader/CourseClerkshipTypeData.php
@@ -15,13 +15,13 @@ class CourseClerkshipTypeData extends AbstractDataLoader
         $arr[] = [
             'id' => 1,
             'title' => 'first clerkship type',
-            'courses' => ['1', '2']
+            'courses' => ['1', '2'],
         ];
 
         $arr[] = [
             'id' => 2,
             'title' => 'second clerkship type',
-            'courses' => []
+            'courses' => [],
         ];
 
 
@@ -33,7 +33,7 @@ class CourseClerkshipTypeData extends AbstractDataLoader
         return [
             'id' => 3,
             'title' => 'third clerkship type',
-            'courses' => []
+            'courses' => [],
         ];
     }
 

--- a/tests/DataLoader/CourseLearningMaterialData.php
+++ b/tests/DataLoader/CourseLearningMaterialData.php
@@ -88,7 +88,7 @@ class CourseLearningMaterialData extends AbstractDataLoader
             'meshDescriptors' => [],
             'position' => 4,
             'startDate' => date_format(new DateTime('+2 days'), 'c'),
-            'endDate' => null
+            'endDate' => null,
         ];
 
         $arr[] = [

--- a/tests/DataLoader/CurriculumInventoryInstitutionData.php
+++ b/tests/DataLoader/CurriculumInventoryInstitutionData.php
@@ -20,7 +20,7 @@ class CurriculumInventoryInstitutionData extends AbstractDataLoader
             'addressStateOrProvince' => 'AB',
             'addressZipCode' => '11111',
             'addressCountryCode' => 'UK',
-            'school' => '1'
+            'school' => '1',
         ];
         $arr[] = [
             'id' => 2,
@@ -31,7 +31,7 @@ class CurriculumInventoryInstitutionData extends AbstractDataLoader
             'addressStateOrProvince' => 'CA',
             'addressZipCode' => '90210',
             'addressCountryCode' => 'BC',
-            'school' => '2'
+            'school' => '2',
         ];
 
         return $arr;
@@ -48,7 +48,7 @@ class CurriculumInventoryInstitutionData extends AbstractDataLoader
             'addressStateOrProvince' => 'XX',
             'addressZipCode' => '44332',
             'addressCountryCode' => 'US',
-            'school' => '3'
+            'school' => '3',
         ];
     }
 

--- a/tests/DataLoader/CurriculumInventorySequenceData.php
+++ b/tests/DataLoader/CurriculumInventorySequenceData.php
@@ -39,7 +39,7 @@ class CurriculumInventorySequenceData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'report' => '4'
+            'report' => '4',
         ];
     }
 

--- a/tests/DataLoader/IlmSessionData.php
+++ b/tests/DataLoader/IlmSessionData.php
@@ -23,7 +23,7 @@ class IlmSessionData extends AbstractDataLoader
             'instructorGroups' => ['1'],
             'instructors' => [],
             'learners' => [],
-            'session' => '5'
+            'session' => '5',
         ];
         $dt->modify('+1 month');
         $arr[] = [
@@ -34,7 +34,7 @@ class IlmSessionData extends AbstractDataLoader
             'instructorGroups' => ['3'],
             'instructors' => [],
             'learners' => [],
-            'session' => '6'
+            'session' => '6',
         ];
 
         $dt->modify('+1 month');
@@ -46,7 +46,7 @@ class IlmSessionData extends AbstractDataLoader
             'instructorGroups' => [],
             'instructors' => ['2'],
             'learners' => [],
-            'session' => '7'
+            'session' => '7',
         ];
 
         $dt->modify('+1 month');
@@ -58,7 +58,7 @@ class IlmSessionData extends AbstractDataLoader
             'instructorGroups' => [],
             'instructors' => [],
             'learners' => ['2'],
-            'session' => '8'
+            'session' => '8',
         ];
 
         return $arr;
@@ -76,7 +76,7 @@ class IlmSessionData extends AbstractDataLoader
             'instructorGroups' => ['1', '2'],
             'instructors' => ['1', '2'],
             'learners' => ['1', '2'],
-            'session' => '1'
+            'session' => '1',
         ];
     }
 

--- a/tests/DataLoader/IngestionExceptionData.php
+++ b/tests/DataLoader/IngestionExceptionData.php
@@ -15,12 +15,12 @@ class IngestionExceptionData extends AbstractDataLoader
         $arr[] = [
             'id' => 1,
             'uid' => 'first exception',
-            'user' => '1'
+            'user' => '1',
         ];
         $arr[] = [
             'id' => 2,
             'uid' => 'second exception',
-            'user' => '2'
+            'user' => '2',
         ];
 
         return $arr;

--- a/tests/DataLoader/InstructorGroupData.php
+++ b/tests/DataLoader/InstructorGroupData.php
@@ -19,7 +19,7 @@ class InstructorGroupData extends AbstractDataLoader
             'learnerGroups' => ['1'],
             'ilmSessions' => ['1'],
             'users' => ['2'],
-            'offerings' => ['1']
+            'offerings' => ['1'],
         ];
 
         $arr[] = [
@@ -29,7 +29,7 @@ class InstructorGroupData extends AbstractDataLoader
             'learnerGroups' => [],
             'ilmSessions' => [],
             'users' => ['2', '4'],
-            'offerings' => ['3']
+            'offerings' => ['3'],
         ];
 
         $arr[] = [
@@ -39,7 +39,7 @@ class InstructorGroupData extends AbstractDataLoader
             'learnerGroups' => [],
             'ilmSessions' => ['2'],
             'users' => ['2'],
-            'offerings' => []
+            'offerings' => [],
         ];
 
         $arr[] = [
@@ -49,7 +49,7 @@ class InstructorGroupData extends AbstractDataLoader
             'learnerGroups' => [],
             'ilmSessions' => [],
             'users' => [],
-            'offerings' => []
+            'offerings' => [],
         ];
 
 
@@ -65,7 +65,7 @@ class InstructorGroupData extends AbstractDataLoader
             'learnerGroups' => ['1'],
             'ilmSessions' => ['1'],
             'users' => [],
-            'offerings' => []
+            'offerings' => [],
         ];
     }
 

--- a/tests/DataLoader/LearningMaterialData.php
+++ b/tests/DataLoader/LearningMaterialData.php
@@ -60,7 +60,7 @@ class LearningMaterialData extends AbstractDataLoader
             'courseLearningMaterials' => ['4'],
             'filename' => 'testfile.txt',
             'mimetype' => 'text/plain',
-            'filesize' => 1000
+            'filesize' => 1000,
         ];
 
         $arr[] = [
@@ -77,7 +77,7 @@ class LearningMaterialData extends AbstractDataLoader
             'courseLearningMaterials' => [],
             'filename' => 'testfile.pdf',
             'mimetype' => 'application/pdf',
-            'filesize' => 1000
+            'filesize' => 1000,
         ];
 
         $arr[] = [
@@ -94,7 +94,7 @@ class LearningMaterialData extends AbstractDataLoader
             'courseLearningMaterials' => ['5'],
             'filename' => 'testfile.pdf',
             'mimetype' => 'application/pdf',
-            'filesize' => 1000
+            'filesize' => 1000,
         ];
 
         $arr[] = [
@@ -111,7 +111,7 @@ class LearningMaterialData extends AbstractDataLoader
             'courseLearningMaterials' => ['6'],
             'filename' => 'testfile.pdf',
             'mimetype' => 'application/pdf',
-            'filesize' => 1000
+            'filesize' => 1000,
         ];
 
         $arr[] = [
@@ -128,7 +128,7 @@ class LearningMaterialData extends AbstractDataLoader
             'courseLearningMaterials' => ['7'],
             'filename' => 'testfile.pdf',
             'mimetype' => 'application/pdf',
-            'filesize' => 1000
+            'filesize' => 1000,
         ];
 
         $arr[] = [
@@ -145,7 +145,7 @@ class LearningMaterialData extends AbstractDataLoader
             'courseLearningMaterials' => ['8'],
             'filename' => 'testfile.pdf',
             'mimetype' => 'application/pdf',
-            'filesize' => 1000
+            'filesize' => 1000,
         ];
         $arr[] = [
             'id' => 9,
@@ -161,7 +161,7 @@ class LearningMaterialData extends AbstractDataLoader
             'courseLearningMaterials' => ['9'],
             'filename' => 'testfile.pdf',
             'mimetype' => 'application/pdf',
-            'filesize' => 1000
+            'filesize' => 1000,
         ];
         $arr[] = [
             'id' => 10,
@@ -177,7 +177,7 @@ class LearningMaterialData extends AbstractDataLoader
             'courseLearningMaterials' => ['10'],
             'filename' => 'testfile.pdf',
             'mimetype' => 'application/pdf',
-            'filesize' => 1000
+            'filesize' => 1000,
         ];
 
         return $arr;
@@ -262,7 +262,7 @@ class LearningMaterialData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'id' => 12
+            'id' => 12,
         ];
     }
 

--- a/tests/DataLoader/LearningMaterialStatusData.php
+++ b/tests/DataLoader/LearningMaterialStatusData.php
@@ -15,15 +15,15 @@ class LearningMaterialStatusData extends AbstractDataLoader
 
         $arr[] = [
             'id' => LearningMaterialStatusInterface::IN_DRAFT,
-            'title' => 'Draft'
+            'title' => 'Draft',
         ];
         $arr[] = [
             'id' => LearningMaterialStatusInterface::FINALIZED,
-            'title' => 'Final'
+            'title' => 'Final',
         ];
         $arr[] = [
             'id' => LearningMaterialStatusInterface::REVISED,
-            'title' => 'Revised'
+            'title' => 'Revised',
         ];
 
         return $arr;
@@ -33,7 +33,7 @@ class LearningMaterialStatusData extends AbstractDataLoader
     {
         return [
             'id' => 4,
-            'title' => 'new status'
+            'title' => 'new status',
         ];
     }
 

--- a/tests/DataLoader/LearningMaterialUserRoleData.php
+++ b/tests/DataLoader/LearningMaterialUserRoleData.php
@@ -14,12 +14,12 @@ class LearningMaterialUserRoleData extends AbstractDataLoader
 
         $arr[] = [
             'id' => 1,
-            'title' => 'first lm user role'
+            'title' => 'first lm user role',
         ];
 
         $arr[] = [
             'id' => 2,
-            'title' => 'second lm user role'
+            'title' => 'second lm user role',
         ];
 
         return $arr;
@@ -29,7 +29,7 @@ class LearningMaterialUserRoleData extends AbstractDataLoader
     {
         return [
             'id' => 3,
-            'title' => 'third lm user role'
+            'title' => 'third lm user role',
         ];
     }
 

--- a/tests/DataLoader/MeshConceptData.php
+++ b/tests/DataLoader/MeshConceptData.php
@@ -19,7 +19,7 @@ class MeshConceptData extends AbstractDataLoader
             'casn1Name' => 'casn123456',
             'registryNumber' => 'abc1234',
             'terms' => ['1', '2'],
-            'descriptors' => ['abc1']
+            'descriptors' => ['abc1'],
         ];
         $arr[] = [
             'id' => '2',
@@ -29,7 +29,7 @@ class MeshConceptData extends AbstractDataLoader
             'casn1Name' => 'second casn',
             'registryNumber' => 'abcd',
             'terms' => [],
-            'descriptors' => ['abc1']
+            'descriptors' => ['abc1'],
         ];
 
         return $arr;
@@ -45,14 +45,14 @@ class MeshConceptData extends AbstractDataLoader
             'casn1Name' => 'casn1122433',
             'registryNumber' => '112233',
             'terms' => ['1'],
-            'descriptors' => []
+            'descriptors' => [],
         ];
     }
 
     public function createInvalid(): array
     {
         return [
-            'id' => 'bad'
+            'id' => 'bad',
         ];
     }
 

--- a/tests/DataLoader/MeshDescriptorData.php
+++ b/tests/DataLoader/MeshDescriptorData.php
@@ -26,7 +26,7 @@ class MeshDescriptorData extends AbstractDataLoader
             'deleted' => false,
             'sessionObjectives' => ['2'],
             'courseObjectives' => ['1', '2'],
-            'programYearObjectives' => ['1']
+            'programYearObjectives' => ['1'],
         ];
         $arr[] = [
             'id' => 'abc2',
@@ -43,7 +43,7 @@ class MeshDescriptorData extends AbstractDataLoader
             'deleted' => false,
             'sessionObjectives' => ['1'],
             'courseObjectives' => ['4'],
-            'programYearObjectives' => []
+            'programYearObjectives' => [],
         ];
         $arr[] = [
             'id' => 'abc3',
@@ -60,7 +60,7 @@ class MeshDescriptorData extends AbstractDataLoader
             'deleted' => false,
             'sessionObjectives' => ['3'],
             'courseObjectives' => ['3'],
-            'programYearObjectives' => ['2']
+            'programYearObjectives' => ['2'],
         ];
 
         return $arr;
@@ -90,7 +90,7 @@ class MeshDescriptorData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'id' => 'bad'
+            'id' => 'bad',
         ];
     }
 

--- a/tests/DataLoader/MeshPreviousIndexingData.php
+++ b/tests/DataLoader/MeshPreviousIndexingData.php
@@ -37,7 +37,7 @@ class MeshPreviousIndexingData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'id' => 'bad'
+            'id' => 'bad',
         ];
     }
 

--- a/tests/DataLoader/MeshQualifierData.php
+++ b/tests/DataLoader/MeshQualifierData.php
@@ -14,12 +14,12 @@ class MeshQualifierData extends AbstractDataLoader
         $arr[] = [
             'id' => '1',
             'name' => 'qual one',
-            'descriptors' => ['abc1']
+            'descriptors' => ['abc1'],
         ];
         $arr[] = [
             'id' => '2',
             'name' => 'second qualifier',
-            'descriptors' => ['abc1']
+            'descriptors' => ['abc1'],
         ];
 
         return $arr;
@@ -30,7 +30,7 @@ class MeshQualifierData extends AbstractDataLoader
         return [
             'id' => '3',
             'name' => 'third qualifier',
-            'descriptors' => []
+            'descriptors' => [],
         ];
     }
 

--- a/tests/DataLoader/MeshTermData.php
+++ b/tests/DataLoader/MeshTermData.php
@@ -19,7 +19,7 @@ class MeshTermData extends AbstractDataLoader
             'conceptPreferred' => true,
             'recordPreferred' => false,
             'permuted' => true,
-            'concepts' => ['1']
+            'concepts' => ['1'],
         ];
         $arr[] = [
             'id' => 2,
@@ -29,7 +29,7 @@ class MeshTermData extends AbstractDataLoader
             'conceptPreferred' => false,
             'recordPreferred' => true,
             'permuted' => false,
-            'concepts' => ['1']
+            'concepts' => ['1'],
         ];
 
         return $arr;
@@ -46,14 +46,14 @@ class MeshTermData extends AbstractDataLoader
             'conceptPreferred' => true,
             'recordPreferred' => true,
             'permuted' => true,
-            'concepts' => ['1']
+            'concepts' => ['1'],
         ];
     }
 
     public function createInvalid(): array
     {
         return [
-            'id' => 'bad'
+            'id' => 'bad',
         ];
     }
 

--- a/tests/DataLoader/MeshTreeData.php
+++ b/tests/DataLoader/MeshTreeData.php
@@ -14,12 +14,12 @@ class MeshTreeData extends AbstractDataLoader
         $arr[] = [
             'id' => 1,
             'treeNumber' => 'tree1',
-            'descriptor' => 'abc1'
+            'descriptor' => 'abc1',
         ];
         $arr[] = [
             'id' => 2,
             'treeNumber' => 'tree2',
-            'descriptor' => 'abc1'
+            'descriptor' => 'abc1',
         ];
 
         return $arr;
@@ -30,14 +30,14 @@ class MeshTreeData extends AbstractDataLoader
         return [
             'id' => 3,
             'treeNumber' => 'tree3',
-            'descriptor' => 'abc2'
+            'descriptor' => 'abc2',
         ];
     }
 
     public function createInvalid(): array
     {
         return [
-            'id' => 'bad'
+            'id' => 'bad',
         ];
     }
 

--- a/tests/DataLoader/OfferingData.php
+++ b/tests/DataLoader/OfferingData.php
@@ -23,7 +23,7 @@ class OfferingData extends AbstractDataLoader
             'learnerGroups' => ['1', '5'],
             'instructorGroups' => ['1'],
             'learners' => [],
-            'instructors' => []
+            'instructors' => [],
         ];
 
         $arr[] = [

--- a/tests/DataLoader/ProgramYearObjectiveData.php
+++ b/tests/DataLoader/ProgramYearObjectiveData.php
@@ -37,7 +37,7 @@ class ProgramYearObjectiveData extends AbstractDataLoader
             'courseObjectives' => [],
             'descendants' => [],
             'ancestor' => 1,
-            'competency' => '2'
+            'competency' => '2',
         ];
 
         return $arr;

--- a/tests/DataLoader/SchoolData.php
+++ b/tests/DataLoader/SchoolData.php
@@ -27,7 +27,7 @@ class SchoolData extends AbstractDataLoader
             'vocabularies' => ['1'],
             'directors' => ['1'],
             'administrators' => ['1'],
-            'configurations' => ['1', '2']
+            'configurations' => ['1', '2'],
         ];
 
         $arr[] = [
@@ -45,7 +45,7 @@ class SchoolData extends AbstractDataLoader
             'vocabularies' => ['2'],
             'directors' => [],
             'administrators' => [],
-            'configurations' => ['3']
+            'configurations' => ['3'],
         ];
 
         $arr[] = [
@@ -62,7 +62,7 @@ class SchoolData extends AbstractDataLoader
             'vocabularies' => [],
             'directors' => [],
             'administrators' => [],
-            'configurations' => []
+            'configurations' => [],
         ];
 
 
@@ -93,7 +93,7 @@ class SchoolData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'id' => 'lkjdsf'
+            'id' => 'lkjdsf',
         ];
     }
 

--- a/tests/DataLoader/ServiceTokenData.php
+++ b/tests/DataLoader/ServiceTokenData.php
@@ -50,7 +50,7 @@ class ServiceTokenData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'id' => 'bad'
+            'id' => 'bad',
         ];
     }
 

--- a/tests/DataLoader/SessionData.php
+++ b/tests/DataLoader/SessionData.php
@@ -165,7 +165,7 @@ class SessionData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'course' => 11
+            'course' => 11,
         ];
     }
 

--- a/tests/DataLoader/SessionLearningMaterialData.php
+++ b/tests/DataLoader/SessionLearningMaterialData.php
@@ -152,7 +152,7 @@ class SessionLearningMaterialData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'session' => 11
+            'session' => 11,
         ];
     }
 

--- a/tests/DataLoader/TermData.php
+++ b/tests/DataLoader/TermData.php
@@ -135,7 +135,7 @@ class TermData extends AbstractDataLoader
     public function createInvalid(): array
     {
         return [
-            'vocabulary' => 11
+            'vocabulary' => 11,
         ];
     }
 

--- a/tests/DataLoader/UserRoleData.php
+++ b/tests/DataLoader/UserRoleData.php
@@ -37,7 +37,7 @@ class UserRoleData extends AbstractDataLoader
 
         $arr[] = [
             'id' => 4,
-            'title' => 'user role 4'
+            'title' => 'user role 4',
         ];
 
         return $arr[0];

--- a/tests/DataLoader/VocabularyData.php
+++ b/tests/DataLoader/VocabularyData.php
@@ -16,14 +16,14 @@ class VocabularyData extends AbstractDataLoader
             'title' => 'first vocabulary',
             'active' => true,
             'school' => 1,
-            'terms' => ['1', '2', '3']
+            'terms' => ['1', '2', '3'],
         ];
         $arr[] = [
             'id' => 2,
             'title' => 'second vocabulary',
             'active' => false,
             'school' => 2,
-            'terms' => ['4', '5', '6']
+            'terms' => ['4', '5', '6'],
         ];
         return $arr;
     }
@@ -35,7 +35,7 @@ class VocabularyData extends AbstractDataLoader
             'title' => 'third vocabulary',
             'active' => true,
             'school' => 2,
-            'terms' => []
+            'terms' => [],
         ];
     }
 

--- a/tests/Endpoints/AamcPcrsTest.php
+++ b/tests/Endpoints/AamcPcrsTest.php
@@ -24,7 +24,7 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
     {
         return [
             LoadAamcPcrsData::class,
-            LoadCompetencyData::class
+            LoadCompetencyData::class,
         ];
     }
 

--- a/tests/Endpoints/AamcResourceTypeTest.php
+++ b/tests/Endpoints/AamcResourceTypeTest.php
@@ -23,7 +23,7 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
     {
         return [
             LoadAamcResourceTypeData::class,
-            LoadTermData::class
+            LoadTermData::class,
         ];
     }
 

--- a/tests/Endpoints/AbstractEndpoint.php
+++ b/tests/Endpoints/AbstractEndpoint.php
@@ -128,7 +128,7 @@ abstract class AbstractEndpoint extends WebTestCase
     protected function compareJsonApiData(array $expected, object $result): void
     {
         $transformed = [
-            'id' => (string) $result->id
+            'id' => (string) $result->id,
         ];
         foreach ($result->attributes as $key => $value) {
             if (!is_null($value)) {
@@ -588,7 +588,7 @@ abstract class AbstractEndpoint extends WebTestCase
         $data = $loader->getAll();
         $this->createGraphQLRequest(
             json_encode([
-                'query' => "query { $name { $fields }}"
+                'query' => "query { $name { $fields }}",
             ]),
             $jwt
         );
@@ -723,7 +723,7 @@ abstract class AbstractEndpoint extends WebTestCase
         $ids = array_map(fn(array $arr) => $arr['id'], $responseData);
         $filters = [
             'filters[id]' => $ids,
-            'limit' => count($ids)
+            'limit' => count($ids),
         ];
         //re-fetch the data to test persistence
         $fetchedResponseData = $this->getFiltered($endpoint, $responseKey, $filters, $jwt);
@@ -762,7 +762,7 @@ abstract class AbstractEndpoint extends WebTestCase
         $responseData = $this->postManyJsonApi($postData, $jwt);
         $ids = array_column($responseData, 'id');
         $filters = [
-            'filters[id]' => $ids
+            'filters[id]' => $ids,
         ];
         //re-fetch the data to test persistence
         $fetchedResponseData = $this->getFiltered($endpoint, $responseKey, $filters, $jwt);
@@ -1452,7 +1452,7 @@ abstract class AbstractEndpoint extends WebTestCase
 
         $this->createGraphQLRequest(
             json_encode([
-                'query' => "query { $name$filterString { $idField }}"
+                'query' => "query { $name$filterString { $idField }}",
             ]),
             $jwt
         );

--- a/tests/Endpoints/AcademicYearTest.php
+++ b/tests/Endpoints/AcademicYearTest.php
@@ -87,7 +87,7 @@ class AcademicYearTest extends AbstractReadEndpoint
         sort($academicYears);
         return array_map(fn($year) => [
             'id' => $year,
-            'title' => $year
+            'title' => $year,
         ], $academicYears);
     }
 

--- a/tests/Endpoints/AssessmentOptionTest.php
+++ b/tests/Endpoints/AssessmentOptionTest.php
@@ -23,7 +23,7 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
     {
         return [
             LoadAssessmentOptionData::class,
-            LoadSessionTypeData::class
+            LoadSessionTypeData::class,
         ];
     }
 

--- a/tests/Endpoints/AuthenticationTest.php
+++ b/tests/Endpoints/AuthenticationTest.php
@@ -445,7 +445,7 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
         $ids = array_map(fn(array $arr) => $arr['user'], $responseData);
         $filters = [
             'filters[user]' => $ids,
-            'limit' => count($ids)
+            'limit' => count($ids),
         ];
         //re-fetch the data to test persistence
         $fetchedResponseData = $this->getFiltered($endpoint, $responseKey, $filters, $jwt);
@@ -465,7 +465,7 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
         $responseData = $this->postManyJsonApi($postData, $jwt);
         $ids = array_column($responseData, 'id');
         $filters = [
-            'filters[user]' => $ids
+            'filters[user]' => $ids,
         ];
         //re-fetch the data to test persistence
         $fetchedResponseData = $this->getFiltered($endpoint, $responseKey, $filters, $jwt);
@@ -624,10 +624,10 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
                     'user' => [
                         'data' => [
                             'id' => $user['user'],
-                            'type' => 'users'
-                        ]
-                    ]
-                ]
+                            'type' => 'users',
+                        ],
+                    ],
+                ],
             ];
             if (array_key_exists('password', $user)) {
                 $rhett['attributes']['password'] = $user['password'];

--- a/tests/Endpoints/CohortTest.php
+++ b/tests/Endpoints/CohortTest.php
@@ -31,7 +31,7 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
             LoadProgramYearData::class,
             LoadCourseData::class,
             LoadLearnerGroupData::class,
-            LoadUserData::class
+            LoadUserData::class,
         ];
     }
 
@@ -99,7 +99,7 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
             'PUT',
             $this->getUrl($this->kernelBrowser, 'app_api_cohorts_put', [
                 'version' => $this->apiVersion,
-                'id' => $data['id']
+                'id' => $data['id'],
             ]),
             json_encode(['cohort' => $data]),
             $jwt

--- a/tests/Endpoints/CourseClerkshipTypeTest.php
+++ b/tests/Endpoints/CourseClerkshipTypeTest.php
@@ -23,7 +23,7 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
     {
         return [
             LoadCourseClerkshipTypeData::class,
-            LoadCourseData::class
+            LoadCourseData::class,
         ];
     }
 

--- a/tests/Endpoints/CourseLearningMaterialTest.php
+++ b/tests/Endpoints/CourseLearningMaterialTest.php
@@ -127,7 +127,7 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
             json_encode([
                 'query' =>
                     "query { courseLearningMaterials(id: {$data['id']}) " .
-                    "{ id, course { id, title }, learningMaterial { id } }}"
+                    "{ id, course { id, title }, learningMaterial { id } }}",
             ]),
             $this->createJwtForRootUser($this->kernelBrowser)
         );

--- a/tests/Endpoints/CourseObjectiveTest.php
+++ b/tests/Endpoints/CourseObjectiveTest.php
@@ -49,7 +49,7 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
             'terms' => ['terms', [1, 4]],
             'meshDescriptors' => ['meshDescriptors', ['abc2']],
             'programYearObjectives' => ['programYearObjectives', [2]],
-            'sessionObjectives' => ['sessionObjectives', [2, 3]]
+            'sessionObjectives' => ['sessionObjectives', [2, 3]],
         ];
     }
 
@@ -72,7 +72,7 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
             'title' => [[1], ['title' => 'course objective 2']],
             'active' => [[0, 1, 2, 3, 4], ['active' => true]],
             'notActive' => [[], ['active' => false]],
-            'ancestor' => [[1], ['ancestor' => [1]]]
+            'ancestor' => [[1], ['ancestor' => [1]]],
         ];
     }
 
@@ -101,7 +101,7 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         $this->createJsonRequest(
             'POST',
             $this->getUrl($this->kernelBrowser, 'app_api_courseobjectives_post', [
-                'version' => $this->apiVersion
+                'version' => $this->apiVersion,
             ]),
             json_encode(['courseObjectives' => [$postData]]),
             $this->createJwtForRootUser($this->kernelBrowser)
@@ -127,7 +127,7 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
             ['<script>alert("hello");</script><p>foo</p>', '<p>foo</p>'],
             [
                 '<a href="https://iliosproject.org" target="_blank">Ilios</a>',
-                '<a href="https://iliosproject.org" target="_blank" rel="noreferrer noopener">Ilios</a>'
+                '<a href="https://iliosproject.org" target="_blank" rel="noreferrer noopener">Ilios</a>',
             ],
         ];
     }
@@ -147,7 +147,7 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         $this->createJsonRequest(
             'POST',
             $this->getUrl($this->kernelBrowser, 'app_api_courseobjectives_post', [
-                'version' => $this->apiVersion
+                'version' => $this->apiVersion,
             ]),
             json_encode(['courseObjectives' => [$postData]]),
             $this->createJwtForRootUser($this->kernelBrowser)
@@ -164,7 +164,7 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
 
         $this->createGraphQLRequest(
             json_encode([
-                'query' => "query { courseObjectives(id: {$data['id']}) { id, course { id } }}"
+                'query' => "query { courseObjectives(id: {$data['id']}) { id, course { id } }}",
             ]),
             $this->createJwtForRootUser($this->kernelBrowser)
         );

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -313,7 +313,7 @@ class CourseTest extends AbstractReadWriteEndpoint
         $newCourse = $this->rolloverCourse([
             'id' => $course['id'],
             'year' => 2023,
-            'newStartDate' => '2023-02-05'
+            'newStartDate' => '2023-02-05',
         ]);
 
         $this->assertSame(2023, $newCourse['year']);
@@ -346,7 +346,7 @@ class CourseTest extends AbstractReadWriteEndpoint
         $newCourse = $this->rolloverCourse([
             'id' => $course['id'],
             'year' => 2030,
-            'skipOfferings' => true
+            'skipOfferings' => true,
         ]);
 
         $this->assertSame(2030, $newCourse['year']);
@@ -380,7 +380,7 @@ class CourseTest extends AbstractReadWriteEndpoint
         $newCourse = $this->rolloverCourse([
             'id' => $course['id'],
             'year' => $course['year'],
-            'newCourseTitle' => $newCourseTitle
+            'newCourseTitle' => $newCourseTitle,
         ]);
 
         $this->assertSame($course['year'], $newCourse['year']);
@@ -398,7 +398,7 @@ class CourseTest extends AbstractReadWriteEndpoint
             'version' => $this->apiVersion,
             'id' => $course['id'],
             'year' => $course['year'],
-            'newCourseTitle' => $newCourseTitle
+            'newCourseTitle' => $newCourseTitle,
         ];
 
         $this->createJsonRequest(
@@ -466,7 +466,7 @@ class CourseTest extends AbstractReadWriteEndpoint
             'year' => 2023,
             'newStartDate' => 'false',
             'skipOfferings' => 'true',
-            'newCohorts' => [5]
+            'newCohorts' => [5],
         ]);
 
         $this->assertSame($course['title'], $newCourse['title']);
@@ -801,7 +801,7 @@ class CourseTest extends AbstractReadWriteEndpoint
             [
                 'version' => $this->apiVersion,
                 'id' => 1,
-                'include' => 'sessions.administrators'
+                'include' => 'sessions.administrators',
             ]
         );
         $this->createJsonApiRequest(
@@ -834,7 +834,7 @@ class CourseTest extends AbstractReadWriteEndpoint
         $this->createGraphQLRequest(
             json_encode([
                 'query' =>
-                    "query { courses(id: {$data['id']}) { id, school { id }, sessions { id, administrators { id }} }}"
+                    "query { courses(id: {$data['id']}) { id, school { id }, sessions { id, administrators { id }} }}",
             ]),
             $this->createJwtForRootUser($this->kernelBrowser)
         );
@@ -878,7 +878,7 @@ class CourseTest extends AbstractReadWriteEndpoint
 
         $this->createGraphQLRequest(
             json_encode([
-                'query' => "query { courses(id: {$data['id']}) { id, sessions { id, administrators { id }} }}"
+                'query' => "query { courses(id: {$data['id']}) { id, sessions { id, administrators { id }} }}",
             ]),
             $this->createJwtFromUserId($this->kernelBrowser, 5)
         );

--- a/tests/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/Endpoints/CurriculumInventoryReportTest.php
@@ -218,7 +218,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
         $ids = array_map(fn(array $arr) => $arr['id'], $responseData);
         $filters = [
             'filters[id]' => $ids,
-            'limit' => count($ids)
+            'limit' => count($ids),
         ];
         //re-fetch the data to test persistence
         $fetchedResponseData = $this->getFiltered($endpoint, $responseKey, $filters, $jwt);
@@ -255,7 +255,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
         $responseData = $this->postManyJsonApi($postData, $jwt);
         $ids = array_column($responseData, 'id');
         $filters = [
-            'filters[id]' => $ids
+            'filters[id]' => $ids,
         ];
         //re-fetch the data to test persistence
         $fetchedResponseData = $this->getFiltered($endpoint, $responseKey, $filters, $jwt);
@@ -511,7 +511,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
         $this->createJsonRequest(
             'POST',
             $this->getUrl($this->kernelBrowser, 'app_api_programs_post', [
-                'version' => $this->apiVersion
+                'version' => $this->apiVersion,
             ]),
             json_encode(['programs' => [$postData]]),
             $this->createJwtForRootUser($this->kernelBrowser)

--- a/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
@@ -46,7 +46,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
             // 'children' => ['children', [1]], // skipped
             'report' => ['report', 2],
             'sessions' => ['sessions', [1, 2]],
-            'excludedSessions' => ['excludedSessions', [1, 2]]
+            'excludedSessions' => ['excludedSessions', [1, 2]],
         ];
     }
 
@@ -68,7 +68,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
             'optional' => [[1, 2, 3, 4], ['required' => CurriculumInventorySequenceBlockInterface::OPTIONAL]],
             'childSequenceOrder' => [[0], ['childSequenceOrder' => CurriculumInventorySequenceBlockInterface::ORDERED]],
             'childSequenceOpt' => [[1, 2, 3, 4], [
-                'childSequenceOrder' => CurriculumInventorySequenceBlockInterface::OPTIONAL]
+                'childSequenceOrder' => CurriculumInventorySequenceBlockInterface::OPTIONAL],
             ],
             'orderInSequence' => [[1], ['orderInSequence' => 1]],
             'minimum' => [[0, 1, 2, 3, 4], ['minimum' => 1]],
@@ -638,7 +638,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
             'PUT',
             $this->getUrl($this->kernelBrowser, 'app_api_curriculuminventorysequenceblocks_put', [
                 'version' => $this->apiVersion,
-                'id' => $blockId
+                'id' => $blockId,
             ]),
             json_encode(['curriculumInventorySequenceBlock' => $block]),
             $this->createJwtForRootUser($this->kernelBrowser)
@@ -652,7 +652,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
             'PUT',
             $this->getUrl($this->kernelBrowser, 'app_api_curriculuminventorysequenceblocks_put', [
                 'version' => $this->apiVersion,
-                'id' => $blockId
+                'id' => $blockId,
             ]),
             json_encode(['curriculumInventorySequenceBlock' => $block]),
             $this->createJwtForRootUser($this->kernelBrowser)

--- a/tests/Endpoints/CurriculumInventorySequenceTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceTest.php
@@ -20,7 +20,7 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
     {
         return [
             LoadCurriculumInventorySequenceData::class,
-            LoadCurriculumInventoryReportData::class
+            LoadCurriculumInventoryReportData::class,
         ];
     }
 

--- a/tests/Endpoints/IlmSessionTest.php
+++ b/tests/Endpoints/IlmSessionTest.php
@@ -22,7 +22,7 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
     {
         return [
             LoadIlmSessionData::class,
-            LoadSessionData::class
+            LoadSessionData::class,
         ];
     }
 

--- a/tests/Endpoints/LearningMaterialStatusTest.php
+++ b/tests/Endpoints/LearningMaterialStatusTest.php
@@ -19,7 +19,7 @@ class LearningMaterialStatusTest extends AbstractReadEndpoint
     {
         return [
             LoadLearningMaterialStatusData::class,
-            LoadLearningMaterialData::class
+            LoadLearningMaterialData::class,
         ];
     }
 

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -39,7 +39,7 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
         'owningUser',
         'sessionLearningMaterials',
         'courseLearningMaterials',
-        'copyrightPermission'
+        'copyrightPermission',
     ];
     protected string $testName =  'learningMaterials';
 

--- a/tests/Endpoints/LearningMaterialUserRoleTest.php
+++ b/tests/Endpoints/LearningMaterialUserRoleTest.php
@@ -19,7 +19,7 @@ class LearningMaterialUserRoleTest extends AbstractReadEndpoint
     {
         return [
             LoadLearningMaterialUserRoleData::class,
-            LoadLearningMaterialData::class
+            LoadLearningMaterialData::class,
         ];
     }
 

--- a/tests/Endpoints/OfferingTest.php
+++ b/tests/Endpoints/OfferingTest.php
@@ -56,7 +56,7 @@ class OfferingTest extends AbstractReadWriteEndpoint
             LoadLearnerGroupData::class,
             LoadInstructorGroupData::class,
             LoadIlmSessionData::class,
-            LoadAlertChangeTypeData::class
+            LoadAlertChangeTypeData::class,
         ];
     }
 

--- a/tests/Endpoints/ProgramTest.php
+++ b/tests/Endpoints/ProgramTest.php
@@ -29,7 +29,7 @@ class ProgramTest extends AbstractReadWriteEndpoint
             LoadProgramYearData::class,
             LoadCourseData::class,
             LoadSessionData::class,
-            LoadCurriculumInventoryReportData::class
+            LoadCurriculumInventoryReportData::class,
         ];
     }
 
@@ -163,7 +163,7 @@ class ProgramTest extends AbstractReadWriteEndpoint
 
         $this->createGraphQLRequest(
             json_encode([
-                'query' => "query { programs(id: {$data['id']}) { id, school { id } }}"
+                'query' => "query { programs(id: {$data['id']}) { id, school { id } }}",
             ]),
             $this->createJwtForRootUser($this->kernelBrowser)
         );

--- a/tests/Endpoints/ProgramYearObjectiveTest.php
+++ b/tests/Endpoints/ProgramYearObjectiveTest.php
@@ -49,7 +49,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
             'terms' => ['terms', [1, 4]],
             'meshDescriptors' => ['meshDescriptors', ['abc2']],
             'competency' => ['competency', 2],
-            'courseObjectives' => ['courseObjectives', [2]]
+            'courseObjectives' => ['courseObjectives', [2]],
 
         ];
     }
@@ -151,7 +151,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         $this->createJsonRequest(
             'POST',
             $this->getUrl($this->kernelBrowser, 'app_api_programyearobjectives_post', [
-                'version' => $this->apiVersion
+                'version' => $this->apiVersion,
             ]),
             json_encode(['programYearObjectives' => [$postData]]),
             $this->createJwtForRootUser($this->kernelBrowser)
@@ -177,7 +177,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
             ['<script>alert("hello");</script><p>foo</p>', '<p>foo</p>'],
             [
                 '<a href="https://iliosproject.org" target="_blank">Ilios</a>',
-                '<a href="https://iliosproject.org" target="_blank" rel="noreferrer noopener">Ilios</a>'
+                '<a href="https://iliosproject.org" target="_blank" rel="noreferrer noopener">Ilios</a>',
             ],
         ];
     }
@@ -197,7 +197,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         $this->createJsonRequest(
             'POST',
             $this->getUrl($this->kernelBrowser, 'app_api_programyearobjectives_post', [
-                'version' => $this->apiVersion
+                'version' => $this->apiVersion,
             ]),
             json_encode(['programYearObjectives' => [$postData]]),
             $this->createJwtForRootUser($this->kernelBrowser)

--- a/tests/Endpoints/ProgramYearTest.php
+++ b/tests/Endpoints/ProgramYearTest.php
@@ -214,8 +214,8 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
                 'first competency',
                 'firstCourse',
                 'first',
-                'course objective 1'
-            ]
+                'course objective 1',
+            ],
         ];
 
         $actual = array_map('str_getcsv', explode(PHP_EOL, trim($response->getContent())));

--- a/tests/Endpoints/ReportTest.php
+++ b/tests/Endpoints/ReportTest.php
@@ -24,7 +24,7 @@ class ReportTest extends AbstractReadWriteEndpoint
     {
         return [
             LoadReportData::class,
-            LoadUserData::class
+            LoadUserData::class,
         ];
     }
 

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -640,7 +640,7 @@ class SchooleventsTest extends AbstractEndpoint
         $parameters = [
             'version' => $this->apiVersion,
             'id' => $school['id'],
-            'to' => 1000000
+            'to' => 1000000,
         ];
         $url = $this->getUrl(
             $this->kernelBrowser,
@@ -665,7 +665,7 @@ class SchooleventsTest extends AbstractEndpoint
         $parameters = [
             'version' => $this->apiVersion,
             'id' => $school['id'],
-            'from' => 1000000
+            'from' => 1000000,
         ];
         $url = $this->getUrl(
             $this->kernelBrowser,
@@ -704,7 +704,7 @@ class SchooleventsTest extends AbstractEndpoint
             'version' => $this->apiVersion,
             'id' => $schoolId,
             'from' => $from,
-            'to' => $to
+            'to' => $to,
         ];
         $url = $this->getUrl(
             $this->kernelBrowser,
@@ -737,7 +737,7 @@ class SchooleventsTest extends AbstractEndpoint
         $parameters = [
             'version' => $this->apiVersion,
             'id' => $schoolId,
-            'session' => $sessionId
+            'session' => $sessionId,
         ];
         $url = $this->getUrl(
             $this->kernelBrowser,

--- a/tests/Endpoints/SessionLearningMaterialTest.php
+++ b/tests/Endpoints/SessionLearningMaterialTest.php
@@ -148,7 +148,7 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
             json_encode([
                 'query' =>
                     "query { sessionLearningMaterials(id: {$data['id']}) " .
-                    "{ id, session { id, title, course { id } }, learningMaterial { id } }}"
+                    "{ id, session { id, title, course { id } }, learningMaterial { id } }}",
             ]),
             $this->createJwtForRootUser($this->kernelBrowser)
         );

--- a/tests/Endpoints/SessionObjectiveTest.php
+++ b/tests/Endpoints/SessionObjectiveTest.php
@@ -95,7 +95,7 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
             ['<script>alert("hello");</script><p>foo</p>', '<p>foo</p>'],
             [
                 '<a href="https://iliosproject.org" target="_blank">Ilios</a>',
-                '<a href="https://iliosproject.org" target="_blank" rel="noreferrer noopener">Ilios</a>'
+                '<a href="https://iliosproject.org" target="_blank" rel="noreferrer noopener">Ilios</a>',
             ],
         ];
     }
@@ -116,7 +116,7 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         $this->createJsonRequest(
             'POST',
             $this->getUrl($this->kernelBrowser, 'app_api_sessionobjectives_post', [
-                'version' => $this->apiVersion
+                'version' => $this->apiVersion,
             ]),
             json_encode(['sessionObjectives' => [$postData]]),
             $this->createJwtForRootUser($this->kernelBrowser)
@@ -147,7 +147,7 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         $this->createJsonRequest(
             'POST',
             $this->getUrl($this->kernelBrowser, 'app_api_sessionobjectives_post', [
-                'version' => $this->apiVersion
+                'version' => $this->apiVersion,
             ]),
             json_encode(['sessionObjectives' => [$postData]]),
             $this->createJwtForRootUser($this->kernelBrowser)

--- a/tests/Endpoints/UserRoleTest.php
+++ b/tests/Endpoints/UserRoleTest.php
@@ -20,7 +20,7 @@ class UserRoleTest extends AbstractReadEndpoint
     {
         return [
             LoadUserRoleData::class,
-            LoadUserData::class
+            LoadUserData::class,
         ];
     }
 

--- a/tests/Endpoints/UserSessionMaterialStatusTest.php
+++ b/tests/Endpoints/UserSessionMaterialStatusTest.php
@@ -52,7 +52,7 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
             'status' => [[0], ['status' => UserSessionMaterialStatusInterface::NONE]],
             'statuses' => [[0, 1], ['status' => [
                 UserSessionMaterialStatusInterface::NONE,
-                UserSessionMaterialStatusInterface::STARTED
+                UserSessionMaterialStatusInterface::STARTED,
             ]]],
             'material' => [[1], ['material' => 3]],
             'materials' => [[0, 2], ['material' => [1, 5]]],
@@ -69,7 +69,7 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
         $filters['users'] = [[0, 1, 2], ['users' => [2]]];
         $filters['statuses'] = [[0, 1], ['statuses' => [
             UserSessionMaterialStatusInterface::NONE,
-            UserSessionMaterialStatusInterface::STARTED
+            UserSessionMaterialStatusInterface::STARTED,
         ]]];
 
         return $filters;

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -292,7 +292,7 @@ class UserTest extends AbstractReadWriteEndpoint
         $this->createJsonRequest(
             'POST',
             $this->getUrl($this->kernelBrowser, 'app_api_users_post', [
-                'version' => $this->apiVersion
+                'version' => $this->apiVersion,
             ]),
             json_encode(['users' => [$data]]),
             $rootUserToken

--- a/tests/Endpoints/UsermaterialsTest.php
+++ b/tests/Endpoints/UsermaterialsTest.php
@@ -24,7 +24,7 @@ class UsermaterialsTest extends AbstractEndpoint
             LoadIlmSessionData::class,
             LoadUserData::class,
             LoadSessionLearningMaterialData::class,
-            LoadCourseLearningMaterialData::class
+            LoadCourseLearningMaterialData::class,
         ];
     }
 
@@ -172,7 +172,7 @@ class UsermaterialsTest extends AbstractEndpoint
     {
         $parameters = [
             'version' => $this->apiVersion,
-            'id' => $userId
+            'id' => $userId,
         ];
         if (null !== $before) {
             $parameters['before'] = $before;
@@ -212,7 +212,7 @@ class UsermaterialsTest extends AbstractEndpoint
     ): void {
         $parameters = [
             'version' => $this->apiVersion,
-            'id' => 99
+            'id' => 99,
         ];
         $url = $this->getUrl(
             $this->kernelBrowser,

--- a/tests/Entity/AamcMethodTest.php
+++ b/tests/Entity/AamcMethodTest.php
@@ -30,7 +30,7 @@ class AamcMethodTest extends EntityBase
     {
         $notBlank = [
             'id',
-            'description'
+            'description',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/AamcPcrsTest.php
+++ b/tests/Entity/AamcPcrsTest.php
@@ -30,7 +30,7 @@ class AamcPcrsTest extends EntityBase
     {
         $notBlank = [
             'id',
-            'description'
+            'description',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/AamcResourceTypeTest.php
+++ b/tests/Entity/AamcResourceTypeTest.php
@@ -31,7 +31,7 @@ class AamcResourceTypeTest extends EntityBase
         $notBlank = [
             'id',
             'title',
-            'description'
+            'description',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/AlertChangeTypeTest.php
+++ b/tests/Entity/AlertChangeTypeTest.php
@@ -29,7 +29,7 @@ class AlertChangeTypeTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/AlertTest.php
+++ b/tests/Entity/AlertTest.php
@@ -30,7 +30,7 @@ class AlertTest extends EntityBase
     {
         $notBlank = [
             'tableRowId',
-            'tableName'
+            'tableName',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/ApplicationConfigTest.php
+++ b/tests/Entity/ApplicationConfigTest.php
@@ -30,7 +30,7 @@ class ApplicationConfigTest extends EntityBase
     {
         $notBlank = [
             'name',
-            'value'
+            'value',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/AssessmentOptionTest.php
+++ b/tests/Entity/AssessmentOptionTest.php
@@ -29,7 +29,7 @@ class AssessmentOptionTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'name'
+            'name',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/AuditLogTest.php
+++ b/tests/Entity/AuditLogTest.php
@@ -35,7 +35,7 @@ class AuditLogTest extends EntityBase
             'action',
             'objectId',
             'objectClass',
-            'valuesChanged'
+            'valuesChanged',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/CohortTest.php
+++ b/tests/Entity/CohortTest.php
@@ -32,7 +32,7 @@ class CohortTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/CourseClerkshipTypeTest.php
+++ b/tests/Entity/CourseClerkshipTypeTest.php
@@ -29,7 +29,7 @@ class CourseClerkshipTypeTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/CourseObjectiveTest.php
+++ b/tests/Entity/CourseObjectiveTest.php
@@ -48,7 +48,7 @@ class CourseObjectiveTest extends EntityBase
     {
         $this->object->setCourse(new Course());
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->validateNotBlanks($notBlank);
 
@@ -60,7 +60,7 @@ class CourseObjectiveTest extends EntityBase
     {
         $this->object->setTitle('foo');
         $notNull = [
-            'course'
+            'course',
         ];
         $this->validateNotNulls($notNull);
 

--- a/tests/Entity/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/Entity/CurriculumInventoryAcademicLevelTest.php
@@ -30,7 +30,7 @@ class CurriculumInventoryAcademicLevelTest extends EntityBase
     {
         $notBlank = [
             'name',
-            'level'
+            'level',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/CurriculumInventoryInstitutionTest.php
+++ b/tests/Entity/CurriculumInventoryInstitutionTest.php
@@ -37,7 +37,7 @@ class CurriculumInventoryInstitutionTest extends EntityBase
             'addressCity',
             'addressStateOrProvince',
             'addressZipCode',
-            'addressCountryCode'
+            'addressCountryCode',
         ];
         $this->object->setSchool(m::mock(SchoolInterface::class));
         $this->validateNotBlanks($notBlank);
@@ -55,7 +55,7 @@ class CurriculumInventoryInstitutionTest extends EntityBase
     public function testNotNullValidation(): void
     {
         $notNull = [
-            'school'
+            'school',
         ];
         $this->object->setName('10lenMAX');
         $this->object->setAamcCode('ddd');

--- a/tests/Entity/CurriculumInventoryReportTest.php
+++ b/tests/Entity/CurriculumInventoryReportTest.php
@@ -34,7 +34,7 @@ class CurriculumInventoryReportTest extends EntityBase
         $notBlank = [
             'year',
             'startDate',
-            'endDate'
+            'endDate',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Entity/CurriculumInventorySequenceBlockTest.php
@@ -55,7 +55,7 @@ class CurriculumInventorySequenceBlockTest extends EntityBase
     public function testNotNullValidation(): void
     {
         $notNulls = [
-            'report'
+            'report',
         ];
         $this->object->setTitle('test title for the block max 200');
         $this->object->setChildSequenceOrder(1);

--- a/tests/Entity/IlmSessionTest.php
+++ b/tests/Entity/IlmSessionTest.php
@@ -33,7 +33,7 @@ class IlmSessionTest extends EntityBase
         $notBlank = [
             'session',
             'hours',
-            'dueDate'
+            'dueDate',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/InstructorGroupTest.php
+++ b/tests/Entity/InstructorGroupTest.php
@@ -30,7 +30,7 @@ class InstructorGroupTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
         $this->validateNotBlanks($notBlank);
@@ -42,7 +42,7 @@ class InstructorGroupTest extends EntityBase
     public function testNotNullValidation(): void
     {
         $notNulls = [
-            'school'
+            'school',
         ];
         $this->object->setTitle('test');
 

--- a/tests/Entity/LearnerGroupTest.php
+++ b/tests/Entity/LearnerGroupTest.php
@@ -34,7 +34,7 @@ class LearnerGroupTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->object->setCohort(m::mock('App\Entity\CohortInterface'));
 
@@ -50,7 +50,7 @@ class LearnerGroupTest extends EntityBase
     public function testNotNullValidation(): void
     {
         $notNulls = [
-            'cohort'
+            'cohort',
         ];
         $this->object->setTitle('test');
         $this->validateNotNulls($notNulls);

--- a/tests/Entity/LearningMaterialStatusTest.php
+++ b/tests/Entity/LearningMaterialStatusTest.php
@@ -29,7 +29,7 @@ class LearningMaterialStatusTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/LearningMaterialTest.php
+++ b/tests/Entity/LearningMaterialTest.php
@@ -39,7 +39,7 @@ class LearningMaterialTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->object->setUserRole(m::mock(LearningMaterialUserRoleInterface::class));
         $this->object->setStatus(m::mock(LearningMaterialStatusInterface::class));
@@ -61,7 +61,7 @@ class LearningMaterialTest extends EntityBase
         $notNulls = [
             'userRole',
             'status',
-            'owningUser'
+            'owningUser',
         ];
         $this->object->setTitle('test');
 

--- a/tests/Entity/LearningMaterialUserRoleTest.php
+++ b/tests/Entity/LearningMaterialUserRoleTest.php
@@ -29,7 +29,7 @@ class LearningMaterialUserRoleTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/MeshDescriptorTest.php
+++ b/tests/Entity/MeshDescriptorTest.php
@@ -36,7 +36,7 @@ class MeshDescriptorTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'name'
+            'name',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/MeshPreviousIndexingTest.php
+++ b/tests/Entity/MeshPreviousIndexingTest.php
@@ -29,7 +29,7 @@ class MeshPreviousIndexingTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'previousIndexing'
+            'previousIndexing',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/MeshQualifierTest.php
+++ b/tests/Entity/MeshQualifierTest.php
@@ -30,7 +30,7 @@ class MeshQualifierTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'name'
+            'name',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/MeshTermTest.php
+++ b/tests/Entity/MeshTermTest.php
@@ -31,7 +31,7 @@ class MeshTermTest extends EntityBase
     {
         $notBlank = [
             'name',
-            'meshTermUid'
+            'meshTermUid',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/MeshTreeTest.php
+++ b/tests/Entity/MeshTreeTest.php
@@ -29,7 +29,7 @@ class MeshTreeTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'treeNumber'
+            'treeNumber',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/OfferingTest.php
+++ b/tests/Entity/OfferingTest.php
@@ -36,7 +36,7 @@ class OfferingTest extends EntityBase
     {
         $notBlank = [
             'startDate',
-            'endDate'
+            'endDate',
         ];
         $this->object->setSession(m::mock(SessionInterface::class));
 
@@ -55,7 +55,7 @@ class OfferingTest extends EntityBase
     public function testNotNullValidation(): void
     {
         $notNulls = [
-            'session'
+            'session',
         ];
 
         $this->object->setRoom('RCF 112');

--- a/tests/Entity/ProgramTest.php
+++ b/tests/Entity/ProgramTest.php
@@ -32,7 +32,7 @@ class ProgramTest extends EntityBase
     {
         $notBlank = [
             'title',
-            'duration'
+            'duration',
         ];
         $this->object->setSchool(m::mock(SchoolInterface::class));
 
@@ -49,7 +49,7 @@ class ProgramTest extends EntityBase
     public function testNotNullValidation(): void
     {
         $notNull = [
-            'school'
+            'school',
         ];
         $this->object->setTitle('DVc');
         $this->object->setDuration(30);

--- a/tests/Entity/ProgramYearObjectiveTest.php
+++ b/tests/Entity/ProgramYearObjectiveTest.php
@@ -47,7 +47,7 @@ class ProgramYearObjectiveTest extends EntityBase
     {
         $this->object->setProgramYear(new ProgramYear());
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->validateNotBlanks($notBlank);
 
@@ -59,7 +59,7 @@ class ProgramYearObjectiveTest extends EntityBase
     {
         $this->object->setTitle('foo');
         $notNull = [
-            'programYear'
+            'programYear',
         ];
         $this->validateNotNulls($notNull);
 

--- a/tests/Entity/SchoolConfigTest.php
+++ b/tests/Entity/SchoolConfigTest.php
@@ -31,7 +31,7 @@ class SchoolConfigTest extends EntityBase
     {
         $notBlank = [
             'name',
-            'value'
+            'value',
         ];
         $this->object->setSchool(new School());
         $this->validateNotBlanks($notBlank);
@@ -46,7 +46,7 @@ class SchoolConfigTest extends EntityBase
         $this->object->setName('smallestDog');
         $this->object->setValue('Jayden');
         $notNull = [
-            'school'
+            'school',
         ];
         $this->validateNotNulls($notNull);
 

--- a/tests/Entity/SchoolTest.php
+++ b/tests/Entity/SchoolTest.php
@@ -32,7 +32,7 @@ class SchoolTest extends EntityBase
     {
         $notBlank = [
             'title',
-            'iliosAdministratorEmail'
+            'iliosAdministratorEmail',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/SessionObjectiveTest.php
+++ b/tests/Entity/SessionObjectiveTest.php
@@ -46,7 +46,7 @@ class SessionObjectiveTest extends EntityBase
     {
         $this->object->setSession(new Session());
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->validateNotBlanks($notBlank);
 
@@ -58,7 +58,7 @@ class SessionObjectiveTest extends EntityBase
     {
         $this->object->setTitle('foo');
         $notNull = [
-            'session'
+            'session',
         ];
         $this->validateNotNulls($notNull);
 

--- a/tests/Entity/SessionTest.php
+++ b/tests/Entity/SessionTest.php
@@ -47,7 +47,7 @@ class SessionTest extends EntityBase
     {
         $notNull = [
             'sessionType',
-            'course'
+            'course',
         ];
         $this->validateNotNulls($notNull);
 

--- a/tests/Entity/SessionTypeTest.php
+++ b/tests/Entity/SessionTypeTest.php
@@ -32,7 +32,7 @@ class SessionTypeTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->object->setSchool(m::mock(SchoolInterface::class));
 
@@ -45,7 +45,7 @@ class SessionTypeTest extends EntityBase
     public function testNotNullValidation(): void
     {
         $notNull = [
-            'school'
+            'school',
         ];
         $this->object->setTitle('test');
 

--- a/tests/Entity/UserRoleTest.php
+++ b/tests/Entity/UserRoleTest.php
@@ -29,7 +29,7 @@ class UserRoleTest extends EntityBase
     public function testNotBlankValidation(): void
     {
         $notBlank = [
-            'title'
+            'title',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/Entity/UserSessionMaterialStatusTest.php
+++ b/tests/Entity/UserSessionMaterialStatusTest.php
@@ -35,7 +35,7 @@ class UserSessionMaterialStatusTest extends EntityBase
         $notNull = [
             'user',
             'material',
-            'status'
+            'status',
         ];
         $this->validateNotNulls($notNull);
 

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -33,7 +33,7 @@ class UserTest extends EntityBase
         $notBlank = [
             'lastName',
             'firstName',
-            'email'
+            'email',
         ];
         $this->validateNotBlanks($notBlank);
 

--- a/tests/RelationshipVoter/UserSessionMaterialStatusTest.php
+++ b/tests/RelationshipVoter/UserSessionMaterialStatusTest.php
@@ -48,7 +48,7 @@ class UserSessionMaterialStatusTest extends AbstractBase
             VoterPermissions::VIEW,
             VoterPermissions::DELETE,
             VoterPermissions::CREATE,
-            VoterPermissions::EDIT
+            VoterPermissions::EDIT,
             ] as $attr
         ) {
             $sessionUser->shouldReceive('getUser')->andReturn($user);

--- a/tests/Repository/AamcMethodRepositoryTest.php
+++ b/tests/Repository/AamcMethodRepositoryTest.php
@@ -23,7 +23,7 @@ class AamcMethodRepositoryTest extends KernelTestCase
 
         $databaseToot = self::$kernel->getContainer()->get(DatabaseToolCollection::class)->get();
         $executor = $databaseToot->loadFixtures([
-            LoadAamcMethodData::class
+            LoadAamcMethodData::class,
         ]);
         $this->fixtures = $executor->getReferenceRepository();
 

--- a/tests/Service/ApiRequestParserTest.php
+++ b/tests/Service/ApiRequestParserTest.php
@@ -208,7 +208,7 @@ class ApiRequestParserTest extends KernelTestCase
         return [
             [
                 [],
-                ['offset' => null, 'limit' => null, 'orderBy' => null, 'criteria' => []]
+                ['offset' => null, 'limit' => null, 'orderBy' => null, 'criteria' => []],
             ],
             [
                 ['offset' => '219', 'limit' => '120', 'order_by' => 'foobar'],
@@ -226,7 +226,7 @@ class ApiRequestParserTest extends KernelTestCase
                         'roles' => [
                             '1',
                             '2',
-                        ]
+                        ],
                     ],
                 ],
                 [
@@ -254,7 +254,7 @@ class ApiRequestParserTest extends KernelTestCase
                         'description' => 'some words',
                         'sessionTypes' => ['1', '2'],
                         'active' => true,
-                    ]
+                    ],
                 ],
                 'aamcmethods',
                 [
@@ -262,8 +262,8 @@ class ApiRequestParserTest extends KernelTestCase
                         'description' => 'some words',
                         'sessionTypes' => ['1', '2'],
                         'active' => true,
-                    ]
-                ]
+                    ],
+                ],
             ],
             [
                 true,
@@ -281,8 +281,8 @@ class ApiRequestParserTest extends KernelTestCase
                                     ['type' => 'sessionTypes', 'id' => '2'],
                                 ],
                             ],
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 'aamcmethods',
                 [
@@ -290,9 +290,9 @@ class ApiRequestParserTest extends KernelTestCase
                         'description' => 'some words',
                         'sessionTypes' => ['1', '2'],
                         'active' => false,
-                    ]
+                    ],
                 ],
-            ]
+            ],
         ];
     }
 
@@ -332,7 +332,7 @@ class ApiRequestParserTest extends KernelTestCase
                         'description' => 'some words',
                         'sessionTypes' => ['1', '2'],
                         'active' => true,
-                    ]
+                    ],
                 ],
                 'aamcmethods',
                 (object)[
@@ -359,8 +359,8 @@ class ApiRequestParserTest extends KernelTestCase
                                     ['type' => 'sessionTypes', 'id' => '2'],
                                 ],
                             ],
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 'aamcmethods',
                 (object)[
@@ -369,7 +369,7 @@ class ApiRequestParserTest extends KernelTestCase
                     'sessionTypes' => ['1', '2'],
                     'active' => true,
                 ],
-            ]
+            ],
         ];
     }
 
@@ -428,8 +428,8 @@ class ApiRequestParserTest extends KernelTestCase
                                     ['type' => 'sessionTypes', 'id' => '2'],
                                 ],
                             ],
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 AamcMethod::class . '[]',
                 'does not matter',
@@ -442,7 +442,7 @@ class ApiRequestParserTest extends KernelTestCase
                         'description' => 'some words',
                         'sessionTypes' => ['1', '2'],
                         'active' => true,
-                    ]
+                    ],
                 ],
                 AamcMethod::class . '[]',
                 'aamcmethods',
@@ -483,12 +483,12 @@ class ApiRequestParserTest extends KernelTestCase
                                     ['type' => 'sessionTypes', 'id' => '2'],
                                 ],
                             ],
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 'does not matter',
                 new AamcMethod(),
-                $callback
+                $callback,
             ],
             [
                 false,
@@ -498,11 +498,11 @@ class ApiRequestParserTest extends KernelTestCase
                         'description' => 'some words',
                         'sessionTypes' => ['1', '2'],
                         'active' => true,
-                    ]
+                    ],
                 ],
                 'aamcmethods',
                 new AamcMethod(),
-                $callback
+                $callback,
             ],
         ];
     }
@@ -526,8 +526,8 @@ class ApiRequestParserTest extends KernelTestCase
                                     ['type' => 'sessionTypes', 'id' => '2'],
                                 ],
                             ],
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 [
                     'id' => 'AM001',

--- a/tests/Service/ApiResponseBuilderTest.php
+++ b/tests/Service/ApiResponseBuilderTest.php
@@ -46,10 +46,10 @@ class ApiResponseBuilderTest extends TestCase
         $tree = $this->obj->extractJsonApiSideLoadFields($input);
         $expected = [
             'cohorts' => [
-                'green' => []
+                'green' => [],
             ],
             'objective' => [
-                'green' => []
+                'green' => [],
             ],
         ];
         $this->assertEquals($expected, $tree);
@@ -72,10 +72,10 @@ class ApiResponseBuilderTest extends TestCase
                 'programYear' => [
                     'program' => [],
                     'programYearObjectives' => [
-                        'objective' => []
-                    ]
+                        'objective' => [],
+                    ],
                 ],
-            ]
+            ],
         ];
         $this->assertEquals($expected, $tree);
     }
@@ -92,7 +92,7 @@ class ApiResponseBuilderTest extends TestCase
                         'directors' => [],
                     ],
                 ],
-            ]
+            ],
         ];
         $this->assertEquals($expected, $tree);
     }
@@ -124,7 +124,7 @@ class ApiResponseBuilderTest extends TestCase
                 'learningMaterials' => [
                     'learningMaterial' => [
                         'owningUser' => [],
-                    ]
+                    ],
                 ],
                 'sessionObjectives' => [
                     'objective' => [
@@ -132,37 +132,37 @@ class ApiResponseBuilderTest extends TestCase
                         'meshDescriptors' => [],
                     ],
                     'terms' => [
-                        'vocabulary' => []
+                        'vocabulary' => [],
                     ],
                 ],
                 'offerings' => [
                     'learners' => [],
                     'instructors' => [],
                     'instructorGroups' => [
-                        'users' => []
+                        'users' => [],
                     ],
                     'learnerGroups' => [
-                        'users' => []
-                    ]
+                        'users' => [],
+                    ],
                 ],
                 'ilmSession' => [
                     'learners' => [],
                     'instructors' => [],
                     'instructorGroups' => [
-                        'users' => []
+                        'users' => [],
                     ],
                     'learnerGroups' => [
-                        'users' => []
-                    ]
+                        'users' => [],
+                    ],
                 ],
                 'sessionDescription' => [],
                 'terms' => [
-                    'vocabulary' => []
+                    'vocabulary' => [],
                 ],
                 'meshDescriptors' => [
-                    'trees' => []
+                    'trees' => [],
                 ],
-            ]
+            ],
         ];
         $this->assertEquals($expected, $tree);
     }

--- a/tests/Service/CurriculumInventory/Export/XmlPrinterTest.php
+++ b/tests/Service/CurriculumInventory/Export/XmlPrinterTest.php
@@ -137,7 +137,7 @@ class XmlPrinterTest extends TestCase
                             'event_id' => 1000,
                             'id' => 'D000758',
                             'source' => 'MeSH',
-                            'name' => 'Anesthesia'
+                            'name' => 'Anesthesia',
                         ],
                         [
                             'event_id' => 1000,
@@ -165,7 +165,7 @@ class XmlPrinterTest extends TestCase
                             'event_id' => 2000,
                             'id' => 'D000005',
                             'source' => 'MeSH',
-                            'name' => 'Abdomen'
+                            'name' => 'Abdomen',
                         ],
                         [
                             'event_id' => 2000,
@@ -179,7 +179,7 @@ class XmlPrinterTest extends TestCase
                         'course_objectives' => [ 2 ],
                         'program_objectives' => [ 2 ],
                     ],
-                ]
+                ],
             ],
             'expectations' => [
                 'program_objectives' => [
@@ -236,7 +236,7 @@ class XmlPrinterTest extends TestCase
                             [ 'rel1' => 2, 'rel2' => 2, ],
                         ],
                     ],
-                ]
+                ],
             ],
             'sequence_block_references' => [
                 'events' => [

--- a/tests/Service/CurriculumInventory/ReportRolloverTest.php
+++ b/tests/Service/CurriculumInventory/ReportRolloverTest.php
@@ -150,7 +150,7 @@ class ReportRolloverTest extends TestCase
                 $topLevelBlock1,
                 $topLevelBlock2,
                 $subLevelBlock1, $subLevelBlock2,
-                $subSubLevelBlock1
+                $subSubLevelBlock1,
             ])
         );
         return [[ $report ]];

--- a/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
+++ b/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
@@ -375,19 +375,19 @@ class VerificationPreviewBuilderTest extends TestCase
             'id' => 'AM002',
             'title' => 'Clinical Performance Rating/Checklist',
             'num_summative_assessments' => 0,
-            'num_formative_assessments' => 3
+            'num_formative_assessments' => 3,
         ], $rows[0]);
         $this->assertEquals([
             'id' => 'AM003',
             'title' => 'Exam - Institutionally Developed, Clinical Performance',
             'num_summative_assessments' => 1,
-            'num_formative_assessments' => 1
+            'num_formative_assessments' => 1,
         ], $rows[1]);
         $this->assertEquals([
             'id' => 'AM007',
             'title' => 'Exam - Licensure, Written/Computer-based',
             'num_summative_assessments' => 2,
-            'num_formative_assessments' => 0
+            'num_formative_assessments' => 0,
         ], $rows[2]);
     }
 
@@ -397,11 +397,11 @@ class VerificationPreviewBuilderTest extends TestCase
             [],
             ['resource_types' => [
                 ['resource_type_id' => 1, 'resource_type_title' => 'Foo'],
-                ['resource_type_id' => 2, 'resource_type_title' => 'Bar']
+                ['resource_type_id' => 2, 'resource_type_title' => 'Bar'],
             ]],
             ['resource_types' => [
                 ['resource_type_id' => 3, 'resource_type_title' => 'Baz'],
-                ['resource_type_id' => 2, 'resource_type_title' => 'Bar']
+                ['resource_type_id' => 2, 'resource_type_title' => 'Bar'],
             ]],
             ['resource_types' => [
                 ['resource_type_id' => 3, 'resource_type_title' => 'Baz'],
@@ -465,7 +465,7 @@ class VerificationPreviewBuilderTest extends TestCase
         $report = new CurriculumInventoryReport();
         $report->setSequenceBlocks(
             new ArrayCollection([
-                $sequenceBlock1, $sequenceBlock2, $sequenceBlock3, $sequenceBlock4
+                $sequenceBlock1, $sequenceBlock2, $sequenceBlock3, $sequenceBlock4,
             ])
         );
 
@@ -494,7 +494,7 @@ class VerificationPreviewBuilderTest extends TestCase
                 ['id' => 3, 'event_id' => 6],
                 ['id' => 3, 'event_id' => 7],
                 ['id' => 3, 'event_id' => 8],
-            ]
+            ],
         ];
 
         $rhett = $this->builder->getClerkshipSequenceBlockAssessmentMethods($data);
@@ -664,7 +664,7 @@ class VerificationPreviewBuilderTest extends TestCase
                 ['id' => 3, 'event_id' => 6],
                 ['id' => 3, 'event_id' => 7],
                 ['id' => 3, 'event_id' => 8],
-            ]
+            ],
         ];
 
         $rows = $this->builder->getClerkshipSequenceBlockInstructionalTime($data);
@@ -708,25 +708,25 @@ class VerificationPreviewBuilderTest extends TestCase
             'id' => 'IM001',
             'title' => 'Case-Based Instruction/Learning',
             'num_events_primary_method' => 1,
-            'num_events_non_primary_method' => 0
+            'num_events_non_primary_method' => 0,
         ], $rows[0]);
         $this->assertEquals([
             'id' => 'IM002',
             'title' => 'Clinical Experience - Ambulatory',
             'num_events_primary_method' => 2,
-            'num_events_non_primary_method' => 0
+            'num_events_non_primary_method' => 0,
         ], $rows[1]);
         $this->assertEquals([
             'id' => 'IM007',
             'title' => 'Discussion, Large Group (>12)',
             'num_events_primary_method' => 1,
-            'num_events_non_primary_method' => 0
+            'num_events_non_primary_method' => 0,
         ], $rows[2]);
         $this->assertEquals([
             'id' => 'IM008',
             'title' => 'Discussion, Small Group (?12)',
             'num_events_primary_method' => 1,
-            'num_events_non_primary_method' => 0
+            'num_events_non_primary_method' => 0,
         ], $rows[3]);
     }
 
@@ -777,7 +777,7 @@ class VerificationPreviewBuilderTest extends TestCase
         $report = new CurriculumInventoryReport();
         $report->setSequenceBlocks(
             new ArrayCollection([
-                $sequenceBlock1, $sequenceBlock2, $sequenceBlock3, $sequenceBlock4
+                $sequenceBlock1, $sequenceBlock2, $sequenceBlock3, $sequenceBlock4,
             ])
         );
 
@@ -806,7 +806,7 @@ class VerificationPreviewBuilderTest extends TestCase
                 ['id' => 3, 'event_id' => 6],
                 ['id' => 3, 'event_id' => 7],
                 ['id' => 3, 'event_id' => 8],
-            ]
+            ],
         ];
 
         $rhett = $this->builder->getNonClerkshipSequenceBlockAssessmentMethods($data);
@@ -978,7 +978,7 @@ class VerificationPreviewBuilderTest extends TestCase
                 ['id' => 3, 'event_id' => 6],
                 ['id' => 3, 'event_id' => 7],
                 ['id' => 3, 'event_id' => 8],
-            ]
+            ],
         ];
 
         $rows = $this->builder->getNonClerkshipSequenceBlockInstructionalTime($data);
@@ -1063,7 +1063,7 @@ class VerificationPreviewBuilderTest extends TestCase
                 $sequenceBlock2,
                 $sequenceBlock3,
                 $sequenceBlock4,
-                $sequenceBlock5
+                $sequenceBlock5,
             ])
         );
 
@@ -1090,9 +1090,9 @@ class VerificationPreviewBuilderTest extends TestCase
                     3 => [
                         ['event_id' => 5],
                         ['event_id' => 6],
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
         $rhett = $this->builder->getPrimaryInstructionalMethodsByNonClerkshipSequenceBlock($data);
         $methods = $rhett['methods'];
@@ -1125,7 +1125,7 @@ class VerificationPreviewBuilderTest extends TestCase
             'ending_level' => 3,
             'instructional_methods' => [
                 'Other' => 60,
-                'Patient Contact' => 120
+                'Patient Contact' => 120,
             ],
             'total' => 180,
         ], $rows[2]);
@@ -1149,7 +1149,7 @@ class VerificationPreviewBuilderTest extends TestCase
                         ['rel1' => 3, 'rel2' => 'aamc-pcrs-comp-c0104'],
                         ['rel1' => 3, 'rel2' => 'aamc-pcrs-comp-c0105'],
                     ],
-                ]
+                ],
             ],
         ];
 
@@ -1193,14 +1193,14 @@ class VerificationPreviewBuilderTest extends TestCase
             'report' => $report,
             'events' => [],
             'sequence_block_references' => [
-                'events' => []
+                'events' => [],
             ],
             'expectations' => [
                 'program_objectives' => [],
                 'framework' => [
                     'relations' => [
                         'program_objectives_to_pcrs' => [],
-                    ]
+                    ],
                 ],
             ],
         ]);

--- a/tests/Service/DefaultPermissionMatrixTest.php
+++ b/tests/Service/DefaultPermissionMatrixTest.php
@@ -62,7 +62,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_PROGRAMS,
@@ -79,7 +79,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_ALL_PROGRAMS,
@@ -96,7 +96,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_THEIR_PROGRAMS,
@@ -113,7 +113,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_ALL_PROGRAMS,
@@ -130,7 +130,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_THEIR_PROGRAMS,
@@ -147,7 +147,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_PROGRAM_YEARS,
@@ -164,7 +164,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_ALL_PROGRAM_YEARS,
@@ -181,7 +181,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
                     UserRoles::PROGRAM_DIRECTOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_THEIR_PROGRAM_YEARS,
@@ -198,7 +198,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_ALL_PROGRAM_YEARS,
@@ -215,7 +215,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
                     UserRoles::PROGRAM_DIRECTOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_THEIR_PROGRAM_YEARS,
@@ -232,7 +232,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UNLOCK_ALL_PROGRAM_YEARS,
@@ -249,7 +249,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UNLOCK_THEIR_PROGRAM_YEARS,
@@ -266,7 +266,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_LOCK_ALL_PROGRAM_YEARS,
@@ -283,7 +283,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_LOCK_THEIR_PROGRAM_YEARS,
@@ -300,7 +300,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_ARCHIVE_ALL_PROGRAM_YEARS,
@@ -317,7 +317,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_ARCHIVE_THEIR_PROGRAM_YEARS,
@@ -334,7 +334,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_COURSES,
@@ -351,7 +351,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_ALL_COURSES,
@@ -368,7 +368,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_THEIR_COURSES,
@@ -385,7 +385,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_ALL_COURSES,
@@ -402,7 +402,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_THEIR_COURSES,
@@ -419,7 +419,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UNLOCK_ALL_COURSES,
@@ -436,7 +436,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UNLOCK_THEIR_COURSES,
@@ -453,7 +453,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_LOCK_ALL_COURSES,
@@ -470,7 +470,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_LOCK_THEIR_COURSES,
@@ -487,7 +487,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_ARCHIVE_ALL_COURSES,
@@ -504,7 +504,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_ARCHIVE_THEIR_COURSES,
@@ -521,7 +521,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_SESSIONS,
@@ -538,7 +538,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_ALL_SESSIONS,
@@ -555,7 +555,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
                     UserRoles::COURSE_ADMINISTRATOR,
                     UserRoles::COURSE_DIRECTOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_THEIR_SESSIONS,
@@ -572,7 +572,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::COURSE_DIRECTOR,
                     UserRoles::COURSE_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_ALL_SESSIONS,
@@ -589,7 +589,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
                     UserRoles::COURSE_ADMINISTRATOR,
                     UserRoles::COURSE_DIRECTOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_THEIR_SESSIONS,
@@ -606,7 +606,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_COMPETENCIES,
@@ -623,7 +623,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_COMPETENCIES,
@@ -640,7 +640,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_COMPETENCIES,
@@ -657,7 +657,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_SESSION_TYPES,
@@ -674,7 +674,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_SESSION_TYPES,
@@ -691,7 +691,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_SESSION_TYPES,
@@ -708,7 +708,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_VOCABULARIES,
@@ -725,7 +725,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_VOCABULARIES,
@@ -742,7 +742,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_VOCABULARIES,
@@ -759,7 +759,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_TERMS,
@@ -776,7 +776,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_TERMS,
@@ -793,7 +793,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_TERMS,
@@ -810,7 +810,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_INSTRUCTOR_GROUPS,
@@ -827,7 +827,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_INSTRUCTOR_GROUPS,
@@ -844,7 +844,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_INSTRUCTOR_GROUPS,
@@ -861,7 +861,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_LEARNER_GROUPS,
@@ -878,7 +878,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::COURSE_INSTRUCTOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_LEARNER_GROUPS,
@@ -895,7 +895,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::COURSE_INSTRUCTOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_LEARNER_GROUPS,
@@ -912,7 +912,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_CURRICULUM_INVENTORY_REPORTS,
@@ -929,7 +929,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_ALL_CURRICULUM_INVENTORY_REPORTS,
@@ -946,7 +946,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_THEIR_CURRICULUM_INVENTORY_REPORTS,
@@ -963,7 +963,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::COURSE_INSTRUCTOR,
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_ALL_CURRICULUM_INVENTORY_REPORTS,
@@ -980,7 +980,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_THEIR_CURRICULUM_INVENTORY_REPORTS,
@@ -997,7 +997,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_SCHOOL_CONFIGS,
@@ -1014,7 +1014,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_CURRICULUM_INVENTORY_INSTITUTIONS,
@@ -1031,7 +1031,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_CURRICULUM_INVENTORY_INSTITUTIONS,
@@ -1048,7 +1048,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_CURRICULUM_INVENTORY_INSTITUTIONS,
@@ -1065,7 +1065,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_CREATE_USERS,
@@ -1082,7 +1082,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_UPDATE_USERS,
@@ -1099,7 +1099,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
             [
                 Capabilities::CAN_DELETE_USERS,
@@ -1116,7 +1116,7 @@ class DefaultPermissionMatrixTest extends TestCase
                     UserRoles::SESSION_ADMINISTRATOR,
                     UserRoles::SESSION_INSTRUCTOR,
                     UserRoles::CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR,
-                ]
+                ],
             ],
         ];
     }

--- a/tests/Service/EntityMetadataTest.php
+++ b/tests/Service/EntityMetadataTest.php
@@ -287,7 +287,7 @@ class EntityMetadataTest extends KernelTestCase
                     'instructorGroups',
                     'instructors',
                     'learners',
-                ]
+                ],
             ],
             [stdClass::class, []],
         ];
@@ -301,7 +301,7 @@ class EntityMetadataTest extends KernelTestCase
                 [
                     'schools' => 'array<integer>',
                     'startYears' => 'array<integer>',
-                ]
+                ],
             ],
             [stdClass::class, []],
         ];
@@ -322,7 +322,7 @@ class EntityMetadataTest extends KernelTestCase
                 VocabularyDTO::class,
                 [
                     'school' => 'schools',
-                    'terms' => 'terms'
+                    'terms' => 'terms',
                 ],
             ],
             [
@@ -342,7 +342,7 @@ class EntityMetadataTest extends KernelTestCase
                     'school' => 'schools',
                     'terms' => 'terms',
                 ],
-            ]
+            ],
         ];
     }
 

--- a/tests/Service/FormAuthenticationTest.php
+++ b/tests/Service/FormAuthenticationTest.php
@@ -69,7 +69,7 @@ class FormAuthenticationTest extends TestCase
         $request = m::mock(Request::class);
         $arr = [
             'username' => null,
-            'password' => null
+            'password' => null,
         ];
         $request->shouldReceive('getContent')->once()->andReturn(json_encode($arr));
 
@@ -88,7 +88,7 @@ class FormAuthenticationTest extends TestCase
         $request = m::mock(Request::class);
         $arr = [
             'username' => 'abc',
-            'password' => '123'
+            'password' => '123',
         ];
         $request->shouldReceive('getContent')->once()->andReturn(json_encode($arr));
 
@@ -107,7 +107,7 @@ class FormAuthenticationTest extends TestCase
     {
         $arr = [
             'username' => 'abc',
-            'password' => '123'
+            'password' => '123',
         ];
 
         $request = m::mock(Request::class);
@@ -135,7 +135,7 @@ class FormAuthenticationTest extends TestCase
     {
         $arr = [
             'username' => 'abc',
-            'password' => '123'
+            'password' => '123',
         ];
 
         $request = m::mock(Request::class);
@@ -162,7 +162,7 @@ class FormAuthenticationTest extends TestCase
     {
         $arr = [
             'username' => 'abc',
-            'password' => '123'
+            'password' => '123',
         ];
 
         $request = m::mock(Request::class);

--- a/tests/Service/IliosFileSystemTest.php
+++ b/tests/Service/IliosFileSystemTest.php
@@ -108,7 +108,7 @@ class IliosFileSystemTest extends TestCase
             'learning_materials',
             'lm',
             $hashDirectory,
-            $hash
+            $hash,
         ];
         return implode('/', $parts);
     }
@@ -117,7 +117,7 @@ class IliosFileSystemTest extends TestCase
     {
         $parts = [
             IliosFileSystem::LOCK_FILE_DIRECTORY,
-            $name
+            $name,
         ];
         return implode('/', $parts);
     }

--- a/tests/Service/Index/CurriculumTest.php
+++ b/tests/Service/Index/CurriculumTest.php
@@ -53,7 +53,7 @@ class CurriculumTest extends TestCase
         $courses = [
             m::mock(IndexableCourse::class),
             m::mock(CourseDTO::class),
-            m::mock(IndexableCourse::class)
+            m::mock(IndexableCourse::class),
         ];
         $obj->index($courses);
     }
@@ -73,7 +73,7 @@ class CurriculumTest extends TestCase
         $obj = new Curriculum($this->config, $this->client);
         $course1 = m::mock(IndexableCourse::class);
         $course1->shouldReceive('createIndexObjects')->once()->andReturn([
-            ['id' => 1, 'courseFileLearningMaterialIds' => [], 'sessionFileLearningMaterialIds' => []]
+            ['id' => 1, 'courseFileLearningMaterialIds' => [], 'sessionFileLearningMaterialIds' => []],
         ]);
 
         $course2 = m::mock(IndexableCourse::class);
@@ -87,8 +87,8 @@ class CurriculumTest extends TestCase
                 [
                     'index' => [
                         '_index' => Curriculum::INDEX,
-                        '_id' => 1
-                    ]
+                        '_id' => 1,
+                    ],
                 ],
                 [
                     'id' => 1,
@@ -96,8 +96,8 @@ class CurriculumTest extends TestCase
                 [
                     'index' => [
                         '_index' => Curriculum::INDEX,
-                        '_id' => 2
-                    ]
+                        '_id' => 2,
+                    ],
                 ],
                 [
                     'id' => 2,
@@ -105,13 +105,13 @@ class CurriculumTest extends TestCase
                 [
                     'index' => [
                         '_index' => Curriculum::INDEX,
-                        '_id' => 3
-                    ]
+                        '_id' => 3,
+                    ],
                 ],
                 [
                     'id' => 3,
                 ],
-            ]
+            ],
         ])->andReturn(['errors' => false, 'took' => 1, 'items' => []]);
         $obj->index([$course1, $course2]);
     }

--- a/tests/Service/Index/UsersTest.php
+++ b/tests/Service/Index/UsersTest.php
@@ -54,7 +54,7 @@ class UsersTest extends TestCase
         $users = [
             m::mock(UserDTO::class),
             m::mock(User::class),
-            m::mock(UserDTO::class)
+            m::mock(UserDTO::class),
         ];
         $obj->index($users);
     }
@@ -80,8 +80,8 @@ class UsersTest extends TestCase
                 [
                     'index' => [
                         '_index' => Users::INDEX,
-                        '_id' => $user1->id
-                    ]
+                        '_id' => $user1->id,
+                    ],
                 ],
                 [
                     'id' => $user1->id,
@@ -99,8 +99,8 @@ class UsersTest extends TestCase
                 [
                     'index' => [
                         '_index' => Users::INDEX,
-                        '_id' => $user2->id
-                    ]
+                        '_id' => $user2->id,
+                    ],
                 ],
                 [
                     'id' => $user2->id,
@@ -115,7 +115,7 @@ class UsersTest extends TestCase
                     'fullName' => '11 first 11 middle 11 last',
                     'fullNameLastFirst' => '11 last, 11 first 11 middle',
                 ],
-            ]
+            ],
         ])->andReturn(['errors' => false, 'took' => 1, 'items' => []]);
         $obj->index([$user1, $user2]);
     }

--- a/tests/Service/LdapAuthenticationTest.php
+++ b/tests/Service/LdapAuthenticationTest.php
@@ -63,7 +63,7 @@ class LdapAuthenticationTest extends TestCase
     {
         $arr = [
             'username' => null,
-            'password' => null
+            'password' => null,
         ];
 
         $request = m::mock(Request::class);
@@ -83,7 +83,7 @@ class LdapAuthenticationTest extends TestCase
     {
         $arr = [
             'username' => 'abc',
-            'password' => '123'
+            'password' => '123',
         ];
         $request = m::mock(Request::class);
         $request->shouldReceive('getContent')->once()->andReturn(json_encode($arr));
@@ -107,13 +107,13 @@ class LdapAuthenticationTest extends TestCase
                 $this->authRepository,
                 $this->jwtManager,
                 $this->config,
-                $this->sessionUserProvider
+                $this->sessionUserProvider,
             ]
         );
         $obj->shouldReceive('checkLdapPassword')->once()->andReturn(false);
         $arr = [
             'username' => 'abc',
-            'password' => '123'
+            'password' => '123',
         ];
 
         $request = m::mock(Request::class);
@@ -141,7 +141,7 @@ class LdapAuthenticationTest extends TestCase
     {
         $arr = [
             'username' => 'abc',
-            'password' => '123'
+            'password' => '123',
         ];
 
         $request = m::mock(Request::class);
@@ -176,13 +176,13 @@ class LdapAuthenticationTest extends TestCase
                 $this->authRepository,
                 $this->jwtManager,
                 $this->config,
-                $this->sessionUserProvider
+                $this->sessionUserProvider,
             ]
         );
         $obj->shouldReceive('checkLdapPassword')->once()->andReturn(true);
         $arr = [
             'username' => 'abc',
-            'password' => '123'
+            'password' => '123',
         ];
 
         $request = m::mock(Request::class);

--- a/tests/Service/NonCachingIliosFileSystemTest.php
+++ b/tests/Service/NonCachingIliosFileSystemTest.php
@@ -125,7 +125,7 @@ class NonCachingIliosFileSystemTest extends TestCase
             'learning_materials',
             'lm',
             $hashDirectory,
-            $hash
+            $hash,
         ];
         return implode('/', $parts);
     }
@@ -134,7 +134,7 @@ class NonCachingIliosFileSystemTest extends TestCase
     {
         $parts = [
             IliosFileSystem::LOCK_FILE_DIRECTORY,
-            $name
+            $name,
         ];
         return implode('/', $parts);
     }

--- a/tests/ServiceTokenVoter/GreenlightViewDTOVoterTest.php
+++ b/tests/ServiceTokenVoter/GreenlightViewDTOVoterTest.php
@@ -155,7 +155,7 @@ class GreenlightViewDTOVoterTest extends AbstractReadonlyBase
             [UserDTO::class, true],
             [UserRoleDTO::class, true],
             [VocabularyDTO::class, true],
-            [self::class, false]
+            [self::class, false],
         ];
     }
 }

--- a/tests/Traits/TestableJsonController.php
+++ b/tests/Traits/TestableJsonController.php
@@ -66,7 +66,7 @@ trait TestableJsonController
     ): void {
         $headers = [
             'HTTP_ACCEPT' => 'application/json',
-            'CONTENT_TYPE' => 'application/json'
+            'CONTENT_TYPE' => 'application/json',
         ];
 
         if (! empty($jwt)) {


### PR DESCRIPTION
This makes diffs when an item is added to an array much easier to read. There are a few places where the comma had to be added to a multi line array with a single element, but I'm ok with the trade off.

Inspired by @michaelchadwick's PR comment about this: https://github.com/ilios/ilios/pull/5442#discussion_r1594385353 and turned out to be super easy to lint for and auto fix. 
