### PR TITLE
Fix formatting issues in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 
 **Closed issues:**
 
-- include terms linked to owned sessions in terms filter to course endpoint.  [\#1737](https://github.com/ilios/ilios/issues/1737)
+- include terms linked to owned sessions in terms filter to course endpoint. [\#1737](https://github.com/ilios/ilios/issues/1737)
 - Add 'composer install' step to vagrant build [\#789](https://github.com/ilios/ilios/issues/789)
 
 **Merged pull requests:**
@@ -1793,7 +1793,7 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Feature 3024: display parent competency titles in learner course summary view [\#23](https://github.com/ilios/ilios/pull/23) ([stopfstedt](https://github.com/stopfstedt))
 - reintegrate rb2.1.2 into master  [\#22](https://github.com/ilios/ilios/pull/22) ([stopfstedt](https://github.com/stopfstedt))
 - added proper sort order to competency dropdown in program objective dialog [\#21](https://github.com/ilios/ilios/pull/21) ([stopfstedt](https://github.com/stopfstedt))
-- added download instructions to README file.  [\#20](https://github.com/ilios/ilios/pull/20) ([stopfstedt](https://github.com/stopfstedt))
+- added download instructions to README file. [\#20](https://github.com/ilios/ilios/pull/20) ([stopfstedt](https://github.com/stopfstedt))
 - added indexes/foreign key constraints for user\_x\_user\_role table [\#19](https://github.com/ilios/ilios/pull/19) ([thecoolestguy](https://github.com/thecoolestguy))
 - refactored hardwired path to Shib Logout Service into a config setting. ... [\#18](https://github.com/ilios/ilios/pull/18) ([stopfstedt](https://github.com/stopfstedt))
 - modified idle page timeout mechanism to allow for logout url configurati... [\#17](https://github.com/ilios/ilios/pull/17) ([stopfstedt](https://github.com/stopfstedt))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Release Notes
+
 In order to standardize and improve our release process, the Ilios team has discontinued the use of this change log
-and will instead publish changes in our [Release Notes](https://github.com/ilios/ilios/releases)
+and will instead publish changes in our [Release Notes](https://github.com/ilios/ilios/releases).
 
-# Change Log (for previous releases)
+## Change Log (for previous releases)
 
-## [v3.28.1](https://github.com/ilios/ilios/tree/v3.28.1)
+### [v3.28.1](https://github.com/ilios/ilios/tree/v3.28.1)
 
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.28.0...v3.28.1)
 
@@ -16,7 +17,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 
 - Prevent users from editing their own account [\#1764](https://github.com/ilios/ilios/pull/1764) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.28.0](https://github.com/ilios/ilios/tree/v3.28.0) (2017-02-24)
+### [v3.28.0](https://github.com/ilios/ilios/tree/v3.28.0) (2017-02-24)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.27.0...v3.28.0)
 
 **Implemented enhancements:**
@@ -38,7 +40,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - sortable course/session learning materials [\#1754](https://github.com/ilios/ilios/pull/1754) ([stopfstedt](https://github.com/stopfstedt))
 - Update Dependencies [\#1752](https://github.com/ilios/ilios/pull/1752) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.27.0](https://github.com/ilios/ilios/tree/v3.27.0) (2017-02-10)
+### [v3.27.0](https://github.com/ilios/ilios/tree/v3.27.0) (2017-02-10)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.26.0...v3.27.0)
 
 **Implemented enhancements:**
@@ -60,7 +63,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Allow ILIOS\_\* env variables to fill parameters.yml [\#1740](https://github.com/ilios/ilios/pull/1740) ([jrjohnson](https://github.com/jrjohnson))
 - application and school configuration [\#1736](https://github.com/ilios/ilios/pull/1736) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.26.0](https://github.com/ilios/ilios/tree/v3.26.0) (2017-02-04)
+### [v3.26.0](https://github.com/ilios/ilios/tree/v3.26.0) (2017-02-04)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.25.0...v3.26.0)
 
 **Closed issues:**
@@ -74,7 +78,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - include session terms in course filter [\#1738](https://github.com/ilios/ilios/pull/1738) ([stopfstedt](https://github.com/stopfstedt))
 - Replace Vagrant with docker [\#1607](https://github.com/ilios/ilios/pull/1607) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.25.0](https://github.com/ilios/ilios/tree/v3.25.0) (2017-01-27)
+### [v3.25.0](https://github.com/ilios/ilios/tree/v3.25.0) (2017-01-27)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.24.1...v3.25.0)
 
 **Implemented enhancements:**
@@ -96,7 +101,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - filter session types by terms [\#1726](https://github.com/ilios/ilios/pull/1726) ([stopfstedt](https://github.com/stopfstedt))
 - Grant VIEW permissions for all departments [\#1723](https://github.com/ilios/ilios/pull/1723) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.24.1](https://github.com/ilios/ilios/tree/v3.24.1) (2017-01-13)
+### [v3.24.1](https://github.com/ilios/ilios/tree/v3.24.1) (2017-01-13)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.24.0...v3.24.1)
 
 **Closed issues:**
@@ -117,7 +123,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Update dependencies [\#1712](https://github.com/ilios/ilios/pull/1712) ([jrjohnson](https://github.com/jrjohnson))
 - Correctly apply maximum TTL for tokens [\#1710](https://github.com/ilios/ilios/pull/1710) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.24.0](https://github.com/ilios/ilios/tree/v3.24.0) (2016-12-22)
+### [v3.24.0](https://github.com/ilios/ilios/tree/v3.24.0) (2016-12-22)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.23.0...v3.24.0)
 
 **Implemented enhancements:**
@@ -147,7 +154,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - refactored track api usage listener w/o container aware trait. [\#1693](https://github.com/ilios/ilios/pull/1693) ([stopfstedt](https://github.com/stopfstedt))
 - catch and log tracking exceptions. [\#1690](https://github.com/ilios/ilios/pull/1690) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.23.0](https://github.com/ilios/ilios/tree/v3.23.0) (2016-12-02)
+### [v3.23.0](https://github.com/ilios/ilios/tree/v3.23.0) (2016-12-02)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.22.0...v3.23.0)
 
 **Implemented enhancements:**
@@ -169,7 +177,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - added requirement notes for php-zip extension and URL-rewriting [\#1681](https://github.com/ilios/ilios/pull/1681) ([thecoolestguy](https://github.com/thecoolestguy))
 - track API usage [\#1677](https://github.com/ilios/ilios/pull/1677) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.22.0](https://github.com/ilios/ilios/tree/v3.22.0) (2016-11-18)
+### [v3.22.0](https://github.com/ilios/ilios/tree/v3.22.0) (2016-11-18)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.21.0...v3.22.0)
 
 **Implemented enhancements:**
@@ -194,7 +203,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - added frontend-update command instructions [\#1665](https://github.com/ilios/ilios/pull/1665) ([thecoolestguy](https://github.com/thecoolestguy))
 - updated version requirements in INSTALL.md [\#1662](https://github.com/ilios/ilios/pull/1662) ([thecoolestguy](https://github.com/thecoolestguy))
 
-## [v3.21.0](https://github.com/ilios/ilios/tree/v3.21.0) (2016-10-28)
+### [v3.21.0](https://github.com/ilios/ilios/tree/v3.21.0) (2016-10-28)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.20.0...v3.21.0)
 
 **Implemented enhancements:**
@@ -260,7 +270,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - set a cookie to report download response. [\#1613](https://github.com/ilios/ilios/pull/1613) ([stopfstedt](https://github.com/stopfstedt))
 - Update relationships only when needed [\#1611](https://github.com/ilios/ilios/pull/1611) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.20.0](https://github.com/ilios/ilios/tree/v3.20.0) (2016-09-30)
+### [v3.20.0](https://github.com/ilios/ilios/tree/v3.20.0) (2016-09-30)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.19.0...v3.20.0)
 
 **Implemented enhancements:**
@@ -285,7 +296,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Expand Course externalId to 255 characters [\#1599](https://github.com/ilios/ilios/pull/1599) ([jrjohnson](https://github.com/jrjohnson))
 - Cascade learner group deletes to sub groups [\#1595](https://github.com/ilios/ilios/pull/1595) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.19.0](https://github.com/ilios/ilios/tree/v3.19.0) (2016-09-16)
+### [v3.19.0](https://github.com/ilios/ilios/tree/v3.19.0) (2016-09-16)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.18.1...v3.19.0)
 
 **Implemented enhancements:**
@@ -308,7 +320,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Add ancestry to courses and objectives [\#1585](https://github.com/ilios/ilios/pull/1585) ([jrjohnson](https://github.com/jrjohnson))
 - Allow lockable entities to be unlocked [\#1583](https://github.com/ilios/ilios/pull/1583) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.18.1](https://github.com/ilios/ilios/tree/v3.18.1) (2016-09-09)
+### [v3.18.1](https://github.com/ilios/ilios/tree/v3.18.1) (2016-09-09)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.18.0...v3.18.1)
 
 **Closed issues:**
@@ -333,7 +346,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Don't set the session if we are unsetting the ILM session [\#1566](https://github.com/ilios/ilios/pull/1566) ([jrjohnson](https://github.com/jrjohnson))
 - Detect if a session exists before attempting to destroy it [\#1565](https://github.com/ilios/ilios/pull/1565) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.18.0](https://github.com/ilios/ilios/tree/v3.18.0) (2016-09-02)
+### [v3.18.0](https://github.com/ilios/ilios/tree/v3.18.0) (2016-09-02)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.17.0...v3.18.0)
 
 **Implemented enhancements:**
@@ -356,7 +370,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Add EasyLog logger [\#1552](https://github.com/ilios/ilios/pull/1552) ([jrjohnson](https://github.com/jrjohnson))
 - Improved composer install instructions [\#1550](https://github.com/ilios/ilios/pull/1550) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.17.0](https://github.com/ilios/ilios/tree/v3.17.0) (2016-08-17)
+### [v3.17.0](https://github.com/ilios/ilios/tree/v3.17.0) (2016-08-17)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.16.0...v3.17.0)
 
 **Implemented enhancements:**
@@ -378,7 +393,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - apply correct strategy when changing sequence sort order [\#1537](https://github.com/ilios/ilios/pull/1537) ([stopfstedt](https://github.com/stopfstedt))
 - annotate the track property as exposed. [\#1536](https://github.com/ilios/ilios/pull/1536) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.16.0](https://github.com/ilios/ilios/tree/v3.16.0) (2016-07-29)
+### [v3.16.0](https://github.com/ilios/ilios/tree/v3.16.0) (2016-07-29)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.15.0...v3.16.0)
 
 **Implemented enhancements:**
@@ -414,7 +430,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - grant dev role to first user instead of course director. [\#1515](https://github.com/ilios/ilios/pull/1515) ([stopfstedt](https://github.com/stopfstedt))
 - Disabled/re-enabled foreign key checks on several migrations to get them to work with MySQL 5.6+ [\#1451](https://github.com/ilios/ilios/pull/1451) ([thecoolestguy](https://github.com/thecoolestguy))
 
-## [v3.15.0](https://github.com/ilios/ilios/tree/v3.15.0) (2016-07-08)
+### [v3.15.0](https://github.com/ilios/ilios/tree/v3.15.0) (2016-07-08)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.14.0...v3.15.0)
 
 **Implemented enhancements:**
@@ -435,7 +452,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - corrected table joins in query. [\#1502](https://github.com/ilios/ilios/pull/1502) ([stopfstedt](https://github.com/stopfstedt))
 - Add PHP7 support, remove 5.5 [\#1481](https://github.com/ilios/ilios/pull/1481) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.14.0](https://github.com/ilios/ilios/tree/v3.14.0) (2016-06-30)
+### [v3.14.0](https://github.com/ilios/ilios/tree/v3.14.0) (2016-06-30)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.13.0...v3.14.0)
 
 **Implemented enhancements:**
@@ -486,7 +504,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - fixed toString magic method. [\#1457](https://github.com/ilios/ilios/pull/1457) ([stopfstedt](https://github.com/stopfstedt))
 - log auditable entity creation with record ids. [\#1454](https://github.com/ilios/ilios/pull/1454) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.13.0](https://github.com/ilios/ilios/tree/v3.13.0) (2016-06-10)
+### [v3.13.0](https://github.com/ilios/ilios/tree/v3.13.0) (2016-06-10)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.12.0...v3.13.0)
 
 **Implemented enhancements:**
@@ -513,7 +532,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Update API to v1.5 [\#1434](https://github.com/ilios/ilios/pull/1434) ([jrjohnson](https://github.com/jrjohnson))
 - refactor managers and handlers. [\#1426](https://github.com/ilios/ilios/pull/1426) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.12.0](https://github.com/ilios/ilios/tree/v3.12.0) (2016-05-27)
+### [v3.12.0](https://github.com/ilios/ilios/tree/v3.12.0) (2016-05-27)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.11.0...v3.12.0)
 
 **Implemented enhancements:**
@@ -539,7 +559,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - added min and max attributes on sequence blocks to ci export. [\#1418](https://github.com/ilios/ilios/pull/1418) ([stopfstedt](https://github.com/stopfstedt))
 - added aamc resource type and rigged it up to terms. [\#1399](https://github.com/ilios/ilios/pull/1399) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.11.0](https://github.com/ilios/ilios/tree/v3.11.0) (2016-05-13)
+### [v3.11.0](https://github.com/ilios/ilios/tree/v3.11.0) (2016-05-13)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.10.0...v3.11.0)
 
 **Implemented enhancements:**
@@ -572,7 +593,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - grant view privileges to developers on all published user events [\#1398](https://github.com/ilios/ilios/pull/1398) ([stopfstedt](https://github.com/stopfstedt))
 - Latest updates to dependencies [\#1397](https://github.com/ilios/ilios/pull/1397) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.10.0](https://github.com/ilios/ilios/tree/v3.10.0) (2016-04-30)
+### [v3.10.0](https://github.com/ilios/ilios/tree/v3.10.0) (2016-04-30)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.9.0...v3.10.0)
 
 **Implemented enhancements:**
@@ -599,7 +621,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Fix annotation for SessionDescription [\#1381](https://github.com/ilios/ilios/pull/1381) ([jrjohnson](https://github.com/jrjohnson))
 - Require a frontend when starting up [\#1379](https://github.com/ilios/ilios/pull/1379) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.9.0](https://github.com/ilios/ilios/tree/v3.9.0) (2016-04-08)
+### [v3.9.0](https://github.com/ilios/ilios/tree/v3.9.0) (2016-04-08)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.8.0...v3.9.0)
 
 **Implemented enhancements:**
@@ -625,7 +648,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - added distinct clause to queries. [\#1364](https://github.com/ilios/ilios/pull/1364) ([stopfstedt](https://github.com/stopfstedt))
 - Fix error handling [\#1360](https://github.com/ilios/ilios/pull/1360) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.8.0](https://github.com/ilios/ilios/tree/v3.8.0) (2016-03-22)
+### [v3.8.0](https://github.com/ilios/ilios/tree/v3.8.0) (2016-03-22)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.7.0...v3.8.0)
 
 **Implemented enhancements:**
@@ -654,7 +678,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Bump the api version to 1.2 [\#1344](https://github.com/ilios/ilios/pull/1344) ([jrjohnson](https://github.com/jrjohnson))
 - migrate topics to terms and vocabs, rm topics [\#1281](https://github.com/ilios/ilios/pull/1281) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.7.0](https://github.com/ilios/ilios/tree/v3.7.0) (2016-03-02)
+### [v3.7.0](https://github.com/ilios/ilios/tree/v3.7.0) (2016-03-02)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.6.0...v3.7.0)
 
 **Implemented enhancements:**
@@ -680,7 +705,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Prevent disabled users from logging in [\#1333](https://github.com/ilios/ilios/pull/1333) ([jrjohnson](https://github.com/jrjohnson))
 - Add UserDTO [\#1331](https://github.com/ilios/ilios/pull/1331) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.6.0](https://github.com/ilios/ilios/tree/v3.6.0) (2016-02-12)
+### [v3.6.0](https://github.com/ilios/ilios/tree/v3.6.0) (2016-02-12)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.5.0...v3.6.0)
 
 **Implemented enhancements:**
@@ -706,7 +732,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - losened up views perms. [\#1324](https://github.com/ilios/ilios/pull/1324) ([stopfstedt](https://github.com/stopfstedt))
 - losened up view perms on instructor groups. [\#1323](https://github.com/ilios/ilios/pull/1323) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.5.0](https://github.com/ilios/ilios/tree/v3.5.0) (2016-02-05)
+### [v3.5.0](https://github.com/ilios/ilios/tree/v3.5.0) (2016-02-05)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.4.1...v3.5.0)
 
 **Implemented enhancements:**
@@ -731,7 +758,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Remove support for PHP 5.4 [\#1303](https://github.com/ilios/ilios/pull/1303) ([jrjohnson](https://github.com/jrjohnson))
 - get rid of deprecation warnings [\#1301](https://github.com/ilios/ilios/pull/1301) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.4.1](https://github.com/ilios/ilios/tree/v3.4.1) (2016-02-02)
+### [v3.4.1](https://github.com/ilios/ilios/tree/v3.4.1) (2016-02-02)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.4.0...v3.4.1)
 
 **Closed issues:**
@@ -742,7 +770,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 
 - filter unpublished offerings out of teaching reminders [\#1309](https://github.com/ilios/ilios/pull/1309) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.4.0](https://github.com/ilios/ilios/tree/v3.4.0) (2016-02-01)
+### [v3.4.0](https://github.com/ilios/ilios/tree/v3.4.0) (2016-02-01)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.3.1...v3.4.0)
 
 **Implemented enhancements:**
@@ -771,14 +800,16 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - declared cohort-getter/setters in program-year entity interface. [\#1282](https://github.com/ilios/ilios/pull/1282) ([stopfstedt](https://github.com/stopfstedt))
 - Add new taxonomy system [\#1279](https://github.com/ilios/ilios/pull/1279) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.3.1](https://github.com/ilios/ilios/tree/v3.3.1) (2016-01-25)
+### [v3.3.1](https://github.com/ilios/ilios/tree/v3.3.1) (2016-01-25)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.3.0...v3.3.1)
 
 **Merged pull requests:**
 
 - updated frontend build hash to non-corrupted one [\#1278](https://github.com/ilios/ilios/pull/1278) ([thecoolestguy](https://github.com/thecoolestguy))
 
-## [v3.3.0](https://github.com/ilios/ilios/tree/v3.3.0) (2016-01-23)
+### [v3.3.0](https://github.com/ilios/ilios/tree/v3.3.0) (2016-01-23)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.2.0...v3.3.0)
 
 **Implemented enhancements:**
@@ -808,7 +839,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - throw an exception if remote file could not be loaded. [\#1266](https://github.com/ilios/ilios/pull/1266) ([stopfstedt](https://github.com/stopfstedt))
 - check for pre-existing relationship before adding learner group to ilm [\#1265](https://github.com/ilios/ilios/pull/1265) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.2.0](https://github.com/ilios/ilios/tree/v3.2.0) (2016-01-16)
+### [v3.2.0](https://github.com/ilios/ilios/tree/v3.2.0) (2016-01-16)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.1.0...v3.2.0)
 
 **Implemented enhancements:**
@@ -835,7 +867,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Move publishing migration to the right place in time [\#1252](https://github.com/ilios/ilios/pull/1252) ([jrjohnson](https://github.com/jrjohnson))
 - Publishing Simplified [\#1212](https://github.com/ilios/ilios/pull/1212) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.1.0](https://github.com/ilios/ilios/tree/v3.1.0) (2016-01-11)
+### [v3.1.0](https://github.com/ilios/ilios/tree/v3.1.0) (2016-01-11)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0...v3.1.0)
 
 **Implemented enhancements:**
@@ -886,7 +919,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Update symphony to 2.8 [\#1208](https://github.com/ilios/ilios/pull/1208) ([jrjohnson](https://github.com/jrjohnson))
 - Remove courses, sessions, and programYears from topic endpoint [\#1205](https://github.com/ilios/ilios/pull/1205) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.0.0](https://github.com/ilios/ilios/tree/v3.0.0) (2015-12-15)
+### [v3.0.0](https://github.com/ilios/ilios/tree/v3.0.0) (2015-12-15)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-rc1...v3.0.0)
 
 **Implemented enhancements:**
@@ -977,7 +1011,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Add users as a filter on courses endpoint [\#1126](https://github.com/ilios/ilios/pull/1126) ([jrjohnson](https://github.com/jrjohnson))
 - Allow sessions to be filtered by related entities needed for reporting [\#1124](https://github.com/ilios/ilios/pull/1124) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.0.0-rc1](https://github.com/ilios/ilios/tree/v3.0.0-rc1) (2015-11-16)
+### [v3.0.0-rc1](https://github.com/ilios/ilios/tree/v3.0.0-rc1) (2015-11-16)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-beta9...v3.0.0-rc1)
 
 **Implemented enhancements:**
@@ -1114,7 +1149,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Add a q \(query\) to get learningmaterials [\#1055](https://github.com/ilios/ilios/pull/1055) ([jrjohnson](https://github.com/jrjohnson))
 - fix mesh descriptor search [\#1050](https://github.com/ilios/ilios/pull/1050) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.0.0-beta9](https://github.com/ilios/ilios/tree/v3.0.0-beta9) (2015-10-27)
+### [v3.0.0-beta9](https://github.com/ilios/ilios/tree/v3.0.0-beta9) (2015-10-27)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-beta8...v3.0.0-beta9)
 
 **Implemented enhancements:**
@@ -1143,7 +1179,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - sanitize form input. [\#1053](https://github.com/ilios/ilios/pull/1053) ([stopfstedt](https://github.com/stopfstedt))
 - API improvements [\#1052](https://github.com/ilios/ilios/pull/1052) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.0.0-beta8](https://github.com/ilios/ilios/tree/v3.0.0-beta8) (2015-10-13)
+### [v3.0.0-beta8](https://github.com/ilios/ilios/tree/v3.0.0-beta8) (2015-10-13)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-beta7...v3.0.0-beta8)
 
 **Closed issues:**
@@ -1160,7 +1197,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Fix commands and broken build [\#1036](https://github.com/ilios/ilios/pull/1036) ([jrjohnson](https://github.com/jrjohnson))
 - added teaching reminder command [\#1035](https://github.com/ilios/ilios/pull/1035) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v3.0.0-beta7](https://github.com/ilios/ilios/tree/v3.0.0-beta7) (2015-09-25)
+### [v3.0.0-beta7](https://github.com/ilios/ilios/tree/v3.0.0-beta7) (2015-09-25)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-beta6...v3.0.0-beta7)
 
 **Closed issues:**
@@ -1185,7 +1223,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Fix issue with production install [\#1015](https://github.com/ilios/ilios/pull/1015) ([jrjohnson](https://github.com/jrjohnson))
 - User Management Commands [\#1013](https://github.com/ilios/ilios/pull/1013) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.0.0-beta6](https://github.com/ilios/ilios/tree/v3.0.0-beta6) (2015-09-11)
+### [v3.0.0-beta6](https://github.com/ilios/ilios/tree/v3.0.0-beta6) (2015-09-11)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-beta5...v3.0.0-beta6)
 
 **Merged pull requests:**
@@ -1214,7 +1253,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - defined setter/getter methods for curr inv report in program interface. [\#977](https://github.com/ilios/ilios/pull/977) ([stopfstedt](https://github.com/stopfstedt))
 - Change educational year to academic year [\#970](https://github.com/ilios/ilios/pull/970) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.0.0-beta5](https://github.com/ilios/ilios/tree/v3.0.0-beta5) (2015-08-25)
+### [v3.0.0-beta5](https://github.com/ilios/ilios/tree/v3.0.0-beta5) (2015-08-25)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-beta4...v3.0.0-beta5)
 
 **Closed issues:**
@@ -1246,7 +1286,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - deprecated publish event components [\#946](https://github.com/ilios/ilios/pull/946) ([stopfstedt](https://github.com/stopfstedt))
 - Stop deactivating new student accounts [\#940](https://github.com/ilios/ilios/pull/940) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.0.0-beta4](https://github.com/ilios/ilios/tree/v3.0.0-beta4) (2015-08-10)
+### [v3.0.0-beta4](https://github.com/ilios/ilios/tree/v3.0.0-beta4) (2015-08-10)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-beta3...v3.0.0-beta4)
 
 **Implemented enhancements:**
@@ -1324,7 +1365,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Update a session when its ILM is updated [\#870](https://github.com/ilios/ilios/pull/870) ([jrjohnson](https://github.com/jrjohnson))
 - added INSTALL.md and updated UPGRADE.md files [\#863](https://github.com/ilios/ilios/pull/863) ([thecoolestguy](https://github.com/thecoolestguy))
 
-## [v3.0.0-beta3](https://github.com/ilios/ilios/tree/v3.0.0-beta3) (2015-06-30)
+### [v3.0.0-beta3](https://github.com/ilios/ilios/tree/v3.0.0-beta3) (2015-06-30)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-beta2...v3.0.0-beta3)
 
 **Merged pull requests:**
@@ -1332,14 +1374,16 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Beta 3 Release Prep [\#865](https://github.com/ilios/ilios/pull/865) ([jrjohnson](https://github.com/jrjohnson))
 - Authentication [\#864](https://github.com/ilios/ilios/pull/864) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.0.0-beta2](https://github.com/ilios/ilios/tree/v3.0.0-beta2) (2015-06-20)
+### [v3.0.0-beta2](https://github.com/ilios/ilios/tree/v3.0.0-beta2) (2015-06-20)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v3.0.0-beta1...v3.0.0-beta2)
 
 **Merged pull requests:**
 
 - Release Preparation [\#861](https://github.com/ilios/ilios/pull/861) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v3.0.0-beta1](https://github.com/ilios/ilios/tree/v3.0.0-beta1) (2015-06-19)
+### [v3.0.0-beta1](https://github.com/ilios/ilios/tree/v3.0.0-beta1) (2015-06-19)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.8...v3.0.0-beta1)
 
 **Closed issues:**
@@ -1416,7 +1460,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Linting [\#727](https://github.com/ilios/ilios/pull/727) ([Trott](https://github.com/Trott))
 - updated CHANGELOG.txt, ready for release 2.4.8 [\#726](https://github.com/ilios/ilios/pull/726) ([thecoolestguy](https://github.com/thecoolestguy))
 
-## [v2.4.8](https://github.com/ilios/ilios/tree/v2.4.8) (2014-11-04)
+### [v2.4.8](https://github.com/ilios/ilios/tree/v2.4.8) (2014-11-04)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.7...v2.4.8)
 
 **Implemented enhancements:**
@@ -1438,7 +1483,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - 'scheduled' session icon color change [\#714](https://github.com/ilios/ilios/pull/714) ([thecoolestguy](https://github.com/thecoolestguy))
 - Allow learner groups to be created empty [\#713](https://github.com/ilios/ilios/pull/713) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v2.4.7](https://github.com/ilios/ilios/tree/v2.4.7) (2014-10-14)
+### [v2.4.7](https://github.com/ilios/ilios/tree/v2.4.7) (2014-10-14)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.6...v2.4.7)
 
 **Implemented enhancements:**
@@ -1472,7 +1518,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Basic Structure and Dashboard [\#683](https://github.com/ilios/ilios/pull/683) ([jrjohnson](https://github.com/jrjohnson))
 - Add a cron task to run the user sync process and nothing else. [\#678](https://github.com/ilios/ilios/pull/678) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v2.4.6](https://github.com/ilios/ilios/tree/v2.4.6) (2014-09-02)
+### [v2.4.6](https://github.com/ilios/ilios/tree/v2.4.6) (2014-09-02)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.6-rc1...v2.4.6)
 
 **Implemented enhancements:**
@@ -1494,7 +1541,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - learning material dialog disappears in firefox [\#669](https://github.com/ilios/ilios/pull/669) ([thecoolestguy](https://github.com/thecoolestguy))
 - added learningmaterials to session cloning [\#667](https://github.com/ilios/ilios/pull/667) ([thecoolestguy](https://github.com/thecoolestguy))
 
-## [v2.4.6-rc1](https://github.com/ilios/ilios/tree/v2.4.6-rc1) (2014-08-15)
+### [v2.4.6-rc1](https://github.com/ilios/ilios/tree/v2.4.6-rc1) (2014-08-15)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.5...v2.4.6-rc1)
 
 **Implemented enhancements:**
@@ -1509,7 +1557,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Localsauce README tweaks [\#659](https://github.com/ilios/ilios/pull/659) ([stopfstedt](https://github.com/stopfstedt))
 - Better shibboleth authentication errors [\#658](https://github.com/ilios/ilios/pull/658) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v2.4.5](https://github.com/ilios/ilios/tree/v2.4.5) (2014-08-08)
+### [v2.4.5](https://github.com/ilios/ilios/tree/v2.4.5) (2014-08-08)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.3...v2.4.5)
 
 **Implemented enhancements:**
@@ -1544,7 +1593,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - added changes from the re-tagged CodeIgniter 2.2.0 release. [\#638](https://github.com/ilios/ilios/pull/638) ([stopfstedt](https://github.com/stopfstedt))
 - Allow session offerings to be counted only once [\#635](https://github.com/ilios/ilios/pull/635) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v2.4.3](https://github.com/ilios/ilios/tree/v2.4.3) (2014-06-20)
+### [v2.4.3](https://github.com/ilios/ilios/tree/v2.4.3) (2014-06-20)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.2...v2.4.3)
 
 **Implemented enhancements:**
@@ -1573,7 +1623,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Do background of Behat tests in database [\#621](https://github.com/ilios/ilios/pull/621) ([jrjohnson](https://github.com/jrjohnson))
 - Added audit log config to phing build [\#620](https://github.com/ilios/ilios/pull/620) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v2.4.2](https://github.com/ilios/ilios/tree/v2.4.2) (2014-05-21)
+### [v2.4.2](https://github.com/ilios/ilios/tree/v2.4.2) (2014-05-21)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.2-prerelease-20140407...v2.4.2)
 
 **Implemented enhancements:**
@@ -1605,14 +1656,16 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 
 - Temporarily disable Save All Draft button [\#610](https://github.com/ilios/ilios/pull/610) ([jrjohnson](https://github.com/jrjohnson))
 
-## [v2.4.2-prerelease-20140407](https://github.com/ilios/ilios/tree/v2.4.2-prerelease-20140407) (2014-04-07)
+### [v2.4.2-prerelease-20140407](https://github.com/ilios/ilios/tree/v2.4.2-prerelease-20140407) (2014-04-07)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.1...v2.4.2-prerelease-20140407)
 
 **Closed issues:**
 
 - Remove final instance of abominable deepCloneAssociativeArray\(\) [\#548](https://github.com/ilios/ilios/issues/548)
 
-## [v2.4.1](https://github.com/ilios/ilios/tree/v2.4.1) (2014-04-04)
+### [v2.4.1](https://github.com/ilios/ilios/tree/v2.4.1) (2014-04-04)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.4.0...v2.4.1)
 
 **Closed issues:**
@@ -1626,7 +1679,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - Run Jasmine tests on CI server [\#464](https://github.com/ilios/ilios/issues/464)
 - Documentation of security considerations for learning materials [\#414](https://github.com/ilios/ilios/issues/414)
 
-## [v2.4.0](https://github.com/ilios/ilios/tree/v2.4.0) (2014-02-20)
+### [v2.4.0](https://github.com/ilios/ilios/tree/v2.4.0) (2014-02-20)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.3.2...v2.4.0)
 
 **Implemented enhancements:**
@@ -1656,7 +1710,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - move webcal to webcals [\#348](https://github.com/ilios/ilios/issues/348)
 - Notes field in Learning Materials does not alert user if max char length is exceeded. [\#339](https://github.com/ilios/ilios/issues/339)
 
-## [v2.3.2](https://github.com/ilios/ilios/tree/v2.3.2) (2013-12-10)
+### [v2.3.2](https://github.com/ilios/ilios/tree/v2.3.2) (2013-12-10)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.3.1...v2.3.2)
 
 **Implemented enhancements:**
@@ -1675,7 +1730,8 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - recurring events tool creates additional offerings when used with "create offerings by group" feature [\#275](https://github.com/ilios/ilios/issues/275)
 - mesh picker for my reports not functioning [\#260](https://github.com/ilios/ilios/issues/260)
 
-## [v2.3.1](https://github.com/ilios/ilios/tree/v2.3.1) (2013-11-01)
+### [v2.3.1](https://github.com/ilios/ilios/tree/v2.3.1) (2013-11-01)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.3...v2.3.1)
 
 **Implemented enhancements:**
@@ -1707,19 +1763,24 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - footer shouldn't overlap other items just because I change window size... [\#191](https://github.com/ilios/ilios/pull/191) ([Trott](https://github.com/Trott))
 - Make appalling inline CSS abomination marginally less appalling [\#190](https://github.com/ilios/ilios/pull/190) ([Trott](https://github.com/Trott))
 
-## [v2.3](https://github.com/ilios/ilios/tree/v2.3) (2013-09-23)
+### [v2.3](https://github.com/ilios/ilios/tree/v2.3) (2013-09-23)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.2.2...v2.3)
 
-## [v2.2.2](https://github.com/ilios/ilios/tree/v2.2.2) (2013-07-16)
+### [v2.2.2](https://github.com/ilios/ilios/tree/v2.2.2) (2013-07-16)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.2.1...v2.2.2)
 
-## [v2.2.1](https://github.com/ilios/ilios/tree/v2.2.1) (2013-03-22)
+### [v2.2.1](https://github.com/ilios/ilios/tree/v2.2.1) (2013-03-22)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.2...v2.2.1)
 
-## [v2.2](https://github.com/ilios/ilios/tree/v2.2) (2013-03-06)
+### [v2.2](https://github.com/ilios/ilios/tree/v2.2) (2013-03-06)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.1.2...v2.2)
 
-## [v2.1.2](https://github.com/ilios/ilios/tree/v2.1.2) (2012-12-20)
+### [v2.1.2](https://github.com/ilios/ilios/tree/v2.1.2) (2012-12-20)
+
 [Full Changelog](https://github.com/ilios/ilios/compare/v2.1.1...v2.1.2)
 
 **Merged pull requests:**
@@ -1747,13 +1808,12 @@ and will instead publish changes in our [Release Notes](https://github.com/ilios
 - rm needed dirs from .gitignore [\#6](https://github.com/ilios/ilios/pull/6) ([Trott](https://github.com/Trott))
 - please merge project name changes on landing page [\#5](https://github.com/ilios/ilios/pull/5) ([stopfstedt](https://github.com/stopfstedt))
 
-## [v2.1.1](https://github.com/ilios/ilios/tree/v2.1.1) (2012-12-07)
+### [v2.1.1](https://github.com/ilios/ilios/tree/v2.1.1) (2012-12-07)
+
 **Merged pull requests:**
 
 - please merge with rb2.1.1 and master [\#4](https://github.com/ilios/ilios/pull/4) ([stopfstedt](https://github.com/stopfstedt))
 - Vagrant/Puppet easy dev/demo install [\#3](https://github.com/ilios/ilios/pull/3) ([Trott](https://github.com/Trott))
 - fixed broken SQL INSERT statement. refs \#3037 [\#1](https://github.com/ilios/ilios/pull/1) ([stopfstedt](https://github.com/stopfstedt))
-
-
 
 \* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,28 +1,14 @@
 # Ilios Code of Conduct
 
-The Ilios team and community is made up of a mixture of professionals and 
-volunteers from all over the world, working on every aspect of the mission 
-- including mentorship, teaching, and connecting people.
+The Ilios team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
 
-Diversity is one of our huge strengths, but it can also lead to communication
-issues and unhappiness. To that end, we have a few ground rules that we ask
-people to adhere to. This code applies equally to contributors, mentors, 
-and those seeking help and guidance.
+Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to contributors, mentors, and those seeking help and guidance.
 
-This isn’t an exhaustive list of things that you can’t do. Rather, take it in
-the spirit in which it’s intended - a guide to make it easier to enrich all of
-us and the technical communities in which we participate.
+This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
 
-This code of conduct applies to all spaces managed by the Ilios project. 
-This includes the Slack workspace, the mailing lists, the issue tracker, 
-events, and any other forums created by the project team which the community 
-uses for communication. In addition, violations of this code outside 
-these spaces may affect a person's ability to participate within them.
+This code of conduct applies to all spaces managed by the Ilios project. This includes the Slack workspace, the mailing lists, the issue tracker, events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you
-report it by emailing
-[conduct@iliosproject.org](mailto:conduct@iliosproject.org).
-
+If you believe someone is violating the code of conduct, we ask that you report it by emailing [conduct@iliosproject.org](mailto:conduct@iliosproject.org).
 
 - **Be friendly and patient.**
 
@@ -73,6 +59,7 @@ This text is an adoption of the Code of Conduct provided by the
 [Django Software Foundation](https://www.djangoproject.com/conduct/).
 
 ## Questions?
+
 If you have questions, feel free to [contact us](mailto:info@iliosproject.org).
 
 ## License

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contribute to Ilios
 
-So you want to help out with Ilios development?  **That's Fantastic**.  Here is
-how you can get started:
+So you want to help out with Ilios development? **That's Fantastic**. Here is how you can get started:
 
 ## Overview of the process
 
@@ -10,8 +9,8 @@ how you can get started:
 3. [Make some changes](#writing-code-for-ilios)
 4. Run tests to ensure your changes haven't adversely affected other areas of the system.
 5. Commit your changes with a good [Commit Message](#commit-message)
-5. Push your feature branch to your fork of Ilios on Github
-6. [Create a pull request](#create-a-pull-request-on-github) so we can review, discuss, and merge your changes.
+6. Push your feature branch to your fork of Ilios on Github
+7. [Create a pull request](#create-a-pull-request-on-github) so we can review, discuss, and merge your changes.
 
 ### Initial Setup
 
@@ -22,10 +21,11 @@ how you can get started:
 
 In order to get your changes accepted you will need do:
 
- * Follow the [php coding standards](http://www.php-fig.org/)
- * Write tests which cover your changes
+* Follow the [php coding standards](http://www.php-fig.org/)
+* Write tests which cover your changes
 
 ### Running Tests
+
 1. vendor/bin/phpunit
 2. vendor/bin/phpcs
 
@@ -33,18 +33,12 @@ In order to get your changes accepted you will need do:
 
 Some good rules for commit messages are
 
- * the first line is commit summary, 50 characters or less,
- * followed by an empty line
- * followed by a longer explanation of the commit if necessary
+* the first line is commit summary, 50 characters or less,
+* followed by an empty line
+* followed by a longer explanation of the commit if necessary
 
-The first line of a commit message becomes the **title** of a pull
-request on GitHub, like the subject line of an email.  Including
-the key info in the first line will help us respond faster to
-your pull.
+The first line of a commit message becomes the **title** of a pull request on GitHub, like the subject line of an email. Including the key info in the first line will help us respond faster to your pull.
 
 ### Create a Pull Request on Github
 
-Go to *your* GitHub repository at
-https://github.com/my-github-username/ilios, switch branch to your
-topic branch and click the 'Pull Request' button. You can then add further
-comments to your pull request.
+Go to *your* GitHub repository at [https://github.com/my-github-username/ilios](https://github.com/my-github-username/ilios), switch branch to your topic branch and click the 'Pull Request' button. You can then add further comments to your pull request.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ilios: Curriculum Management from UCSF
 
-# About
+## About
 
 The Ilios Curriculum Management System addresses the needs of the Health Professions educational community by providing a user-friendly, flexible, and robust web application to collect, manage, analyze and deliver curricular information.
 
@@ -12,7 +12,8 @@ Ilios leverages the power of your existing online learning. With its comprehensi
 
 More Information and user documentation is available at [iliosproject.org](http://iliosproject.org)
 
-# Install and Update Instructions
+## Install and Update Instructions
+
 [Instructions for a new Install](docs/install.md)
 
 [Update Ilios](docs/update.md)
@@ -29,25 +30,24 @@ If you want to connect to the Ilios API a good place to start is [docs/ilios_api
 
 ## Interacting with Ilios from the command line
 
-Ilios provides a command line interface, see [docs/custom_cli_commands.md](docs/custom_cli_commands.md) 
-for a list of available commands and how to use them. 
+Ilios provides a command line interface, see [docs/custom_cli_commands.md](docs/custom_cli_commands.md) for a list of available commands and how to use them.
 
-# Get Ilios
+## Get Ilios
 
 Download the [latest distribution](https://github.com/ilios/ilios/releases) or clone the [codebase](https://github.com/ilios/ilios).
 
-# Contact
+## Contact
 
 For more information on Ilios please contact:
 
-The Ilios Project *
-UCSF School of Medicine *
-530 Parnassus Avenue *
-Box 0840 *
-San Francisco, CA 94143  
+The Ilios Project\
+UCSF School of Medicine\
+530 Parnassus Avenue\
+Box 0840\
+San Francisco, CA 94143
 
-Email: info@iliosproject.org
+Email: [info@iliosproject.org](mailto:info@iliosproject.org)
 
-# Development of Ilios
+## Development of Ilios
 
 To get a development instance of Ilios up and running quickly, please review the steps in our [Quick Setup Guide for Ilios](https://github.com/ilios/ilios/blob/master/docs/ilios_quick_setup_for_admins.md) for what is recommended and required.

--- a/docs/authentication_and_users.md
+++ b/docs/authentication_and_users.md
@@ -1,8 +1,9 @@
 # Authentication and Users
 
-Ilios provides several methods for populating and authenticating users within the application, natively and via external processes or systems. 
+Ilios provides several methods for populating and authenticating users within the application, natively and via external processes or systems.
 
 ## Authentication Types
+
 Ilios supports several different authentcation types to choose from, depending on your needs: Form, LDAP, CAS, Shibboleth.
 
 **Form:** Username and password are stored in the Ilios database, users login with a simple form - this is the default authentication type for a new Ilios installation.
@@ -16,13 +17,14 @@ Ilios supports several different authentcation types to choose from, depending o
 ### Initial Setup Ilios for your Authentication type
 
 Change to your Ilios application directory (e.g. `/var/www/ilios`) and run the setup authentication command.
+
 ```bash
-sudo -u apache bin/console ilios:setup:authentication --env=prod 
+sudo -u apache bin/console ilios:setup:authentication --env=prod
 ```
 
-# Using an LDAP Directory Connection for User Population
+## Using an LDAP Directory Connection for User Population
 
-If you are using on of the CAS, LDAP, or Shibboleth authentication types, you will probably want to also connect Ilios to your campus directory in order for users to be programmatically added to Ilios with all of the details they will need to successfully login. If you do not connect Ilios to your campus directory, you will need to ensure that each user has their respective `username` correctly entered into the Ilios application to exactly match the necessary attribute value(s) of your chosen authentication type. 
+If you are using on of the CAS, LDAP, or Shibboleth authentication types, you will probably want to also connect Ilios to your campus directory in order for users to be programmatically added to Ilios with all of the details they will need to successfully login. If you do not connect Ilios to your campus directory, you will need to ensure that each user has their respective `username` correctly entered into the Ilios application to exactly match the necessary attribute value(s) of your chosen authentication type.
 
 Ilios supports the **ldap** protocol for connecting to a campus directory. Unlike the **ldap** authentication
 type, our directory will only use a single account to make all queries instead of users' individual accounts. This is typically a 'service' account created by LDAP administrators expressly for use by Ilios to make directory lookups.

--- a/docs/custom_cli_commands.md
+++ b/docs/custom_cli_commands.md
@@ -6,25 +6,39 @@ These commands fulfill a wide range of maintenance functions, like user account 
 
 ## Run As the Webservices User
 
-All commands must be run on your web server as your webservices user! In these examples we will
-be using the `apache` user for this with `sudo -u apache`. You will need to adjust this for your local environment.
+All commands must be run on your web server as your webservices user! In these examples we will be using the `apache` user for this with `sudo -u apache`. You will need to adjust this for your local environment.
 
 ## User account management
 
-_todo_
+Create a user, find an existing one, or change an existing one's password.
+
+`sudo -u apache bin/console --env=prod ilios:add-user`
+`sudo -u apache bin/console --env=prod ilios:find-user <searchTerm>`
+`sudo -u apache bin/console --env=prod ilios:change-password <userId>`
 
 ## Outbound email processing
 
-_todo_
+Send out change alert message to configured email recipients.
+
+`sudo -u apache bin/console --env=prod ilios:send-change-alerts`
+
+Send out a test email, to ensure the system is working.
+
+`sudo -u apache bin/console --env=prod ilios:send-test-email`
 
 ## Rollover tasks
 
-_todo_
+Rolls over (copies) a given curriculum inventory report.
+
+`sudo -u apache bin/console --env=prod ilios:rollover-ci-report <reportId>`
+
+Roll over a course to a new year using its `course_id`.
+
+`sudo -u apache bin/console --env=prod ilios:rollover-course <courseId> <newAcademicYear>`
 
 ## MeSH Import
 
-NLM releases an updated MeSH compendium quarterly. You should update Ilios to reflect the latest MeSH changes regularly.
-This process takes approximately 20 minutes.
+NLM releases an updated MeSH compendium quarterly. You should update Ilios to reflect the latest MeSH changes regularly. This process takes approximately 20 minutes.
 
 `sudo -u apache bin/console --env=prod ilios:maintenance:import-mesh-universe`
 
@@ -35,4 +49,6 @@ After this command is run you will need to clear your cache for new terms to app
 
 ## Developer tools
 
-_todo_
+Set a configuration value in the database.
+
+`sudo -u apache bin/console --env=prod ilios:set-config-value [-r|--remove] [--] <name> [<value>]`

--- a/docs/custom_cli_commands.md
+++ b/docs/custom_cli_commands.md
@@ -49,6 +49,10 @@ After this command is run you will need to clear your cache for new terms to app
 
 ## Developer tools
 
+List configuration values in the database.
+
+`sudo -u apache bin/console --env=prod ilios:list-config-values`
+
 Set a configuration value in the database.
 
 `sudo -u apache bin/console --env=prod ilios:set-config-value [-r|--remove] [--] <name> [<value>]`

--- a/docs/custom_cli_commands.md
+++ b/docs/custom_cli_commands.md
@@ -12,7 +12,7 @@ All commands must be run on your web server as your webservices user! In these e
 
 Create a user, find an existing one, or change an existing one's password.
 
-`sudo -u apache bin/console --env=prod ilios:add-user`
+`sudo -u apache bin/console --env=prod ilios:add-user` \
 `sudo -u apache bin/console --env=prod ilios:find-user <searchTerm>` \
 `sudo -u apache bin/console --env=prod ilios:change-password <userId>`
 

--- a/docs/custom_cli_commands.md
+++ b/docs/custom_cli_commands.md
@@ -13,7 +13,7 @@ All commands must be run on your web server as your webservices user! In these e
 Create a user, find an existing one, or change an existing one's password.
 
 `sudo -u apache bin/console --env=prod ilios:add-user`
-`sudo -u apache bin/console --env=prod ilios:find-user <searchTerm>`
+`sudo -u apache bin/console --env=prod ilios:find-user <searchTerm>` \
 `sudo -u apache bin/console --env=prod ilios:change-password <userId>`
 
 ## Outbound email processing

--- a/docs/custom_cli_commands.md
+++ b/docs/custom_cli_commands.md
@@ -4,10 +4,10 @@ Ilios provides a host of custom commands that can be invoked from the command li
 
 These commands fulfill a wide range of maintenance functions, like user account management and outbound email processing.
 
-##  Run As the Webservices User
-All commands must be run on your web server as your webservices user! In these examples we will 
-be using the `apache` user for this with `sudo -u apache`. You will need
-to adjust this for your local environment.
+## Run As the Webservices User
+
+All commands must be run on your web server as your webservices user! In these examples we will
+be using the `apache` user for this with `sudo -u apache`. You will need to adjust this for your local environment.
 
 ## User account management
 
@@ -24,7 +24,7 @@ _todo_
 ## MeSH Import
 
 NLM releases an updated MeSH compendium quarterly. You should update Ilios to reflect the latest MeSH changes regularly.
-This process takes approximately 20 minutes. 
+This process takes approximately 20 minutes.
 
 `sudo -u apache bin/console --env=prod ilios:maintenance:import-mesh-universe`
 
@@ -32,7 +32,7 @@ After this command is run you will need to clear your cache for new terms to app
 
 `sudo -u apache bin/console --env=prod cache:clear --no-warmup`
 `sudo -u apache bin/console --env=prod cache:warmup`
- 
-## Developer tools 
+
+## Developer tools
 
 _todo_

--- a/docs/custom_theming.md
+++ b/docs/custom_theming.md
@@ -8,33 +8,33 @@ The following steps specifically outline the process for changing the color of t
 
 ## BEFORE YOU BEGIN
 
-For this excercise, you will need to know what color you would like your main header "banner" to be and you will need a custom logo graphic sized the same as the default Ilios logo graphic.  You should also be somewhat familiar with CSS, but it's not super important if you are just following these instructions to update the banner color and its logo.
+For this excercise, you will need to know what color you would like your main header "banner" to be and you will need a custom logo graphic sized the same as the default Ilios logo graphic. You should also be somewhat familiar with CSS, but it's not super important if you are just following these instructions to update the banner color and its logo.
 
-#### The Main Header Color
+### The Main Header Color
 
-By default, the header that spans the top of every screen in Ilios has a background-color attribute that we on the Ilios team refer to as 'ilios-orange' or '#cc6600' (in hexadecimal). In the [public/theme-overrides/custom.css](https://github.com/ilios/ilios/tree/master/public/theme-overrides/custom.css) file, however, we have the custom style declaration set to '#ff1493' and commented out by default.  To see your instance of Ilios with a horrendous pink banner across the top, just uncomment this line, save the file, and clear your cache!  If you want a color other than 'horrendous pink', just follow the steps below:
+By default, the header that spans the top of every screen in Ilios has a background-color attribute that we on the Ilios team refer to as 'ilios-orange' or `#cc6600` (in hexadecimal). In the [public/theme-overrides/custom.css](https://github.com/ilios/ilios/tree/master/public/theme-overrides/custom.css) file, however, we have the custom style declaration set to `#ff1493` and commented out by default. To see your instance of Ilios with a horrendous pink banner across the top, just uncomment this line, save the file, and clear your cache! If you want a color other than 'horrendous pink', just follow the steps below:
 
-#### The Main Header Logo Graphic
+### The Main Header Logo Graphic
 
-Currently, the [default Ilios logo](https://github.com/ilios/frontend/blob/master/public/assets/images/ilios-logo.png), as it is served from Amazon S3, is 84px wide and 42px tall and the source file can be found at [https://github.com/ilios/frontend/blob/master/public/assets/images/ilios-logo.png](https://github.com/ilios/frontend/blob/master/public/assets/images/ilios-logo.png).  If you would like to use your own institution's logo instead, you will want to create/use a logo image with the same height and width as the default Ilios logo.  You can customize the size of the logo later if you like but, for the sake of easily understanding how this process works, you should leave it the same size for now.
+Currently, the [default Ilios logo](https://github.com/ilios/frontend/blob/master/public/assets/images/ilios-logo.png), as it is served from Amazon S3, is 84px wide and 42px tall and the source file can be found at [https://github.com/ilios/frontend/blob/master/public/assets/images/ilios-logo.png](https://github.com/ilios/frontend/blob/master/public/assets/images/ilios-logo.png). If you would like to use your own institution's logo instead, you will want to create/use a logo image with the same height and width as the default Ilios logo. You can customize the size of the logo later if you like but, for the sake of easily understanding how this process works, you should leave it the same size for now.
 
-Once you have the logo you would like to use, you will want to copy it to your Ilios 3 API server, into the ['public/theme-overrides/'](https://github.com/ilios/ilios/tree/master/public/theme-overrides/) subfolder of the Ilios application.  Once it is uploaded, you will need to update the filename in the [custom.css](https://github.com/ilios/ilios/tree/master/public/theme-overrides/custom.css) stylesheet to specify its proper filename.
+Once you have the logo you would like to use, you will want to copy it to your Ilios 3 API server, into the ['public/theme-overrides/'](https://github.com/ilios/ilios/tree/master/public/theme-overrides/) subfolder of the Ilios application. Once it is uploaded, you will need to update the filename in the [custom.css](https://github.com/ilios/ilios/tree/master/public/theme-overrides/custom.css) stylesheet to specify its proper filename.
 
-### Changing the color and logo of the main header
+#### Changing the color and logo of the main header
 
 In addition to changing the logo in the header of the Ilios application, you may want to change the color of the header banner as well.
 
-To do this, just change value of the header's 'background-color' attribute in the ['custom.css'](https://github.com/ilios/ilios/tree/master/public/theme-overrides/custom.css) theme style override file.
+To do this, just change value of the header's `background-color` attribute in the ['custom.css'](https://github.com/ilios/ilios/tree/master/public/theme-overrides/custom.css) theme style override file.
 
 To change the header color, find the line that reads:
 
 ```//background-color: #ff1493;```
 
-and uncomment the style declaration.  Then explicitly change the '#ff1493' value to the desired new hexadecimal color (eg, '#54bfe2'). After removing the comment lines and making the change, the line should now look like this:
+and uncomment the style declaration. Then explicitly change the `#ff1493` value to the desired new hexadecimal color (e.g., `#54bfe2`). After removing the comment lines and making the change, the line should now look like this:
 
 ```background-color: #54bfe2;```
 
-To point the logo graphic source to the one with the new filename, make sure you have uploaded your new file (eg, 'custom_logo.png') to the 'public/theme-overrides/' folder on your API server and then find the line in 'custom.css' that reads:
+To point the logo graphic source to the one with the new filename, make sure you have uploaded your new file (e.g., `custom_logo.png`) to the `public/theme-overrides/` folder on your API server and then find the line in `custom.css` that reads:
 
 ```//background-image: url('custom_logo.png');```
 
@@ -44,4 +44,4 @@ and change it so that the comment lines are removed and the filename matches tha
 
 Once you make these changes, save the file(s) on the API server, and clear your Symfony cache, refreshing your application frontend should automatically reflect the new changes!
 
-### Congratulations! You've now updated your Ilios theme!
+**Congratulations! You've now updated your Ilios theme!**

--- a/docs/env_vars_and_config.md
+++ b/docs/env_vars_and_config.md
@@ -36,9 +36,11 @@ MESSENGER_TRANSPORT_DSN="doctrine://default"
 ```
 
 To see which environment variables are set for your respective user, you can run the `env` command like so:
+
 ```bash
 env
 ```
+
 When you run this command, all of your current environment variables will be displayed and will look something like the following:
 
 ```bash
@@ -65,17 +67,18 @@ APP_ENV=prod
 
 You'll want to verify that the `APP_ENV` variable is set (typically to `prod`) and that the other variables shown above, prefixed by `ILIOS_`, are also present.
 
-# Setting ENV vars
+## Setting ENV vars
 
-## Setting Environment Variables for each Command-Line User
+### Setting Environment Variables for each Command-Line User
 
-Setting the ENV variables for a given user on a system is typically a pretty straight-forward process and, for installation and maintenance of Ilios using console commands, you would just need to set the required ENV variables directly on the command-line, in a script at runtime, or have them already set upon login by declaring them in one of the respective user's initialization scripts (eg, .bashrc, .bash_profile`, `.profile`, etc.).
+Setting the ENV variables for a given user on a system is typically a pretty straight-forward process and, for installation and maintenance of Ilios using console commands, you would just need to set the required ENV variables directly on the command-line, in a script at runtime, or have them already set upon login by declaring them in one of the respective user's initialization scripts (e.g., `.bashrc`, `.bash_profile`, `.profile`, etc.).
 
 You can set these runtime variables in one of 3 ways:
 
 #### Example #1 - Setting ENV vars upon login by exporting them using a user-initialization script
+
 ```bash
-# Export these vars directly from within your preferred user initialization script (.bash_profile, .bashrc, .profile) and 
+# Export these vars directly from within your preferred user initialization script (.bash_profile, .bashrc, .profile) and
 # they will be set and ready to be used upon login to the terminal and throughout the entirety of your user session
 
 export APP_ENV=prod
@@ -86,11 +89,13 @@ export ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com
 export ILIOS_LOCALE=en
 export ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt
 ```
+
 Doing it this way ensures that these ENV vars will always be available to your user while you work and/or run commands directly from the command line.
 
 #### Example #2 - Setting ENV vars at the top of a shell script that runs the desired console command
 
 Let's say that you are going to run the `/bin/setup` command to install a completely new version of Ilios.  For this approach, you would create a shell script that runs `bin/setup` as its final step, and set the ENV vars above it in the file, like so:
+
 ```bash
 #!/bin/bash
 
@@ -117,17 +122,18 @@ While it is technically possible to set all of the ENV vars at the command line 
 ```bash
 APP_ENV=prod MAILER_DSN=smtp://ilios_mail_user:Passw0rd@smtp-relay.example.com:25 ILIOS_AUTHENTICATION_TYPE=form ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=8.0 ILIOS_LOCALE=en ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt bin/setup
 ```
+
 Furthermore, as was the case in Example #2, the ENV vars set in this way only persist for the duration of the execution of the command being run.
-  
+
 ## Setting Environment Variables for the Web-Services user
 
 The user running the web server processes on your system will most likely NOT have an environment with a typical login shell like `BASH` or `csh`, so setting the ENV vars cannot be done with the usual method (eg, prefixing the command with `APP_ENV=prod ILIOS_SECRET='SomethingSecret'` vars at the command line). In these cases, the web service user's ENV variable values need to be set in the web server configuration directly (eg, within the `httpd.conf` file on Apache) or within the web service user's initialization script (eg, `/etc/sysconfig/httpd` or `/etc/apache/envvars`, depending on your flavor of Linux).
 
-#### Option #1: Setting Web Service ENV vars via Web Service User Initialization Scripts (Apache httpd)
+### Option #1: Setting Web Service ENV vars via Web Service User Initialization Scripts (Apache httpd)
 
 By populating one of these web service user-specific initialization scripts with the ENV vars in the same way as shown for a shell script (see Example #2 above), the variables will be accessible by the web daemon/service while the service remains running.  For example, on a RHEL system (RedHat, CentOS, or Fedora), we would populate the `/etc/sysconfig/http` file with following content:
 
-```
+```bash
 APP_ENV=prod
 MAILER_DSN=smtp://ilios_mail_user:Passw0rd@smtp-relay.example.com:25
 ILIOS_AUTHENTICATION_TYPE=form
@@ -135,13 +141,13 @@ ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials
 ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=8.0
 ILIOS_LOCALE=en
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt
-``` 
+```
 
-#### Option #2: Setting Web Service ENV vars via the Web Service Configuration Files (Apache httpd)
+### Option #2: Setting Web Service ENV vars via the Web Service Configuration Files (Apache httpd)
 
 In order to set runtime environment variables within the Apache httpd web service configuration itself, you will need to enable the `mod_env` Apache module and set the `SetEnv` directives in the appropriate section(s) of your httpd configuration files as shown:
 
-```
+```bash
 SetEnv ILIOS_DATABASE_URL mysql://ilios_db_user:Pa$$w0rd@db-host1/ilios_db?serverVersion=8.0
 SetEnv ILIOS_DATABASE_PORT 3306
 SetEnv MAILER_DSN=smtp://ilios_mail_user:Passw0rd@smtp-relay.example.com:25
@@ -149,10 +155,11 @@ SetEnv ILIOS_LOCALE en
 SetEnv ILIOS_SECRET ThisTokenIsNotSoSecretChangeIt
 ```
 
-#### Multiple Ilios instances on single Apache httpd server:
-If you are running more than one Ilios instance (eg, production and staging instances) on a single Apache httpd server using multiple VirtualHost configurations, certain variables will collide (eg, `ILIOS_DATABASE_URL`), so these will need to be set conditionally.  In order to do this, you will need to install/enable the `mod_setenvif` Apache module and set the 'SetEnvIf' directives in the appropriate section(s) of your httpd configuration files as shown.  Note that the values shared between the two instances are set using `SetEnv`, while the conditional values are set with `SetEnvIf` and require a specific condition to be true in order to be set.  
+### Multiple Ilios instances on single Apache httpd server
 
-```
+If you are running more than one Ilios instance (eg, production and staging instances) on a single Apache httpd server using multiple VirtualHost configurations, certain variables will collide (eg, `ILIOS_DATABASE_URL`), so these will need to be set conditionally.  In order to do this, you will need to install/enable the `mod_setenvif` Apache module and set the 'SetEnvIf' directives in the appropriate section(s) of your httpd configuration files as shown.  Note that the values shared between the two instances are set using `SetEnv`, while the conditional values are set with `SetEnvIf` and require a specific condition to be true in order to be set.
+
+```bash
 SetEnv MAILER_DSN=smtp://ilios_mail_user:Passw0rd@smtp-relay.example.com:25
 SetEnv ILIOS_LOCALE en
 
@@ -163,11 +170,11 @@ SetEnvIf Host "ilios-production\.example\.com" ILIOS_DATABASE_URL=mysql://ilios_
 SetEnvIf Host "ilios-production\.example\.com ILIOS_SECRET=PR0DUCT10nS3CRET12345
 ```
 
-For more information on Apache Environments, `SetEnv`, and `SetEnvIf`, please refer to the Apache 2.4.x documentation at https://httpd.apache.org/docs/2.4/env.html
+For more information on Apache Environments, `SetEnv`, and `SetEnvIf`, please refer to the Apache 2.4.x documentation at [https://httpd.apache.org/docs/2.4/env.html](https://httpd.apache.org/docs/2.4/env.html).
 
 ## Verifying your Environment Variables
 
-#### Verifying the user Environment at the Command Line
+### Verifying the user Environment at the Command Line
 
 If you would like to verify that you have set all of the ENV variables required to install Ilios or use its command-line tools, you can run the following console command to do and Ilios-readiness health check (example shown being run in the context of the `apache` command-line user):
 
@@ -218,7 +225,8 @@ env
 sudo -u [USER_NAME] env
 ```
 
-#### Verifying the Environment on the Web Server
+### Verifying the Environment on the Web Server
+
 To verify that the web-service user has all of the required ENV vars set for your Ilios instance, you can launch the Ilios health check by visiting the health-check URL of your Ilios system in your browser by going to https://[YOUR ILIOS FQDN]/ilios/health
 
 If all of the settings are correct, all of the boxes of the 'System Health Status' grid shown at the top page should be displayed in green as shown here:
@@ -234,9 +242,9 @@ phpinfo();
 
 For Apache-based web servers, the currently-set Environment Variables should appear under the 'Apache Environment' or 'Environment' sections of the output.  If they are not set, you need to set them via one of the appropriate configurations as described above.
 
-#### Setting ENV vars globally and concurrently (command-line AND web-services users)
+## Setting ENV vars globally and concurrently (command-line AND web-services users)
 
-Regardless of how you plan to use Ilios, we know that you will be working with it heavily at both the command line, for scheduled 'cron' jobs and maintenance tasks, AND as a web-service, for hosting the application GUI.  We also know that maintaining multiple environments for each use-case (command line users vs. web-service) can be a hassle, especially when the ENV values would typically be the same between the two and could effectively be shared.  
+Regardless of how you plan to use Ilios, we know that you will be working with it heavily at both the command line, for scheduled 'cron' jobs and maintenance tasks, AND as a web-service, for hosting the application GUI.  We also know that maintaining multiple environments for each use-case (command line users vs. web-service) can be a hassle, especially when the ENV values would typically be the same between the two and could effectively be shared.
 
 Unfortunately, there is no easy "standard" solution for sharing the ENV variables between command-line use-cases and the web service, so we've come up with a bit of a workaround for accomplishing this and we thought we'd mention it here. While this isn't necessarily a recommendation or a "best practice" per sé, we have had some success in keeping all of our required ENV vars in-sync between our command-line `apache` user and the `apache` user running our web service by using the following method:
 
@@ -260,7 +268,7 @@ And then we delete the global `/etc/environment` init script, and recreate it as
 sudo rm /etc/environment && sudo ln -s /etc/sysconfig/httpd /etc/environment
 ```
 
-The idea behind this is that EVERYONE who logs in to the system will have the properly-configured ENV settings that match those set for the apache httpd web service user by having the two init scripts point to the exact same file.  One file ensures the settings will ALWAYS be in-sync. If you'd like to try this, but are confused, or if you can come up with a better way for managing this file-synchronicity, please do not hesitate to contact us at support@iliosproject.org with any questions or suggestions!
+The idea behind this is that EVERYONE who logs in to the system will have the properly-configured ENV settings that match those set for the apache httpd web service user by having the two init scripts point to the exact same file.  One file ensures the settings will ALWAYS be in-sync. If you'd like to try this, but are confused, or if you can come up with a better way for managing this file-synchronicity, please do not hesitate to contact us at ][support@iliosproject.org](mailto:support@iliosproject.org) with any questions or suggestions!
 
 ## Why Environment Variables?
 

--- a/docs/env_vars_and_config.md
+++ b/docs/env_vars_and_config.md
@@ -1,6 +1,6 @@
 # Using Environmental Variables for Ilios Configuration Settings
 
-If you are familiar with versions of Ilios prior to v3.56.0, you have probably already noticed that there is no longer a `parameters.yml` file for managing the configuration settings of an Ilios instance, including its database connection settings and credentials.  As of Ilios v3.56.0, the parameters.yml file has been removed in favor of storing these values in the database or, where that is not possible (eg, database settings and credentials), setting the configuration variables as 'Runtime Environment Variables' within the context of the user that runs your web service processes on the system (typically 'apache', 'www', 'nginx', etc) instead.
+If you are familiar with versions of Ilios prior to v3.56.0, you have probably already noticed that there is no longer a `parameters.yml` file for managing the configuration settings of an Ilios instance, including its database connection settings and credentials. As of Ilios v3.56.0, the parameters.yml file has been removed in favor of storing these values in the database or, where that is not possible (eg, database settings and credentials), setting the configuration variables as 'Runtime Environment Variables' within the context of the user that runs your web service processes on the system (typically 'apache', 'www', 'nginx', etc) instead.
 
 Currently, almost all of the configuration settings for Ilios are stored within the `application_config` table of the Ilios database, except as noted below. The values listed here must be set in the local user's environment for initial installation and when running console commands on the command line and, for the actual web-server processes, these variables must also be set in the context of the user/daemon that runs the web services while the services are running (eg, `apache`, etc).
 
@@ -94,7 +94,7 @@ Doing it this way ensures that these ENV vars will always be available to your u
 
 #### Example #2 - Setting ENV vars at the top of a shell script that runs the desired console command
 
-Let's say that you are going to run the `/bin/setup` command to install a completely new version of Ilios.  For this approach, you would create a shell script that runs `bin/setup` as its final step, and set the ENV vars above it in the file, like so:
+Let's say that you are going to run the `/bin/setup` command to install a completely new version of Ilios. For this approach, you would create a shell script that runs `bin/setup` as its final step, and set the ENV vars above it in the file, like so:
 
 ```bash
 #!/bin/bash
@@ -117,7 +117,7 @@ Note that doing it this way will only set the ENV variables for the duration of 
 
 #### Example #3 - Setting ENV vars at the command line directly
 
-While it is technically possible to set all of the ENV vars at the command line on the same line when you run the `bin/setup` command, we do not recommend this approach.  However, if you choose to do so, it would look something like this:
+While it is technically possible to set all of the ENV vars at the command line on the same line when you run the `bin/setup` command, we do not recommend this approach. However, if you choose to do so, it would look something like this:
 
 ```bash
 APP_ENV=prod MAILER_DSN=smtp://ilios_mail_user:Passw0rd@smtp-relay.example.com:25 ILIOS_AUTHENTICATION_TYPE=form ILIOS_FILE_SYSTEM_STORAGE_PATH=/var/www/files/learning_materials ILIOS_DATABASE_URL=mysql://ilios_user:ili0s_passw0rd@database.example.com/ilios_db?serverVersion=8.0 ILIOS_LOCALE=en ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt bin/setup
@@ -131,7 +131,7 @@ The user running the web server processes on your system will most likely NOT ha
 
 ### Option #1: Setting Web Service ENV vars via Web Service User Initialization Scripts (Apache httpd)
 
-By populating one of these web service user-specific initialization scripts with the ENV vars in the same way as shown for a shell script (see Example #2 above), the variables will be accessible by the web daemon/service while the service remains running.  For example, on a RHEL system (RedHat, CentOS, or Fedora), we would populate the `/etc/sysconfig/http` file with following content:
+By populating one of these web service user-specific initialization scripts with the ENV vars in the same way as shown for a shell script (see Example #2 above), the variables will be accessible by the web daemon/service while the service remains running. For example, on a RHEL system (RedHat, CentOS, or Fedora), we would populate the `/etc/sysconfig/http` file with following content:
 
 ```bash
 APP_ENV=prod
@@ -157,7 +157,7 @@ SetEnv ILIOS_SECRET ThisTokenIsNotSoSecretChangeIt
 
 ### Multiple Ilios instances on single Apache httpd server
 
-If you are running more than one Ilios instance (eg, production and staging instances) on a single Apache httpd server using multiple VirtualHost configurations, certain variables will collide (eg, `ILIOS_DATABASE_URL`), so these will need to be set conditionally.  In order to do this, you will need to install/enable the `mod_setenvif` Apache module and set the 'SetEnvIf' directives in the appropriate section(s) of your httpd configuration files as shown.  Note that the values shared between the two instances are set using `SetEnv`, while the conditional values are set with `SetEnvIf` and require a specific condition to be true in order to be set.
+If you are running more than one Ilios instance (eg, production and staging instances) on a single Apache httpd server using multiple VirtualHost configurations, certain variables will collide (eg, `ILIOS_DATABASE_URL`), so these will need to be set conditionally. In order to do this, you will need to install/enable the `mod_setenvif` Apache module and set the 'SetEnvIf' directives in the appropriate section(s) of your httpd configuration files as shown. Note that the values shared between the two instances are set using `SetEnv`, while the conditional values are set with `SetEnvIf` and require a specific condition to be true in order to be set.
 
 ```bash
 SetEnv MAILER_DSN=smtp://ilios_mail_user:Passw0rd@smtp-relay.example.com:25
@@ -240,11 +240,11 @@ If you would like to verify/review all of the ENV vars are set for within your w
 phpinfo();
 ```
 
-For Apache-based web servers, the currently-set Environment Variables should appear under the 'Apache Environment' or 'Environment' sections of the output.  If they are not set, you need to set them via one of the appropriate configurations as described above.
+For Apache-based web servers, the currently-set Environment Variables should appear under the 'Apache Environment' or 'Environment' sections of the output. If they are not set, you need to set them via one of the appropriate configurations as described above.
 
 ## Setting ENV vars globally and concurrently (command-line AND web-services users)
 
-Regardless of how you plan to use Ilios, we know that you will be working with it heavily at both the command line, for scheduled 'cron' jobs and maintenance tasks, AND as a web-service, for hosting the application GUI.  We also know that maintaining multiple environments for each use-case (command line users vs. web-service) can be a hassle, especially when the ENV values would typically be the same between the two and could effectively be shared.
+Regardless of how you plan to use Ilios, we know that you will be working with it heavily at both the command line, for scheduled 'cron' jobs and maintenance tasks, AND as a web-service, for hosting the application GUI. We also know that maintaining multiple environments for each use-case (command line users vs. web-service) can be a hassle, especially when the ENV values would typically be the same between the two and could effectively be shared.
 
 Unfortunately, there is no easy "standard" solution for sharing the ENV variables between command-line use-cases and the web service, so we've come up with a bit of a workaround for accomplishing this and we thought we'd mention it here. While this isn't necessarily a recommendation or a "best practice" per sé, we have had some success in keeping all of our required ENV vars in-sync between our command-line `apache` user and the `apache` user running our web service by using the following method:
 
@@ -268,7 +268,7 @@ And then we delete the global `/etc/environment` init script, and recreate it as
 sudo rm /etc/environment && sudo ln -s /etc/sysconfig/httpd /etc/environment
 ```
 
-The idea behind this is that EVERYONE who logs in to the system will have the properly-configured ENV settings that match those set for the apache httpd web service user by having the two init scripts point to the exact same file.  One file ensures the settings will ALWAYS be in-sync. If you'd like to try this, but are confused, or if you can come up with a better way for managing this file-synchronicity, please do not hesitate to contact us at ][support@iliosproject.org](mailto:support@iliosproject.org) with any questions or suggestions!
+The idea behind this is that EVERYONE who logs in to the system will have the properly-configured ENV settings that match those set for the apache httpd web service user by having the two init scripts point to the exact same file. One file ensures the settings will ALWAYS be in-sync. If you'd like to try this, but are confused, or if you can come up with a better way for managing this file-synchronicity, please do not hesitate to contact us at ][support@iliosproject.org](mailto:support@iliosproject.org) with any questions or suggestions!
 
 ## Why Environment Variables?
 

--- a/docs/error_reporting.md
+++ b/docs/error_reporting.md
@@ -2,7 +2,7 @@
 
 Would you like to help with Ilios development without having to do any extra work?  How about sending us your error logs in real-time so we can review them and pre-emptively fix them in the next release before they have the chance to become something larger?!
 
-With the release of Ilios v3.57.0, you can enable the ability to automatically capture and send information about any errors or crashes of your Ilios instance to the [Ilios Team](https://www.iliosproject.org) for real-time monitoring and tracking by us.  By doing so, you can help to keep us informed of any potential bugs or problems with our code, and we can use this information to make Ilios better for everyone!
+With the release of Ilios v3.57.0, you can enable the ability to automatically capture and send information about any errors or crashes of your Ilios instance to the [Ilios Team](https://www.iliosproject.org) for real-time monitoring and tracking by us. By doing so, you can help to keep us informed of any potential bugs or problems with our code, and we can use this information to make Ilios better for everyone!
 
 If your organization would like to share any errors or crashes in your Ilios instance with the Ilios Team, you can easily enable the error-capturing functionality required on your instance by running the console command below in the context of your web services user (eg, `apache`, `www`, `www-data`, etc.):
 
@@ -11,17 +11,14 @@ sudo -u apache bin/console ilios:set-config-value errorCaptureEnabled true
 sudo -u apache bin/console ilios:set-config-value errorCaptureEnvironment YOUR_CAMPUS_NAME
 ```
 
-This command will simply add a configuration setting named `errorCaptureEnabled` to the `application_config` table in your Ilios database and set its value to `true`.  In turn, this will activate the extra features necessary for sending information about your application's errors/issues directly to us in the background.
-
+This command will simply add a configuration setting named `errorCaptureEnabled` to the `application_config` table in your Ilios database and set its value to `true`. In turn, this will activate the extra features necessary for sending information about your application's errors/issues directly to us in the background.
 
 To disable the error-capturing feature within your Ilios app, simply run the same command, but set the configuration value to `false`, as shown:
 
  ```bash
  sudo -u apache bin/console ilios:set-config-value errorCaptureEnabled false
  ```
- 
+
 Only issues with your Ilios instance as tracked by its logs will be sent to us. No private information or sensitive data will be included in the information we receive, so please consider helping us create a better Ilios for everyone by enabling this extra feature in your Ilios application!
 
 We would really appreciate it!
-
-

--- a/docs/ilios_api.md
+++ b/docs/ilios_api.md
@@ -4,7 +4,7 @@ This document provides instructions for connecting to the Ilios API for making r
 
 ## API Endpoints
 
-The functional endpoints provided by the Ilios API, and how they are called, are listed and documented at /api/doc on the webserver that runs Ilios. For example, to examine the API endpoints and their use on the publicly-accessible Ilios demo server ([https://ilios3-demo.ucsf.edu](https://ilios3-demo.ucsf.edu)), one would just need to visit [https://ilios3-demo.ucsf.edu/api/doc](https://ilios3-demo.ucsf.edu/api/doc) in their browser.
+The functional endpoints provided by the Ilios API, and how they are called, are listed and documented at /api/doc on the webserver that runs Ilios. For example, to examine the API endpoints and their use on the publicly-accessible Ilios demo server ([https://demo.iliosproject.org](https://demo.iliosproject.org)), one would just need to visit [https://demo.iliosproject.org/api/doc](https://demo.iliosproject.org/api/doc) in their browser.
 
 ## API Authentication - Using JSON Web Tokens
 

--- a/docs/ilios_api.md
+++ b/docs/ilios_api.md
@@ -80,7 +80,7 @@ If all went as planned, this header value should now be sent with EVERY request 
 
 To test that the header is being sent correctly, visit your Ilios API instance and check for users by appending `/api/v1/users` to your own Ilios URL as shown here:
 
-[https://ilios3-demo.ucsf.edu/api/v1/users](https://ilios3-demo.ucsf.edu/api/v1/users)
+[https://demo.iliosproject.org/api/v1/users](https://demo.iliosproject.org/api/v1/users)
 
 If adding the token to the headers was successful, you will see a JSON-formatted display of all the user accounts in Ilios. Congratulations! Your JWT token is working correctly!
 

--- a/docs/ilios_api.md
+++ b/docs/ilios_api.md
@@ -3,19 +3,20 @@
 This document provides instructions for connecting to the Ilios API for making requests to an Ilios backend from third-party applications.
 
 ## API Endpoints
-The functional endpoints provided by the Ilios API, and how they are called, are listed and documented at /api/doc on the webserver that runs Ilios. For example, to examine the API endpoints and their use on the publicly-accessible Ilios demo server ([https://ilios3-demo.ucsf.edu](https://ilios3-demo.ucsf.edu)), one would just need to visit https://ilios3-demo.ucsf.edu/api/doc in their browser.
+
+The functional endpoints provided by the Ilios API, and how they are called, are listed and documented at /api/doc on the webserver that runs Ilios. For example, to examine the API endpoints and their use on the publicly-accessible Ilios demo server ([https://ilios3-demo.ucsf.edu](https://ilios3-demo.ucsf.edu)), one would just need to visit [https://ilios3-demo.ucsf.edu/api/doc](https://ilios3-demo.ucsf.edu/api/doc) in their browser.
 
 ## API Authentication - Using JSON Web Tokens
 
-To make calls to any of the endpoints provided by the Ilios API, a valid JSON Web Token (JWT) must be sent along in the headers of the HTTP request.  JWT's can be created and invalidated as-needed by any user when they visit their profile page (/myprofile) in the Ilios application. The permissions for the token reflect those of the account of the user creating the token - any tasks available to the user within the Ilios frontend GUI application will be available to the user's API request(s) when making API calls using the JWT token they generated.
+To make calls to any of the endpoints provided by the Ilios API, a valid JSON Web Token (JWT) must be sent along in the headers of the HTTP request. JWT's can be created and invalidated as-needed by any user when they visit their profile page (`/myprofile`) in the Ilios application. The permissions for the token reflect those of the account of the user creating the token - any tasks available to the user within the Ilios frontend GUI application will be available to the user's API request(s) when making API calls using the JWT token they generated.
 
 ### Creating a JSON Web Token (JWT)
 
-To create a new JWT, a user should log into their Ilios application and visit their profile page at /myprofile (eg, [https://ilios3-demo.ucsf.edu/myprofile](https://ilios3-demo.ucsf.edu/myprofile)). Once on their profile page, they can create a new token by clicking on the 'Create New' button, selecting an expiration date for the token, and copying the JWT text returned. For security reasons, it is ill-advised to create a token with an expiration date far out into the future; tokens should only remain valid for their intended duration and no longer.  All tokens no longer being used should be invalidated ASAP.
+To create a new JWT, a user should log into their Ilios application and visit their profile page at `/myprofile` (e.g., [https://ilios3-demo.ucsf.edu/myprofile](https://ilios3-demo.ucsf.edu/myprofile)). Once on their profile page, they can create a new token by clicking on the 'Create New' button, selecting an expiration date for the token, and copying the JWT text returned. For security reasons, it is ill-advised to create a token with an expiration date far out into the future; tokens should only remain valid for their intended duration and no longer. All tokens no longer being used should be invalidated ASAP.
 
 ### Creating JWT tokens from the command line
 
-JSON Web Tokens can also be created by an Ilios administrator using the Ilios console application at the command-line and running the following command in the context of the user that runs the webserver (eg, 'apache').  The Ilios user_id = 18 for this example:
+JSON Web Tokens can also be created by an Ilios administrator using the Ilios console application at the command-line and running the following command in the context of the user that runs the webserver (e.g., `apache`). The Ilios `user_id` = `18` for this example:
 
 ```bash
 sudo -u apache bin/console ilios:maintenance:create-user-token 18 --env=prod
@@ -23,61 +24,63 @@ sudo -u apache bin/console ilios:maintenance:create-user-token 18 --env=prod
 
 ### Authenticating requests using 'X-JWT-Authorization' in your HTTP request headers
 
-The value of JWT that was copied when the token was generated should be added to the HTTP headers as the value associated with 'X-JWT-Authorization' header and it should be prefixed with the work 'Token ' (the word 'Token', followed by a single space).  For example, if the token generated is:
+The value of JWT that was copied when the token was generated should be added to the HTTP headers as the value associated with `X-JWT-Authorization` header and it should be prefixed with the word 'Token', followed by a single space. For example, if the token generated is:
 
-```
+```shell
 eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpbGlvcyIsImF1ZCI6ImlsaW9zIiwiaWF0IjoiMTQ3OTE2NDIxNSIsImV4cCI6IjE0ODA0MDY0MDAiLCJ1c2VyX2lkIjoxNn0.45RN1Tw9bd_dgeiGVTJCm8sy_x4UD_a9xE4hHYS6H08
 ```
 
 then the header attribute sent should look like this:
 
-```
+```shell
 X-JWT-Authorization: Token eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpbGlvcyIsImF1ZCI6ImlsaW9zIiwiaWF0IjoiMTQ3OTE2NDIxNSIsImV4cCI6IjE0ODA0MDY0MDAiLCJ1c2VyX2lkIjoxNn0.45RN1Tw9bd_dgeiGVTJCm8sy_x4UD_a9xE4hHYS6H08
 ```
+
 (Note the space between the word 'Token' and the token value itself!)
 
 This is the header value that should be sent with every HTTP request that uses this token to authenticate.
 
 ### Verifying/testing JWT Authentication
 
-There are two ways to easily test the validity of a JSON Web Token, through the Ilios API Sandbox (at /api/doc on your Ilios installation) or by using a browser extension for either Google Chrome or Firefox.  Both methods are described below:
+There are two ways to easily test the validity of a JSON Web Token, through the Ilios API Sandbox (at `/api/doc` on your Ilios installation) or by using a browser extension for either Google Chrome or Firefox. Both methods are described below:
 
 #### Verifying JWT in the Ilios API Sandbox (at /api/doc)
 
-Aside from being a great source of up-to-date documentation of the methods available via the Ilios API, the Ilios API endpoint reference also provides a sandbox for testing specific calls using your JWT.  To test your newly created JWT in the API sandbox, do the following:
+Aside from being a great source of up-to-date documentation of the methods available via the Ilios API, the Ilios API endpoint reference also provides a sandbox for testing specific calls using your JWT. To test your newly created JWT in the API sandbox, do the following:
 
 1. Visit /api/doc on your Ilios installation (for this example, we'll use [https://ilios3-demo.ucsf.edu/api/doc](https://ilios3-demo.ucsf.edu/api/doc))
 2. Scroll down and find the Ilios API endpoint that you would like to test (ie, 'User')
 3. Expand the desired endpoint's documentation by clicking on the request method (ie, "GET")
 4. In the area that expands, you will see the endpoint's documentation with two options listed at the very top: 'Documentation' and 'Sandbox'.
-5. Click on the 'Sandbox' link and you will be presented with several form fields. Find the ones under the 'Headers' label.  There should be one field for 'Key' and another for 'Value'.
+5. Click on the 'Sandbox' link and you will be presented with several form fields. Find the ones under the 'Headers' label. There should be one field for 'Key' and another for 'Value'.
 6. In the 'Key' field, enter this text: X-JWT-Authorization
 7. In the 'Value' field, enter 'Token [YOUR JWT VALUE]' (Replacing [YOUR JWT VALUE] with the value of the token you are testing) as shown:
-```
-Token eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpbGlvcyIsImF1ZCI6ImlsaW9zIiwiaWF0IjoiMTQ3OTE2NDIxNSIsImV4cCI6IjE0ODA0MDY0MDAiLCJ1c2VyX2lkIjoxNn0.45RN1Tw9bd_dgeiGVTJCm8sy_x4UD_a9xE4hHYS6H08
-```
+
+    ```shell
+    Token eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpbGlvcyIsImF1ZCI6ImlsaW9zIiwiaWF0IjoiMTQ3OTE2NDIxNSIsImV4cCI6IjE0ODA0MDY0MDAiLCJ1c2VyX2lkIjoxNn0.45RN1Tw9bd_dgeiGVTJCm8sy_x4UD_a9xE4hHYS6H08
+    ```
 
 Now, when you click the 'Try!' button at the bottom of that section, you should see the JSON-formatted result of the API call! Congratulations! Your JWT token is working correctly!
 
 #### Verifying JWT using browser extensions for Chrome or Firefox
 
-If you would like to test the functionality of your new JWT and verify that it is working and/or that the proper results are being returned as-expected WITHOUT using the Ilios API Sandbox, we recommend you test your JWT using the browser extension [Modify Headers for Google Chrome](https://chrome.google.com/webstore/detail/modify-headers-for-google/innpjfdalfhpcoinfnehdnbkglpmogdi) or the [Modify Headers extension for Firefox](https://addons.mozilla.org/en-US/firefox/addon/modify-headers/).  These extensions will allow you to test a token and view the results of API calls directly within the browser.
+If you would like to test the functionality of your new JWT and verify that it is working and/or that the proper results are being returned as-expected WITHOUT using the Ilios API Sandbox, we recommend you test your JWT using the browser extension [Modify Headers for Google Chrome](https://chrome.google.com/webstore/detail/modify-headers-for-google/innpjfdalfhpcoinfnehdnbkglpmogdi) or the [Modify Headers extension for Firefox](https://addons.mozilla.org/en-US/firefox/addon/modify-headers/). These extensions will allow you to test a token and view the results of API calls directly within the browser.
 
 Using the 'Modify Headers for Google Chrome' extension in Google Chrome as an example, visit the extension's configuration page and do the following:
 
-1. Click the 'Add New' button - a new row should appear to allow for adding a new header.
-2. In the new row that appears, select 'Add' for the 'Action' attribute and enter 'X-JWT-Authorization' for the 'Name' attribute.
-3. Under 'Value', enter the following exactly as displayed below and save/enable it when you're done:
+1. Click the `Add New` button - a new row should appear to allow for adding a new header.
+2. In the new row that appears, select `Add` for the `Action` attribute and enter `X-JWT-Authorization` for the `Name` attribute.
+3. Under `Value`, enter the following exactly as displayed below and save/enable it when you're done:
 
-```
-Token eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpbGlvcyIsImF1ZCI6ImlsaW9zIiwiaWF0IjoiMTQ3OTE2NDIxNSIsImV4cCI6IjE0ODA0MDY0MDAiLCJ1c2VyX2lkIjoxNn0.45RN1Tw9bd_dgeiGVTJCm8sy_x4UD_a9xE4hHYS6H08
-```
+    ```shell
+    Token eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpbGlvcyIsImF1ZCI6ImlsaW9zIiwiaWF0IjoiMTQ3OTE2NDIxNSIsImV4cCI6IjE0ODA0MDY0MDAiLCJ1c2VyX2lkIjoxNn0.45RN1Tw9bd_dgeiGVTJCm8sy_x4UD_a9xE4hHYS6H08
+    ```
 
 If all went as planned, this header value should now be sent with EVERY request you make from the browser until you choose to disable it or you disable and/or uninstall the extension entirely.
 
-To test that the header is being sent correctly, visit your Ilios API instance and check for users by appending '/api/v1/users' to your own Ilios URL as shown here:
+To test that the header is being sent correctly, visit your Ilios API instance and check for users by appending `/api/v1/users` to your own Ilios URL as shown here:
 
-https://ilios3-demo.ucsf.edu/api/v1/users
+[https://ilios3-demo.ucsf.edu/api/v1/users](https://ilios3-demo.ucsf.edu/api/v1/users)
 
 If adding the token to the headers was successful, you will see a JSON-formatted display of all the user accounts in Ilios. Congratulations! Your JWT token is working correctly!
 

--- a/docs/ilios_api.md
+++ b/docs/ilios_api.md
@@ -12,7 +12,7 @@ To make calls to any of the endpoints provided by the Ilios API, a valid JSON We
 
 ### Creating a JSON Web Token (JWT)
 
-To create a new JWT, a user should log into their Ilios application and visit their profile page at `/myprofile` (e.g., [https://ilios3-demo.ucsf.edu/myprofile](https://ilios3-demo.ucsf.edu/myprofile)). Once on their profile page, they can create a new token by clicking on the 'Create New' button, selecting an expiration date for the token, and copying the JWT text returned. For security reasons, it is ill-advised to create a token with an expiration date far out into the future; tokens should only remain valid for their intended duration and no longer. All tokens no longer being used should be invalidated ASAP.
+To create a new JWT, a user should log into their Ilios application and visit their profile page at `/myprofile` (e.g., [https://demo.iliosproject.org/myprofile](https://demo.iliosproject.org/myprofile)). Once on their profile page, they can create a new token by clicking on the 'Create New' button, selecting an expiration date for the token, and copying the JWT text returned. For security reasons, it is ill-advised to create a token with an expiration date far out into the future; tokens should only remain valid for their intended duration and no longer. All tokens no longer being used should be invalidated ASAP.
 
 ### Creating JWT tokens from the command line
 

--- a/docs/ilios_php_version_policy.md
+++ b/docs/ilios_php_version_policy.md
@@ -1,21 +1,21 @@
 # Ilios and PHP
 
 In an effort to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios.
-  
-### The Ilios PHP Version Policy
+
+## The Ilios PHP Version Policy
 
 At any given time, the Ilios application will only be supported on the very latest minor version of PHP and, for the first 3 months of that version's release, we will also ensure support for the previous minor version.  After 3 months, only Ilios instances running on the newest version of PHP will continue to be supported.
- 
-#### Policy Example
+
+### Policy Example
 
 For example, the current minimum version of PHP is v8.3.  When PHP v8.4 is released, we will continue to ensure the Ilios code will work on PHP 8.3 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 8.4 going forward.
 
-### Currently Supported Versions of PHP
+## Currently Supported Versions of PHP
 
 Based on the policy above, Ilios is currently compatible with the following versions of PHP:
 
 * PHP 8.3
- 
-### Up-To-Date PHP Repositories for CentOS and RHEL
+
+## Up-To-Date PHP Repositories for CentOS and RHEL
 
 While some Linux distributions like Ubuntu and Fedora maintain package repositories with the very latest versions of PHP, it can be difficult to find trustworthy ones for CentOS and RHEL distributions. For RedHat-based systems such as these, we have found reliable YUM package repositories at the [IUS Community Project](https://ius.io).

--- a/docs/ilios_php_version_policy.md
+++ b/docs/ilios_php_version_policy.md
@@ -4,11 +4,11 @@ In an effort to ensure the best security and performance of the application over
 
 ## The Ilios PHP Version Policy
 
-At any given time, the Ilios application will only be supported on the very latest minor version of PHP and, for the first 3 months of that version's release, we will also ensure support for the previous minor version.  After 3 months, only Ilios instances running on the newest version of PHP will continue to be supported.
+At any given time, the Ilios application will only be supported on the very latest minor version of PHP and, for the first 3 months of that version's release, we will also ensure support for the previous minor version. After 3 months, only Ilios instances running on the newest version of PHP will continue to be supported.
 
 ### Policy Example
 
-For example, the current minimum version of PHP is v8.3.  When PHP v8.4 is released, we will continue to ensure the Ilios code will work on PHP 8.3 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 8.4 going forward.
+For example, the current minimum version of PHP is v8.3. When PHP v8.4 is released, we will continue to ensure the Ilios code will work on PHP 8.3 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 8.4 going forward.
 
 ## Currently Supported Versions of PHP
 

--- a/docs/ilios_quick_setup_for_admins.md
+++ b/docs/ilios_quick_setup_for_admins.md
@@ -2,13 +2,13 @@
 
 If you want to work on a development instance of Ilios using a copy of your school’s own Ilios production database, or a copy of the Ilios Demo Database, here is a quick guide to the steps experienced sysadmins and developers will need to perform to get up and running in no time:
 
-1. Have a copy of the Ilios database you would like to use, and know what Ilios backend version it is at.  You can use a backup copy of your institution’s Ilios database, or you can download the latest Ilios Demo DB at https://ilios-demo-db.iliosproject.org.  The version of the Ilios demo db corresponds with the latest version of Ilios at the time of download (currently `v3.76.1`).
+1. Have a copy of the Ilios database you would like to use, and know what Ilios backend version it is at. You can use a backup copy of your institution’s Ilios database, or you can download the latest Ilios Demo DB at [https://ilios-demo-db.iliosproject.org](https://ilios-demo-db.iliosproject.org). The version of the Ilios demo db corresponds with the latest version of Ilios at the time of download (currently `v3.76.1`).
 
-2. Verify the version of Ilios that you should be running with the copy of the database you plan to use.  You should note this version when you create your database backup file, and you can always migrate to the latest version once it is loaded, but will want to know which version you are working with when you get started.
+2. Verify the version of Ilios that you should be running with the copy of the database you plan to use. You should note this version when you create your database backup file, and you can always migrate to the latest version once it is loaded, but will want to know which version you are working with when you get started.
 
-3. Set up a LAMP web application server (comprised of Linux, Apache, MySQL, PHP) to run the web/database services required for your development Ilios application. This is a fairly common requirement for web applications, see [here](https://github.com/ilios/ilios/blob/master/docs/install.md#pre-requisitesrequirements) for more info. RECOMMENDED: We recommend using Docker and Docker Composer! (See [below](https://github.com/ilios/ilios/edit/quickstart-docs/docs/ilios_quick_setup_for_admins.md#Using-Docker-and-Docker-Compose-to-set-up-a-Development-System-for-Ilios)!) 
+3. Set up a LAMP web application server (comprised of Linux, Apache, MySQL, PHP) to run the web/database services required for your development Ilios application. This is a fairly common requirement for web applications, see [here](https://github.com/ilios/ilios/blob/master/docs/install.md#pre-requisitesrequirements) for more info. RECOMMENDED: We recommend using Docker and Docker Composer! (See [below](https://github.com/ilios/ilios/edit/quickstart-docs/docs/ilios_quick_setup_for_admins.md#Using-Docker-and-Docker-Compose-to-set-up-a-Development-System-for-Ilios)!)
 
-4. Make sure that the getcomposer.org PHP dependency manager is installed on your LAMP system. 
+4. Make sure that the getcomposer.org PHP dependency manager is installed on your LAMP system.
 
 5. Use git to checkout the correct version of the Ilios codebase to your LAMP system, or copy over the code from the Ilios instance from where you got your database backup file you plan to use for your instance. (Eg, `git checkout --tags v3.76.1`)
 
@@ -44,7 +44,7 @@ $ docker compose up -d
 
 ### Accessing Ilios
 
-You should now be able to access your newly-Dockerized instance of Ilios 
+You should now be able to access your newly-Dockerized instance of Ilios
 by visiting [http://localhost:8000](http://localhost:8000) in your browser.
 
 ### Shutting down the development server

--- a/docs/ilios_quick_setup_for_admins.md
+++ b/docs/ilios_quick_setup_for_admins.md
@@ -2,7 +2,7 @@
 
 If you want to work on a development instance of Ilios using a copy of your school’s own Ilios production database, or a copy of the Ilios Demo Database, here is a quick guide to the steps experienced sysadmins and developers will need to perform to get up and running in no time:
 
-1. Have a copy of the Ilios database you would like to use, and know what Ilios backend version it is at. You can use a backup copy of your institution’s Ilios database, or you can download the latest Ilios Demo DB at [https://ilios-demo-db.iliosproject.org](https://ilios-demo-db.iliosproject.org). The version of the Ilios demo db corresponds with the latest version of Ilios at the time of download (currently `v3.76.1`).
+1. Have a copy of the Ilios database you would like to use, and know what Ilios backend version it is at. You can use a backup copy of your institution’s Ilios database, or you can download the latest Ilios Demo DB at [https://ilios-demo-db.iliosproject.org](https://ilios-demo-db.iliosproject.org). The version of the Ilios demo db corresponds with the latest version of Ilios at the time of download.
 
 2. Verify the version of Ilios that you should be running with the copy of the database you plan to use. You should note this version when you create your database backup file, and you can always migrate to the latest version once it is loaded, but will want to know which version you are working with when you get started.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,19 +6,21 @@ If you are looking to update your installation of Ilios, please see [Updating Il
 
 If you are looking to upgrade a previous v2.x installation of Ilios, please see [Upgrading From Ilios 2.x](upgrade_ilios_2_to_3.md).
 
-### Summary
+## Summary
+
 To build/deploy the Ilios 3 backend, you will need to install the default Ilios database schema and then follow the steps for deploying code to your webserver(s) and configuring them to connect to the database and serve the API.
 
 ## Pre-requisites/requirements
+
 Ilios 3 uses a Symfony (PHP/SQL) backend to serve its API, so these tools and their required dependencies need to be installed before you can install the application itself. Here at the Ilios Project, we currently run and recommend running Ilios 3 using a "LAMP" (Linux Apache MySQL PHP) technology stack with the following software packages and versions:
 
 * CentOS 7 - Any modern Linux should work, but we recommend Redhat (RHEL, CentOS, or Fedora) or Ubuntu
 * MySQL using the InnoDB database engine (v5.7 or later required, 8+ recommended)
 * PHP v8.3+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
 
-NOTE: Several institutions have successfully deployed Ilios using Microsoft IIS on Windows as their webserver, but we do not recommend it as we do not have alot of experience with it ourselves and we've only ever support Ilios on Linux systems.  That being said, if you MUST use IIS for Windows and are having trouble getting Ilios running properly, please contact the [Ilios Project Support Team](https://iliosproject.org) at support@iliosproject.org if you have any problems and we might be able to help you out!
+NOTE: Several institutions have successfully deployed Ilios using Microsoft IIS on Windows as their webserver, but we do not recommend it as we do not have alot of experience with it ourselves and we've only ever support Ilios on Linux systems. That being said, if you MUST use IIS for Windows and are having trouble getting Ilios running properly, please contact the [Ilios Project Support Team](https://iliosproject.org) at [support@iliosproject.org](mailto:support@iliosproject.org) if you have any problems and we might be able to help you out!
 
-PHP should configured with a 'memory_limit' setting of at least 386MB and have the following required packages/modules/extensions enabled:
+PHP should configured with a `memory_limit` setting of at least 386MB and have the following required packages/modules/extensions enabled:
 
 * php-mbstring - for UTF-8 support
 * php-ldap - for ldap-connectivity support (when using LDAP)
@@ -29,54 +31,62 @@ PHP should configured with a 'memory_limit' setting of at least 386MB and have t
 * php-pdo - DB connectivity
 * php-zip - for native zip package [de]compression during the composer installation process
 
-##### A note about SELinux
- 
-CentOS, RedHat, and Fedora Linux distributions come with SELinux installed and enabled by default.  SELinux, aka "Security-Enhanced Linux", greatly limits many actions typically allowed out-of-the-box on most Linux distros so, if you seem to be having issues with your Ilios installation not working correctly and you have SELinux installed and enabled, we recommend you review your SELinux settings and/or check out our [Troubleshooting](#troubleshooting) section below.
+> A note about SELinux
+>
+> CentOS, RedHat, and Fedora Linux distributions come with SELinux installed and enabled by default. SELinux, aka "Security-Enhanced Linux", greatly limits many actions typically allowed out-of-the-box on most Linux distros so, if you seem to be having issues with your Ilios installation not working correctly and you have SELinux installed and enabled, we recommend you review your SELinux settings and/or check out our [Troubleshooting](#troubleshooting) section below.
 
 ### URL Rewriting
+
 You must enable URL-rewriting on your webserver. For those using Apache, this can be done by installing and enabling the 'mod_rewrite' module. In IIS, this is handled via the [Microsoft IIS URL Rewrite extension](https://www.iis.net/downloads/microsoft/url-rewrite)
 
 ### Composer
-You will need the Composer PHP package management tool.  If you do not have it, you can learn about it and download it at https://getcomposer.org
+
+You will need the Composer PHP package management tool. If you do not have it, you can learn about it and download it at [https://getcomposer.org](https://getcomposer.org).
 
 ### Code Deployment
 
 These steps assume that you are deploying the Ilios 3 backend via a Git clone from the Ilios repository at [https://github.com/ilios/ilios.git](https://github.com/ilios/ilios.git) and building the install using PHP's 'composer' package manager.
 
-All the steps below should be performed in the context of the user that runs your webserver process (typically, 'apache')
+All the steps below should be performed in the context of the user that runs your webserver process (typically, `apache`)
 
-1. Log into your webserver(s) and change to your web server root ('/web/ilios3' for this example).
-2. Clone/update Ilios 3 directory tree to this directory (assuming 'git clone' for this example).
-```bash
-sudo -u apache git clone https://github.com/ilios/ilios.git
-```
-This will create a folder named 'ilios' in your server root directory.  The entire application source tree will be downloaded to this folder and when this process is finished, the 'web' subfolder should be set as your web server's document root ('/web/ilios3/ilios/public') in your webserver configuration.  
+1. Log into your webserver(s) and change to your web server root (`/web/ilios3` for this example).
+2. Clone/update Ilios 3 directory tree to this directory (assuming `git clone` for this example).
+
+    ```bash
+    sudo -u apache git clone https://github.com/ilios/ilios.git
+    ```
+
+    This will create a folder named `ilios` in your server root directory. The entire application source tree will be downloaded to this folder and when this process is finished, the 'web' subfolder should be set as your web server's document root (`/web/ilios3/ilios/public`) in your webserver configuration.
+
 3. Change into the newly created folder
 
-```bash
-cd ilios
-```
-You should now be in the '/web/ilios3/ilios' directory
+    ```bash
+    cd ilios
+    ```
+
+    You should now be in the `/web/ilios3/ilios` directory
 
 4. Checkout the latest release tag:
-```bash
-# NOTE: When running this command in the context of your web services user, you can ignore any `Permission denied`
-# errors related to git files in your own user's `.config` directory:
-sudo -u apache git checkout tags/$(git fetch --tags; git describe --tags `git rev-list --tags --max-count=1`)
-```
-5. Run the following command to build the packages and its dependencies.  This step assumes you have PHP 8.3+ and Composer installed on your system:
-```bash
-sudo -u apache bin/setup
-```
-This will install the required PHP Symfony packages and their dependencies and check your system for any issues.
+
+    ```bash
+    # NOTE: When running this command in the context of your web services user, you can ignore any `Permission denied`
+    # errors related to git files in your own user's .config directory:
+    sudo -u apache git checkout tags/$(git fetch --tags; git describe --tags `git rev-list --tags --max-count=1`)
+    ```
+
+5. Run the following command to build the packages and its dependencies. This step assumes you have PHP 8.3+ and Composer installed on your system:
+
+    ```bash
+    sudo -u apache bin/setup
+    ```
+
+    This will install the required PHP Symfony packages and their dependencies and check your system for any issues.
 
 Congratulations! Once you've the completed the above steps, the latest codebase will have been built and deployed!
 
 ## Configurations
-There are three [configuration parameters](./env_vars_and_config.md) that *must* be supplied to ilios for basic functionality.
-A path to your database connection, a path on the file system to store learning materials, and a secret to use for encrypting 
-user passwords, tokens and other sensitive data. For the initial installation it is sufficient to place this information in the
-ilios filesystem.
+
+There are three [configuration parameters](./env_vars_and_config.md) that *must* be supplied to Ilios for basic functionality: a path to your database connection, a path on the file system to store learning materials, and a secret to use for encrypting user passwords, tokens and other sensitive data. For the initial installation it is sufficient to place this information in the Ilios filesystem.
 
 ```bash
 sudo -u apache echo "ILIOS_SECRET='NotSecretChangeMe'" >> .env.local
@@ -93,6 +103,7 @@ These values will need to be adjusted to your environment and setup.
 If you are already running a 2.x version of Ilios, you can upgrade your current database by following the intructions at [Upgrading From Ilios 2.x](docs/upgrade_ilios_2_to_3.md).
 
 ### Creating a new database for Ilios
+
 If you are NOT upgrading from a previous version of Ilios, you can create a new, empty database schema by using the following Symfony console command:
 
 ```bash
@@ -105,54 +116,60 @@ bin/console ilios:import-mesh-universe --env=prod
 This will create your database schema, with all tables and constraints, and will also load in all the default lookup table data, like competencies and topics --- which you can modify once you're done with setup --- but it won't have any course data or any other unique data about your specific school or curriculum until you log in and add some.
 
 ## Check your setup
+
 There are a number of automated health checks which will ensure that your system is configured optimally and point to any issues. Run them as:
+
 ```bash
 bin/console monitor:health  --group=default --group=production
 ```
 
 * Finally, you should clear all cached items from the system, including the Symfony Cache (and its store on the filesystem) and the APC cache:
+
 ```bash
 # clear the Symfony cache...
 sudo -u apache bin/console cache:clear --env=prod
 # and finally, the APC cache (by restarting the httpd server)
 sudo service httpd restart
 ```
+
 **And that's it!  You should now have a working Ilios 3 backend!**
 
 ## Setup a First User
 
-To get started with your new version of Ilios, you are going to have to create the 'first user' in order to get into the application. The username for this user will be 'first_user', the password will be 'Ch4nge_m3', and the user will be granted 'root'-level privileges, which will allow you to perform all necessary tasks to start administering the application.
+To get started with your new version of Ilios, you are going to have to create the 'first user' in order to get into the application. The username for this user will be `first_user`, the password will be `Ch4nge_m3`, and the user will be granted 'root'-level privileges, which will allow you to perform all necessary tasks to start administering the application.
 
-To add the first user, we need to return to the the Ilios application root folder ('/web/ilios3/ilios') and get ready to run the following console command.  Before running the command, however, you'll want to gather this information about the user you intend to add:
+To add the first user, we need to return to the the Ilios application root folder (`/web/ilios3/ilios`) and get ready to run the following console command. Before running the command, however, you'll want to gather this information about the user you intend to add:
 
-* The user's email address (eg, ilios_admin@example.edu)
+* The user's email address (eg, [ilios_admin@example.edu](maito:ilios_admin@example.edu))
 * The id of the school that user will be part of; this will most likely be '1' (School of Medicine)
 
 You will be prompted for the email address and school id info when you run the following command (And don't worry, you can change this info after you login!):
 
 ```bash
-sudo -u apache bin/console ilios:setup:first-user --env=prod 
+sudo -u apache bin/console ilios:setup:first-user --env=prod
 ```
 
-After that, visit the url of your new Ilios 3 site and you should see a login form.  Enter 'first_user' in the login field and 'Ch4nge_m3' (without the quotes!) in the password field and submit!
+After that, visit the url of your new Ilios 3 site and you should see a login form. Enter 'first_user' in the login field and 'Ch4nge_m3' (without the quotes!) in the password field and submit!
 
-If everything went correctly, you're ready to go!  Congratulations on installing Ilios! If not, please see some of our troubleshooting suggestions below.
+If everything went correctly, you're ready to go! Congratulations on installing Ilios! If not, please see some of our troubleshooting suggestions below.
 
-Make sure to take a look at [update](update.md) for information on staying up to date and
-[authentication](authentication.md) for help setting up ilios to use your campus single sign on system.
+Make sure to take a look at [update](update.md) for information on staying up to date and [authentication](authentication.md) for help setting up Ilios to use your campus single sign on system.
 
-## <a name="troubleshooting"></a>Troubleshooting
+## Troubleshooting
 
 If you've followed all of the instructions in this document and are still unable to get Ilios work properly, here are some things to try and/or verify:
 
 1. Using SELinux? - If you are attempting to run Ilios on a system that has SELinux enabled and running, you may need to run the following commands in order to allow your webserver to connect to your database:
- ```bash
- setsebool -P httpd_can_network_connect 1
- setsebool -P httpd_can_network_connect_db 1
- ```
-2. If you are making changes to your parameters.yml configuration file and your changes do not seem to be taking effect, remember to clear your Symfony cache any time you make a change to the file. This command must be run from the root directory of your Ilios application, in the context of the user running your web services (eg, 'apache' or 'nginx'):
-```bash
-sudo -u apache bin/console cache:clear --env=prod
-```
 
-If you have tried the above steps without any luck, of if you think we should add another troubleshooting suggestion/solution, please feel free to contact us at support@iliosproject.org if you have any questions, comments, or suggestions!
+    ```bash
+    setsebool -P httpd_can_network_connect 1
+    setsebool -P httpd_can_network_connect_db 1
+    ```
+
+2. If you are making changes to your parameters.yml configuration file and your changes do not seem to be taking effect, remember to clear your Symfony cache any time you make a change to the file. This command must be run from the root directory of your Ilios application, in the context of the user running your web services (eg, `apache` or `nginx`):
+
+    ```bash
+    sudo -u apache bin/console cache:clear --env=prod
+    ```
+
+If you have tried the above steps without any luck, of if you think we should add another troubleshooting suggestion/solution, please feel free to contact us at [support@iliosproject.org](support@iliosproject.org) if you have any questions, comments, or suggestions!

--- a/docs/shibboleth_authentication.md
+++ b/docs/shibboleth_authentication.md
@@ -2,19 +2,19 @@
 
 Ilios includes support for institutions using [Shibboleth](https://www.internet2.edu/products-services/trust-identity/shibboleth/) for their SAML-based Single Sign-On authenticaton solution.
 
-If you would like to enable Shibboleth authentication in Ilios, you should first follow the steps provided by your institution for setting up your Ilios host system as a Shibboleth Service Provider, or "SP".  When You have completed the steps they outline as required, you will need to make several configuration changes to your webserver (Apache) configuration, as well as within the Ilios configuratrion settings in order to activate it.
+If you would like to enable Shibboleth authentication in Ilios, you should first follow the steps provided by your institution for setting up your Ilios host system as a Shibboleth Service Provider, or "SP". When You have completed the steps they outline as required, you will need to make several configuration changes to your webserver (Apache) configuration, as well as within the Ilios configuratrion settings in order to activate it.
 
 ## Web Server Settings
 
-#### _Note: Currently, Ilios only provides documentation for webservers running the Apache 2.4 httpd web server software.  For Nginx or other servers, the settings may be different from what is included here._
+_Note: Currently, Ilios only provides documentation for webservers running the Apache 2.4 httpd web server software. For Nginx or other servers, the settings may be different from what is included here._
 
-When you install the Shibboleth software package on your application server, a Shibboleth configuration file for Apache should be created for you automatically as part of the package install.  On Redhat-based Linux installations, this file is typically named `shibd.conf` and resides in your Apache extension configuration directory (typically `/etc/httpd/conf.d/` or `/etc/apache2/conf.d/`).  
+When you install the Shibboleth software package on your application server, a Shibboleth configuration file for Apache should be created for you automatically as part of the package install. On Redhat-based Linux installations, this file is typically named `shibd.conf` and resides in your Apache extension configuration directory (typically `/etc/httpd/conf.d/` or `/etc/apache2/conf.d/`).
 
-Most of the default settings of this file can remain unchanged, but it is important to update the settings within the `<Location></Location>` configuration container with the following settings to ensure that the entire Ilios application is protected, as well as simplifying the Shibboleth authentication 'handshake' process to accommodate Ilios' use of JSON Web Tokens for authentication/permissions-checking.  
+Most of the default settings of this file can remain unchanged, but it is important to update the settings within the `<Location></Location>` configuration container with the following settings to ensure that the entire Ilios application is protected, as well as simplifying the Shibboleth authentication 'handshake' process to accommodate Ilios' use of JSON Web Tokens for authentication/permissions-checking.
 
-For an Ilios instance, the `<Location></Location>` container in the shibd.conf should read as follows:
+For an Ilios instance, the `<Location></Location>` container in the `shibd.conf` should read as follows:
 
-```
+```conf
 <Location />
   AuthType shibboleth
   Require shibboleth
@@ -25,15 +25,15 @@ For an Ilios instance, the `<Location></Location>` container in the shibd.conf s
 
 After configuring your Ilios application server as a Shibboleth SP and verifying its functionality with your institution's Shibboleth Identity Provider (or "IDp"), you will need to set `shibboleth` as the authentication method within the Ilios configuration settings:
 
-First, make sure that you set any `ILIOS_AUTHENTICATION_TYPE` environment variables on the system to `shibboleth`.  Environment variables in Ilios can be set in several places, but are typically found in the `.env.local` dotfile in your Ilios application root.  Please see our [documentation on ENV vars and Configuration](env_vars_and_config.md) for more information on where environment variables can be set for an Ilios installation.
+First, make sure that you set any `ILIOS_AUTHENTICATION_TYPE` environment variables on the system to `shibboleth`. Environment variables in Ilios can be set in several places, but are typically found in the `.env.local` dotfile in your Ilios application root. Please see our [documentation on ENV vars and Configuration](env_vars_and_config.md) for more information on where environment variables can be set for an Ilios installation.
 
 Second, you will need to set/update the following settings to reflect their proper values in the `application_config` table of the Ilios application's database:
 
-|`name`|`value`|
-|---|---|
-|`authentication_type`|`shibboleth`|
-|`shibboleth_authentication_login_path`|`/Shibboleth.sso/Login`| (<-- Default Shibboleth value, your institution's setting may differ)
-|`shibboleth_authentication_logout_path`|`/Shibboleth.sso/Logout`| (<-- Default Shibboleth value, your institution's setting may differ)
+|`name`|`value`||
+|---|---|---|
+|`authentication_type`|`shibboleth`||
+|`shibboleth_authentication_login_path`|`/Shibboleth.sso/Login`| (<-- Default Shibboleth value, your institution's setting may differ)|
+|`shibboleth_authentication_logout_path`|`/Shibboleth.sso/Logout`| (<-- Default Shibboleth value, your institution's setting may differ)|
 
 If necessary, these settings can be easily added or updated using the following console commands from within the Ilios application directory, run in the context of your Web-service user (eg, `apache`):
 

--- a/docs/store_learning_materials_in_s3.md
+++ b/docs/store_learning_materials_in_s3.md
@@ -1,60 +1,52 @@
 # Storing Learning Materials in and AWS S3 Bucket
 
-By default Ilios will store all of your learning materials in the location
-configured by `file_system_storage_path`. For most environments this is a
-good default. If you wish to run Ilios inside a docker container, in a
-non-traditional hosting environment, or not worry about backing up this data,
-it may make sense to move your learning materials to AWS's S3 service. 
+By default Ilios will store all of your learning materials in the location configured by `file_system_storage_path`. For most environments this is a good default. If you wish to run Ilios inside a docker container, in a non-traditional hosting environment, or not worry about backing up this data, it may make sense to move your learning materials to AWS's S3 service.
 
 ## AWS Configuration
 
 1) Create an S3 bucket in your preferred region.
 
     a) we recommend turning on object encryption.
-    
+
     b) The should *not* be public or publicly accessible. Ilios will use the AWS API and a key you
     setup to access the learning material data.
 
 2) Add an access policy with the correct permissions to your new S3 bucket:
 
-```json 
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "VisualEditor0",
-            "Effect": "Allow",
-            "Action": [
-                "s3:ReplicateObject",
-                "s3:PutObject",
-                "s3:GetObjectAcl",
-                "s3:GetObject",
-                "s3:ListBucket",
-                "s3:DeleteObject",
-                "s3:PutObjectAcl"
-            ],
-            "Resource": [
-                "arn:aws:s3:::YOUR-BUCKET-NAME/*",
-                "arn:aws:s3:::YOUR-BUCKET-NAME"
-            ]
-        }
-    ]
-}
-```
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "VisualEditor0",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ReplicateObject",
+                    "s3:PutObject",
+                    "s3:GetObjectAcl",
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:DeleteObject",
+                    "s3:PutObjectAcl"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::YOUR-BUCKET-NAME/*",
+                    "arn:aws:s3:::YOUR-BUCKET-NAME"
+                ]
+            }
+        ]
+    }
+    ```
 
-Replace `YOUR-BUCKET-NAME` with the S3 bucket you configured in step 1.
+    Replace `YOUR-BUCKET-NAME` with the S3 bucket you configured in step 1.
 
-
-3) Create an AWS user with *only* this policy applied. *Do not* use your root or personal 
+3) Create an AWS user with *only* this policy applied. *Do not* use your root or personal
 account for this purpose.
-    
+
     a) This is an API user and does not need console access
-    
     b) Generate a token and note the *key* and *secret* from AWS, you will need these to configure Ilios.
-    
 
 ## Ilios Configuration
 
 1) Create a special s3 URL for your bucket. The format of this URL is `s3://KEY:SECRET@bucket.region`.
 2) Tell Ilios about this URL by adding it to your configuration by running `$ sudo -u apache bin/console ilios:set-config-value storage_s3_url 'YOUR_S3_URL'`
-

--- a/docs/update.md
+++ b/docs/update.md
@@ -78,7 +78,7 @@ A new asynchronous queue service has been added. You must run `bin/console messe
 
 1. `parameters.yml` has been replaced with ENV configuration. See [env_vars_and_config](env_vars_and_config.md) for details.
 
-2. Individual database configuration options have been replaced with a single database URL setting (`ILIOS_DATABASE_UR`L). See [https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url) for details.
+2. Individual database configuration options have been replaced with a single database URL setting (`ILIOS_DATABASE_URL`). See [https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url) for details.
 
 ### Upgrading to Ilios 3.36.1
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -5,6 +5,7 @@ These instructions pertain to upgrades within the "Version 3"-branch of Ilios.
 For upgrade instructions from Ilios 2 see [Upgrading From Ilios 2.x](upgrade_ilios_2_to_3.md).
 
 ## Frontend
+
 The Ilios Frontend is always up-to-date on our content-delivery servers at Amazon S3, but you will need to regularly run a console command on your backend instance in order ensure that your users are seeing the latest version and that they are getting all the latest features and bugfixes. To make sure you users are receiving the latest frontend code at all times, just follow these steps:
 
 ```bash
@@ -17,49 +18,48 @@ Frontend updated successfully!
 
 # and that's it!
 ```
+
 It is a good idea to run this command often (we run it in a cron job every minute).
 
-Though you will probably never need to deploy the Ilios 3 Frontend on your own servers, the source for the frontend code can always be found at https://github.com/ilios/frontend.
+Though you will probably never need to deploy the Ilios 3 Frontend on your own servers, the source for the frontend code can always be found at [https://github.com/ilios/frontend](https://github.com/ilios/frontend).
 
 ## General steps
 
-_NOTE:_ The steps below assume that file ownership of the deployed codebase belongs to the user account that
- runs your web server. Therefore, commands that affect the file system should also be performed as this user.
- In this example, this account is `apache`, but it could also be `www`, `www-data`, or something else - depending on the
- flavour of Linux (or alternate operating system) running on your server.
+_NOTE:_ The steps below assume that file ownership of the deployed codebase belongs to the user account that runs your web server. Therefore, commands that affect the file system should also be performed as this user. In this example, this account is `apache`, but it could also be `www`, `www-data`, or something else - depending on the flavour of Linux (or alternate operating system) running on your server.
 
 1. Back up your database. _Always._
 
-2. Update your code to the latest desired version.  See https://github.com/ilios/ilios/releases for the most up-to-date list of releases.  There are zipped and tarball downloads included in the release notes for each version.  After making sure you've moved or backed-up your learning materials directory and have a copy of all the settings in you parameters.yml file, you can replace your current code entirely with the code from one of the release distributions and run the steps below.
+2. Update your code to the latest desired version.
 
-If you use git to manage your Ilios you can update the code by checking it out using the respective tag name eg, `git checkout tags/v3.36.0`
+    See [https://github.com/ilios/ilios/releases](https://github.com/ilios/ilios/releases) for the most up-to-date list of releases. There are zipped and tarball downloads included in the release notes for each version. After making sure you've moved or backed-up your learning materials directory and have a copy of all the settings in you parameters.yml file, you can replace your current code entirely with the code from one of the release distributions and run the steps below.
+
+    If you use git to manage your Ilios you can update the code by checking it out using the respective tag name e.g., `git checkout tags/v3.36.0`.
 
 3. Rebuild the application code via composer.
 
- ```bash
-cd YOUR_ILIOS_APPLICATION_ROOT
-sudo -u apache bin/setup
-```
+    ```bash
+    cd YOUR_ILIOS_APPLICATION_ROOT
+    sudo -u apache bin/setup
+    ```
 
 4. Execute any pending database migrations.
 
- ```bash
-cd YOUR_ILIOS_APPLICATION_ROOT
-sudo -u apache bin/console doctrine:migrations:migrate --env=prod --no-interaction
-```
+    ```bash
+    cd YOUR_ILIOS_APPLICATION_ROOT
+    sudo -u apache bin/console doctrine:migrations:migrate --env=prod --no-interaction
+    ```
 
 ## Version-specific steps
 
 ### Upgrading to Ilios 3.105.0
 
-1. The `ILIOS_ELASTICSEARCH_HOSTS` and `ILIOS_ELASTICSEARCH_UPLOAD_LIMIT` parameters have
-been renamed to `ILIOS_SEARCH_HOSTS` and `ILIOS_SEARCH_UPLOAD_LIMIT` to be more vendor neutral. They will need to
-be replaced in your configuration if you have search and indexing enabled.
+The `ILIOS_ELASTICSEARCH_HOSTS` and `ILIOS_ELASTICSEARCH_UPLOAD_LIMIT` parameters have been renamed to `ILIOS_SEARCH_HOSTS` and `ILIOS_SEARCH_UPLOAD_LIMIT` to be more vendor neutral. They will need to be replaced in your configuration if you have search and indexing enabled.
 
 ### Upgrading to Ilios 3.100.0
 
-1. The `enable_tracking` and `tracking_code` parameters have been removed as google analytics is no longer supported.
+The `enable_tracking` and `tracking_code` parameters have been removed as google analytics is no longer supported.
 You should remove these parameters from your configuration by running:
+
 ```bash
 cd YOUR_ILIOS_APPLICATION_ROOT
 bin/console ilios:set-config-value --remove enable_tracking
@@ -68,25 +68,21 @@ bin/console ilios:set-config-value --remove tracking_code
 
 ### Upgrading to Ilios 3.71.0
 
-1. The `ILIOS_DATABASE_MYSQL_VERSION` parameter has been removed, instead the MySQL version should be specified in the `ILIOS_DATABASE_URL`
-as `?serverVersion=8.0`. for example 
-`ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=8.0`.
+The `ILIOS_DATABASE_MYSQL_VERSION` parameter has been removed, instead the MySQL version should be specified in the `ILIOS_DATABASE_URL` as `?serverVersion=8.0`. For example: `ILIOS_DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=8.0`.
 
 ### Upgrading to Ilios 3.69.1
 
-1. A new asynchronous queue service has been added. You must run `bin/console messenger:setup-transports` to set it up.
+A new asynchronous queue service has been added. You must run `bin/console messenger:setup-transports` to set it up.
 
 ### Upgrading to Ilios 3.56.0
 
-1. `parameters.yml` has been replaced with ENV configuration. See [env_vars_and_config](env_vars_and_config) for details.
+1. `parameters.yml` has been replaced with ENV configuration. See [env_vars_and_config](env_vars_and_config.md) for details.
 
-2. Individual database configuration options have been replaced with a single database URL setting (ILIOS_DATABASE_URL). See https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url for details.
+2. Individual database configuration options have been replaced with a single database URL setting (`ILIOS_DATABASE_UR`L). See [https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url) for details.
 
 ### Upgrading to Ilios 3.36.1
 
-A command was added in this version to fix an issue with Learning
-Material metadata. After upgrading to this version you need
-to run the command to scan and fix your learning materials.
+A command was added in this version to fix an issue with Learning Material metadata. After upgrading to this version you need to run the command to scan and fix your learning materials.
 
 ```bash
 cd YOUR_ILIOS_APPLICATION_ROOT
@@ -97,8 +93,7 @@ sudo -u apache bin/console ilios:maintenance:fix-mime-types --env=prod
 
 This version adds the "AAMC Resource Type" as a new entity to the application.
 
-Please execute the following console command _after_ running migrations 
-in order to load the default resource-types data set.
+Please execute the following console command _after_ running migrations in order to load the default resource-types data set:
 
 ```bash
 cd YOUR_ILIOS_APPLICATION_ROOT

--- a/docs/upgrade_ilios_2_to_3.md
+++ b/docs/upgrade_ilios_2_to_3.md
@@ -1,46 +1,45 @@
 
 # Upgrading Ilios 2.x to Ilios 3
 
-As Ilios 3 uses an entirely different codebase from Ilios 2.x, only the database needs to be updated when upgrading to version 3 from version 2.x.  With the exception of the folder that contains your Ilios learning materials, which should be backed-up before performing this process, the new Ilios 3 codebase entirely replaces the Ilios 2.x codebase, so you should follow the instructions in [INSTALL.md](https://github.com/ilios/ilios/blob/master/INSTALL.md) to bring the codebase up-to-date.
+As Ilios 3 uses an entirely different codebase from Ilios 2.x, only the database needs to be updated when upgrading to version 3 from version 2.x. With the exception of the folder that contains your Ilios learning materials, which should be backed-up before performing this process, the new Ilios 3 codebase entirely replaces the Ilios 2.x codebase, so you should follow the instructions in [INSTALL.md](https://github.com/ilios/ilios/blob/master/INSTALL.md) to bring the codebase up-to-date.
 
-###*NOTE:* These steps cover upgrading your Ilios database from an Ilios *2.4.8* installation ONLY.###
+*NOTE:* These steps cover upgrading your Ilios database from an Ilios *2.4.8* installation ONLY.
 
-####*If you are running a version of Ilios earlier than v2.4.8 and would like to upgrade to Ilios 3, you MUST upgrade your Ilios software to release version 2.4.8 BEFORE running these steps! If you do not update to version 2.4.8 before upgrading, your database schema will be incorrect and unusable!*####
+*If you are running a version of Ilios earlier than v2.4.8 and would like to upgrade to Ilios 3, you MUST upgrade your Ilios software to release version 2.4.8 BEFORE running these steps! If you do not update to version 2.4.8 before upgrading, your database schema will be incorrect and unusable!*
 
 Before upgrading your system, you will want to bring down your webserver or redirect users to some kind of 503 maintenance page, so that they will not be making changes to the Ilios database while the upgrade is in-process. We recommend trying this on a development server to test everything out before trying to do it on your production machine.
 
 To upgrade from an already-existing Ilios 2.4.8 installation, perform the following steps in order:
 
-### Steps:
+## Upgrade Steps
 
 1. Backup all of your learning materials or move them to a location where they will be accessible by the new Ilios 3 installation. *WARNING:* If your learning materials are stored in the default location, be careful to not accidentally delete them when you change your codebase.
-2. Backup your current database completely, and do not forget to add the '-R' or'--routines' flags to ensure that your stored procedures and triggers are included in the back up. The command would probably look something like this:
+2. Backup your current database completely, and do not forget to add the `-R` or `--routines` flags to ensure that your stored procedures and triggers are included in the back up. The command would probably look something like this:
 
- ```bash
-mysqldump -u YOUR_ILIOS_DATABASE_USERNAME -h YOUR_ILIOS_HOSTNAME -R -p YOUR_ILIOS_DATABASE_NAME -r YOUR_DATABASE_BACKUP_FILENAME.sql
-```
+    ```bash
+    mysqldump -u YOUR_ILIOS_DATABASE_USERNAME -h YOUR_ILIOS_HOSTNAME -R -p YOUR_ILIOS_DATABASE_NAME -r YOUR_DATABASE_BACKUP_FILENAME.sql
+    ```
 
-3. Backup your current database completely! (Yes, this was just mentioned, but it's extremely important that you do not run this update on your production database without a backup!) 
-4. Check your current Ilios installation's 'version.php' file to verify that you are currently running version 2.4.8 of the Ilios software.  If you are not running version *2.4.8* specifically , you will need to upgrade to 2.4.8 *BEFORE* continuing with these steps!
-5. Checkout the most current release of the Ilios 3 codebase from https://github.com/ilios/ilios/releases (using '/web/ilios3/ilios' for this example)
-6. In the newly-checked out directory, navigate to the 'app/Resources' folder where you will find the [updateSchemaFromIlios2toIlios3.sql](https://github.com/ilios/ilios/blob/master/sql/updateSchemaFromIlios2toIlios3.sql) file.
+3. Backup your current database completely! (Yes, this was just mentioned, but it's extremely important that you do not run this update on your production database without a backup!)
+4. Check your current Ilios installation's `version.php` file to verify that you are currently running version 2.4.8 of the Ilios software. If you are not running version *2.4.8* specifically, you will need to upgrade to 2.4.8 *BEFORE* continuing with these steps!
+5. Checkout the most current release of the Ilios 3 codebase from [https://github.com/ilios/ilios/releases](https://github.com/ilios/ilios/releases) (using `/web/ilios3/ilios` for this example).
+6. In the newly-checked out directory, navigate to the `app/Resources` folder where you will find the [updateSchemaFromIlios2toIlios3.sql](https://github.com/ilios/ilios/blob/master/sql/updateSchemaFromIlios2toIlios3.sql) file.
 7. Backup your current database completely! (<= That's the 3rd time we've said it! It's probably pretty important!)
-8. Apply the sql changes from updateSchemaFromIlios2toIlios3.sql to your database by using the mysql command line client as follows:
+8. Apply the sql changes from `updateSchemaFromIlios2toIlios3.sql` to your database by using the mysql command line client as follows:
 
- ```bash
-mysql -u YOUR_ILIOS_DATABASE_USERNAME -h YOUR_ILIOS_DATABASE_HOSTNAME -p YOUR_ILIOS_DATABASE_NAME < updateSchemaFromIlios2toIlios3.sql
-```
+    ```bash
+    mysql -u YOUR_ILIOS_DATABASE_USERNAME -h YOUR_ILIOS_DATABASE_HOSTNAME -p YOUR_ILIOS_DATABASE_NAME < updateSchemaFromIlios2toIlios3.sql
+    ```
 
-*NOTE:* This process could take a while, depending on your the size of your database and the speed of your database server! On a decent database server with an moderate-sized database, this can take up to 20 mins... If everything goes as it should, you will not see ANY status messages on your screen when it completes: it will just return you to another command prompt. If you are doing this on a remote database server, you will want to make sure that your terminal session does not disconnect before the process completes. We recommend using the 'screen' or 'tmux' Linux apps to ensure your terminal session stays connected during this process.
+*NOTE:* This process could take a while, depending on the size and speed of your database server! On a decent database server with a moderate-sized database, this can take up to 20 mins. If everything goes as it should, you will not see ANY status messages on your screen when it completes: it will just return you to another command prompt. If you are doing this on a remote database server, you will want to make sure that your terminal session does not disconnect before the process completes. We recommend using the `screen` or `tmux` Linux apps to ensure your terminal session stays connected during this process.
 
-When the above steps are completed, there is one final step to the database migration that must be run from the Symfony console *AFTER* you have completed setting up the Ilios 3 backend.  When you have completed installing the Ilios 3 backend, run the following command from the 'bin/' directory of the new installation's codebase:
-
-The command will look like this:
+When the above steps are completed, there is one final step to the database migration that must be run from the Symfony console *AFTER* you have completed setting up the Ilios 3 backend. When you have completed installing the Ilios 3 backend, run the following command from the `bin/` directory of the new installation's codebase:
 
 ```bash
 sudo -u apache bin/console doctrine:migrations:migrate --env=prod --no-interaction
 ```
-This will apply the final migrations to your database.  All future database updates to Ilios 3 will be take place via this method and this command should be run any time you update your codebase to a later version of Ilios.
+
+This will apply the final migrations to your database. All future database updates to Ilios 3 will be take place via this method, and this command should be run any time you update your codebase to a later version of Ilios.
 
 For information on setting up the Ilios 3 backend, please see the instructions in the [INSTALL.md](https://github.com/ilios/ilios/blob/master/INSTALL.md) file.
 
@@ -49,55 +48,54 @@ Good job migrating your database, but we're not quite finished yet!
 ## Migrating your old learning materials and cleaning up the text of your Topics
 
 ### Learning Materials
-The file storage/naming functionality for handling Learning Materials in Ilios 3 has changed slightly from the way it was done in Ilios 2.x.  In order to support the new formatting and storage, you will need to migrate your learning materials to their new storage location and naming convention.  Thankfully, Ilios 3 provides a console command to do this!
 
-The Learning Material migration *copies* learning materials, it does not *move* them so, before you begin migrating your learning materials, you want to make ABSOLUTELY CERTAIN that you have enough free space in your system's storage (hard disk space) in order to accommodate copying all of your materials to the new location.  At the very least, you will want as much free space as you already use for your learning materials.
+The file storage/naming functionality for handling Learning Materials in Ilios 3 has changed slightly from the way it was done in Ilios 2.x. In order to support the new formatting and storage, you will need to migrate your learning materials to their new storage location and naming convention. Thankfully, Ilios 3 provides a console command to do this!
 
-To find out how much space your learning materials are currently taking, login to your Ilios server and change directories to the folder that contains your learning materials and then run this command:
+The Learning Material migration *copies* learning materials, it does not *move* them so, before you begin migrating your learning materials, you want to make ABSOLUTELY CERTAIN that you have enough free space in your system's storage (hard disk space) in order to accommodate copying all of your materials to the new location. At the very least, you will want as much free space as you already use for your learning materials.
+
+To find out how much space your learning materials are currently taking, login to your Ilios server, change directories to the folder that contains your learning materials, and then run this command:
 
  ```bash
-df -h . 
+df -h .
 ```
 
-This is will output something like the following:
+This will output something like the following:
 
  ```bash
 Filesystem   Size   Used  Avail Capacity  iused    ifree %iused  Mounted on
 /dev/disk1  465Gi  209Gi  255Gi    46% 54901683 66942027   45%   /
 ```
 
-If the total number of Gigabytes listed under 'Avail' is significantly greater (20Gi+) than what is listed under 'Used,' you should be good to go!  If the 'Avail' value is less (or even just "pretty close") to what is listed under 'Used', you will probably want to increase the storage on your server before running the Learning Material migration.  If you try to run this migration and do not have enough space to store the files when they are copied over, it can fill up your storage space completely and render your server inoperable!  Please be careful and be certain of your storage availability before performing this operation!
+If the total number of Gigabytes listed under `Avail` is significantly greater (20Gi+) than what is listed under `Used`, you should be good to go! If the `Avail` value is less (or even just "pretty close") to what is listed under `Used` you will probably want to increase the storage on your server before running the Learning Material migration. If you try to run this migration and do not have enough space to store the files when they are copied over, it can fill up your storage space completely and render your server inoperable! Please be careful and be certain of your storage availability before performing this operation!
 
 If you have plenty of space and believe you are able to migrate your learning materials, do the following:
 
 1. Backup your learning materials!!!
-2. Seriously! Back up your learning materials before running this command!!!  If you cannot back up your learning materials or quarantine a copy of them to a separate place on your server where they cannot be affected by this process, you should really consider backing them up offline to some type of external storage device.  Do not risk losing your existing learning materials!
-3. Now that you're sure you're ready to migrate, navigate into your Ilios application's root directory (eg, /web/ilios3/ilios) and examine the file at app/config/parameters.yml.  Look for the value that corresponds to file_system_storage_path.  This location to where your learning materials will be copied.
-4. Now, check to see where your *CURRENT* Ilios 2 learning materials reside.  If your Ilios 2 installation is at /web/ilios2/htdocs, your current learning material are probably in '/web/ilios2/htdocs/learning_materials'. If this is the case, your learning materials reside in '/web/ilios2/htdocs' -- this is the 'Path to Ilios 2' location that you should enter in the following migration command:
+2. Seriously! Back up your learning materials before running this command!!! If you cannot back up your learning materials or quarantine a copy of them to a separate place on your server where they cannot be affected by this process, you should really consider backing them up offline to some type of external storage device. Do not risk losing your existing learning materials!
+3. Now that you're sure you're ready to migrate, navigate into your Ilios application's root directory (e.g., `/web/ilios3/ilios`) and examine the file `at app/config/parameters.yml`. Look for the value that corresponds to `file_system_storage_path`. This location is where your learning materials will be copied.
+4. Now, check to see where your *CURRENT* Ilios 2 learning materials reside. If your Ilios 2 installation is at `/web/ilios2/htdocs`, your current learning materials are probably in `/web/ilios2/htdocs/learning_materials`. If this is the case, your learning materials reside in `/web/ilios2/htdocs` -- this is the 'Path to Ilios 2' location that you should enter in the following migration command:
 
-Now, while still in your Ilios application's root directory, run this command:
+    Now, while still in your Ilios application's root directory, run this command:
 
- ```bash
-sudo -u apache bin/console ilios:setup:migrate-learning-materials /web/ilios2/htdocs --env=prod
-```
+    ```bash
+    sudo -u apache bin/console ilios:setup:migrate-learning-materials /web/ilios2/htdocs --env=prod
+    ```
 
-Make sure that you have entered YOUR 'Path to Ilios 2' location and also do not forget to add '--env=prod' to end of the command!  When you hit enter, you learning materials will be copied to the location as listed in your parameters.xml file.
+Make sure that you have entered YOUR 'Path to Ilios 2' location and also do not forget to add `--env=prod` to end of the command! When you hit enter, your learning materials will be copied to the location as listed in your `parameters.xml` file.
 
 This process can take a while to complete, depending on the number/size of the Learning Materials being copied.
 
 If you would like to verify that your new learning materials are correctly stored, you can run the following command when the migration is complete:
 
- ```bash
+```bash
 sudo -u apache bin/console ilios:maintenance:validate-learning-materials /web/ilios2/htdocs --env=prod
 ```
 
-## Cleaning up the text of your Ilios 2.x Topics
+### Cleaning up the text of your Ilios 2.x Topics
 
-One of the biggest complaints of users of Ilios 2.x, regarding the application, was the poor-formatting of the text in item titles and descriptions. While Ilios 2.x did provide a WYSIWYG editor to its users, too many of the users chose to paste text directly into the Ilios text fields from whatever application they were already in (usually MS Word or some other MS Office application), instead of re-entering the text using the in-app editor.  This caused a real problem with the formatting of text in Ilios, so we've updated the handling of text in Ilios 3 and limited the formatting options to only those most-used in Ilios 2.  Doing so, while making new and future text entries format quite nicely, has made the old, over-formatted, pasted-from-Word text format terribly, rendering much of it unreadable.
+One of the biggest complaints of users of Ilios 2.x, regarding the application, was the poor formatting of the text in item titles and descriptions. While Ilios 2.x did provide a WYSIWYG editor to its users, too many of the users chose to paste text directly into the Ilios text fields from whatever application they were already in (usually MS Word or some other MS Office application), instead of re-entering the text using the in-app editor. This caused a real problem with the formatting of text in Ilios, so we've updated the handling of text in Ilios 3 and limited the formatting options to only those most-used in Ilios 2. Doing so, while making new and future text entries format quite nicely, has made the old, over-formatted, pasted-from-Word text format terrible, rendering much of it unreadable.
 
-We have provided a solution to this problem with a fix that will allow you to quickly remove all but only the allowed characters from your item title and description text.  To apply this fix and reformat all your text to only use the proper formatting native to Ilios 3, do the following:
-
-Navigate to your Ilios application root directory (`/web/ilios3/ilios`, for example) and run the following command for each respective text-type:
+We have provided a solution to this problem with a fix that will allow you to quickly remove all but only the allowed characters from your item title and description text. To apply this fix and reformat all your text to only use the proper formatting native to Ilios 3, navigate to your Ilios application root directory (`/web/ilios3/ilios`, for example) and run the following command for each respective text-type:
 
  ```bash
 #for Objective Titles


### PR DESCRIPTION
Documentation files (`./*.md` and `./docs/*.md`) needed some Markdown linting updates (as well as some other formatting fixes).

Markdown rules fixed:
* [MD001 - Header levels should only increment by one level at a time](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md001---header-levels-should-only-increment-by-one-level-at-a-time)
* [MD012 - Multiple consecutive blank lines](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md012---multiple-consecutive-blank-lines)
* [MD022 - Headers should be surrounded by blank lines](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md022---headers-should-be-surrounded-by-blank-lines)
* [MD031 - Fenced code blocks should be surrounded by blank lines](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines)
* [MD034 - Bare URL used](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md034---bare-url-used)
* [MD040 - Fenced code blocks should have a language specified](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md040---fenced-code-blocks-should-have-a-language-specified)

Markdown rules _ignored_ as unsure how best to update:
* [MD013 - Line length](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md013---line-length)
* [MD014 - Dollar signs used before commands without showing output](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md014---dollar-signs-used-before-commands-without-showing-output)

Additionally:
* Removed extra spaces at ends of sentences
* Removed extra line breaks in the middle of paragraphs (maybe this was to fix `MD013`? If so, it was only done on a few files, so we are at least consistently breaking it now)
* Other proofreading-type changes