### PR TITLE
Handle Missing IDs Better

### DIFF
--- a/src/Traits/ManagerRepository.php
+++ b/src/Traits/ManagerRepository.php
@@ -91,7 +91,10 @@ trait ManagerRepository
         }
         $rhett = [];
         foreach ($ids as $id) {
-            $rhett[] = $dtosById[$id];
+            //Protect against request with ids that are not in the DB
+            if (array_key_exists($id, $dtosById)) {
+                $rhett[] = $dtosById[$id];
+            }
         }
 
         return $rhett;

--- a/tests/Endpoints/AamcMethodTest.php
+++ b/tests/Endpoints/AamcMethodTest.php
@@ -48,6 +48,8 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 'AM001']],
             'ids' => [[0, 1], ['id' => ['AM001', 'AM002']]],
+            'missingId' => [[], ['id' => 'nothing']],
+            'missingIds' => [[], ['id' => ['nothing']]],
             'description' => [[1], ['description' => 'filterable description']],
             'sessionTypes' => [[0], ['sessionTypes' => [1]]],
             'active' => [[0], ['active' => true]],
@@ -59,6 +61,7 @@ class AamcMethodTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => ['AM001', 'AM002']]];
+        $filters['missingIds'] = [[], ['ids' => ['nothing']]];
 
         return $filters;
     }

--- a/tests/Endpoints/AamcPcrsTest.php
+++ b/tests/Endpoints/AamcPcrsTest.php
@@ -47,6 +47,9 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
     {
         return [
             'id' => [[0], ['id' => 'aamc-pcrs-comp-c0101']],
+            'ids' => [[0], ['id' => ['aamc-pcrs-comp-c0101']]],
+            'missingId' => [[], ['id' => 'nothing']],
+            'missingIds' => [[], ['id' => ['nothing']]],
             'description' => [[1], ['description' => 'second description']],
             'competencies' => [[0], ['competencies' => [1]]],
         ];
@@ -54,7 +57,11 @@ class AamcPcrsTest extends AbstractReadWriteEndpoint
 
     public static function graphQLFiltersToTest(): array
     {
-        return self::filtersToTest();
+        $filters = self::filtersToTest();
+        $filters['ids'] = [[0], ['ids' => ['aamc-pcrs-comp-c0101']]];
+        $filters['missingIds'] = [[], ['ids' => ['nothing']]];
+
+        return $filters;
     }
 
     public function testPostTermAamcResourceType(): void

--- a/tests/Endpoints/AamcResourceTypeTest.php
+++ b/tests/Endpoints/AamcResourceTypeTest.php
@@ -47,6 +47,9 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
     {
         return [
             'id' => [[2], ['id' => 'RE003']],
+            'ids' => [[2], ['id' => ['RE003']]],
+            'missingId' => [[], ['id' => 'nothing']],
+            'missingIds' => [[], ['id' => ['nothing']]],
             'title' => [[0], ['title' => 'first title']],
             'description' => [[1], ['description' => 'second description']],
             'terms' => [[0], ['terms' => [1]]],
@@ -55,7 +58,10 @@ class AamcResourceTypeTest extends AbstractReadWriteEndpoint
 
     public static function graphQLFiltersToTest(): array
     {
-        return self::filtersToTest();
+        $filters = self::filtersToTest();
+        $filters['ids'] = [[2], ['ids' => ['RE003']]];
+        $filters['missingIds'] = [[], ['ids' => ['nothing']]];
+        return $filters;
     }
 
     public function testPostTermAamcResourceType(): void

--- a/tests/Endpoints/ApplicationConfigTest.php
+++ b/tests/Endpoints/ApplicationConfigTest.php
@@ -48,6 +48,7 @@ class ApplicationConfigTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingIds' => [[], ['id' => [99]]],
             'name' => [[1], ['name' => 'second name']],
             'value' => [[2], ['value' => 'third value']],
         ];

--- a/tests/Endpoints/AssessmentOptionTest.php
+++ b/tests/Endpoints/AssessmentOptionTest.php
@@ -48,6 +48,8 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'name' => [[1], ['name' => 'second option']],
             'sessionTypes' => [[0], ['sessionTypes' => [1]]],
         ];
@@ -57,6 +59,7 @@ class AssessmentOptionTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CohortTest.php
+++ b/tests/Endpoints/CohortTest.php
@@ -58,6 +58,8 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'Class of 2018']],
             'programYear' => [[1], ['programYear' => 2]],
             'courses' => [[2], ['courses' => [4]]],
