### PR TITLE
Extract Text from Learning Materials

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -20,3 +20,5 @@
 #ILIOS_STORAGE_S3_URL=null
 
 #MAILER_DSN=null://null
+
+#ILIOS_TIKA_URL=null

--- a/.env.test
+++ b/.env.test
@@ -16,3 +16,5 @@ PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
 
 MAILER_DSN=null://null
+
+ILIOS_TIKA_URL=null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
           - mysql-demo
           - opensearch
           - redis
+          - tika
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -191,6 +192,7 @@ jobs:
           - mysql-demo
           - opensearch
           - redis
+          - tika
      steps:
      - name: Set up QEMU
        uses: docker/setup-qemu-action@v3
@@ -320,7 +322,7 @@ jobs:
         docker stop ilios-opensearch
         docker rm --volumes ilios-opensearch
         docker image rm opensearch:testing
-    - name: REdis
+    - name: Redis
       if: ${{ always() }}
       run: |
         docker image load --input /tmp/redis.tar
@@ -330,6 +332,16 @@ jobs:
         docker stop ilios-redis
         docker rm --volumes ilios-redis
         docker image rm redis:testing
+    - name: Tika
+      if: ${{ always() }}
+      run: |
+        docker image load --input /tmp/tika.tar
+        docker run -d --name ilios-tika tika:testing
+        docker ps
+        docker ps | grep -q ilios-tika
+        docker stop ilios-tika
+        docker rm --volumes ilios-tika
+        docker image rm tika:testing
     - name: Output Docker Logs
       if: failure()
       run: |
@@ -343,6 +355,7 @@ jobs:
         docker logs ilios-mysql-demo
         docker logs ilios-opensearch
         docker logs ilios-redis
+        docker logs ilios-tika
   check_setup_command:
     name: Setup Command
     needs: code_style

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -23,6 +23,7 @@ jobs:
           - mysql-demo
           - opensearch
           - redis
+          - tika
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -54,6 +54,7 @@ jobs:
           - mysql-demo
           - opensearch
           - redis
+          - tika
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -24,6 +24,7 @@ jobs:
           - mysql-demo
           - opensearch
           - redis
+          - tika
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -46,6 +46,7 @@ jobs:
           - mysql-demo
           - opensearch
           - redis
+          - tika
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -241,31 +241,10 @@ COPY docker/redis/redis.conf /usr/local/etc/redis/redis.conf
 CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
 
 ###############################################################################
-# Build apache tika ourselves so it's multi platform while we wait
-# for an official release that works on ARM
-# Mostly stolen from https://github.com/apache/tika-docker/blob/e8819e3e2a8d29e803ecdc6b0c6169ed19c5b1c3/minimal/Dockerfile
+# Create our own tika, so we can customize it if needed
 ###############################################################################
-FROM debian:bookworm-slim as tika
+FROM apache/tika as tika
 LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
-ENV TIKA_VERSION=3.0.0
-
-RUN set -eux \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        openjdk-17-jre-headless \
-        wget ca-certificates gnupg2 \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && wget -qO- https://downloads.apache.org/tika/KEYS | gpg --import
-
-RUN wget https://dlcdn.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar -O /tika-server.jar
-RUN wget https://downloads.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar.asc -O /tika-server.jar.asc
-
-RUN gpg --verify /tika-server.jar.asc /tika-server.jar
-
-#random user not root, same as official image
-USER 35002:35002
-EXPOSE 9998
-ENTRYPOINT [ "/bin/sh", "-c", "exec java -cp \"/tika-server.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $0 $@"]
 
 ###############################################################################
 # Our original and still relevant apache based runtime, includes everything in

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,6 +35,7 @@ services:
       - ILIOS_REDIS_URL=redis://redis
       - ILIOS_FEATURE_DTO_CACHING=false
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/ilios-storage
+      - ILIOS_TIKA_URL=http://tika:9998
     volumes:
       # The "cached" option has no effect on Linux but improves performance on Mac
       - ./:/srv/app:ro,cached
@@ -55,12 +56,14 @@ services:
       - ILIOS_SEARCH_HOSTS=opensearch:9200
       - ILIOS_REDIS_URL=redis://redis
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/ilios-storage
+      - ILIOS_TIKA_URL=http://tika:9998
     restart: always
     command: [ "--time-limit", "3600", "-vv"]
     depends_on:
