### PR TITLE
Clear Messages When Updating the Index 

### DIFF
--- a/src/Command/Index/UpdateCommand.php
+++ b/src/Command/Index/UpdateCommand.php
@@ -12,6 +12,7 @@ use App\Repository\CourseRepository;
 use App\Repository\LearningMaterialRepository;
 use App\Repository\MeshDescriptorRepository;
 use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,7 +33,8 @@ class UpdateCommand extends Command
         protected CourseRepository $courseRepository,
         protected MeshDescriptorRepository $descriptorRepository,
         protected LearningMaterialRepository $learningMaterialRepository,
-        protected MessageBusInterface $bus
+        protected MessageBusInterface $bus,
+        protected EntityManagerInterface $em
     ) {
         parent::__construct();
     }
@@ -50,44 +52,71 @@ class UpdateCommand extends Command
 
     protected function queueUsers(OutputInterface $output): void
     {
+        $clearedCount = $this->clearMessages('UserIndexRequest');
         $allIds = $this->userRepository->getIds();
         $count = count($allIds);
         $chunks = array_chunk($allIds, UserIndexRequest::MAX_USERS);
         foreach ($chunks as $ids) {
             $this->bus->dispatch(new UserIndexRequest($ids));
         }
-        $output->writeln("<info>{$count} users have been queued for indexing.</info>");
+        $this->confirmationMessage($output, $clearedCount, $count, 'users');
     }
 
     protected function queueCourses(OutputInterface $output): void
     {
+        $clearedCount = $this->clearMessages('CourseIndexRequest');
         $allIds = $this->courseRepository->getIds();
         $count = count($allIds);
         $chunks = array_chunk($allIds, CourseIndexRequest::MAX_COURSES);
         foreach ($chunks as $ids) {
             $this->bus->dispatch(new CourseIndexRequest($ids));
         }
-        $output->writeln("<info>{$count} courses have been queued for indexing.</info>");
+        $this->confirmationMessage($output, $clearedCount, $count, 'courses');
     }
 
     protected function queueLearningMaterials(OutputInterface $output): void
     {
+        $clearedCount = $this->clearMessages('LearningMaterialIndexRequest');
         $allIds = $this->learningMaterialRepository->getFileLearningMaterialIds();
         $count = count($allIds);
         foreach ($allIds as $id) {
             $this->bus->dispatch(new LearningMaterialIndexRequest($id));
         }
-        $output->writeln("<info>{$count} learning materials have been queued for indexing.</info>");
+        $this->confirmationMessage($output, $clearedCount, $count, 'learning materials');
     }
 
     protected function queueMesh(OutputInterface $output): void
     {
+        $clearedCount = $this->clearMessages('MeshDescriptorIndexRequest');
         $allIds = $this->descriptorRepository->getIds();
         $count = count($allIds);
         $chunks = array_chunk($allIds, MeshDescriptorIndexRequest::MAX_DESCRIPTORS);
         foreach ($chunks as $ids) {
             $this->bus->dispatch(new MeshDescriptorIndexRequest($ids));
         }
-        $output->writeln("<info>{$count} descriptors have been queued for indexing.</info>");
+
+        $this->confirmationMessage($output, $clearedCount, $count, 'MeSH descriptors');
+    }
+
+    protected function clearMessages(string $type): int
+    {
+        $connection = $this->em->getConnection();
+        $stmt = $connection->prepare('DELETE FROM messenger_messages WHERE body LIKE :type');
+        $stmt->bindValue("type", "%{$type}%");
+        $results = $stmt->executeQuery();
+        return $results->rowCount();
+    }
+
+    protected function confirmationMessage(
+        OutputInterface $output,
+        int $clearedCount,
+        int $newRecords,
+        string $type,
+    ): void {
+        $message = '';
+        if ($clearedCount) {
+            $message .= "Existing {$type} have been removed from the queue and ";
+        }
+        $output->writeln("<info>{$message}{$newRecords} {$type} have been queued for indexing.</info>");
     }
 }

