### PR TITLE
Run ClassOnThisVariableObjectRector

### DIFF
--- a/tests/Endpoints/AuthenticationTest.php
+++ b/tests/Endpoints/AuthenticationTest.php
@@ -335,7 +335,7 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
         if (array_key_exists($key, $data) and $data[$key] == $value) {
             $this->fail(
                 "This value is already set for $key. " .
-                "Modify " . $this::class . '::putsToTest'
+                "Modify " . static::class . '::putsToTest'
             );
         }
         unset($data['passwordHash']);
@@ -531,7 +531,7 @@ class AuthenticationTest extends AbstractReadWriteEndpoint
             if (array_key_exists($key, $data) and $data[$key] == $value) {
                 $this->fail(
                     "This value is already set for $key. " .
-                    "Modify " . $this::class . '::readOnlyPropertiesToTest'
+                    "Modify " . static::class . '::readOnlyPropertiesToTest'
                 );
             }
             unset($data['passwordHash']);

--- a/tests/Endpoints/OfferingTest.php
+++ b/tests/Endpoints/OfferingTest.php
@@ -136,7 +136,7 @@ class OfferingTest extends AbstractReadWriteEndpoint
         if (array_key_exists($key, $data) and $data[$key] == $value) {
             $this->fail(
                 "This value is already set for $key. " .
-                "Modify " . $this::class . '::putsToTest'
+                "Modify " . static::class . '::putsToTest'
             );
         }
         //extract the ID before changing anything in case


### PR DESCRIPTION
This feature became available in PHP 8.0, I see no reason not to use it.