### PR TITLE
replace calls to deprecated method with supported equivalent.

### DIFF
--- a/tests/Traits/CohortsEntityTest.php
+++ b/tests/Traits/CohortsEntityTest.php
@@ -18,14 +18,15 @@ class CohortsEntityTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $traitName = CohortsEntity::class;
-        $this->traitObject = $this->getObjectForTrait($traitName);
+        $this->traitObject = new class {
+            use CohortsEntity;
+        };
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->object);
+        unset($this->traitObject);
     }
 
     public function testSetCohorts(): void

--- a/tests/Traits/CompetenciesEntityTest.php
+++ b/tests/Traits/CompetenciesEntityTest.php
@@ -18,14 +18,15 @@ class CompetenciesEntityTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $traitName = CompetenciesEntity::class;
-        $this->traitObject = $this->getObjectForTrait($traitName);
+        $this->traitObject = new class {
+            use CompetenciesEntity;
+        };
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->object);
+        unset($this->traitObject);
     }
 
     public function testSetCompetencies(): void

--- a/tests/Traits/ConceptsEntityTest.php
+++ b/tests/Traits/ConceptsEntityTest.php
@@ -18,14 +18,15 @@ class ConceptsEntityTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $traitName = ConceptsEntity::class;
-        $this->traitObject = $this->getObjectForTrait($traitName);
+        $this->traitObject = new class {
+            use ConceptsEntity;
+        };
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->object);
+        unset($this->traitObject);
     }
 
     public function testSetConcepts(): void

--- a/tests/Traits/CoursesEntityTest.php
+++ b/tests/Traits/CoursesEntityTest.php
@@ -18,14 +18,15 @@ class CoursesEntityTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $traitName = CoursesEntity::class;
-        $this->traitObject = $this->getObjectForTrait($traitName);
+        $this->traitObject = new class {
+            use CoursesEntity;
+        };
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->object);
+        unset($this->traitObject);
     }
 
     public function testSetCourses(): void

--- a/tests/Traits/IlmSessionsEntityTest.php
+++ b/tests/Traits/IlmSessionsEntityTest.php
@@ -18,14 +18,15 @@ class IlmSessionsEntityTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $traitName = IlmSessionsEntity::class;
-        $this->traitObject = $this->getObjectForTrait($traitName);
+        $this->traitObject = new class {
+            use IlmSessionsEntity;
+        };
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->object);
+        unset($this->traitObject);
     }
 
     public function testSetIlmSessions(): void

--- a/tests/Traits/LearningMaterialsEntityTest.php
+++ b/tests/Traits/LearningMaterialsEntityTest.php
@@ -18,14 +18,15 @@ class LearningMaterialsEntityTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $traitName = LearningMaterialsEntity::class;
-        $this->traitObject = $this->getObjectForTrait($traitName);
+        $this->traitObject = new class {
+            use LearningMaterialsEntity;
+        };
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->object);
+        unset($this->traitObject);
     }
 
     public function testSetLearningMaterials(): void

--- a/tests/Traits/ProgramYearsEntityTest.php
+++ b/tests/Traits/ProgramYearsEntityTest.php
@@ -18,14 +18,15 @@ class ProgramYearsEntityTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $traitName = ProgramYearsEntity::class;
-        $this->traitObject = $this->getObjectForTrait($traitName);
+        $this->traitObject = new class {
+            use ProgramYearsEntity;
+        };
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->object);
+        unset($this->traitObject);
     }
 
     public function testSetProgramYears(): void

--- a/tests/Traits/ProgramsEntityTest.php
+++ b/tests/Traits/ProgramsEntityTest.php
@@ -18,14 +18,15 @@ class ProgramsEntityTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $traitName = ProgramsEntity::class;
-        $this->traitObject = $this->getObjectForTrait($traitName);
+        $this->traitObject = new class {
+            use ProgramsEntity;
+        };
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->object);
+        unset($this->traitObject);
     }
 
     public function testSetPrograms(): void

--- a/tests/Traits/UsersEntityTest.php
+++ b/tests/Traits/UsersEntityTest.php
@@ -18,14 +18,15 @@ class UsersEntityTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $traitName = UsersEntity::class;
-        $this->traitObject = $this->getObjectForTrait($traitName);
+        $this->traitObject = new class {
+            use UsersEntity;
+        };
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->object);
+        unset($this->traitObject);
     }
 
     public function testSetUsers(): void


### PR DESCRIPTION
`getObjectForTrait() is deprecated and will be removed in PHPUnit 12 without replacement.`