--- a/tests/Command/Index/UpdateCommandTest.php
+++ b/tests/Command/Index/UpdateCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command\Index;
+
+use App\Command\Index\UpdateCommand;
+use App\Repository\CourseRepository;
+use App\Repository\LearningMaterialRepository;
+use App\Repository\MeshDescriptorRepository;
+use App\Repository\UserRepository;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use stdClass;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @group cli
+ */
+class UpdateCommandTest extends KernelTestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected CommandTester $commandTester;
+    protected m\MockInterface $userRepository;
+    protected m\MockInterface $courseRepository;
+    protected m\MockInterface $learningMaterialRepository;
+    protected m\MockInterface $meshDescriptorRepository;
+    protected m\MockInterface $messageBus;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->userRepository = m::mock(UserRepository::class);
+        $this->courseRepository = m::mock(CourseRepository::class);
+        $this->learningMaterialRepository = m::mock(LearningMaterialRepository::class);
+        $this->meshDescriptorRepository = m::mock(MeshDescriptorRepository::class);
+        $this->messageBus = m::mock(MessageBusInterface::class);
+
+        $command = new UpdateCommand(
+            $this->userRepository,
+            $this->courseRepository,
+            $this->meshDescriptorRepository,
+            $this->learningMaterialRepository,
+            $this->messageBus,
+        );
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->add($command);
+        $commandInApp = $application->find($command->getName());
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->userRepository);
+        unset($this->courseRepository);
+        unset($this->learningMaterialRepository);
+        unset($this->meshDescriptorRepository);
+        unset($this->messageBus);
+        unset($this->commandTester);
+    }
+
+    public function testUpdate(): void
+    {
+        $this->userRepository->shouldReceive('getIds')->once()->andReturn([1, 2]);
+        $this->courseRepository->shouldReceive('getIds')->once()->andReturn([1, 2]);
+        $this->meshDescriptorRepository->shouldReceive('getIds')->once()->andReturn([1, 2]);
+//        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([1, 2]);
+
+        $this->messageBus->shouldReceive('dispatch')
+            ->times(3)
+            //have to get creative with return as Symfony has marked Envelope as final
+            ->andReturnUsing(fn() => new Envelope(m::mock(stdClass::class)));
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/2 users have been queued for indexing./',
+            $output
+        );
+//        $this->assertMatchesRegularExpression(
+//            '/2 learning materials have been queued for indexing./',
+//            $output
+//        );
+        $this->assertMatchesRegularExpression(
+            '/2 courses have been queued for indexing./',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/2 descriptors have been queued for indexing./',
+            $output
+        );
+    }
+}

--- a/tests/Command/Index/UpdateCommandTest.php
+++ b/tests/Command/Index/UpdateCommandTest.php
@@ -9,6 +9,10 @@ use App\Repository\CourseRepository;
 use App\Repository\LearningMaterialRepository;
 use App\Repository\MeshDescriptorRepository;
 use App\Repository\UserRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Statement;
+use Doctrine\ORM\EntityManagerInterface;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use stdClass;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -31,6 +35,7 @@ class UpdateCommandTest extends KernelTestCase
     protected m\MockInterface $learningMaterialRepository;
     protected m\MockInterface $meshDescriptorRepository;
     protected m\MockInterface $messageBus;
