### PR TITLE
Sign redirect requests for CAS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
     "symfony/validator": "@stable",
     "symfony/web-link": "@stable",
     "symfony/yaml": "@stable",
-    "webonyx/graphql-php": "^15.0"
+    "webonyx/graphql-php": "^15.0",
+    "ext-sodium": "*"
   },
   "require-dev": {
     "infection/infection": "^0.28.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e406aed25b90982d0cdb5a608e2bd0f2",
+    "content-hash": "5945c83963bdec6892a8669ff5aa4b98",
     "packages": [
         {
             "name": "async-aws/core",
@@ -15606,7 +15606,8 @@
         "ext-pdo": "*",
         "ext-simplexml": "*",
         "ext-xmlwriter": "*",
-        "ext-zlib": "*"
+        "ext-zlib": "*",
+        "ext-sodium": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/Service/CasAuthentication.php
+++ b/src/Service/CasAuthentication.php
@@ -27,7 +27,6 @@ class CasAuthentication implements AuthenticationInterface
     protected const string REDIRECT_COOKIE = 'ilios-cas-redirect';
     protected const string JWT_COOKIE = 'ilios-cas-jwt';
     protected const string NO_ACCOUNT_EXISTS_COOKIE = 'ilios-cas-no-account-exists';
-    protected const string COOKIE_SIGNATURE_SEPARATOR = '..xxx..';
 
     /**
      * Constructor
@@ -93,7 +92,7 @@ class CasAuthentication implements AuthenticationInterface
                 $jwt = $this->jwtManager->createJwtFromSessionUser($sessionUser);
                 if ($request->cookies->has(self::REDIRECT_COOKIE)) {
                     $value = $request->cookies->get(self::REDIRECT_COOKIE);
-                    [$providedHash, $redirectUrl] = explode(self::COOKIE_SIGNATURE_SEPARATOR, $value);
+                    [$providedHash, $redirectUrl] = unserialize($value);
                     $signature = $this->generateSignature($redirectUrl);
                     //validate the signature to ensure the redirect hasn't been tampered with
                     if (!hash_equals($signature, $providedHash)) {
@@ -175,11 +174,11 @@ class CasAuthentication implements AuthenticationInterface
 
             $signature = $this->generateSignature($redirectUrl);
             //store the redirect along with a signature to ensure it hasn't been tampered with
-            $value = implode(self::COOKIE_SIGNATURE_SEPARATOR, [$signature, $redirectUrl]);
+            $value = serialize([$signature, $redirectUrl]);
             $response->headers->setCookie(Cookie::create(
                 name: self::REDIRECT_COOKIE,
                 value: $value,
-                expire: strtotime('now + 2 minutes'),
+                expire: strtotime('+2 minutes'),
             ));
         }
 

--- a/src/Service/CasAuthentication.php
+++ b/src/Service/CasAuthentication.php
@@ -24,9 +24,10 @@ class CasAuthentication implements AuthenticationInterface
 {
     use AuthenticationService;
 
-    protected const REDIRECT_COOKIE = 'ilios-cas-redirect';
-    protected const JWT_COOKIE = 'ilios-cas-jwt';
-    protected const NO_ACCOUNT_EXISTS_COOKIE = 'ilios-cas-no-account-exists';
+    protected const string REDIRECT_COOKIE = 'ilios-cas-redirect';
+    protected const string JWT_COOKIE = 'ilios-cas-jwt';
+    protected const string NO_ACCOUNT_EXISTS_COOKIE = 'ilios-cas-no-account-exists';
+    protected const string COOKIE_SIGNATURE_SEPARATOR = '..xxx..';
 
     /**
      * Constructor
@@ -37,14 +38,15 @@ class CasAuthentication implements AuthenticationInterface
         protected LoggerInterface $logger,
         protected RouterInterface $router,
         protected CasManager $casManager,
-        protected SessionUserProvider $sessionUserProvider
+        protected SessionUserProvider $sessionUserProvider,
+        protected string $kernelSecret,
     ) {
     }
 
     /**
      * Authenticate a user from CAS
      *
-     * If a JWT cookie exists user it to create a JSON response
+     * If a JWT cookie exists use it to create a JSON response
      * If the user account doesn't exist send a JSON response with that error
      * If the user is not yet logged in send a redirect Request
      * If the user is logged in, but no account exists set a cookie and redirect them back to the frontend
@@ -90,7 +92,20 @@ class CasAuthentication implements AuthenticationInterface
             if ($sessionUser->isEnabled()) {
                 $jwt = $this->jwtManager->createJwtFromSessionUser($sessionUser);
                 if ($request->cookies->has(self::REDIRECT_COOKIE)) {
-                    $response = new RedirectResponse($request->cookies->get(self::REDIRECT_COOKIE));
+                    $value = $request->cookies->get(self::REDIRECT_COOKIE);
+                    [$providedHash, $redirectUrl] = explode(self::COOKIE_SIGNATURE_SEPARATOR, $value);
+                    $signature = $this->generateSignature($redirectUrl);
+                    //validate the signature to ensure the redirect hasn't been tampered with
+                    if (!hash_equals($signature, $providedHash)) {
+                        $this->logger->error(
+                            "Invalid signature in redirect cookie. " .
+                            "This is shady and may indicate someone is attempting " .
+                            "to use our redirect cookie for something nefarious. "
+                        );
+                        $response = $this->createSuccessResponseFromJWT($jwt);
+                    } else {
+                        $response = new RedirectResponse($redirectUrl);
+                    }
                     $response->headers->clearCookie(self::REDIRECT_COOKIE);
                 } else {
                     $response = $this->createSuccessResponseFromJWT($jwt);
@@ -161,7 +176,15 @@ class CasAuthentication implements AuthenticationInterface
 
         if (!$request->cookies->has(self::REDIRECT_COOKIE)) {
             $redirectUrl = $this->getAllowedRedirectUrl($request);
-            $response->headers->setCookie(Cookie::create(self::REDIRECT_COOKIE, $redirectUrl));
+
+            $signature = $this->generateSignature($redirectUrl);
+            //store the redirect along with a signature to ensure it hasn't been tampered with
+            $value = implode(self::COOKIE_SIGNATURE_SEPARATOR, [$signature, $redirectUrl]);
+            $response->headers->setCookie(Cookie::create(
+                name: self::REDIRECT_COOKIE,
+                value: $value,
+                expire: strtotime('now + 2 minutes'),
+            ));
         }
 
         return $response;
@@ -228,5 +251,18 @@ class CasAuthentication implements AuthenticationInterface
         } else {
             return $this->getRootUrl();
         }
+    }
+
+    /**
+     * Build a HMAC signature for a value
+     * We use a combination of the secret and a string to build a key and then hash the value,
+     * the result is binary, so we have to pass it through the sodium_bin2hex function to get a string.
+     * This results in a signature that is unique for the value and cannot be duplicated without the secret.
+     */
+    protected function generateSignature(string $value): string
+    {
+        return sodium_bin2hex(
+            sodium_crypto_generichash($value, $this->kernelSecret . self::REDIRECT_COOKIE)
+        );
     }
 }

--- a/src/Service/CasAuthentication.php
+++ b/src/Service/CasAuthentication.php
@@ -121,18 +121,14 @@ class CasAuthentication implements AuthenticationInterface
             }
         }
 
-        if ($request->cookies->has(self::REDIRECT_COOKIE)) {
-            $url = $request->cookies->get(self::REDIRECT_COOKIE);
-        } else {
-            $url = $this->getRootUrl();
-        }
-
-        $response = new RedirectResponse($url);
+        $response = new RedirectResponse($this->getRootUrl());
         $response->headers->setCookie(Cookie::create(
             self::NO_ACCOUNT_EXISTS_COOKIE,
             $username,
             strtotime('now + 45 seconds')
         ));
+        //just in case the redirect cookie hasn't expired, we should trash it
+        $response->headers->removeCookie(self::REDIRECT_COOKIE);
 
         return $response;
     }


### PR DESCRIPTION
We were allowing a cookie, which can be user defined, to redirect users after CAS authentication. This could potentially be tampered with or set by a bad actor.

By signing these cookies and validating them we remove this possibility and ensure that whatever is supplied in the cookie was created by us.