### PR TITLE
Fix Deploy and Align Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        image: tonistiigi/binfmt:latest
+        image: tonistiigi/binfmt:qemu-v8.1.5
         platforms: linux/amd64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -207,7 +207,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        image: tonistiigi/binfmt:latest
+        image: tonistiigi/binfmt:qemu-v8.1.5
         platforms: linux/arm64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,11 @@ jobs:
           - redis
           - tika
     steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: linux/amd64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Build ${{ matrix.image }}
@@ -171,6 +176,7 @@ jobs:
         push: false
         outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar,compression=gzip
         tags: ${{ matrix.image }}:testing
+        platforms: linux/amd64
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
@@ -179,37 +185,38 @@ jobs:
         retention-days: 1
 
   build_arm_containers:
-     name: Build Containers (arm64)
-     needs: code_style
-     runs-on: ubuntu-latest
-     strategy:
-       matrix:
-         image:
-          - php-apache
-          - nginx
-          - fpm
-          - fpm-dev
-          - admin
-          - update-frontend
-          - consume-messages
-          - mysql
-          - mysql-demo
-          - opensearch
-          - redis
-          - tika
-     steps:
-     - name: Set up QEMU
-       uses: docker/setup-qemu-action@v3
-       with:
-         image: tonistiigi/binfmt:latest
-         platforms: linux/arm64
-     - name: Set up Docker Buildx
-       uses: docker/setup-buildx-action@v3
-     - name: Build ${{ matrix.image }}
-       uses: docker/build-push-action@v6
-       with:
-         target: ${{ matrix.image }}
-         push: false
+    name: Build Containers (arm64)
+    needs: code_style
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+        - php-apache
+        - nginx
+        - fpm
+        - fpm-dev
+        - admin
+        - update-frontend
+        - consume-messages
+        - mysql
+        - mysql-demo
+        - opensearch
+        - redis
+        - tika
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: linux/arm64
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build ${{ matrix.image }}
+      uses: docker/build-push-action@v6
+      with:
+        target: ${{ matrix.image }}
+        push: false
+        platforms: linux/arm64
 
   run_containers:
     name: Run and Test Containers

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        image: tonistiigi/binfmt:latest
+        image: tonistiigi/binfmt:qemu-v8.1.5
         platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        image: tonistiigi/binfmt:latest
+        image: tonistiigi/binfmt:qemu-v8.1.5
         platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        image: tonistiigi/binfmt:latest
+        image: tonistiigi/binfmt:qemu-v8.1.5
         platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        image: tonistiigi/binfmt:latest
+        image: tonistiigi/binfmt:qemu-v8.1.5
         platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -243,7 +243,7 @@ CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
 ###############################################################################
 # Create our own tika, so we can customize it if needed
 ###############################################################################
-FROM apache/tika as tika
+FROM apache/tika AS tika
 LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
 
 ###############################################################################


### PR DESCRIPTION
Updating the version of our emulators to address an issue with the Linux kernel in the latest GitHub action release preventing QEMU from emulating sporadically that was breaking our ability to build our containers. 

To align tests: Use the same QEMU to build containers in CI as we do in deployment and actually build the arm container with the emulator platform.