### PR TITLE
rm CodeClimate integation for code coverage stats from workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,31 +346,11 @@ jobs:
       - name: Run Update Frontend
         run: bin/console ilios:update-frontend
 
-  coverage:
-    name: Upload Code Coverage
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: tests
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download Coverage Report
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-output
-      - run: ls -lh coverage.xml
-      - name: Upload to CodeClimate
-        uses: paambaati/codeclimate-action@v6.0.0
-        with:
-          coverageLocations:
-            coverage.xml:clover
-        env:
-          CC_TEST_REPORTER_ID: c2e072c72320901c23741e4c25bfd28e149441b5a19ba9abb8cf80ca0363ff9a
-
   sonarqube_scan:
     name: Scan with UCSF SonarQube
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    env: 
+    env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     needs: tests
     steps:


### PR DESCRIPTION
this has become redundant - sonarqube gives us coverage reports as well.

refs #5529 