### PR TITLE
change failed transport queue from default to failed

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -4,7 +4,7 @@ framework:
     transports:
       # https://symfony.com/doc/current/messenger.html#transport-configuration
        async: '%env(MESSENGER_TRANSPORT_DSN)%'
-       failed: '%env(MESSENGER_TRANSPORT_DSN)%'
+       failed: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=failed'
 
     routing:
       # Route your messages to the transports


### PR DESCRIPTION
Messages are moved to the `failure_transport` after failing to index to OpenSearch after the default `max_retries` = 3. Messages retried from the `failure_transport` are discarded permanently once `max_retries` is hit. The `async` and `failed` transport were using the same transport DSN causing Symfony to categorize all messages as already failed, thus discarding them permanently after failure (with retries) instead of saving them to the `failure_transport`.

Updating the queue name for the `failed` transport to `failed`, to separate the `async` and `failed` transport queues within `messenger_messages` table. Queue name is a column in the default, `messenger_messages` table, and keeps one table for multiple transports.

`messenger:stats` will show the number of messages in the queue of each transport. The saved failed messages can be reviewed with `messenger:failed:show` and then retried or referenced for further investigation.

https://symfony.com/doc/current/messenger.html#retries-failures