### PR TITLE
Allow sending an environment with sentry errors

### DIFF
--- a/docs/error_reporting.md
+++ b/docs/error_reporting.md
@@ -8,6 +8,7 @@ If your organization would like to share any errors or crashes in your Ilios ins
 
 ```bash
 sudo -u apache bin/console ilios:set-config-value errorCaptureEnabled true
+sudo -u apache bin/console ilios:set-config-value errorCaptureEnvironment YOUR_CAMPUS_NAME
 ```
 
 This command will simply add a configuration setting named `errorCaptureEnabled` to the `application_config` table in your Ilios database and set its value to `true`.  In turn, this will activate the extra features necessary for sending information about your application's errors/issues directly to us in the background.

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -176,6 +176,7 @@ class IndexController extends AbstractController
             'noScripts' => $noScripts,
             'divs' => $divs,
             'errorCaptureEnabled' => $this->config->get('errorCaptureEnabled'),
+            'errorCaptureEnvironment' => $this->config->get('errorCaptureEnvironment'),
         ];
     }
 

--- a/src/Service/SentryBeforeSend.php
+++ b/src/Service/SentryBeforeSend.php
@@ -10,11 +10,13 @@ use Sentry\Event;
 class SentryBeforeSend
 {
     protected bool $errorCaptureEnabled;
+    protected ?string $errorCaptureEnvironment;
 
     public function __construct(
         Config $config,
     ) {
         $this->errorCaptureEnabled = (bool) $config->get('errorCaptureEnabled');
+        $this->errorCaptureEnvironment = $config->get('errorCaptureEnvironment');
     }
 
     public function __invoke(Event $event)
@@ -24,6 +26,7 @@ class SentryBeforeSend
         }
 
         $event->setRelease(InstalledVersions::getPrettyVersion(InstalledVersions::getRootPackage()['name']));
+        $event->setEnvironment($this->errorCaptureEnvironment);
 
         return $event;
     }

--- a/templates/index/webindex.html.twig
+++ b/templates/index/webindex.html.twig
@@ -24,6 +24,7 @@
     <meta name='iliosconfig-api-name-space' content='api/v3'>
     <meta name='iliosconfig-api-host' content=''>
     <meta name='iliosconfig-error-capture-enabled' content="{{ errorCaptureEnabled ? 'true':'false' }}">
+    <meta name='iliosconfig-error-capture-environment' content="{{ errorCaptureEnvironment }}">
     <title>Ilios</title>
 
     {% for l in preloadLinks %}


### PR DESCRIPTION
This will make it much easier to categorize errors in our reporting and alarms.