### PR TITLE
Test PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.3]
+        php-version: [8.4, 8.3]
 
     steps:
     - uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.3]
+        php-version: [8.4, 8.3]
 
     steps:
     - uses: actions/checkout@v4
@@ -349,7 +349,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.3]
+        php-version: [8.4, 8.3]
 
     steps:
       - uses: actions/checkout@v4
@@ -368,7 +368,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.3]
+        php-version: [8.4, 8.3]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Newly [released](https://www.php.net/releases/8.4/en.php) and ready to officially enter our CI pipeline.