### PR TITLE
updates recipe symfony/sentry-symfony bundle to v5.0

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -14,12 +14,6 @@ when@prod:
                 - Symfony\Component\ErrorHandler\Error\FatalError
                 - Symfony\Component\Debug\Exception\FatalErrorException
 
-        # this hooks into critical paths of the framework (and vendors) to perform
-        # automatic instrumentation (there might be some performance penalty)
-        # https://docs.sentry.io/platforms/php/guides/symfony/performance/instrumentation/automatic-instrumentation/
-        tracing:
-            enabled: true
-
 #        If you are using Monolog, you also need this additional configuration to log the errors correctly:
 #        https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
 #        register_error_listener: false

--- a/symfony.lock
+++ b/symfony.lock
@@ -478,12 +478,12 @@
         "version": "3.1.1"
     },
     "sentry/sentry-symfony": {
-        "version": "4.14",
+        "version": "5.0",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
             "branch": "main",
-            "version": "4.6",
-            "ref": "153de5f041f7e8a9c19f3674b800b76be0e6fd90"
+            "version": "5.0",
+            "ref": "76afa07d23e76f678942f00af5a6a417ba0816d0"
         },
         "files": [
             "config/packages/sentry.yaml"


### PR DESCRIPTION
the entire tracing section was removed in v5.0 from the blueprint.

 see https://github.com/symfony/recipes-contrib/blob/main/sentry/sentry-symfony/5.0/config/packages/sentry.yaml 

it looks like sentry: tracing: enabled: true is the default anyway, so i removed that whole section from our config as well.

for reference:

```bash
stefan@nichtsnutz: ~/dev/projects/ilios on update_symfony_sentry_recipe
$ bin/console debug:config SentryBundle

Current configuration for "SentryBundle"
========================================

sentry:
    dsn: '%env(SENTRY_DSN)%'
    options:
        before_send: App\Service\SentryBeforeSend
        send_default_pii: true
        traces_sampler: sentry.callback.traces_sampler
        ignore_exceptions:
            - Symfony\Component\Security\Core\Exception\AccessDeniedException
            - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
            - Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
            - Symfony\Component\ErrorHandler\Error\FatalError
            - Symfony\Component\Debug\Exception\FatalErrorException
        integrations: {  }
        prefixes:
            - /home/stefan/dev/projects/ilios
            - /home/stefan/dev/projects/ilios/vendor/pear/archive_tar
            - /home/stefan/dev/projects/ilios/vendor/pear/console_getopt
            - /home/stefan/dev/projects/ilios/vendor/pear/pear-core-minimal/src
            - /home/stefan/dev/projects/ilios/vendor/pear/pear_exception
            - .
            - /usr/share/php
        environment: prod
        release: '%env(default::SENTRY_RELEASE)%'
        ignore_transactions: {  }
        tags: {  }
        in_app_exclude:
            - /home/stefan/dev/projects/ilios/var/cache/prod
            - /home/stefan/dev/projects/ilios/vendor
            - /home/stefan/dev/projects/ilios/var/cache/prod
        in_app_include: {  }
        class_serializers: {  }
    register_error_listener: true
    register_error_handler: true
    logger: null
    messenger:
        enabled: true
        capture_soft_fails: true
    tracing:
        enabled: true
        dbal:
            enabled: true
            connections: {  }
        twig:
            enabled: true
        cache:
            enabled: true
        http_client:
            enabled: true
        console:
            excluded_commands:
                - 'messenger:consume'

```