-        - db
-        - opensearch
-        - redis
+      - db
+      - opensearch
+      - redis
+      - tika
     volumes:
       # The "cached" option has no effect on Linux but improves performance on Mac
       - ./:/srv/app:ro,cached
@@ -83,3 +86,9 @@ services:
       target: redis
     ports:
       - "6379:6379"
+  tika:
+    build:
+      context: .
+      target: tika
+    ports:
+      - "9998:9998"

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,14 @@
     "php": ">= 8.3",
     "ext-apcu": "*",
     "ext-ctype": "*",
+    "ext-curl": "*",
     "ext-dom": "*",
     "ext-iconv": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
     "ext-pdo": "*",
     "ext-simplexml": "*",
+    "ext-sodium": "*",
     "ext-xmlwriter": "*",
     "ext-zlib": "*",
     "composer/composer": "^2.1",
@@ -68,8 +70,8 @@
     "symfony/validator": "@stable",
     "symfony/web-link": "@stable",
     "symfony/yaml": "@stable",
-    "webonyx/graphql-php": "^15.0",
-    "ext-sodium": "*"
+    "vaites/php-apache-tika": "^1.3",
+    "webonyx/graphql-php": "^15.0"
   },
   "require-dev": {
     "infection/infection": "^0.29.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96c12b31c4ecc78c3bbaab4320b23a53",
+    "content-hash": "ab4bcdb1f74a1a2a9faeebafa7a122c2",
     "packages": [
         {
             "name": "async-aws/core",
@@ -187,16 +187,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.330.0",
+            "version": "3.330.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "dd1b65a4329f91d5e282a92fab2be7bdf6e2adea"
+                "reference": "136749f15d1dbff07064ef5ba1c2f08b96cf78ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/dd1b65a4329f91d5e282a92fab2be7bdf6e2adea",
-                "reference": "dd1b65a4329f91d5e282a92fab2be7bdf6e2adea",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/136749f15d1dbff07064ef5ba1c2f08b96cf78ff",
+                "reference": "136749f15d1dbff07064ef5ba1c2f08b96cf78ff",
                 "shasum": ""
             },
             "require": {
@@ -279,9 +279,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.330.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.330.1"
             },
-            "time": "2024-11-22T19:10:26+00:00"
+            "time": "2024-11-25T19:20:00+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -361,16 +361,16 @@
         },
         {
             "name": "composer/class-map-generator",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "98bbf6780e56e0fd2404fe4b82eb665a0f93b783"
+                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/98bbf6780e56e0fd2404fe4b82eb665a0f93b783",
-                "reference": "98bbf6780e56e0fd2404fe4b82eb665a0f93b783",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
+                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
                 "shasum": ""
             },
             "require": {
@@ -379,10 +379,10 @@
                 "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.6",
-                "phpstan/phpstan-deprecation-rules": "^1",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
+                "phpstan/phpstan-phpunit": "^1 || ^2",
+                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
                 "phpunit/phpunit": "^8",
                 "symfony/filesystem": "^5.4 || ^6"
             },
@@ -414,7 +414,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.4.0"
+                "source": "https://github.com/composer/class-map-generator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -430,7 +430,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-03T18:14:00+00:00"
+            "time": "2024-11-25T16:11:06+00:00"
         },
         {
             "name": "composer/composer",
@@ -3399,20 +3399,20 @@
         },
         {
             "name": "jaybizzle/crawler-detect",
-            "version": "v1.2.121",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JayBizzle/Crawler-Detect.git",
-                "reference": "40ecda6322d4163fe2c6e1dd47c574f580b8487f"
+                "reference": "be155e11613fa618aa18aee438955588d1092a47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/40ecda6322d4163fe2c6e1dd47c574f580b8487f",
-                "reference": "40ecda6322d4163fe2c6e1dd47c574f580b8487f",
+                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/be155e11613fa618aa18aee438955588d1092a47",
+                "reference": "be155e11613fa618aa18aee438955588d1092a47",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8|^5.5|^6.5|^9.4"
@@ -3445,9 +3445,9 @@
             ],
             "support": {
                 "issues": "https://github.com/JayBizzle/Crawler-Detect/issues",
-                "source": "https://github.com/JayBizzle/Crawler-Detect/tree/v1.2.121"
+                "source": "https://github.com/JayBizzle/Crawler-Detect/tree/v1.3.0"
             },
