### PR TITLE
add CommandNotFoundException to ignore_exceptions

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -13,6 +13,7 @@ when@prod:
                 - Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
                 - Symfony\Component\ErrorHandler\Error\FatalError
                 - Symfony\Component\Debug\Exception\FatalErrorException
+                - Symfony\Component\Debug\Exception\CommandNotFoundException
 
 #        If you are using Monolog, you also need this additional configuration to log the errors correctly:
 #        https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration


### PR DESCRIPTION
Add CommandNotFoundException to ignore_exceptions list to ignore Sentry alerting error.