### PR TITLE
Skip Re-indexing Courses

### DIFF
--- a/src/Message/CourseIndexRequest.php
+++ b/src/Message/CourseIndexRequest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Message;
 
+use DateTime;
 use InvalidArgumentException;
 
 class CourseIndexRequest
 {
     private array $courseIds;
+    private DateTime $createdAt;
     public const int MAX_COURSES = 50;
 
     /**
@@ -28,10 +30,16 @@ class CourseIndexRequest
             );
         }
         $this->courseIds = $courseIds;
+        $this->createdAt = new DateTime();
     }
 
     public function getCourseIds(): array
     {
         return $this->courseIds;
+    }
+
+    public function getCreatedAt(): DateTime
+    {
+        return $this->createdAt;
     }
 }

--- a/src/MessageHandler/CourseIndexHandler.php
+++ b/src/MessageHandler/CourseIndexHandler.php
@@ -21,6 +21,6 @@ class CourseIndexHandler
     public function __invoke(CourseIndexRequest $message): void
     {
         $indexes = $this->courseRepository->getCourseIndexesFor($message->getCourseIds());
-        $this->curriculumIndex->index($indexes);
+        $this->curriculumIndex->index($indexes, $message->getCreatedAt());
     }
 }

--- a/src/Service/Index/Manager.php
+++ b/src/Service/Index/Manager.php
@@ -45,6 +45,7 @@ class Manager extends OpenSearchBase
             'body' => Curriculum::getMapping(),
         ]);
 
+        $this->client->ingest()->putPipeline(Curriculum::getPipeline());
         $this->client->ingest()->putPipeline(LearningMaterials::getPipeline());
         $this->client->indices()->create([
             'index' => LearningMaterials::INDEX,


### PR DESCRIPTION
Improve performance of course indexing by skipping any course that has been indexed already. When we add or update the index with the data in a course we also store the ingestion time. When courses are updated and we put a message in the async queue to be processed we record that time as well. This allows skipping indexing a course if it has been indexed since the message was added to the queue. When a course is being heavily updated and the index process gets a bit behind this can be a real time saver.