-            "time": "2024-10-20T21:42:39+00:00"
+            "time": "2024-11-25T19:38:36+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -11202,6 +11202,107 @@
             "time": "2024-11-17T15:59:19+00:00"
         },
         {
+            "name": "vaites/php-apache-tika",
+            "version": "v1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vaites/php-apache-tika.git",
+                "reference": "9d7d13aad7df5789b765977f57f2c1d000c4cfa4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vaites/php-apache-tika/zipball/9d7d13aad7df5789b765977f57f2c1d000c4cfa4",
+                "reference": "9d7d13aad7df5789b765977f57f2c1d000c4cfa4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=7.3.0"
+            },
+            "require-dev": {
+                "filp/whoops": "^2.7",
+                "nunomaduro/collision": "^5.11",
+                "nunomaduro/phpinsights": "^1.14",
+                "phpstan/phpstan": "^0.12.26",
+                "phpunit/phpunit": "^9.0",
+                "psy/psysh": "^0.10.8",
+                "symfony/var-dumper": "^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "supported-versions": [
+                    "1.15",
+                    "1.16",
+                    "1.17",
+                    "1.18",
+                    "1.19",
+                    "1.19.1",
+                    "1.20",
+                    "1.21",
+                    "1.22",
+                    "1.23",
+                    "1.24",
+                    "1.24.1",
+                    "1.25",
+                    "1.26",
+                    "1.27",
+                    "1.28",
+                    "1.28.1",
+                    "1.28.2",
+                    "1.28.3",
+                    "1.28.4",
+                    "1.28.5",
+                    "2.0.0",
+                    "2.1.0",
+                    "2.2.0",
+                    "2.2.1",
+                    "2.3.0",
+                    "2.4.0",
+                    "2.5.0",
+                    "2.6.0",
+                    "2.7.0",
+                    "2.8.0",
+                    "2.9.0",
+                    "2.9.1",
+                    "2.9.2"
+                ]
+            },
+            "autoload": {
+                "psr-4": {
+                    "Vaites\\ApacheTika\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Martínez",
+                    "email": "contacto@davidmartinez.net"
+                }
+            ],
+            "description": "Apache Tika bindings for PHP: extracts text from documents and images (with OCR), metadata and more...",
+            "keywords": [
+                "OCR",
+                "apache",
+                "doc",
+                "documents",
+                "docx",
+                "odt",
+                "office",
+                "pdf",
+                "ppt",
+                "pptx",
+                "tika"
+            ],
+            "support": {
+                "issues": "https://github.com/vaites/php-apache-tika/issues",
+                "source": "https://github.com/vaites/php-apache-tika/tree/v1.3.2"
+            },
+            "time": "2024-05-28T22:00:22+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.11.0",
             "source": {
@@ -15216,15 +15317,16 @@
         "php": ">= 8.3",
         "ext-apcu": "*",
         "ext-ctype": "*",
+        "ext-curl": "*",
         "ext-dom": "*",
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-pdo": "*",
         "ext-simplexml": "*",
+        "ext-sodium": "*",
         "ext-xmlwriter": "*",
-        "ext-zlib": "*",
-        "ext-sodium": "*"
+        "ext-zlib": "*"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -12,6 +12,7 @@ framework:
        'App\Message\UserIndexRequest': async
        'App\Message\MeshDescriptorIndexRequest': async
        'App\Message\LearningMaterialIndexRequest': async
+       'App\Message\LearningMaterialTextExtractionRequest': async
 
     default_bus: messenger.bus.default
     buses:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -181,6 +181,10 @@ services:
       factory: ['App\Service\OpenSearchFactory', 'getClient']
       arguments: ['@App\Service\Config']
 
+    Vaites\ApacheTika\Client:
+      factory: ['App\Service\TikaFactory', 'getClient']
+      arguments: ['@App\Service\Config']
+
     http_client:
       class: Symfony\Component\HttpClient\NativeHttpClient
 

--- a/docs/docker-examples/docker-compose.demo.yml
+++ b/docs/docker-examples/docker-compose.demo.yml
@@ -24,6 +24,7 @@ services:
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_SEARCH_HOSTS=opensearch
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+      - ILIOS_TIKA_URL=http://tika:9998
     depends_on:
       - db
   messages:
@@ -33,6 +34,7 @@ services:
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_SEARCH_HOSTS=opensearch
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp
+      - ILIOS_TIKA_URL=http://tika:9998
     depends_on:
         - db
   opensearch:
@@ -45,3 +47,7 @@ services:
     image: ilios/redis:v3
     ports:
       - "6379:6379"
+  tika:
+    image: apache/tika:2.9.1.0-full
+    ports:
+      - "9998:9998"

--- a/docs/env_vars_and_config.md
+++ b/docs/env_vars_and_config.md
@@ -28,6 +28,8 @@ ILIOS_FILE_SYSTEM_PATH=/var/www/ilios/learning_materials
 
 ILIOS_SEARCH_HOSTS=https://fqdn.searchhost.edu:443
 
+ILIOS_TIKA_URL=https://fqdn.searchhost.edu:9998
+
 #default mail service for sending mails directly from Ilios (local smtpd server or relay required)
 MAILER_DSN=smtp://localhost:25
 

--- a/src/Command/ExtractLearningMaterialsTextCommand.php
+++ b/src/Command/ExtractLearningMaterialsTextCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Message\LearningMaterialTextExtractionRequest;
+use App\Repository\LearningMaterialRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Queues extraction of learning material text
+ */
+#[AsCommand(
+    name: 'ilios:extract-material-text',
+    description: 'Queue extraction of learning material text.'
+)]
+class ExtractLearningMaterialsTextCommand extends Command
+{
+    public function __construct(
+        protected LearningMaterialRepository $learningMaterialRepository,
+        protected MessageBusInterface $bus
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $allIds = $this->learningMaterialRepository->getFileLearningMaterialIds();
+        $count = count($allIds);
+        $chunks = array_chunk($allIds, LearningMaterialTextExtractionRequest::MAX_MATERIALS);
+        foreach ($chunks as $ids) {
+            $this->bus->dispatch(new LearningMaterialTextExtractionRequest($ids));
+        }
+        $output->writeln("<info>{$count} learning materials have been queued for text extraction.</info>");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -10,6 +10,7 @@ use App\Entity\LearningMaterialInterface;
 use App\Entity\SessionInterface;
 use App\Entity\UserInterface;
 use App\Message\CourseIndexRequest;
+use App\Message\LearningMaterialTextExtractionRequest;
 use App\Message\UserIndexRequest;
 use App\Service\Index\Curriculum;
 use App\Service\Index\LearningMaterials;
@@ -54,6 +55,7 @@ class IndexEntityChanges
 
         if ($entity instanceof LearningMaterialInterface) {
             $this->indexLearningMaterial($entity);
+            $this->bus->dispatch(new LearningMaterialTextExtractionRequest([$entity->getId()]));
         }
 
         if ($entity instanceof IndexableCoursesEntityInterface) {

--- a/src/Exception/LearningMaterialTextExtractorException.php
+++ b/src/Exception/LearningMaterialTextExtractorException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Exception;
+
+class LearningMaterialTextExtractorException extends Exception
+{
+}

--- a/src/Message/LearningMaterialTextExtractionRequest.php
+++ b/src/Message/LearningMaterialTextExtractionRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+use InvalidArgumentException;
+
+class LearningMaterialTextExtractionRequest
+{
+    private array $learningMaterialIds;
+    public const int MAX_MATERIALS = 50;
+
+    public function __construct(array $learningMaterialIds)
+    {
+        $count = count($learningMaterialIds);
+        if ($count > self::MAX_MATERIALS) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'A maximum of %d learning materials can be extracted at the same time, you sent %d',
+                    self::MAX_MATERIALS,
+                    $count
+                )
+            );
+        }
+        $this->learningMaterialIds = $learningMaterialIds;
+    }
+
+    public function getLearningMaterialIds(): array
+    {
+        return $this->learningMaterialIds;
+    }
+}