@@ -72,6 +74,7 @@ class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterfac
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CompetencyTest.php
+++ b/tests/Endpoints/CompetencyTest.php
@@ -67,6 +67,8 @@ class CompetencyTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[2], ['title' => 'third competency']],
             'school' => [[0, 1, 2], ['school' => 1]],
             'schools' => [[0, 1, 2], ['schools' => [1]]],
@@ -89,6 +91,7 @@ class CompetencyTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CourseClerkshipTypeTest.php
+++ b/tests/Endpoints/CourseClerkshipTypeTest.php
@@ -48,6 +48,8 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'second clerkship type']],
             'courses' => [[0], ['courses' => [1]]],
         ];
@@ -57,6 +59,7 @@ class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CourseLearningMaterialTest.php
+++ b/tests/Endpoints/CourseLearningMaterialTest.php
@@ -56,6 +56,8 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'notes' => [[2], ['notes' => 'third note']],
             'notRequired' => [[1], ['required' => false]],
             'required' => [[0, 2, 3, 4, 5, 6, 7, 8, 9], ['required' => true]],
@@ -72,6 +74,7 @@ class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CourseObjectiveTest.php
+++ b/tests/Endpoints/CourseObjectiveTest.php
@@ -67,6 +67,8 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'course' => [[1, 3], ['course' => 2]],
             'courses' => [[1, 3], ['courses' => [2]]],
             'terms' => [[0, 1], ['terms' => [1]]],
@@ -82,6 +84,7 @@ class CourseObjectiveTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
         $filters['ancestor'] = [[1], ['ancestor' => 1]];
 
         return $filters;

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -102,6 +102,8 @@ class CourseTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 2], ['id' => [1, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[0], ['title' => 'firstCourse']],
             'level' => [[3, 4], ['level' => 3]],
             'year' => [[1, 2], ['year' => 2012]],
@@ -141,6 +143,7 @@ class CourseTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/Endpoints/CurriculumInventoryAcademicLevelTest.php
@@ -35,6 +35,8 @@ class CurriculumInventoryAcademicLevelTest extends AbstractReadEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'name' => [[1], ['name' => 'second name']],
             'description' => [[0], ['description' => 'first description']],
             'level' => [[1], ['level' => 2]],
@@ -48,6 +50,7 @@ class CurriculumInventoryAcademicLevelTest extends AbstractReadEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CurriculumInventoryInstitutionTest.php
+++ b/tests/Endpoints/CurriculumInventoryInstitutionTest.php
@@ -51,6 +51,8 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'name' => [[1], ['name' => 'second institution']],
             'aamcCode' => [[1], ['aamcCode' => '14']],
             'addressStreet' => [[1], ['addressStreet' => '221 East']],
@@ -66,6 +68,7 @@ class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/Endpoints/CurriculumInventoryReportTest.php
@@ -68,6 +68,9 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
     {
         return [
             'id' => [[0], ['id' => 1]],
+            'ids' => [[0, 2], ['id' => [1, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'name' => [[1], ['name' => 'second report']],
             'description' => [[2], ['description' => 'third report']],
             'year' => [[1], ['year' => 2015]],
@@ -85,6 +88,7 @@ class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
@@ -63,6 +63,8 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'Nested Sequence Block 1']],
             'description' => [[0], ['description' => 'first description']],
             'required' => [[0], ['required' => CurriculumInventorySequenceBlockInterface::REQUIRED]],
@@ -91,6 +93,7 @@ class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/CurriculumInventorySequenceTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceTest.php
@@ -44,6 +44,8 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'report' => [[1], ['report' => 2]],
             'description' => [[1], ['description' => 'second description']],
         ];
@@ -53,6 +55,7 @@ class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/IlmSessionTest.php
+++ b/tests/Endpoints/IlmSessionTest.php
@@ -51,6 +51,8 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'session' => [[1], ['session' => 6]],
             'sessions' => [[1, 2], ['sessions' => [6, 7]]],
             'hours' => [[1], ['hours' => 21.2]],
@@ -66,6 +68,7 @@ class IlmSessionTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/IngestionExceptionTest.php
+++ b/tests/Endpoints/IngestionExceptionTest.php
@@ -29,6 +29,8 @@ class IngestionExceptionTest extends AbstractReadEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'uid' => [[1], ['uid' => 'second exception']],
             'user' => [[1], ['user' => 2]],
         ];

--- a/tests/Endpoints/InstructorGroupTest.php
+++ b/tests/Endpoints/InstructorGroupTest.php
@@ -62,6 +62,8 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'second instructor group']],
             'school' => [[0, 1, 2], ['school' => 1]],
             'schools' => [[0, 1, 2], ['schools' => [1]]],