+    protected m\MockInterface $entityManager;
 
     public function setUp(): void
     {
@@ -40,6 +45,7 @@ class UpdateCommandTest extends KernelTestCase
         $this->learningMaterialRepository = m::mock(LearningMaterialRepository::class);
         $this->meshDescriptorRepository = m::mock(MeshDescriptorRepository::class);
         $this->messageBus = m::mock(MessageBusInterface::class);
+        $this->entityManager = m::mock(EntityManagerInterface::class);
 
         $command = new UpdateCommand(
             $this->userRepository,
@@ -47,6 +53,7 @@ class UpdateCommandTest extends KernelTestCase
             $this->meshDescriptorRepository,
             $this->learningMaterialRepository,
             $this->messageBus,
+            $this->entityManager,
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
@@ -69,8 +76,25 @@ class UpdateCommandTest extends KernelTestCase
         unset($this->commandTester);
     }
 
-    public function testUpdate(): void
+    public function testUpdateWithNoMessages(): void
     {
+        $cn = m::mock(Connection::class);
+        $st = m::mock(Statement::class);
+        $r = m::mock(Result::class);
+
+        $cn->shouldReceive('prepare')->times(3)->andReturn($st);
+        $r->shouldReceive('rowCount')->times(3)->andReturn(0);
+
+        $st->shouldReceive('bindValue')->once()->with('type', '%UserIndexRequest%');
+        $st->shouldReceive('bindValue')->once()->with('type', '%CourseIndexRequest%');
+//        $st->shouldReceive('bindValue')->once()->with('type', '%LearningMaterialIndexRequest%');
+        $st->shouldReceive('bindValue')->once()->with('type', '%MeshDescriptorIndexRequest%');
+
+        $st->shouldReceive('executeQuery')->times(3)->andReturn($r);
+
+        $this->entityManager->shouldReceive('getConnection')->times(3)->andReturn($cn);
+
+
         $this->userRepository->shouldReceive('getIds')->once()->andReturn([1, 2]);
         $this->courseRepository->shouldReceive('getIds')->once()->andReturn([1, 2]);
         $this->meshDescriptorRepository->shouldReceive('getIds')->once()->andReturn([1, 2]);
@@ -97,7 +121,73 @@ class UpdateCommandTest extends KernelTestCase
             $output
         );
         $this->assertMatchesRegularExpression(
-            '/2 descriptors have been queued for indexing./',
+            '/2 MeSH descriptors have been queued for indexing./',
+            $output
+        );
+    }
+
+    public function testUpdateWithMessages(): void
+    {
+        $cn = m::mock(Connection::class);
+        $st = m::mock(Statement::class);
+        $r = m::mock(Result::class);
+
+        $cn->shouldReceive('prepare')->times(3)->andReturn($st);
+        $r->shouldReceive('rowCount')->times(3)->andReturn(24);
+
+        $st->shouldReceive('bindValue')->once()->with('type', '%UserIndexRequest%');
+        $st->shouldReceive('bindValue')->once()->with('type', '%CourseIndexRequest%');
+//        $st->shouldReceive('bindValue')->once()->with('type', '%LearningMaterialIndexRequest%');
+        $st->shouldReceive('bindValue')->once()->with('type', '%MeshDescriptorIndexRequest%');
+
+        $st->shouldReceive('executeQuery')->times(3)->andReturn($r);
+
+        $this->entityManager->shouldReceive('getConnection')->times(3)->andReturn($cn);
+
+
+        $this->userRepository->shouldReceive('getIds')->once()->andReturn([1, 2]);
+        $this->courseRepository->shouldReceive('getIds')->once()->andReturn([1, 2]);
+        $this->meshDescriptorRepository->shouldReceive('getIds')->once()->andReturn([1, 2]);
+//        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([1, 2]);
+
+        $this->messageBus->shouldReceive('dispatch')
+            ->times(3)
+            //have to get creative with return as Symfony has marked Envelope as final
+            ->andReturnUsing(fn() => new Envelope(m::mock(stdClass::class)));
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/Existing users have been removed from the queue and /',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/2 users have been queued for indexing./',
+            $output
+        );
+//        $this->assertMatchesRegularExpression(
+//            '/Existing learning materails have been removed from the queue and /',
+//            $output
+//        );
+//        $this->assertMatchesRegularExpression(
+//            '/2 learning materials have been queued for indexing./',
+//            $output
+//        );
+        $this->assertMatchesRegularExpression(
+            '/Existing courses have been removed from the queue and /',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/2 courses have been queued for indexing./',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/Existing MeSH descriptors have been removed from the queue and /',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/2 MeSH descriptors have been queued for indexing./',
             $output
         );
     }


### PR DESCRIPTION
When we run an index update it's going to index everything in the
system, we should clear out any existing messages so we don't double
index anything. This is the only way I could figure out how to clear
these without clearing something else that may show up in the future.