--- a/src/MessageHandler/LearningMaterialTextExtractionHandler.php
+++ b/src/MessageHandler/LearningMaterialTextExtractionHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\LearningMaterialTextExtractionRequest;
+use App\Repository\LearningMaterialRepository;
+use App\Service\LearningMaterialTextExtractor;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class LearningMaterialTextExtractionHandler
+{
+    public function __construct(
+        protected LearningMaterialTextExtractor $extractor,
+        protected LearningMaterialRepository $repository,
+    ) {
+    }
+
+    public function __invoke(LearningMaterialTextExtractionRequest $message): void
+    {
+        $dtos = $this->repository->findDTOsBy(['id' => $message->getLearningMaterialIds()]);
+        foreach ($dtos as $dto) {
+            $this->extractor->extract($dto);
+        }
+    }
+}

--- a/src/Service/IliosFileSystem.php
+++ b/src/Service/IliosFileSystem.php
@@ -102,6 +102,15 @@ class IliosFileSystem
     }
 
     /**
+     * Get if a learning material file path is valid
+     */
+    public function checkIfLearningMaterialTextFileExists(string $lmRelativePath): bool
+    {
+        $path = $this->getLearningMaterialTextPath($lmRelativePath);
+        return $this->fileSystem->fileExists($path);
+    }
+
+    /**
      * Remove a file from the filesystem by hash
      */
     public function removeFile(string $relativePath): void