@@ -84,6 +86,7 @@ class InstructorGroupTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/LearnerGroupTest.php
+++ b/tests/Endpoints/LearnerGroupTest.php
@@ -66,6 +66,8 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[2], ['title' => 'third learner group']],
             'location' => [[3], ['location' => 'fourth location']],
             'url' => [[0, 3], ['url' => 'https://iliosproject.org']],
@@ -89,6 +91,7 @@ class LearnerGroupTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/LearningMaterialStatusTest.php
+++ b/tests/Endpoints/LearningMaterialStatusTest.php
@@ -29,6 +29,8 @@ class LearningMaterialStatusTest extends AbstractReadEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'Final']],
         ];
     }
@@ -37,6 +39,7 @@ class LearningMaterialStatusTest extends AbstractReadEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -94,6 +94,8 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 2], ['id' => [1, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[2], ['title' => 'thirdlm']],
             'description' => [[0], ['description' => 'desc1']],
             'originalAuthor' => [[0], ['originalAuthor' => 'author1']],
@@ -131,6 +133,7 @@ class LearningMaterialTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
         unset($filters['school']);
 
         return $filters;

--- a/tests/Endpoints/LearningMaterialUserRoleTest.php
+++ b/tests/Endpoints/LearningMaterialUserRoleTest.php
@@ -29,6 +29,8 @@ class LearningMaterialUserRoleTest extends AbstractReadEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'second lm user role']],
         ];
     }
@@ -37,6 +39,7 @@ class LearningMaterialUserRoleTest extends AbstractReadEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/MeshConceptTest.php
+++ b/tests/Endpoints/MeshConceptTest.php
@@ -29,6 +29,8 @@ class MeshConceptTest extends AbstractMeshEndpoint
         return [
             'id' => [[0], ['id' => '1']],
             'ids' => [[0, 1], ['id' => ['1', '2']]],
+            'missingId' => [[], ['id' => '99']],
+            'missingIds' => [[], ['id' => ['99']]],
             'name' => [[1], ['name' => 'second concept']],
             'preferred' => [[0], ['preferred' => true]],
             'notPreferred' => [[1], ['preferred' => false]],
@@ -44,6 +46,7 @@ class MeshConceptTest extends AbstractMeshEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => ['1', '2']]];
+        $filters['missingIds'] = [[], ['ids' => ['99']]];
 
         return $filters;
     }

--- a/tests/Endpoints/MeshDescriptorTest.php
+++ b/tests/Endpoints/MeshDescriptorTest.php
@@ -54,6 +54,8 @@ class MeshDescriptorTest extends AbstractMeshEndpoint
         return [
             'id' => [[0], ['id' => 'abc1']],
             'ids' => [[1, 2], ['id' => ['abc2', 'abc3']]],
+            'missingId' => [[], ['id' => 'nothing']],
+            'missingIds' => [[], ['id' => ['nothing']]],
             'name' => [[2], ['name' => 'desc3']],
             'annotation' => [[0], ['annotation' => 'annotation1']],
             'courses' => [[0, 1], ['courses' => [2, 3]]],
@@ -77,6 +79,7 @@ class MeshDescriptorTest extends AbstractMeshEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => ['abc2', 'abc3']]];
+        $filters['missingIds'] = [[], ['ids' => ['nothing']]];
         unset($filters['school']);
 
         return $filters;

--- a/tests/Endpoints/MeshPreviousIndexingTest.php
+++ b/tests/Endpoints/MeshPreviousIndexingTest.php
@@ -35,6 +35,8 @@ class MeshPreviousIndexingTest extends AbstractMeshEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'descriptor' => [[1], ['descriptor' => 'abc2']],
             'previousIndexing' => [[1], ['previousIndexing' => 'second previous indexing']],
         ];
@@ -44,6 +46,7 @@ class MeshPreviousIndexingTest extends AbstractMeshEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/MeshQualifierTest.php
+++ b/tests/Endpoints/MeshQualifierTest.php
@@ -27,6 +27,8 @@ class MeshQualifierTest extends AbstractMeshEndpoint
         return [
             'id' => [[0], ['id' => '1']],
             'ids' => [[0, 1], ['id' => ['1', '2']]],
+            'missingId' => [[], ['id' => '99']],
+            'missingIds' => [[], ['id' => ['99']]],
             'name' => [[1], ['name' => 'second qualifier']],
             'descriptors' => [[0, 1], ['descriptors' => ['abc1']]],
         ];
