### PR TITLE
Fix Testing Memory Leak

### DIFF
--- a/tests/Endpoints/AbstractEndpoint.php
+++ b/tests/Endpoints/AbstractEndpoint.php
@@ -71,6 +71,8 @@ abstract class AbstractEndpoint extends WebTestCase
         parent::tearDown();
         unset($this->kernelBrowser);
         unset($this->fixtures);
+        unset($this->databaseTool);
+        unset($this->inflector);
     }
 
 


### PR DESCRIPTION
We were not unsetting all the properties on the test object which caused it to get held in memory and was the source of our massive memory leak in tests.