### PR TITLE
Pin our BuildX Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        version: v0.19.3
     - name: Build ${{ matrix.image }}
       uses: docker/build-push-action@v6
       with:
@@ -179,37 +181,39 @@ jobs:
         retention-days: 1
 
   build_arm_containers:
-     name: Build Containers (arm64)
-     needs: code_style
-     runs-on: ubuntu-latest
-     strategy:
-       matrix:
-         image:
-          - php-apache
-          - nginx
-          - fpm
-          - fpm-dev
-          - admin
-          - update-frontend
-          - consume-messages
-          - mysql
-          - mysql-demo
-          - opensearch
-          - redis
-          - tika
-     steps:
-     - name: Set up QEMU
-       uses: docker/setup-qemu-action@v3
-       with:
-         image: tonistiigi/binfmt:latest
-         platforms: linux/arm64
-     - name: Set up Docker Buildx
-       uses: docker/setup-buildx-action@v3
-     - name: Build ${{ matrix.image }}
-       uses: docker/build-push-action@v6
-       with:
-         target: ${{ matrix.image }}
-         push: false
+    name: Build Containers (arm64)
+    needs: code_style
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+        - php-apache
+        - nginx
+        - fpm
+        - fpm-dev
+        - admin
+        - update-frontend
+        - consume-messages
+        - mysql
+        - mysql-demo
+        - opensearch
+        - redis
+        - tika
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: linux/arm64
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        version: v0.19.3
+    - name: Build ${{ matrix.image }}
+      uses: docker/build-push-action@v6
+      with:
+        target: ${{ matrix.image }}
+        push: false
 
   run_containers:
     name: Run and Test Containers

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -32,6 +32,8 @@ jobs:
         platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        version: v0.19.3
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -66,6 +66,8 @@ jobs:
         platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        version: v0.19.3
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -33,6 +33,8 @@ jobs:
         platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        version: v0.19.3
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -55,6 +55,8 @@ jobs:
         platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        version: v0.19.3
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:


### PR DESCRIPTION
The v0.20.0 release  doesn't seem stable, it keeps breaking in various ways with a segfault while building different PHP extensions inside our various containers. Attempting a quick solution of controlling the buildx version ourselves while we look for a longer term fix.