### PR TITLE
Replace Names with Constants

### DIFF
--- a/src/Controller/DownloadController.php
+++ b/src/Controller/DownloadController.php
@@ -47,7 +47,7 @@ class DownloadController extends AbstractController
 
         $path = $learningMaterial->getRelativePath();
         if (!$path) {
-            throw new \Exception(
+            throw new Exception(
                 "No valid path for learning material with token: " . $token
             );
         }

--- a/src/Repository/AuditLogRepository.php
+++ b/src/Repository/AuditLogRepository.php
@@ -36,7 +36,7 @@ class AuditLogRepository extends ServiceEntityRepository implements DTORepositor
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('a as log', 'u.id as userId')
-            ->from('App\Entity\AuditLog', 'a')
+            ->from(AuditLog::class, 'a')
             ->leftJoin('a.user', 'u')
             ->where(
                 $qb->expr()->between(
@@ -71,7 +71,7 @@ class AuditLogRepository extends ServiceEntityRepository implements DTORepositor
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb
-            ->delete('App\Entity\AuditLog', 'a')
+            ->delete(AuditLog::class, 'a')
             ->add(
                 'where',
                 $qb->expr()->between(

--- a/src/Repository/CurriculumInventorySequenceBlockRepository.php
+++ b/src/Repository/CurriculumInventorySequenceBlockRepository.php
@@ -61,7 +61,7 @@ class CurriculumInventorySequenceBlockRepository extends ServiceEntityRepository
                 'startingAcademicLevel.id AS startingAcademicLevelId, ' .
                 'endingAcademicLevel.id AS endingAcademicLevelId, course.id AS courseId, parent.id AS parentId '
             )
-            ->from('App\Entity\CurriculumInventorySequenceBlock', 'x')
+            ->from(CurriculumInventorySequenceBlock::class, 'x')
             ->join('x.report', 'report')
             ->join('report.program', 'program')
             ->join('program.school', 'school')

--- a/src/Repository/CurriculumInventorySequenceRepository.php
+++ b/src/Repository/CurriculumInventorySequenceRepository.php
@@ -46,7 +46,7 @@ class CurriculumInventorySequenceRepository extends ServiceEntityRepository impl
             ->select(
                 'x.id as xId, report.id AS reportId, school.id AS schoolId'
             )
-            ->from('App\Entity\CurriculumInventorySequence', 'x')
+            ->from(CurriculumInventorySequence::class, 'x')
             ->join('x.report', 'report')
             ->join('report.program', 'program')
             ->join('program.school', 'school')

--- a/src/Repository/IlmSessionRepository.php
+++ b/src/Repository/IlmSessionRepository.php
@@ -46,7 +46,7 @@ class IlmSessionRepository extends ServiceEntityRepository implements DTOReposit
             ->select(
                 'x.id as xId, session.id AS sessionId, course.id AS courseId, school.id AS schoolId'
             )
-            ->from('App\Entity\IlmSession', 'x')
+            ->from(IlmSession::class, 'x')
             ->join('x.session', 'session')
             ->join('session.course', 'course')
             ->join('course.school', 'school')

--- a/src/Repository/IngestionExceptionRepository.php
+++ b/src/Repository/IngestionExceptionRepository.php
@@ -47,7 +47,7 @@ class IngestionExceptionRepository extends ServiceEntityRepository implements
             ->select(
                 'x.id as xId, user.id AS userId'
             )
-            ->from('App\Entity\IngestionException', 'x')
+            ->from(IngestionException::class, 'x')
             ->join('x.user', 'user')
             ->where($qb->expr()->in('x.id', ':ids'))
             ->setParameter('ids', array_keys($dtos));

--- a/src/Repository/InstructorGroupRepository.php
+++ b/src/Repository/InstructorGroupRepository.php
@@ -46,7 +46,7 @@ class InstructorGroupRepository extends ServiceEntityRepository implements DTORe
             ->select(
                 'x.id as xId, school.id AS schoolId'
             )
-            ->from('App\Entity\InstructorGroup', 'x')
+            ->from(InstructorGroup::class, 'x')
             ->join('x.school', 'school')
             ->where($qb->expr()->in('x.id', ':ids'))
             ->setParameter('ids', array_keys($dtos));

--- a/src/Repository/MeshDescriptorRepository.php
+++ b/src/Repository/MeshDescriptorRepository.php
@@ -103,7 +103,7 @@ class MeshDescriptorRepository extends ServiceEntityRepository implements
         $descriptorIds = array_keys($dtos);
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('p.id AS prevId, m.id AS descriptorId')
-            ->from('App\Entity\MeshPreviousIndexing', 'p')
+            ->from(MeshPreviousIndexing::class, 'p')
             ->join('p.descriptor', 'm')
             ->where($qb->expr()->in('m.id', ':descriptorIds'))
             ->setParameter('descriptorIds', $descriptorIds);

--- a/src/Repository/MeshPreviousIndexingRepository.php
+++ b/src/Repository/MeshPreviousIndexingRepository.php
@@ -50,7 +50,7 @@ class MeshPreviousIndexingRepository extends ServiceEntityRepository implements
             ->select(
                 'x.id as xId, descriptor.id AS descriptorId'
             )
-            ->from('App\Entity\MeshPreviousIndexing', 'x')
+            ->from(MeshPreviousIndexing::class, 'x')
             ->join('x.descriptor', 'descriptor')
             ->where($qb->expr()->in('x.id', ':ids'))
             ->setParameter('ids', $meshPreviousIndexingIds);

--- a/src/Repository/MeshTreeRepository.php
+++ b/src/Repository/MeshTreeRepository.php
@@ -45,7 +45,7 @@ class MeshTreeRepository extends ServiceEntityRepository implements DTORepositor
             ->select(
                 'x.id as xId, descriptor.id AS descriptorId'
             )
-            ->from('App\Entity\MeshTree', 'x')
+            ->from(MeshTree::class, 'x')
             ->join('x.descriptor', 'descriptor')
             ->where($qb->expr()->in('x.id', ':ids'))
             ->setParameter('ids', array_keys($dtos));

--- a/src/Repository/OfferingRepository.php
+++ b/src/Repository/OfferingRepository.php
@@ -68,7 +68,7 @@ class OfferingRepository extends ServiceEntityRepository implements DTORepositor
 
         $qb = $this->getEntityManager()->createQueryBuilder()
             ->select('x.id as offeringId, school.id as schoolId, course.id as courseId, session.id as sessionId')
-            ->from('App\Entity\Offering', 'x')
+            ->from(Offering::class, 'x')
             ->join('x.session', 'session')
             ->join('session.course', 'course')
             ->join('course.school', 'school')
@@ -97,13 +97,13 @@ class OfferingRepository extends ServiceEntityRepository implements DTORepositor
     public function getOfferingsForTeachingReminders(int $daysInAdvance, array $schoolIds): array
     {
         $now = time();
-        $startDate = new \DateTime();
+        $startDate = new DateTime();
         $startDate->setTimezone(new DateTimeZone('UTC'));
         $startDate->setTimestamp($now);
         $startDate->modify("midnight +{$daysInAdvance} days");
 
         $daysInAdvance++;
-        $endDate = new \DateTime();
+        $endDate = new DateTime();
         $endDate->setTimezone(new DateTimeZone('UTC'));
         $endDate->setTimestamp($now);
         $endDate->modify("midnight +{$daysInAdvance} days");

--- a/src/Repository/PendingUserUpdateRepository.php
+++ b/src/Repository/PendingUserUpdateRepository.php
@@ -47,7 +47,7 @@ class PendingUserUpdateRepository extends ServiceEntityRepository implements DTO
             ->select(
                 'x.id as xId, user.id AS userId'
             )
-            ->from('App\Entity\PendingUserUpdate', 'x')
+            ->from(PendingUserUpdate::class, 'x')
             ->join('x.user', 'user')
             ->where($qb->expr()->in('x.id', ':ids'))
             ->setParameter('ids', array_keys($dtos));
@@ -94,7 +94,7 @@ class PendingUserUpdateRepository extends ServiceEntityRepository implements DTO
     public function removeAllPendingUserUpdates()
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->delete('App\Entity\PendingUserUpdate', 'p');
+        $qb->delete(PendingUserUpdate::class, 'p');
         $qb->getQuery()->execute();
     }
 }

--- a/src/Repository/ReportRepository.php
+++ b/src/Repository/ReportRepository.php
@@ -49,7 +49,7 @@ class ReportRepository extends ServiceEntityRepository implements DTORepositoryI
             ->select(
                 'x.id as xId, school.id AS schoolId, user.id AS userId'
             )
-            ->from('App\Entity\Report', 'x')
+            ->from(Report::class, 'x')
             ->join('x.user', 'user')
             ->leftJoin('x.school', 'school')
             ->where($qb->expr()->in('x.id', ':ids'))

--- a/src/Repository/SchoolConfigRepository.php
+++ b/src/Repository/SchoolConfigRepository.php
@@ -45,7 +45,7 @@ class SchoolConfigRepository extends ServiceEntityRepository implements DTORepos
 
         $qb = $this->getEntityManager()->createQueryBuilder()
             ->select('x.id as xId, school.id AS schoolId')
-            ->from('App\Entity\SchoolConfig', 'x')
+            ->from(SchoolConfig::class, 'x')
             ->join('x.school', 'school')
             ->where($qb->expr()->in('x.id', ':ids'))
             ->setParameter('ids', $schoolConfigIds);
@@ -63,7 +63,7 @@ class SchoolConfigRepository extends ServiceEntityRepository implements DTORepos
     public function getValue($name): mixed
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->select('x.value')->from('App\Entity\SchoolConfig', 'x')
+        $qb->select('x.value')->from(SchoolConfig::class, 'x')
             ->where($qb->expr()->eq('x.name', ':name'))
             ->setParameter('name', $name);
 

--- a/src/Repository/SchoolRepository.php
+++ b/src/Repository/SchoolRepository.php
@@ -152,7 +152,7 @@ class SchoolRepository extends ServiceEntityRepository implements
             'c.level as courseLevel, st.id as sessionTypeId, ' .
             'c.externalId as courseExternalId, s.description AS sessionDescription';
 
-        $qb->addSelect($what)->from('App\Entity\School', 'school');
+        $qb->addSelect($what)->from(School::class, 'school');
         $qb->join('school.courses', 'c');
         $qb->join('c.sessions', 's');
         $qb->join('s.offerings', 'o');
@@ -196,7 +196,7 @@ class SchoolRepository extends ServiceEntityRepository implements
             'c.level as courseLevel, st.id as sessionTypeId, ' .
             'c.externalId as courseExternalId, s.description AS sessionDescription';
 
-        $qb->addSelect($what)->from('App\Entity\School', 'school');
+        $qb->addSelect($what)->from(School::class, 'school');
 
         $qb->join('school.courses', 'c');
         $qb->join('c.sessions', 's');
@@ -298,7 +298,7 @@ class SchoolRepository extends ServiceEntityRepository implements
             'c.externalId as courseExternalId, s.description AS sessionDescription';
 
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->addSelect($what)->from('App\Entity\School', 'school');
+        $qb->addSelect($what)->from(School::class, 'school');
         $qb->join('school.courses', 'c');
         $qb->join('c.sessions', 's');
         $qb->join('s.offerings', 'o');
@@ -345,7 +345,7 @@ class SchoolRepository extends ServiceEntityRepository implements
             'c.externalId as courseExternalId, s.description AS sessionDescription';
 
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->addSelect($what)->from('App\Entity\School', 'school');
+        $qb->addSelect($what)->from(School::class, 'school');
         $qb->join('school.courses', 'c');
         $qb->join('c.sessions', 's');
         $qb->join('s.ilmSession', 'ilm');
@@ -416,7 +416,7 @@ class SchoolRepository extends ServiceEntityRepository implements
             'c.externalId as courseExternalId, s.description AS sessionDescription';
 
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->addSelect($what)->from('App\Entity\School', 'school');
+        $qb->addSelect($what)->from(School::class, 'school');
         $qb->join('school.courses', 'c');
         $qb->join('c.sessions', 's');
         $qb->join('s.offerings', 'o');
@@ -463,7 +463,7 @@ class SchoolRepository extends ServiceEntityRepository implements
             'c.externalId as courseExternalId, s.description AS sessionDescription';
 
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->addSelect($what)->from('App\Entity\School', 'school');
+        $qb->addSelect($what)->from(School::class, 'school');
         $qb->join('school.courses', 'c');
         $qb->join('c.sessions', 's');
         $qb->join('s.ilmSession', 'ilm');

--- a/src/Repository/SessionLearningMaterialRepository.php
+++ b/src/Repository/SessionLearningMaterialRepository.php
@@ -55,7 +55,7 @@ class SessionLearningMaterialRepository extends ServiceEntityRepository implemen
                 'course.id AS courseId, course.locked AS courseIsLocked, course.archived AS courseIsArchived, ' .
                 'status.id as statusId, school.id AS schoolId'
             )
-            ->from('App\Entity\SessionLearningMaterial', 'x')
+            ->from(SessionLearningMaterial::class, 'x')
             ->join('x.session', 'session')
             ->join('session.course', 'course')
             ->join('course.school', 'school')

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Offering;
+use App\Entity\IlmSession;
 use App\Classes\CalendarEventUserContext;
 use App\Entity\Session;
 use App\Entity\UserRole;
@@ -123,7 +125,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('u')
-            ->from('App\Entity\User', 'u')
+            ->from(User::class, 'u')
             ->where($qb->expr()->in('u.campusId', ':campusIds'));
         $qb->setParameter(':campusIds', $campusIds);
 
@@ -308,7 +310,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
     public function getIds($includeDisabled = true, $includeSyncIgnore = true): array
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->addSelect('u.id')->from('App\Entity\User', 'u');
+        $qb->addSelect('u.id')->from(User::class, 'u');
         if (!$includeDisabled) {
             $qb->andWhere('u.enabled=1');
         }
@@ -328,7 +330,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
     public function getAllCampusIds($includeDisabled = true, $includeSyncIgnore = true): array
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->addSelect('u.campusId')->from('App\Entity\User', 'u');
+        $qb->addSelect('u.campusId')->from(User::class, 'u');
         if (!$includeDisabled) {
             $qb->andWhere('u.enabled=1');
         }
@@ -346,7 +348,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
 
-        $qb->update('App\Entity\User', 'u')
+        $qb->update(User::class, 'u')
             ->set('u.examined', $qb->expr()->literal(false));
 
         $qb->getQuery()->execute();
@@ -375,7 +377,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             'c.level as courseLevel, st.id as sessionTypeId, ' .
             's.description AS sessionDescription, st.title AS sessionTypeTitle, c.externalId AS courseExternalId';
 
-        $qb->addSelect($what)->from('App\Entity\User', 'u');
+        $qb->addSelect($what)->from(User::class, 'u');
         foreach ($joins as $key => $statement) {
             $qb->leftJoin($statement, $key);
         }
@@ -421,7 +423,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             'c.level as courseLevel, st.id as sessionTypeId, ' .
             's.description AS sessionDescription, st.title AS sessionTypeTitle, c.externalId AS courseExternalId';
 
-        $qb->addSelect($what)->from('App\Entity\User', 'u');
+        $qb->addSelect($what)->from(User::class, 'u');
 
         foreach ($joins as $key => $statement) {
             $qb->leftJoin($statement, $key);
@@ -500,7 +502,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             'c.externalId as courseExternalId, s.description AS sessionDescription';
         foreach ($joinsAndUserContexts as $joinsAndUserContext) {
             $qb = $this->getEntityManager()->createQueryBuilder();
-            $qb->addSelect($what)->from('App\Entity\User', 'u');
+            $qb->addSelect($what)->from(User::class, 'u');
             foreach ($joinsAndUserContext[0] as $key => $statement) {
                 $qb->leftJoin($statement, $key);
             }
@@ -567,7 +569,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             's.description AS sessionDescription, st.title AS sessionTypeTitle, c.externalId AS courseExternalId';
         foreach ($joinsAndUserContexts as $joinsAndUserContext) {
             $qb = $this->getEntityManager()->createQueryBuilder();
-            $qb->addSelect($what)->from('App\Entity\User', 'u');
+            $qb->addSelect($what)->from(User::class, 'u');
             foreach ($joinsAndUserContext[0] as $key => $statement) {
                 $qb->leftJoin($statement, $key);
             }
@@ -659,7 +661,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             'c.externalId as courseExternalId, s.description AS sessionDescription';
         foreach ($joinsAndUserContexts as $joinsAndUserContext) {
             $qb = $this->getEntityManager()->createQueryBuilder();
-            $qb->addSelect($what)->from('App\Entity\User', 'u');
+            $qb->addSelect($what)->from(User::class, 'u');
             foreach ($joinsAndUserContext[0] as $key => $statement) {
                 $qb->leftJoin($statement, $key);
             }
@@ -724,7 +726,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
             'c.externalId as courseExternalId, s.description AS sessionDescription';
         foreach ($joinsAndUserContexts as $joinsAndUserContext) {
             $qb = $this->getEntityManager()->createQueryBuilder();
-            $qb->addSelect($what)->from('App\Entity\User', 'u');
+            $qb->addSelect($what)->from(User::class, 'u');
             foreach ($joinsAndUserContext[0] as $key => $statement) {
                 $qb->leftJoin($statement, $key);
             }
@@ -1098,19 +1100,19 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
     {
         $factory = $this->factory;
         $offIdQb = $this->getEntityManager()->createQueryBuilder();
-        $offIdQb->select('learnerOffering.id')->from('App\Entity\User', 'learnerU');
+        $offIdQb->select('learnerOffering.id')->from(User::class, 'learnerU');
         $offIdQb->join('learnerU.offerings', 'learnerOffering');
         $offIdQb->andWhere($offIdQb->expr()->eq('learnerU.id', ':user_id'));
 
         $groupOfferingQb = $this->getEntityManager()->createQueryBuilder();
-        $groupOfferingQb->select('groupOffering.id')->from('App\Entity\User', 'groupU');
+        $groupOfferingQb->select('groupOffering.id')->from(User::class, 'groupU');
         $groupOfferingQb->leftJoin('groupU.learnerGroups', 'g');
         $groupOfferingQb->leftJoin('g.offerings', 'groupOffering');
         $groupOfferingQb->andWhere($groupOfferingQb->expr()->eq('groupU.id', ':user_id'));
 
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('s.id, o.startDate, o.id as offeringId');
-        $qb->from('App\Entity\Offering', 'o');
+        $qb->from(Offering::class, 'o');
         $qb->join('o.session', 's');
         $qb->where($qb->expr()->orX(
             $qb->expr()->in('o.id', $offIdQb->getDQL()),
@@ -1129,19 +1131,19 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
         $offeringSessions = $qb->getQuery()->getArrayResult();
 
         $ilmQb = $this->getEntityManager()->createQueryBuilder();
-        $ilmQb->select('learnerIlmSession.id')->from('App\Entity\User', 'learnerU');
+        $ilmQb->select('learnerIlmSession.id')->from(User::class, 'learnerU');
         $ilmQb->join('learnerU.learnerIlmSessions', 'learnerIlmSession');
         $ilmQb->andWhere($ilmQb->expr()->eq('learnerU.id', ':user_id'));
 
         $groupIlmSessionQb = $this->getEntityManager()->createQueryBuilder();
-        $groupIlmSessionQb->select('groupIlmSession.id')->from('App\Entity\User', 'groupU');
+        $groupIlmSessionQb->select('groupIlmSession.id')->from(User::class, 'groupU');
         $groupIlmSessionQb->leftJoin('groupU.learnerGroups', 'g');
         $groupIlmSessionQb->leftJoin('g.ilmSessions', 'groupIlmSession');
         $groupIlmSessionQb->andWhere($groupIlmSessionQb->expr()->eq('groupU.id', ':user_id'));
 
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('s.id, ilm.dueDate, ilm.id AS ilmId');
-        $qb->from('App\Entity\IlmSession', 'ilm');
+        $qb->from(IlmSession::class, 'ilm');
         $qb->join('ilm.session', 's');
         $qb->where($qb->expr()->orX(
             $qb->expr()->in('ilm.id', $ilmQb->getDQL()),

--- a/src/Repository/VocabularyRepository.php
+++ b/src/Repository/VocabularyRepository.php
@@ -54,7 +54,7 @@ class VocabularyRepository extends ServiceEntityRepository implements
             ->select(
                 'x.id as xId, school.id AS schoolId'
             )
-            ->from('App\Entity\Vocabulary', 'x')
+            ->from(Vocabulary::class, 'x')
             ->join('x.school', 'school')
             ->where($qb->expr()->in('x.id', ':ids'))
             ->setParameter('ids', $vocabularyIds);

--- a/src/Service/CurriculumInventory/Export/XmlPrinter.php
+++ b/src/Service/CurriculumInventory/Export/XmlPrinter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\CurriculumInventory\Export;
 
+use App\Entity\CurriculumInventorySequenceBlock;
 use App\Entity\CourseClerkshipTypeInterface;
 use App\Entity\CurriculumInventoryAcademicLevelInterface;
 use App\Entity\CurriculumInventoryInstitutionInterface;
@@ -328,7 +329,7 @@ class XmlPrinter
         usort(
             $topLevelSequenceBlocks,
             [
-                'App\Entity\CurriculumInventorySequenceBlock',
+                CurriculumInventorySequenceBlock::class,
                 'compareSequenceBlocksWithDefaultStrategy',
             ]
         );

--- a/src/Service/Fetch.php
+++ b/src/Service/Fetch.php
@@ -53,7 +53,7 @@ class Fetch
         }
 
         if (empty($fileContents)) {
-            throw new \Exception('Failed to load ' . $url);
+            throw new Exception('Failed to load ' . $url);
         }
 
         return $fileContents;

--- a/src/Traits/CalendarEventRepository.php
+++ b/src/Traits/CalendarEventRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Traits;
 
+use App\Entity\Competency;
 use App\Entity\Course;
 use App\Entity\Session;
 use App\Entity\User;
@@ -237,7 +238,7 @@ trait CalendarEventRepository
         $qb = $em->createQueryBuilder();
         $qb->select('s.id AS session_id, so.id, so.title, so.position, cm.id AS competency_id')
             ->distinct()
-            ->from('App\Entity\Session', 's')
+            ->from(Session::class, 's')
             ->join('s.sessionObjectives', 'so')
             ->leftJoin('so.courseObjectives', 'co')
             ->leftJoin('co.programYearObjectives', 'po')
@@ -322,7 +323,7 @@ trait CalendarEventRepository
         $qb = $em->createQueryBuilder();
         $qb->select('cm.id, cm.title, cm2.id AS parent_id, cm2.title AS parent_title')
             ->distinct()
-            ->from('App\Entity\Competency', 'cm')
+            ->from(Competency::class, 'cm')
             ->leftJoin('cm.parent', 'cm2')
             ->where($qb->expr()->in('cm.id', ':ids'))
             ->setParameter(':ids', $competencyIds);
@@ -502,7 +503,7 @@ trait CalendarEventRepository
             'slm.id as slmId, slm.position, slm.notes, slm.required, slm.publicNotes, slm.startDate, slm.endDate, ' .
             'lm.id, lm.title, lm.description, lm.originalAuthor, lm.token, ' .
             'lm.citation, lm.link, lm.filename, lm.filesize, lm.mimetype, lms.id AS status';
-        $qb->select($what)->from('App\Entity\Session', 's');
+        $qb->select($what)->from(Session::class, 's');
         $qb->join('s.learningMaterials', 'slm');
         $qb->join('slm.learningMaterial', 'lm');
         $qb->join('lm.status', 'lms');
@@ -552,7 +553,7 @@ trait CalendarEventRepository
             'clm.id as clmId, clm.position, clm.notes, clm.required, clm.publicNotes, clm.startDate, clm.endDate, ' .
             'lm.id, lm.title, lm.description, lm.originalAuthor, lm.token, ' .
             'lm.citation, lm.link, lm.filename, lm.filesize, lm.mimetype, lms.id AS status';
-        $qb->select($what)->from('App\Entity\Session', 's');
+        $qb->select($what)->from(Session::class, 's');
         $qb->join('s.course', 'c');
         $qb->join('c.learningMaterials', 'clm');
         $qb->join('clm.learningMaterial', 'lm');

--- a/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
+++ b/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
@@ -77,7 +77,7 @@ class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
         $this->learningMaterialRepository->shouldReceive('flushAndClear')->once();
 
         $this->iliosFileSystem
-            ->shouldReceive('storeLearningMaterialFile')->with(\Mockery::on(function ($argument) {
+            ->shouldReceive('storeLearningMaterialFile')->with(m::on(function ($argument) {
                 if ($argument instanceof File && $argument->getRealPath() === __FILE__) {
                     return true;
                 }

--- a/tests/Entity/CompetencyTest.php
+++ b/tests/Entity/CompetencyTest.php
@@ -84,7 +84,7 @@ class CompetencyTest extends EntityBase
      */
     public function testRemoveParent(): void
     {
-        $obj = m::mock('App\Entity\Competency');
+        $obj = m::mock(Competency::class);
         $this->object->setParent($obj);
         $this->assertSame($obj, $this->object->getParent());
         $this->object->setParent(null);

--- a/tests/Entity/CourseTest.php
+++ b/tests/Entity/CourseTest.php
@@ -309,7 +309,7 @@ class CourseTest extends EntityBase
      */
     public function testGetAncestorOrSelfWithAncestor(): void
     {
-        $ancestor = m::mock('App\Entity\Course');
+        $ancestor = m::mock(Course::class);
         $this->object->setAncestor($ancestor);
         $this->assertSame($ancestor, $this->object->getAncestorOrSelf());
     }

--- a/tests/Entity/CurriculumInventoryInstitutionTest.php
+++ b/tests/Entity/CurriculumInventoryInstitutionTest.php
@@ -66,7 +66,7 @@ class CurriculumInventoryInstitutionTest extends EntityBase
         $this->object->setAddressCountryCode('US');
         $this->validateNotNulls($notNull);
 
-        $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
+        $this->object->setSchool(m::mock(SchoolInterface::class));
         $this->validate(0);
     }
 

--- a/tests/Entity/InstructorGroupTest.php
+++ b/tests/Entity/InstructorGroupTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\SchoolInterface;
 use App\Entity\InstructorGroup;
 use Mockery as m;
 
@@ -32,7 +33,7 @@ class InstructorGroupTest extends EntityBase
         $notBlank = [
             'title',
         ];
-        $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
+        $this->object->setSchool(m::mock(SchoolInterface::class));
         $this->validateNotBlanks($notBlank);
 
         $this->object->setTitle('test');
@@ -47,7 +48,7 @@ class InstructorGroupTest extends EntityBase
         $this->object->setTitle('test');
 
         $this->validateNotNulls($notNulls);
-        $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
+        $this->object->setSchool(m::mock(SchoolInterface::class));
 
 
         $this->validate(0);

--- a/tests/Entity/LearnerGroupTest.php
+++ b/tests/Entity/LearnerGroupTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\CohortInterface;
 use App\Entity\Cohort;
 use App\Entity\LearnerGroup;
 use App\Entity\Program;
@@ -36,7 +37,7 @@ class LearnerGroupTest extends EntityBase
         $notBlank = [
             'title',
         ];
-        $this->object->setCohort(m::mock('App\Entity\CohortInterface'));
+        $this->object->setCohort(m::mock(CohortInterface::class));
 
         $this->validateNotBlanks($notBlank);
 
@@ -55,7 +56,7 @@ class LearnerGroupTest extends EntityBase
         $this->object->setTitle('test');
         $this->validateNotNulls($notNulls);
 
-        $this->object->setCohort(m::mock('App\Entity\CohortInterface'));
+        $this->object->setCohort(m::mock(CohortInterface::class));
 
         $this->validate(0);
     }
@@ -338,7 +339,7 @@ class LearnerGroupTest extends EntityBase
      */
     public function testGetAncestorOrSelfWithAncestor(): void
     {
-        $ancestor = m::mock('App\Entity\LearnerGroup');
+        $ancestor = m::mock(LearnerGroup::class);
         $this->object->setAncestor($ancestor);
         $this->assertSame($ancestor, $this->object->getAncestorOrSelf());
     }

--- a/tests/Entity/OfferingTest.php
+++ b/tests/Entity/OfferingTest.php
@@ -63,7 +63,7 @@ class OfferingTest extends EntityBase
         $this->object->setEndDate(new DateTime());
 
         $this->validateNotNulls($notNulls);
-        $this->object->setSession(m::mock('App\Entity\SessionInterface'));
+        $this->object->setSession(m::mock(SessionInterface::class));
 
         $this->validate(0);
     }

--- a/tests/Entity/ProgramTest.php
+++ b/tests/Entity/ProgramTest.php
@@ -56,7 +56,7 @@ class ProgramTest extends EntityBase
 
         $this->validateNotNulls($notNull);
 
-        $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
+        $this->object->setSchool(m::mock(SchoolInterface::class));
 
         $this->validate(0);
     }

--- a/tests/Entity/ProgramYearTest.php
+++ b/tests/Entity/ProgramYearTest.php
@@ -51,7 +51,7 @@ class ProgramYearTest extends EntityBase
         $this->object->setStartYear(3);
 
         $this->validateNotNulls($notNull);
-        $this->object->setProgram(m::mock('App\Entity\ProgramInterface'));
+        $this->object->setProgram(m::mock(ProgramInterface::class));
 
 
         $this->validate(0);

--- a/tests/Entity/SessionTest.php
+++ b/tests/Entity/SessionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\IlmSession;
 use App\Entity\Course;
 use App\Entity\CourseInterface;
 use App\Entity\School;
@@ -180,7 +181,7 @@ class SessionTest extends EntityBase
     {
         $this->assertTrue(method_exists($this->object, 'getIlmSession'), "Method getIlmSession missing");
         $this->assertTrue(method_exists($this->object, 'setIlmSession'), "Method setIlmSession missing");
-        $obj = m::mock('App\Entity\IlmSession');
+        $obj = m::mock(IlmSession::class);
         $obj->shouldReceive('setSession')->with($this->object)->once();
         $this->object->setIlmSession($obj);
         $this->assertSame($obj, $this->object->getIlmSession());

--- a/tests/Entity/SessionTypeTest.php
+++ b/tests/Entity/SessionTypeTest.php
@@ -51,7 +51,7 @@ class SessionTypeTest extends EntityBase
 
         $this->validateNotNulls($notNull);
 
-        $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
+        $this->object->setSchool(m::mock(SchoolInterface::class));
 
 
         $this->validate(0);
@@ -163,7 +163,7 @@ class SessionTypeTest extends EntityBase
     public function testValidHexCodes(): void
     {
         $this->object->setTitle('test');
-        $this->object->setSchool(m::mock('App\Entity\SchoolInterface'));
+        $this->object->setSchool(m::mock(SchoolInterface::class));
         $this->object->setCalendarColor('#123abc');
         $this->validate(0);
 

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\Cohort;
+use App\Entity\Authentication;
 use App\Entity\User;
 use Mockery as m;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -618,10 +620,10 @@ class UserTest extends EntityBase
         $this->assertTrue(method_exists($this->object, 'setPrimaryCohort'));
         $this->assertTrue(method_exists($this->object, 'getPrimaryCohort'));
 
-        $obj = m::mock('App\Entity\Cohort');
+        $obj = m::mock(Cohort::class);
         $this->object->addCohort($obj);
         $this->object->setPrimaryCohort($obj);
-        $obj2 = m::mock('App\Entity\Cohort');
+        $obj2 = m::mock(Cohort::class);
         $this->object->setCohorts(new ArrayCollection([$obj2]));
         $this->assertNull($this->object->getPrimaryCohort());
     }
@@ -724,7 +726,7 @@ class UserTest extends EntityBase
         $this->assertTrue(method_exists($this->object, 'setPrimaryCohort'));
         $this->assertTrue(method_exists($this->object, 'getPrimaryCohort'));
 
-        $obj = m::mock('App\Entity\Cohort');
+        $obj = m::mock(Cohort::class);
         $this->object->addCohort($obj);
         $this->object->setPrimaryCohort($obj);
         $this->assertSame($obj, $this->object->getPrimaryCohort());
@@ -873,7 +875,7 @@ class UserTest extends EntityBase
     {
         $this->assertTrue(method_exists($this->object, 'getAuthentication'), "Method getAuthentication missing");
         $this->assertTrue(method_exists($this->object, 'setAuthentication'), "Method setAuthentication missing");
-        $obj = m::mock('App\Entity\Authentication');
+        $obj = m::mock(Authentication::class);
         $obj->shouldReceive('setUser')->with($this->object)->once();
         $this->object->setAuthentication($obj);
         $this->assertSame($obj, $this->object->getAuthentication());
@@ -884,7 +886,7 @@ class UserTest extends EntityBase
      */
     public function testSetAuthenticationNull(): void
     {
-        $obj = m::mock('App\Entity\Authentication');
+        $obj = m::mock(Authentication::class);
         $obj->shouldReceive('setUser')->with($this->object)->once();
         $this->object->setAuthentication($obj);
         $this->assertSame($obj, $this->object->getAuthentication());

--- a/tests/Service/EntityMetadataTest.php
+++ b/tests/Service/EntityMetadataTest.php
@@ -411,8 +411,8 @@ class EntityMetadataTest extends KernelTestCase
     protected function getEntityForTypeProvider(): array
     {
         return [
-            ['aamcMethods', 'App\Entity\AamcMethod'],
-            ['vocabularies', 'App\Entity\Vocabulary'],
+            ['aamcMethods', AamcMethod::class],
+            ['vocabularies', Vocabulary::class],
         ];
     }
 }


### PR DESCRIPTION
Constants allow us to find usage much easier and to avoid any typos.

Thanks to https://getrector.com/rule-detail/string-class-name-to-class-constant-rector for this codemod!

I wasn't able to find a way to enforce this in the future, we'll just have to keep an eye on it.

A side effect of the code mod also removed the leading `\` when we had already imported a class.