### PR TITLE
Add missing lang attribute

### DIFF
--- a/templates/index/webindex.html.twig
+++ b/templates/index/webindex.html.twig
@@ -16,7 +16,7 @@
 #}
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     {% for m in metas %}
         <meta {% if m.httpequiv %} http-equiv="{{ m.httpequiv }}" {% endif %} {% if m.charset %} charset="{{ m.charset }}" {% endif %} {% if m.name %} name="{{ m.name }}" {% endif %} {% if m.content %} content="{{ m.content }}" {% endif %} />


### PR DESCRIPTION
This is always a good idea, we have it on the frontend, but didn't include it in this HTML where almost all of our users load Ilios from. Since this is the default loading language on the frontend I'm ok with setting it to en, when a user changes their language this property gets updated as well.