### PR TITLE
Add Opensearch Dashboard

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -92,3 +92,10 @@ services:
       target: tika
     ports:
       - "9998:9998"
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:2
+    ports:
+      - 5601:5601
+    environment:
+      - DISABLE_SECURITY_DASHBOARDS_PLUGIN=true
+      - OPENSEARCH_HOSTS=["http://opensearch:9200"]


### PR DESCRIPTION
This is setup for development. It's useful as a way to test queries and explore the index visually. Primarily it's purpose is to create visualizations for data, like log files, that are part of the index. We'll probably never use it for that, but I've found it useful in development.

I've disabled security as this is strictly for development.