### PR TITLE
Add waiting messages to consume container

### DIFF
--- a/docker/messages-entrypoint
+++ b/docker/messages-entrypoint
@@ -1,8 +1,13 @@
 #!/bin/sh
 set -e
 
+echo "Waiting for db to be ready..."
 /srv/app/bin/console ilios:wait-for-database
+echo "The db is now ready and reachable"
+
+echo "Waiting for search index to be ready..."
 /srv/app/bin/console ilios:wait-for-index
+echo "The search index is now ready and reachable"
 
 # use exec so the process is the container's PID 1 which will allow
 # signals (Kill, Quit, Term) to be passed to the process.


### PR DESCRIPTION
When either the DB or index isn't ready it's hard to tell from the container logs. Adding some logging output will make it much easier to identify issues.