### PR TITLE
Fix Nullable GraphQL Relationships

### DIFF
--- a/src/Service/GraphQL/TypeResolver.php
+++ b/src/Service/GraphQL/TypeResolver.php
@@ -41,6 +41,9 @@ class TypeResolver
             //we have already fetched an object and just need to fetch
             //things related to it
             $value = $source->$fieldName;
+            if (is_null($value)) {
+                return null;
+            }
             if (is_array($value)) {// one-to-many and many-to-many relationships are arrays
                 $this->buffer->bufferRequest($type, $value);
                 return new Deferred(

--- a/tests/Endpoints/AbstractEndpoint.php
+++ b/tests/Endpoints/AbstractEndpoint.php
@@ -600,7 +600,9 @@ abstract class AbstractEndpoint extends WebTestCase
 
         $content = json_decode($response->getContent());
 
+        $this->assertObjectHasProperty('data', $content);
         $this->assertIsObject($content->data);
+        $this->assertObjectNotHasProperty('errors', $content);
         $this->assertIsArray($content->data->{$name});
 
         $now = new DateTime();
@@ -1462,6 +1464,8 @@ abstract class AbstractEndpoint extends WebTestCase
         $this->assertGraphQLResponse($response);
         $content = json_decode($response->getContent());
 
+        $this->assertObjectHasProperty('data', $content);
+        $this->assertObjectNotHasProperty('errors', $content);
         $this->assertIsArray($content->data->{$name});
 
         return $content->data->{$name};


### PR DESCRIPTION
These were working, but throwing errors which then resulted in null being set, which was what we wanted... anyway, we're checking for null now. I added some tests for this and also added a check to see if there are any errors on other requests.