### PR TITLE
Update directory commands to use preferred names

### DIFF
--- a/src/Command/AddDirectoryUserCommand.php
+++ b/src/Command/AddDirectoryUserCommand.php
@@ -79,12 +79,13 @@ class AddDirectoryUserCommand extends Command
 
         $table = new Table($output);
         $table
-            ->setHeaders(['Campus ID', 'First', 'Last', 'Email', 'Username', 'Phone Number'])
+            ->setHeaders(['Campus ID', 'First', 'Last', 'Display', 'Email', 'Username', 'Phone Number'])
             ->setRows([
                 [
                     $userRecord['campusId'],
-                    $userRecord['firstName'],
-                    $userRecord['lastName'],
+                    $userRecord['preferredFirstName'] ?? $userRecord['firstName'],
+                    $userRecord['preferredLastName'] ?? $userRecord['lastName'],
+                    $userRecord['displayName'],
                     $userRecord['email'],
                     $userRecord['username'],
                     $userRecord['telephoneNumber'],
@@ -102,8 +103,9 @@ class AddDirectoryUserCommand extends Command
 
         if ($helper->ask($input, $output, $question)) {
             $user = $this->userRepository->create();
-            $user->setFirstName($userRecord['firstName']);
-            $user->setLastName($userRecord['lastName']);
+            $user->setFirstName($userRecord['preferredFirstName'] ?? $userRecord['firstName']);
+            $user->setLastName($userRecord['preferredLastName'] ?? $userRecord['lastName']);
+            $user->setDisplayName($userRecord['displayName']);
             $user->setEmail($userRecord['email']);
             $user->setCampusId($userRecord['campusId']);
             $user->setAddedViaIlios(true);

--- a/src/Command/AddNewStudentsToSchoolCommand.php
+++ b/src/Command/AddNewStudentsToSchoolCommand.php
@@ -92,8 +92,8 @@ class AddNewStudentsToSchoolCommand extends Command
         );
         $rows = array_map(fn(array $arr) => [
             $arr['campusId'],
-            $arr['firstName'],
-            $arr['lastName'],
+            $arr['preferredFirstName'] ?? $arr['firstName'],
+            $arr['preferredLastName'] ?? $arr['lastName'],
             $arr['email'],
         ], $newStudents);
         $table = new Table($output);
@@ -135,8 +135,9 @@ class AddNewStudentsToSchoolCommand extends Command
                     continue;
                 }
                 $user = $this->userRepository->create();
-                $user->setFirstName($userRecord['firstName']);
-                $user->setLastName($userRecord['lastName']);
+                $user->setFirstName($userRecord['preferredFirstName'] ?? $userRecord['firstName']);
+                $user->setLastName($userRecord['preferredLastName'] ?? $userRecord['lastName']);
+                $user->setDisplayName($userRecord['displayName']);
                 $user->setEmail($userRecord['email']);
                 $user->setCampusId($userRecord['campusId']);
                 $user->setAddedViaIlios(true);

--- a/src/Command/FindUserCommand.php
+++ b/src/Command/FindUserCommand.php
@@ -51,14 +51,15 @@ class FindUserCommand extends Command
 
         $rows = array_map(fn($arr) => [
             $arr['campusId'],
-            $arr['firstName'],
-            $arr['lastName'],
+            $arr['displayName'],
+            $arr['preferredFirstName'] ?? $arr['firstName'],
+            $arr['preferredLastName'] ?? $arr['lastName'],
             $arr['email'],
             $arr['telephoneNumber'],
         ], $userRecords);
         $table = new Table($output);
         $table
-            ->setHeaders(['Campus ID', 'First', 'Last', 'Email', 'Phone Number'])
+            ->setHeaders(['Campus ID', 'Display', 'First', 'Last', 'Email', 'Phone Number'])
             ->setRows($rows)
         ;
         $table->render();

--- a/src/Service/Directory.php
+++ b/src/Service/Directory.php
@@ -15,9 +15,8 @@ class Directory
 
     /**
      * Get directory information for a single user
-     * @param  string $campusId
      */
-    public function findByCampusId($campusId): ?array
+    public function findByCampusId(string $campusId): ?array
     {
         $ldapCampusIdProperty = $this->config->get('ldap_directory_campus_id_property');
 
@@ -79,9 +78,8 @@ class Directory
 
     /**
      * Find all users matching LDAP filter
-     * @param  string $filter
      */
-    public function findByLdapFilter($filter): ?array
+    public function findByLdapFilter(string $filter): ?array
     {
         $users = $this->ldapManager->search($filter);
         if ($users !== []) {

--- a/tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -79,18 +79,24 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
         $fakeDirectoryUser1 = [
             'firstName' => 'first',
             'lastName' => 'last',
+            'displayName' => 'first last',
             'email' => 'email',
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
             'username' => 'username',
+            'preferredFirstName' => 'preferredFirst',
+            'preferredLastName' => 'preferredLast',
         ];
         $fakeDirectoryUser2 = [
             'firstName' => 'first2',
             'lastName' => 'last2',
+            'displayName' => 'first2 last2',
             'email' => 'email2',
             'telephoneNumber' => 'phone2',
             'campusId' => 'abc2',
             'username' => 'username2',
+            'preferredFirstName' => null,
+            'preferredLastName' => null,
         ];
         $school = m::mock(SchoolInterface::class);
         $school->shouldReceive('getTitle')->andReturn('school 1');
@@ -101,8 +107,9 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
         $user->shouldReceive('getFirstAndLastName')->andReturn('first last');
         $user->shouldReceive('getEmail')->andReturn('email');
         $user->shouldReceive('getCampusId')->andReturn('abc');
-        $user->shouldReceive('setFirstName')->with('first');
-        $user->shouldReceive('setLastName')->with('last');
+        $user->shouldReceive('setFirstName')->with('preferredFirst');
+        $user->shouldReceive('setLastName')->with('preferredLast');
+        $user->shouldReceive('setDisplayName')->with('first last');
         $user->shouldReceive('setEmail')->with('email');
         $user->shouldReceive('setPhone')->with('phone');
         $user->shouldReceive('setCampusId')->with('abc');
@@ -163,7 +170,7 @@ class AddNewStudentsToSchoolCommandTest extends KernelTestCase
             $output
         );
         $this->assertMatchesRegularExpression(
-            '/abc\s+\| first\s+\| last\s+\| email /',
+            '/abc\s+\| preferredFirst\s+\| preferredLast\s+\| email /',
             $output
         );
         $this->assertMatchesRegularExpression(

--- a/tests/Command/FindUserCommandTest.php
+++ b/tests/Command/FindUserCommandTest.php
@@ -52,9 +52,12 @@ class FindUserCommandTest extends KernelTestCase
         $fakeDirectoryUser = [
             'firstName' => 'first',
             'lastName' => 'last',
+            'displayName' => 'first last',
             'email' => 'email',
             'telephoneNumber' => 'phone',
             'campusId' => 'abc',
+            'preferredFirstName' => null,
+            'preferredLastName' => null,
         ];
         $this->directory->shouldReceive('find')->with(['a', 'b'])->andReturn([$fakeDirectoryUser]);
 
@@ -65,7 +68,33 @@ class FindUserCommandTest extends KernelTestCase
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
-            '/abc\s+\| first\s+\| last\s+\| email\s+\| phone/',
+            '/abc\s+\| first last\s+\| first\s+\| last\s+\| email\s+\| phone/',
+            $output
+        );
+    }
+
+    public function testExecuteWithPreferredNames(): void
+    {
+        $fakeDirectoryUser = [
+            'firstName' => 'first',
+            'lastName' => 'last',
+            'displayName' => 'first last',
+            'email' => 'email',
+            'telephoneNumber' => 'phone',
+            'campusId' => 'abc',
+            'preferredFirstName' => 'preferredFirst',
+            'preferredLastName' => 'preferredLast',
+        ];
+        $this->directory->shouldReceive('find')->with(['a', 'b'])->andReturn([$fakeDirectoryUser]);
+
+        $this->commandTester->execute([
+            'searchTerms' => ['a', 'b'],
+        ]);
+
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/abc\s+\| first last\s+\| preferredFirst\s+\| preferredLast\s+\| email\s+\| phone/',
             $output
         );
     }

--- a/tests/Service/DirectoryTest.php
+++ b/tests/Service/DirectoryTest.php
@@ -51,7 +51,7 @@ class DirectoryTest extends TestCase
         $this->config->shouldReceive('get')->once()->with('ldap_directory_campus_id_property')->andReturn('campusId');
         $this->ldapManager->shouldReceive('search')->with('(campusId=1234)')->andReturn([['id' => 1]]);
 
-        $result = $this->obj->findByCampusId(1234);
+        $result = $this->obj->findByCampusId('1234');
         $this->assertSame($result, ['id' => 1]);
     }
 
@@ -144,7 +144,7 @@ class DirectoryTest extends TestCase
     {
         $this->setupConfigForSearch([
             'ldap_directory_first_name_property' => null,
-            'ldap_directory_last_name_property' => null
+            'ldap_directory_last_name_property' => null,
         ]);
         $filter = '(&(|(mail=jj*)(cid=jj*)(dn=jj*)(givenName=jj*)(sn=jj*)(pfn=jj*)(pln=jj*)))';
         $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1,2]);
@@ -157,7 +157,7 @@ class DirectoryTest extends TestCase
     {
         $this->setupConfigForSearch([
             'ldap_directory_preferred_first_name_property' => null,
-            'ldap_directory_preferred_last_name_property' => null
+            'ldap_directory_preferred_last_name_property' => null,
         ]);
         $filter = '(&(|(mail=jj*)(cid=jj*)(dn=jj*)(f=jj*)(l=jj*)))';
         $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1,2]);


### PR DESCRIPTION
Adding the display name and replacing output of the first and last name with the preferred version as well as saving the preferred version for new students synced into a school to match the behavior of the user sync command.

Refs #5453