@@ -36,6 +38,7 @@ class MeshQualifierTest extends AbstractMeshEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => ['1', '2']]];
+        $filters['missingIds'] = [[], ['ids' => ['99']]];
 
         return $filters;
     }

--- a/tests/Endpoints/MeshTermTest.php
+++ b/tests/Endpoints/MeshTermTest.php
@@ -29,6 +29,8 @@ class MeshTermTest extends AbstractMeshEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'meshTermUid' => [[1], ['meshTermUid' => 'uid2']],
             'name' => [[1], ['name' => 'second term']],
             'lexicalTag' => [[0], ['lexicalTag' => 'first tag']],
@@ -46,6 +48,7 @@ class MeshTermTest extends AbstractMeshEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/MeshTreeTest.php
+++ b/tests/Endpoints/MeshTreeTest.php
@@ -27,6 +27,8 @@ class MeshTreeTest extends AbstractMeshEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'treeNumber' => [[1], ['treeNumber' => 'tree2']],
             'descriptor' => [[0, 1], ['descriptor' => 'abc1']],
         ];
@@ -36,6 +38,7 @@ class MeshTreeTest extends AbstractMeshEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/OfferingTest.php
+++ b/tests/Endpoints/OfferingTest.php
@@ -99,6 +99,8 @@ class OfferingTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[3, 4], ['id' => [4, 5]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'room' => [[2], ['room' => 'room 3']],
             'site' => [[3], ['site' => 'site 4']],
             'url' => [[4], ['url' => 'https://example.com']],
@@ -117,6 +119,7 @@ class OfferingTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[3, 4], ['ids' => [4, 5]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/PendingUserUpdateTest.php
+++ b/tests/Endpoints/PendingUserUpdateTest.php
@@ -49,6 +49,8 @@ class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointI
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'type' => [[1], ['type' => 'second type']],
             'property' => [[0], ['property' => 'first property']],
             'value' => [[1], ['value' => 'second value']],

--- a/tests/Endpoints/ProgramTest.php
+++ b/tests/Endpoints/ProgramTest.php
@@ -59,6 +59,8 @@ class ProgramTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 2], ['id' => [1, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'second program']],
             'shortTitle' => [[0], ['shortTitle' => 'fp']],
             'duration' => [[1, 2], ['duration' => 4]],
@@ -78,6 +80,7 @@ class ProgramTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/ProgramYearObjectiveTest.php
+++ b/tests/Endpoints/ProgramYearObjectiveTest.php
@@ -68,6 +68,8 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'programYear' => [[0], ['programYear' => 1]],
             'terms' => [[0, 1], ['terms' => [2]]],
             'position' => [[0, 1], ['position' => 0]],
@@ -83,6 +85,7 @@ class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/ProgramYearTest.php
+++ b/tests/Endpoints/ProgramYearTest.php
@@ -72,6 +72,8 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'locked' => [[3], ['locked' => true]],
             'notLocked' => [[0, 1, 2, 4], ['locked' => false]],
             'archived' => [[2], ['archived' => true]],
@@ -93,6 +95,7 @@ class ProgramYearTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
         $filters['startYear'] = [[1], ['startYear' => 2014]];
 
         return $filters;

--- a/tests/Endpoints/ReportTest.php
+++ b/tests/Endpoints/ReportTest.php
@@ -54,6 +54,8 @@ class ReportTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'second report']],
             'school' => [[2], ['school' => 1]],
             'subject' => [[2], ['subject' => 'subject3']],
@@ -68,6 +70,7 @@ class ReportTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
         unset($filters['prepositionalObjectTableRowId']);
 
         return $filters;

--- a/tests/Endpoints/SchoolConfigTest.php
+++ b/tests/Endpoints/SchoolConfigTest.php
@@ -46,6 +46,8 @@ class SchoolConfigTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'name' => [[1], ['name' => 'second config']],
             'value' => [[2], ['value' => 'third value']],
             'school' => [[2], ['school' => 2]],

--- a/tests/Endpoints/SchoolTest.php
+++ b/tests/Endpoints/SchoolTest.php
@@ -72,6 +72,8 @@ class SchoolTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[2], ['title' => 'third school']],
             'iliosAdministratorEmail' => [[1], ['iliosAdministratorEmail' => 'info@example.com']],
             'changeAlertRecipients' => [[2], ['changeAlertRecipients' => 'info@example.com']],
