### PR TITLE
Make Session Description Nullable in Index

### DIFF
--- a/src/Classes/IndexableSession.php
+++ b/src/Classes/IndexableSession.php
@@ -16,7 +16,7 @@ class IndexableSession
 
     public string $sessionType;
 
-    public string $description;
+    public ?string $description;
 
     public array $directors = [];
 


### PR DESCRIPTION
When indexing a session the description can be null as it can on the entity.

Refs #5842 

(quick fix, we really need to find a way to test this)