### PR TITLE
Store SQ Token in Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
   MESSENGER_TRANSPORT_DSN: doctrine://default
   latest_php: 8.3
   DOCKER_BUILDKIT: 1
+  UCSF_SQ_TK: sqp_d0279fe2dd0d948f8366350841b7ac5d0682e0c9
 
 jobs:
   code_style:
@@ -359,8 +360,6 @@ jobs:
     name: Scan with UCSF SonarQube
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    env:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     needs: tests
     steps:
       - uses: actions/checkout@v4
@@ -371,9 +370,8 @@ jobs:
           name: coverage-output
       - run: ls -lh coverage.xml
       - uses: sonarsource/sonarqube-scan-action@v3.0
-        if: ${{ env.SONAR_TOKEN != '' }}
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ env.UCSF_SQ_TK }}
           SONAR_HOST_URL: https://sonarqube.ucsf.edu
         with:
           args: >


### PR DESCRIPTION
After extensive dicussion with SQ and with the owners of this service at UCSF we have determined this is the only path forward for scanning pull requests from forks. The exposure risk for this token is very low, essentially only allowing a bad actor to scan code we're already scanning. Hopefully SQ will figure out how to use the pull_request_target trigger at some point, but for now this is our best path forward.

Info on approval process and SQ details is in UCSF web services Jira DEVEXP-144 (inaccessible to most people, but here for reference later if needed).