@@ -92,6 +94,7 @@ class SchoolTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/SessionLearningMaterialTest.php
+++ b/tests/Endpoints/SessionLearningMaterialTest.php
@@ -62,6 +62,8 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'notes' => [[1], ['notes' => 'second slm']],
             'required' => [[0, 8], ['required' => true]],
             'notRequired' => [[1, 2, 3, 4, 5, 6, 7], ['required' => false]],
@@ -80,6 +82,7 @@ class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/SessionObjectiveTest.php
+++ b/tests/Endpoints/SessionObjectiveTest.php
@@ -66,6 +66,8 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'session' => [[1, 2], ['session' => 4]],
             'sessions' => [[1, 2], ['sessions' => [4]]],
             'terms' => [[0, 1], ['terms' => [3]]],
@@ -84,6 +86,7 @@ class SessionObjectiveTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/SessionTest.php
+++ b/tests/Endpoints/SessionTest.php
@@ -110,6 +110,8 @@ class SessionTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 2], ['id' => [1, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[0], ['title' => 'session1Title']],
             'attireRequired' => [[1], ['attireRequired' => true]],
             'equipmentRequired' => [[1], ['equipmentRequired' => true]],
@@ -147,6 +149,7 @@ class SessionTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
         $filters['multipleCourse'] = [[0, 1, 3], ['courses' => [1, 4]]];
         $filters['multipleSessionTypes'] = [[1, 2, 3], ['sessionTypes' => [2]]];
 

--- a/tests/Endpoints/SessionTypeTest.php
+++ b/tests/Endpoints/SessionTypeTest.php
@@ -85,6 +85,8 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'second session type']],
             'assessmentOption' => [[1], ['assessmentOption' => 2]],
             'school' => [[0, 1], ['school' => 1]],
@@ -113,6 +115,7 @@ class SessionTypeTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
         $filters['schools'] = [[0, 1], ['schools' => [1]]];
 
         return $filters;

--- a/tests/Endpoints/TermTest.php
+++ b/tests/Endpoints/TermTest.php
@@ -81,6 +81,8 @@ class TermTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'second term']],
             'courses' => [[0, 1, 3, 4], ['courses' => [1]]],
             'description' => [[2], ['description' => 'third description']],
@@ -112,6 +114,7 @@ class TermTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/UserRoleTest.php
+++ b/tests/Endpoints/UserRoleTest.php
@@ -30,6 +30,8 @@ class UserRoleTest extends AbstractReadEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'Something Else']],
         ];
     }

--- a/tests/Endpoints/UserSessionMaterialStatusTest.php
+++ b/tests/Endpoints/UserSessionMaterialStatusTest.php
@@ -50,6 +50,8 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 2], ['id' => [1, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'status' => [[0], ['status' => UserSessionMaterialStatusInterface::NONE]],
             'statuses' => [[0, 1], ['status' => [
                 UserSessionMaterialStatusInterface::NONE,
@@ -66,6 +68,7 @@ class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 2], ['ids' => [1, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
         $filters['materials'] = [[0, 2], ['materials' => [1, 5]]];
         $filters['users'] = [[0, 1, 2], ['users' => [2]]];
         $filters['statuses'] = [[0, 1], ['statuses' => [

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -117,6 +117,8 @@ class UserTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[1, 2], ['id' => [2, 3]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'lastName' => [[1], ['lastName' => 'first']],
             'firstName' => [[2], ['firstName' => 'second']],
             'middleName' => [[1], ['middleName' => 'first']],
@@ -175,6 +177,7 @@ class UserTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[1, 2], ['ids' => [2, 3]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }

--- a/tests/Endpoints/VocabularyTest.php
+++ b/tests/Endpoints/VocabularyTest.php
@@ -47,6 +47,8 @@ class VocabularyTest extends AbstractReadWriteEndpoint
         return [
             'id' => [[0], ['id' => 1]],
             'ids' => [[0, 1], ['id' => [1, 2]]],
+            'missingId' => [[], ['id' => 99]],
+            'missingIds' => [[], ['id' => [99]]],
             'title' => [[1], ['title' => 'second vocabulary']],
             'school' => [[1], ['school' => 2]],
             'terms' => [[1], ['terms' => [5]]],
@@ -59,6 +61,7 @@ class VocabularyTest extends AbstractReadWriteEndpoint
     {
         $filters = self::filtersToTest();
         $filters['ids'] = [[0, 1], ['ids' => [1, 2]]];
+        $filters['missingIds'] = [[], ['ids' => [99]]];
 
         return $filters;
     }


### PR DESCRIPTION
For performance we don't do a database query on ids when that is they are passed as the filter, however if they don't exist we don't have them to load.

Adding tests for each endpoint and the two lines of code to fix.