### PR TITLE
explictly set requireTld on URL assertion attributes.

### DIFF
--- a/src/Entity/LearnerGroup.php
+++ b/src/Entity/LearnerGroup.php
@@ -62,7 +62,7 @@ class LearnerGroup implements LearnerGroupInterface
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
     #[Assert\Length(max: 2000)]
-    #[Assert\Url]
+    #[Assert\Url(requireTld: false)]
     protected ?string $url = null;
 
     #[ORM\Column(name: 'needs_accommodation', type: 'boolean')]

--- a/src/Entity/Offering.php
+++ b/src/Entity/Offering.php
@@ -64,7 +64,7 @@ class Offering implements OfferingInterface
     #[IA\Type('string')]
     #[Assert\Type(type: 'string')]
     #[Assert\Length(max: 2000)]
-    #[Assert\Url]
+    #[Assert\Url(requireTld: false)]
     protected ?string $url = null;
 
     #[ORM\Column(name: 'start_date', type: 'datetime')]


### PR DESCRIPTION
not setting is deprecated, and the default will toggle from FALSE to TRUE in Symfony 8.

for reference, please see https://symfony.com/doc/current/reference/constraints/Url.html#requiretld

fixes  https://github.com/ilios/ilios/issues/5831