--- a/src/Service/IliosFileSystem.php
+++ b/src/Service/IliosFileSystem.php
@@ -32,6 +32,13 @@ class IliosFileSystem
     public const string HASHED_LM_DIRECTORY = 'learning_materials/lm';
 
     /**
+     * Extracted test from uploaded materials are stored here
+     * based on the hashed file name of the LM they were
+     * extracted from
+     */
+    public const string HASHED_LM_TEXT_DIRECTORY = 'learning_materials/text';
+
+    /**
      * Lock files are stored in this directory
      */
     public const string LOCK_FILE_DIRECTORY = 'locks';
@@ -64,13 +71,34 @@ class IliosFileSystem
     }
 
     /**
-     * Store a learning material file and return the relativePath
+     * Get the path to a learning material file
      */
     public function getLearningMaterialFilePath(File $file): string
     {
         $hash = md5_file($file->getPathname());
 
         return self::HASHED_LM_DIRECTORY . '/' . substr($hash, 0, 2) . '/' . $hash;
+    }
+
+    /**
+     * Store the extracted text from a learning material
+     */
+    public function storeLearningMaterialText(string $lmRelativePath, string $contents): string
+    {
+        $relativePath = $this->getLearningMaterialTextPath($lmRelativePath);
+        $this->fileSystem->write($relativePath, $contents);
+
+        return $relativePath;
+    }
+
+    /**
+     * Get the path to a learning material extracted text file
+     */
+    public function getLearningMaterialTextPath(string $lmRelativePath): string
+    {
+        $arr = explode('/', $lmRelativePath);
+        $hash = $arr[3];
+        return self::HASHED_LM_TEXT_DIRECTORY . '/' . substr($hash, 0, 2) . '/' . $hash . '.txt';
     }
 
     /**

--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -11,7 +11,6 @@ use Vaites\ApacheTika\Client;
 
 class LearningMaterialTextExtractor
 {
-    private bool $enabled = false;
     private Client $client;
 
     public function __construct(
@@ -21,14 +20,13 @@ class LearningMaterialTextExtractor
         ?Client $client = null,
     ) {
         if ($client) {
-            $this->enabled = true;
             $this->client = $client;
         }
     }
 
     public function extract(LearningMaterialDTO $dto): void
     {
-        if (!$this->enabled) {
+        if (!$this->isEnabled()) {
             return;
         }
 
@@ -73,5 +71,10 @@ class LearningMaterialTextExtractor
                 unlink($tmpFile->getRealPath());
             }
         }
+    }
+
+    private function isEnabled(): bool
+    {
+        return !empty($this->client);
     }
 }

--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Entity\DTO\LearningMaterialDTO;
 use App\Exception\LearningMaterialTextExtractorException;
 use Exception;
+use Symfony\Component\HttpFoundation\Response;
 use Vaites\ApacheTika\Client;
 
 class LearningMaterialTextExtractor
@@ -59,7 +60,9 @@ class LearningMaterialTextExtractor
             $this->iliosFileSystem->storeLearningMaterialText($dto->relativePath, $text);
         } catch (Exception $exception) {
             if (
-                $exception->getCode() === 422 &&
+                // error code from php-tika library (422)
+                // https://github.com/vaites/php-apache-tika/blob/792dc1254b4ccd92c6964ab477a1626dca6784ee/src/Clients/WebClient.php#L620
+                $exception->getCode() === Response::HTTP_UNPROCESSABLE_ENTITY &&
                 $exception->getMessage() === 'Unprocessable document'
             ) {
                 //this document can't be processed by tika

--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\DTO\LearningMaterialDTO;
+use Exception;
+use Vaites\ApacheTika\Client;
+
+class LearningMaterialTextExtractor
+{
+    private bool $enabled = false;
+    private Client $client;
+
+    public function __construct(
+        protected NonCachingIliosFileSystem $fileSystem,
+        protected TemporaryFileSystem $temporaryFileSystem,
+        protected IliosFileSystem $iliosFileSystem,
+        ?Client $client = null,
+    ) {
+        if ($client) {
+            $this->enabled = true;
+            $this->client = $client;
+        }
+    }
+
+    public function extract(LearningMaterialDTO $dto): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        if (!$this->fileSystem->checkLearningMaterialRelativePath($dto->relativePath)) {
+            throw new Exception("There is no material on this system at $dto->relativePath");
+        }
+
+        $contents = $this->fileSystem->getFileContents($dto->relativePath);
+        $tmpFile = $this->temporaryFileSystem->createFile($contents);
+        $text = $this->client->getText($tmpFile->getRealPath());
+        $this->iliosFileSystem->storeLearningMaterialText($dto->relativePath, $text);
+        unlink($tmpFile->getRealPath());
+    }
+}

--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Entity\DTO\LearningMaterialDTO;
+use App\Exception\LearningMaterialTextExtractorException;
 use Exception;
 use Vaites\ApacheTika\Client;
 
@@ -47,7 +48,9 @@ class LearningMaterialTextExtractor
         }
 
         if (!$this->fileSystem->checkLearningMaterialRelativePath($dto->relativePath)) {
-            throw new Exception("There is no material on this system at $dto->relativePath");
+            throw new LearningMaterialTextExtractorException(
+                "There is no material on this system at $dto->relativePath"
+            );
         }
 
         $contents = $this->fileSystem->getFileContents($dto->relativePath);

--- a/src/Service/TikaFactory.php
+++ b/src/Service/TikaFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Vaites\ApacheTika\Client;
+
+class TikaFactory
+{
+    public static function getClient(Config $config): ?Client
+    {
+        $url = $config->get('tika_url');
+        if ($url) {
+            return Client::prepare($url, null, [CURLOPT_TIMEOUT => 30]);
+        }
+
+        return null;
+    }
+}

--- a/tests/Command/ExtractLearningMaterialsTextCommandTest.php
+++ b/tests/Command/ExtractLearningMaterialsTextCommandTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\ExtractLearningMaterialsTextCommand;
+use App\Message\LearningMaterialTextExtractionRequest;
+use App\Repository\LearningMaterialRepository;
+use PHPUnit\Framework\Attributes\Group;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use stdClass;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[Group('cli')]
+class ExtractLearningMaterialsTextCommandTest extends KernelTestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected CommandTester $commandTester;
+    protected LearningMaterialRepository|m\MockInterface $repository;
+    protected MessageBusInterface|m\MockInterface $bus;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = m::mock(LearningMaterialRepository::class);
+        $this->bus = m::mock(MessageBusInterface::class);
+
+        $command = new ExtractLearningMaterialsTextCommand($this->repository, $this->bus);
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->add($command);
+        $commandInApp = $application->find($command->getName());
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->repository);
+        unset($this->bus);
+        unset($this->commandTester);
+    }
+
+    public function testExtract(): void
+    {
+        $this->repository->shouldReceive('getFileLearningMaterialIds')->andReturn([1, 4]);
+        $this->bus
+            ->shouldReceive('dispatch')
+            ->withArgs(fn (LearningMaterialTextExtractionRequest $r) => $r->getLearningMaterialIds() === [1, 4])
+            ->andReturn(new Envelope(new stdClass()))
+            ->once();
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/2 learning materials have been queued for text extraction./',
+            $output
+        );
+    }
+}

--- a/tests/Message/LearningMaterialTextExtractionRequestTest.php
+++ b/tests/Message/LearningMaterialTextExtractionRequestTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Message;
+
+use App\Message\LearningMaterialTextExtractionRequest;
+use App\Tests\TestCase;
+use Exception;
+
+class LearningMaterialTextExtractionRequestTest extends TestCase
+{
+    public function testMaximumValues(): void
+    {
+        $this->expectException(Exception::class);
+        $arr = array_fill(0, 100, '');
+        new LearningMaterialTextExtractionRequest($arr);
+    }
+}

--- a/tests/Service/IliosFileSystemTest.php
+++ b/tests/Service/IliosFileSystemTest.php
@@ -40,7 +40,7 @@ class IliosFileSystemTest extends TestCase
         unset($this->fakeTestFileDir);
     }
 
-    public function testStoreLeaningMaterialFile(): void
+    public function testStoreLearningMaterialFile(): void
     {
         $path = __FILE__;
         $file = m::mock(File::class);
@@ -202,5 +202,24 @@ class IliosFileSystemTest extends TestCase
         $this->fileSystemMock->shouldReceive('delete')->with("tmp/{$hash}");
         $contents = $this->iliosFileSystem->getUploadedTemporaryFileContentsAndRemoveFile($hash);
         $this->assertSame($contents, $testContents);
+    }
+
+    public function testStoreLearningMaterialText(): void
+    {
+        $lmHashPath = '/24/24jonandjen';
+        $lmPath = IliosFileSystem::HASHED_LM_DIRECTORY . $lmHashPath;
+        $textPath = IliosFileSystem::HASHED_LM_TEXT_DIRECTORY . "{$lmHashPath}.txt";
+        $this->fileSystemMock->shouldReceive('write')->with($textPath, 'some text');
+        $newPath = $this->iliosFileSystem->storeLearningMaterialText($lmPath, 'some text');
+        $this->assertEquals($textPath, $newPath);
+    }
+
+    public function testGetLearningMaterialTextPath(): void
+    {
+        $lmHashPath = '/24/24jonandjen';
+        $lmPath = IliosFileSystem::HASHED_LM_DIRECTORY . $lmHashPath;
+        $textPath = IliosFileSystem::HASHED_LM_TEXT_DIRECTORY . "{$lmHashPath}.txt";
+        $newPath = $this->iliosFileSystem->getLearningMaterialTextPath($lmPath);
+        $this->assertEquals($textPath, $newPath);
     }
 }

--- a/tests/Service/LearningMaterialTextExtractorTest.php
+++ b/tests/Service/LearningMaterialTextExtractorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\DTO\LearningMaterialDTO;
+use App\Service\LearningMaterialTextExtractor;
+use App\Service\NonCachingIliosFileSystem;
+use App\Service\TemporaryFileSystem;
+use Mockery as m;
+use App\Service\IliosFileSystem;
+use App\Tests\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\File\File;
+use Vaites\ApacheTika\Client;
+
+class LearningMaterialTextExtractorTest extends TestCase
+{
+    public const string TEST_FILE_PATH = __DIR__ . '/FakeTestFiles/LearningMaterialTextExtractor_TEST.txt';
+    private LearningMaterialTextExtractor $extractor;
+    private NonCachingIliosFileSystem|m\MockInterface $nonCachingFileSystem;
+    private IliosFileSystem|m\MockInterface $fileSystem;
+    private TemporaryFileSystem|m\MockInterface $temporaryFileSystem;
+    private Client|m\MockInterface $tikaClient;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->nonCachingFileSystem = m::mock(NonCachingIliosFileSystem::class);
+        $this->temporaryFileSystem = m::mock(TemporaryFileSystem::class);
+        $this->fileSystem = m::mock(IliosFileSystem::class);
+        $this->tikaClient = m::mock(Client::class);
+        $this->extractor = new LearningMaterialTextExtractor(
+            $this->nonCachingFileSystem,
+            $this->temporaryFileSystem,
+            $this->fileSystem,
+            $this->tikaClient,
+        );
+        $fs = new Filesystem();
+        if (!$fs->exists(dirname(self::TEST_FILE_PATH))) {
+            $fs->mkdir(dirname(self::TEST_FILE_PATH));
+        }
+        $fs->copy(__FILE__, self::TEST_FILE_PATH);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->nonCachingFileSystem);
+        unset($this->temporaryFileSystem);
+        unset($this->fileSystem);
+        unset($this->tikaClient);
+        unset($this->extractor);
+    }
+
+    public function testDisabled(): void
+    {
+        self::expectNotToPerformAssertions();
+        $extractor = new LearningMaterialTextExtractor(
+            $this->nonCachingFileSystem,
+            $this->temporaryFileSystem,
+            $this->fileSystem,
+            null,
+        );
+        $dto = m::mock(LearningMaterialDTO::class);
+        $extractor->extract($dto);
+    }
+
+    public function testExtract(): void
+    {
+        $dto = m::mock(LearningMaterialDTO::class);
+        $dto->relativePath = 'dir/lm/24/24jj';
+        $this->nonCachingFileSystem
+            ->shouldReceive('checkLearningMaterialRelativePath')
+            ->with($dto->relativePath)
+            ->once()
+            ->andReturn(true);
+        $this->nonCachingFileSystem
+            ->shouldReceive('getFileContents')
+            ->with($dto->relativePath)
+            ->once()
+            ->andReturn('lm-contents');
+        $tmpFile = new File(self::TEST_FILE_PATH);
+        $this->temporaryFileSystem
+            ->shouldReceive('createFile')
+            ->with('lm-contents')
+            ->once()
+            ->andReturn($tmpFile);
+        $this->tikaClient
+            ->shouldReceive('getText')
+            ->once()
+            ->with(self::TEST_FILE_PATH)
+            ->andReturn('lm-text');
+        $this->fileSystem
+            ->shouldReceive('storeLearningMaterialText')
+            ->once()
+            ->with($dto->relativePath, 'lm-text')
+            ->andReturn('lm-text-path');
+        $this->assertTrue(file_exists(self::TEST_FILE_PATH));
+        $this->extractor->extract($dto);
+        $this->assertFalse(file_exists(self::TEST_FILE_PATH));
+    }
+}

--- a/tests/Service/TikaFactoryTest.php
+++ b/tests/Service/TikaFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\Config;
+use App\Service\TikaFactory;
+use App\Tests\TestCase;
+use Mockery as m;
+use Vaites\ApacheTika\Client;
+use Vaites\ApacheTika\Clients\WebClient;
+
+class TikaFactoryTest extends TestCase
+{
+    protected m\MockInterface|Config $config;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->config = m::mock(Config::class);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->config);
+    }
+
+    public function testCreate(): void
+    {
+        $this->config->shouldReceive('get')
+            ->once()->with('tika_url')->andReturn('https://tika.com');
+        $client = TikaFactory::getClient($this->config);
+        $this->assertInstanceOf(WebClient::class, $client);
+        $this->assertSame('https://tika.com:9998', $client->getUrl());
+    }
+
+    public function testNothingWithNoUrl(): void
+    {
+        $this->config->shouldReceive('get')
+            ->once()->with('tika_url')->andReturn(null);
+        $client = TikaFactory::getClient($this->config);
+        $this->assertNull($client);
+    }
+}


### PR DESCRIPTION
Adds an Apache Tika container which we use as a service to send learning materials to and extract their text. The extracted text is stored based on the hash of the material, but in a parallel location (to make it easier to manager and see the impact of the materials).
The process for extraction runs asynchronously like our search index through smyfonys messenger system and is queued when a new material is added or when a command is run to build the index. The extraction process checks to see if the file exists first and assumes it is correct and doesn't attempt to re-extract.

Wip:
- [x] need to test locally on all of our materials
- [x] Need to test on AWS with materials to ensure there are no issues with S3
- [x] Need to validate what happens when something like a movie is sent to the process
- [x] I don't think we need to build our own Tika anymore, have to check that.
- [x] Validate what happens to non-file learning materials, probably we need to check on this in a few places
- [x] LM Text is a ton of whitespace, do we want to keep it?