### PR TITLE
Skip Indexing Unchanged Synced Users

### DIFF
--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -30,7 +30,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 class IndexEntityChanges
 {
     /**
-     * ACHTUNG!!! Do NOT change the name of $dispatchBus it tells the dependency injection system what bus to inject!!!
+     * ACHTUNG!!! Do NOT change the name of $bus it tells the dependency injection system what bus to inject!!!
      */
     public function __construct(
         protected Curriculum $curriculumIndex,
@@ -66,7 +66,12 @@ class IndexEntityChanges
         $entity = $args->getObject();
 
         if ($entity instanceof UserInterface) {
-            $this->indexUser($entity);
+            $changeSet = $args->getObjectManager()->getUnitOfWork()->getEntityChangeSet($entity);
+            $changed = array_keys($changeSet);
+            //if the only field that changed was examined this is a usersync job and doesn't need to get indexed
+            if ($changed !== ['examined']) {
+                $this->indexUser($entity);
+            }
         }
 
         if ($entity instanceof AuthenticationInterface) {


### PR DESCRIPTION
At the start of the sync process we set everyone to an unexamined state and then flip that back after they're synchronized. This causes a lot of churn in our search index as these users get re-indexed every time the job is run. There isn't any need for that.

This change checks the fields that have been modified and skips indexing users where only the examined flag has been set.

Fixes #5664

I don't see a way to test this. Open to ideas.