### PR TITLE
Ignore Major and Minor Symfony Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     time: "02:30"
     timezone: America/Los_Angeles
   open-pull-requests-limit: 10
+  ignore:
+      - dependency-name: "symfony/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
   groups:
     symfony:
       patterns:


### PR DESCRIPTION
This will keep us from getting anything but patch version updates for symfony, we'll have to keep track of the larger version upgrades ourselves. This is necessary to prevent weird partial updates when our extras.symfony.version value in composer isn't updated to match the new symfony version.