### PR TITLE
Increase the sleep time for indexing

### DIFF
--- a/src/Classes/OpenSearchBase.php
+++ b/src/Classes/OpenSearchBase.php
@@ -167,7 +167,7 @@ class OpenSearchBase
             }
             $results['items'] = array_merge($results['items'], $rhett['items']);
             //allow search time to catch up https://github.com/opensearch-project/opensearch-php/blob/9457c505e9bce68ca81932a461159517635aeba1/USER_GUIDE.md?plain=1#L139-L140
-            sleep(2);
+            sleep(10);
         }
 
         return $results;


### PR DESCRIPTION
We're hitting resource limits on open search with our bulk index requests, let's try bumping up this sleep so it isn't necessary to spend more on a larger instance.