### PR TITLE
Validate Composer Lock File

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         extensions: apcu
     - name: install dependencies
       run: composer install --no-interaction --prefer-dist
+    - name: Check Composer Lock
+      run: composer validate --no-check-all --no-check-version --strict
     - name: lint PHP
       run: vendor/bin/phpcs
     - name: lint twig


### PR DESCRIPTION
Using this composer command we can ensure that the lock file is up to date and working.
- `no-check-all`: remove errors where we use `@stable` for the version 
- `no-check-version`: ignores that we store the version in our composer.json file - this isn't recommended for unpublished packages but it's where we track this critical data.