### PR TITLE
Check Schema Differently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
     name: Test Migrations Against MySQL
     needs: code_style
     runs-on: ubuntu-latest
+    env:
+      ILIOS_DATABASE_URL: mysql://root:root@127.0.0.1:3306/ilios?serverVersion=8.0
     steps:
     - uses: actions/checkout@v4
     - name: Use PHP ${{ env.latest_php }}
@@ -102,15 +104,15 @@ jobs:
         extensions: apcu
     - name: install dependencies
       run: composer install --no-interaction --prefer-dist
-    - name: Drop, Create, Migrate, and Validate DB
-      env:
-        ILIOS_DATABASE_URL: mysql://root:root@127.0.0.1:3306/ilios?serverVersion=8.0
+    - run: sudo systemctl start mysql.service
+    - name: Drop, Create, Migrate
       run: |
-        sudo systemctl start mysql.service
         bin/console doctrine:database:drop --if-exists --force
         bin/console doctrine:database:create
         bin/console doctrine:migrations:migrate  --no-interaction
-        bin/console doctrine:schema:validate
+    - name: Validate Schema Matches Migrations
+      # Workaround from https://github.com/doctrine/migrations/issues/1406#issuecomment-2402548597
+      run: true && ! bin/console doctrine:migrations:diff
 
   run_twice:
     name: PHPUnit Run Twice


### PR DESCRIPTION
This is a workaround for an issue present in doctrine orm v3 where the migration table shows up as missing from the schema and fails this test. Refs #5266.

Tests:
- [x] ensure test passes as is
- [x] Change the schema and see a failure
- [x] Cleanup and test again

https://github.com/ilios/ilios/actions/runs/11679136817/job/32519798299
Shows a failure as expected when I changed the length of the first name field for a user:
<img width="1265" alt="Screenshot 2024-11-04 at 11 06 00 PM" src="https://github.com/user-attachments/assets/3ac80ebf-de1e-464c-beb9-66d5f613ec3a">
