### PR TITLE
Comment out settings in dev environment

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,22 +1,22 @@
 # Template for developers
 # Copy to .env.dev.local to make changes
 
-ILIOS_SECRET=NotSecretChangeMe
+#ILIOS_SECRET=NotSecretChangeMe
 
 # Configure your db driver and server_version in config/packages/doctrine.yaml
 # ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=8.0
 
 # Where on the file system to store upload learning materials
-ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+#ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
 
 # These options will override the data in the application_config database table
 # They aren't required, but can make it easier to develop locally against a production database
-ILIOS_AUTHENTICATION_TYPE=form
-ILIOS_REQUIRE_SECURE_CONNECTION=false
-ILIOS_ERROR_CAPTURE_ENABLED=false
-ILIOS_LDAP_DIRECTORY_URL=null
+#ILIOS_AUTHENTICATION_TYPE=form
+#ILIOS_REQUIRE_SECURE_CONNECTION=false
+#ILIOS_ERROR_CAPTURE_ENABLED=false
+#ILIOS_LDAP_DIRECTORY_URL=null
 
-ILIOS_SEARCH_HOSTS=null
-ILIOS_STORAGE_S3_URL=null
+#ILIOS_SEARCH_HOSTS=null
+#ILIOS_STORAGE_S3_URL=null
 
-MAILER_DSN=null://null
+#MAILER_DSN=null://null


### PR DESCRIPTION
Symfony loads this files in an order that means settings in a the .env.local file will be overwritten by settings in the .env.dev file. This is almost never what you would expect and leads to needing to specify some things in a .env.dev.local file that could otherwise be consolidated in a single .env.local file. By commenting out all of these vars we avoid this issue.