### PR TITLE
Use FirstClassCallable Syntax

### DIFF
--- a/src/Controller/API/CurriculumInventorySequenceBlocks.php
+++ b/src/Controller/API/CurriculumInventorySequenceBlocks.php
@@ -458,7 +458,7 @@ class CurriculumInventorySequenceBlocks extends AbstractApiController
 
         switch ($newValue) {
             case CurriculumInventorySequenceBlockInterface::ORDERED:
-                usort($children, [CurriculumInventorySequenceBlock::class, 'compareSequenceBlocksWithDefaultStrategy']);
+                usort($children, CurriculumInventorySequenceBlock::compareSequenceBlocksWithDefaultStrategy(...));
                 for ($i = 0, $n = count($children); $i < $n; $i++) {
                     $children[$i]->setOrderInSequence($i + 1);
                     $this->repository->update($children[$i], false);

--- a/src/Normalizer/DTONormalizer.php
+++ b/src/Normalizer/DTONormalizer.php
@@ -71,7 +71,7 @@ class DTONormalizer implements NormalizerInterface
         }
 
         if ($type === IA\Type::DTOS) {
-            return array_map([$this, 'normalize'], $value);
+            return array_map($this->normalize(...), $value);
         }
 
         return $value;

--- a/src/Service/CurriculumInventory/Export/XmlPrinter.php
+++ b/src/Service/CurriculumInventory/Export/XmlPrinter.php
@@ -328,10 +328,7 @@ class XmlPrinter
         })->toArray();
         usort(
             $topLevelSequenceBlocks,
-            [
-                CurriculumInventorySequenceBlock::class,
-                'compareSequenceBlocksWithDefaultStrategy',
-            ]
+            CurriculumInventorySequenceBlock::compareSequenceBlocksWithDefaultStrategy(...)
         );
         foreach ($topLevelSequenceBlocks as $block) {
             $this->writeSequenceBlockNode(

--- a/src/Service/GraphQL/DTOInfo.php
+++ b/src/Service/GraphQL/DTOInfo.php
@@ -60,7 +60,7 @@ class DTOInfo
     {
         $ref = $this->getRefForType($type);
         $exposedProperties = $this->entityMetadata->extractExposedProperties($ref);
-        $relatedProperties = array_filter($exposedProperties, [$this, 'isRelated']);
+        $relatedProperties = array_filter($exposedProperties, $this->isRelated(...));
         $regularProperties = array_diff($exposedProperties, $relatedProperties);
 
         $graphQlRelated = array_filter($relatedProperties, [$this, 'isGraphQlRelated']);


### PR DESCRIPTION
Instead of creating these closures from an array PHP [now allows this syntax](https://wiki.php.net/rfc/first_class_callable_syntax), which does the same thing with the `...` notation acting to unpack any arguments passed in.

