### PR TITLE
Add a timeout to test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     name: PHPUnit Tests
     needs: code_style
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       matrix:


### PR DESCRIPTION
Let's not get back in a situation with super long tests accidentally. Adding a timeout.