### PR TITLE
Add Test for Deeper Course Mesh Filter

### DIFF
--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -124,6 +124,7 @@ class CourseTest extends AbstractReadWriteEndpoint
             // 'cohorts' => [[2], ['cohorts' => [2]]], // skipped
             'terms' => [[0, 1], ['terms' => [1]]],
             'meshDescriptors' => [[0, 1, 3], ['meshDescriptors' => ['abc1', 'abc2']]],
+            'deepMeshDescriptors' => [[3], ['meshDescriptors' => ['abc3']]],
             'learningMaterials' => [[0, 1, 3], ['learningMaterials' => [1, 3]]],
             'sessions' => [[1], ['sessions' => [3]]],
             'ancestor' => [[3], ['ancestor' => 3]],


### PR DESCRIPTION
This finds likes from the session and course objectives, which is part of the filter.

Added this while working on #4540 and it's nice, so let's keep it.