### PR TITLE
Replace Modified Doctrine Parameter API

### DIFF
--- a/src/Repository/AuditLogRepository.php
+++ b/src/Repository/AuditLogRepository.php
@@ -45,12 +45,8 @@ class AuditLogRepository extends ServiceEntityRepository implements DTORepositor
                     ':to'
                 )
             )
-            ->setParameters(
-                [
-                    'from' => $from->format('Y-m-d H:i:s'),
-                    'to' => $to->format('Y-m-d H:i:s:'),
-                ]
-            );
+            ->setParameter('from', $from->format('Y-m-d H:i:s'))
+            ->setParameter('to', $to->format('Y-m-d H:i:s'));
 
         $results = $qb->getQuery()->getArrayResult();
         $rhett = [];
@@ -80,12 +76,8 @@ class AuditLogRepository extends ServiceEntityRepository implements DTORepositor
                     ':to'
                 )
             )
-            ->setParameters(
-                [
-                    'from' => $from->format('Y-m-d H:i:s'),
-                    'to' => $to->format('Y-m-d H:i:s:'),
-                ]
-            );
+            ->setParameter('from', $from->format('Y-m-d H:i:s'))
+            ->setParameter('to', $to->format('Y-m-d H:i:s'));
         $qb->getQuery()->execute();
     }
 


### PR DESCRIPTION
The API for setParameters has changed in the latest doctrine and now requires an ArrayCollection and Parameter objects. Seemed easier to just use the same single invocation we use elsewhere so I replaced it.

Also dropped an extra colon at the end of each of the `to` formats. I think this was a typo.

Fixes #5851