### PR TITLE
Index Improvements

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -3,18 +3,18 @@ framework:
     failure_transport: failed
     transports:
       # https://symfony.com/doc/current/messenger.html#transport-configuration
-      search:
+      async:
         dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
         options:
-          queue_name: search
+          queue_name: async
       failed: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=failed'
 
     routing:
-      # Route your messages to the transports
-       'App\Message\CourseIndexRequest': search
-       'App\Message\UserIndexRequest': search
-       'App\Message\MeshDescriptorIndexRequest': search
-       'App\Message\LearningMaterialIndexRequest': search
+       # Route your messages to the transports
+       'App\Message\CourseIndexRequest': async
+       'App\Message\UserIndexRequest': async
+       'App\Message\MeshDescriptorIndexRequest': async
+       'App\Message\LearningMaterialIndexRequest': async
        'App\Message\LearningMaterialTextExtractionRequest': async
        'App\Message\CourseDeleteRequest': async
        'App\Message\SessionDeleteRequest': async
@@ -45,5 +45,5 @@ when@test:
            transports:
                # replace with your transport name here (e.g., my_transport: 'in-memory://')
                # For more Messenger testing tools, see https://github.com/zenstruck/messenger-test
-               search: 'in-memory://'
+               async: 'in-memory://'
                failed: 'in-memory://'

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -3,10 +3,7 @@ framework:
     failure_transport: failed
     transports:
       # https://symfony.com/doc/current/messenger.html#transport-configuration
-      async:
-        dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
-        options:
-          queue_name: async
+      async: '%env(MESSENGER_TRANSPORT_DSN)%'
       failed: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=failed'
 
     routing:

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -3,15 +3,18 @@ framework:
     failure_transport: failed
     transports:
       # https://symfony.com/doc/current/messenger.html#transport-configuration
-       async: '%env(MESSENGER_TRANSPORT_DSN)%'
-       failed: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=failed'
+      search:
+        dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+        options:
+          queue_name: search
+      failed: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=failed'
 
     routing:
       # Route your messages to the transports
-       'App\Message\CourseIndexRequest': async
-       'App\Message\UserIndexRequest': async
-       'App\Message\MeshDescriptorIndexRequest': async
-       'App\Message\LearningMaterialIndexRequest': async
+       'App\Message\CourseIndexRequest': search
+       'App\Message\UserIndexRequest': search
+       'App\Message\MeshDescriptorIndexRequest': search
+       'App\Message\LearningMaterialIndexRequest': search
        'App\Message\LearningMaterialTextExtractionRequest': async
        'App\Message\CourseDeleteRequest': async
        'App\Message\SessionDeleteRequest': async
@@ -42,5 +45,5 @@ when@test:
            transports:
                # replace with your transport name here (e.g., my_transport: 'in-memory://')
                # For more Messenger testing tools, see https://github.com/zenstruck/messenger-test
-               async: 'in-memory://'
+               search: 'in-memory://'
                failed: 'in-memory://'

--- a/config/packages/test/messenger.yaml
+++ b/config/packages/test/messenger.yaml
@@ -1,0 +1,4 @@
+framework:
+  messenger:
+    transports:
+      search: 'in-memory:///'

--- a/config/packages/test/messenger.yaml
+++ b/config/packages/test/messenger.yaml
@@ -1,4 +1,4 @@
 framework:
   messenger:
     transports:
-      search: 'in-memory:///'
+      async: 'in-memory:///'

--- a/config/packages/test/messenger.yaml
+++ b/config/packages/test/messenger.yaml
@@ -1,4 +1,0 @@
-framework:
-  messenger:
-    transports:
-      async: 'in-memory:///'

--- a/src/Classes/OpenSearchBase.php
+++ b/src/Classes/OpenSearchBase.php
@@ -99,10 +99,10 @@ class OpenSearchBase
      * front of every item. This allows bulk indexing on many types at the same time, and
      * this convenience method takes care of that for us.
      */
-    protected function doBulkIndex(string $index, array $items): array
+    protected function doBulkIndex(string $index, array $items): bool
     {
         if (!$this->enabled || empty($items)) {
-            return ['errors' => false];
+            return true;
         }
 
         $totalItems = count($items);

--- a/src/Classes/OpenSearchBase.php
+++ b/src/Classes/OpenSearchBase.php
@@ -167,6 +167,20 @@ class OpenSearchBase
             sleep(10);
         }
 
-        return $results;
+        if ($results['errors']) {
+            $errors = array_map(function (array $item) {
+                if (array_key_exists('error', $item['index'])) {
+                    return $item['index']['error']['reason'];
+                }
+
+                return null;
+            }, $results['items']);
+            $clean = array_filter($errors);
+            $str = join(';', array_unique($clean));
+            $count = count($clean);
+            throw new Exception("Failed to bulk index {$index} {$count} errors. Error text: {$str}");
+        }
+
+        return true;
     }
 }

--- a/src/Command/Index/DropCommand.php
+++ b/src/Command/Index/DropCommand.php
@@ -61,7 +61,7 @@ class DropCommand extends Command
 
     protected function clearIndexQueue(OutputInterface $output)
     {
-        $sql = 'DELETE FROM messenger_messages WHERE queue_name="search"';
+        $sql = 'DELETE FROM messenger_messages WHERE queue_name="default"';
         $conn = $this->entityManager->getConnection();
         $removed = $conn->executeStatement($sql);
 

--- a/src/Command/Index/DropCommand.php
+++ b/src/Command/Index/DropCommand.php
@@ -65,6 +65,6 @@ class DropCommand extends Command
         $conn = $this->entityManager->getConnection();
         $removed = $conn->executeStatement($sql);
 
-        $output->writeln("<info>Cleared ${removed} existing index messages from queue.</info>");
+        $output->writeln("<info>Cleared {$removed} existing index messages from queue.</info>");
     }
 }

--- a/src/Command/Index/DropCommand.php
+++ b/src/Command/Index/DropCommand.php
@@ -59,7 +59,7 @@ class DropCommand extends Command
         return Command::SUCCESS;
     }
 
-    protected function clearIndexQueue(OutputInterface $output)
+    protected function clearIndexQueue(OutputInterface $output): void
     {
         $sql = 'DELETE FROM messenger_messages WHERE queue_name="default"';
         $conn = $this->entityManager->getConnection();

--- a/src/Command/Index/UpdateCommand.php
+++ b/src/Command/Index/UpdateCommand.php
@@ -12,8 +12,6 @@ use App\Repository\CourseRepository;
 use App\Repository\LearningMaterialRepository;
 use App\Repository\MeshDescriptorRepository;
 use App\Repository\UserRepository;
-use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -34,14 +32,12 @@ class UpdateCommand extends Command
         protected MeshDescriptorRepository $descriptorRepository,
         protected LearningMaterialRepository $learningMaterialRepository,
         protected MessageBusInterface $bus,
-        protected EntityManagerInterface $entityManager,
     ) {
         parent::__construct();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->clearIndexQueue($output);
         $this->queueUsers($output);
         //temporarily disable LM indexing for performance reasons.
 //        $this->queueLearningMaterials($output);
@@ -49,15 +45,6 @@ class UpdateCommand extends Command
         $this->queueMesh($output);
 
         return Command::SUCCESS;
-    }
-
-    protected function clearIndexQueue(OutputInterface $output): void
-    {
-        $sql = 'DELETE FROM messenger_messages WHERE queue_name="search"';
-        $conn = $this->entityManager->getConnection();
-        $removed = $conn->executeStatement($sql);
-
-        $output->writeln("<info>Cleared ${removed} Existing search requests from queue.</info>");
     }
 
     protected function queueUsers(OutputInterface $output): void

--- a/src/Command/Index/UpdateCommand.php
+++ b/src/Command/Index/UpdateCommand.php
@@ -12,6 +12,7 @@ use App\Repository\CourseRepository;
 use App\Repository\LearningMaterialRepository;
 use App\Repository\MeshDescriptorRepository;
 use App\Repository\UserRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Message/CourseIndexRequest.php
+++ b/src/Message/CourseIndexRequest.php
@@ -11,7 +11,7 @@ class CourseIndexRequest
 {
     private array $courseIds;
     private DateTime $createdAt;
-    public const int MAX_COURSES = 50;
+    public const int MAX_COURSES = 500;
 
     /**
      * CourseIndexRequest constructor.

--- a/src/Message/CourseIndexRequest.php
+++ b/src/Message/CourseIndexRequest.php
@@ -11,7 +11,7 @@ class CourseIndexRequest
 {
     private array $courseIds;
     private DateTime $createdAt;
-    public const int MAX_COURSES = 500;
+    public const int MAX_COURSES = 100;
 
     /**
      * CourseIndexRequest constructor.

--- a/src/Message/UserIndexRequest.php
+++ b/src/Message/UserIndexRequest.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
 class UserIndexRequest
 {
     private array $userIds;
-    public const int MAX_USERS = 250;
+    public const int MAX_USERS = 500;
 
     /**
      * @param int[] $userIds

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -343,7 +343,7 @@ class Curriculum extends OpenSearchBase
                 'query' => $query,
                 '_name' => $field,
             ] ] ];
-        }, $mustFields);
+        }, $shouldFields);
 
         return [
             'bool' => [

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -85,6 +85,9 @@ class Curriculum extends OpenSearchBase
                 );
             }
         }
+        if (!$this->enabled) {
+            throw new Exception("Search is not configured, isEnabled() should be called before calling this method");
+        }
         $courseIds = array_map(function (IndexableCourse $idx) {
             return $idx->courseDTO->id;
         }, $courses);

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -101,23 +101,7 @@ class Curriculum extends OpenSearchBase
             return array_merge($carry, $sessionsWithMaterials);
         }, []);
 
-        $result = $this->doBulkIndex(self::INDEX, $input);
-
-        if ($result['errors']) {
-            $errors = array_map(function (array $item) {
-                if (array_key_exists('error', $item['index'])) {
-                    return $item['index']['error']['reason'];
-                }
-
-                return null;
-            }, $result['items']);
-            $clean = array_filter($errors);
-            $str = join(';', array_unique($clean));
-            $count = count($clean);
-            throw new Exception("Failed to index all courses {$count} errors. Error text: {$str}");
-        }
-
-        return true;
+        return $this->doBulkIndex(self::INDEX, $input);
     }
 
     protected function findSkippableCourseIds(array $ids, DateTime $stamp): array
@@ -547,7 +531,7 @@ class Curriculum extends OpenSearchBase
                     ],
                     'sessionMeshDescriptorNames' => $txtTypeFieldWithCompletion,
                     'sessionMeshDescriptorAnnotations' => $txtTypeField,
-                    'ingestedTime' => [
+                    'ingestTime' => [
                         'type' => 'date',
                         'format' => 'date_optional_time||basic_date_time_no_millis||epoch_second||epoch_millis',
                     ],

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -298,7 +298,7 @@ class Curriculum extends OpenSearchBase
             $mustFields,
             function (array $carry, string $field) use ($query) {
                 $matches = array_map(function (string $type) use ($field, $query) {
-                    $fullField = "${field}.${type}";
+                    $fullField = "{$field}.{$type}";
                     return [ 'match_phrase_prefix' => [ $fullField => ['query' => $query, '_name' => $fullField] ] ];
                 }, ['english', 'french', 'spanish']);
 
@@ -323,7 +323,7 @@ class Curriculum extends OpenSearchBase
          * than a partial match on movement
          */
         $should = array_map(function ($field) use ($query) {
-            return [ 'match' => [ "${field}.raw" => [
+            return [ 'match' => [ "{$field}" => [
                 'query' => $query,
                 '_name' => $field,
             ] ] ];

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -297,10 +297,7 @@ class Curriculum extends OpenSearchBase
             'sessionLearningMaterialAttachments',
         ];
 
-        $mustMatch = array_map(fn($field) => [ 'match_phrase_prefix' => [ $field => [
-            'query' => $query,
-            '_name' => $field,
-        ] ] ], $mustFields);
+        $mustMatch = [];
 
         /**
          * Keyword index types cannot user the match_phrase_prefix query
@@ -312,6 +309,20 @@ class Curriculum extends OpenSearchBase
                 '_name' => $field,
             ] ] ];
         }
+
+        $mustMatch = array_reduce(
+            $mustFields,
+            function (array $carry, string $field) use ($query) {
+                $matches = array_map(function (string $type) use ($field, $query) {
+                    $fullField = "${field}.${type}";
+                    return [ 'match_phrase_prefix' => [ $fullField => ['query' => $query, '_name' => $fullField] ] ];
+                }, ['english', 'french', 'spanish']);
+
+                return array_merge($carry, $matches);
+            },
+            $mustMatch
+        );
+
 
         /**
          * At least one of the mustMatch queries has to be a match
@@ -327,18 +338,12 @@ class Curriculum extends OpenSearchBase
          * users enter a complete word like move it will score higher than
          * than a partial match on movement
          */
-        $should = array_reduce(
-            $shouldFields,
-            function (array $carry, string $field) use ($query) {
-                $matches = array_map(function (string $type) use ($field, $query) {
-                    $fullField = "{$field}.{$type}";
-                    return [ 'match' => [ $fullField => ['query' => $query, '_name' => $fullField] ] ];
-                }, ['english', 'raw']);
-
-                return array_merge($carry, $matches);
-            },
-            []
-        );
+        $should = array_map(function ($field) use ($query) {
+            return [ 'match' => [ "${field}.raw" => [
+                'query' => $query,
+                '_name' => $field,
+            ] ] ];
+        }, $mustFields);
 
         return [
             'bool' => [
@@ -447,6 +452,14 @@ class Curriculum extends OpenSearchBase
                 'english' => [
                     'type' => 'text',
                     'analyzer' => 'english',
+                ],
+                'french' => [
+                    'type' => 'text',
+                    'analyzer' => 'french',
+                ],
+                'spanish' => [
+                    'type' => 'text',
+                    'analyzer' => 'spanish',
                 ],
                 'raw' => [
                     'type' => 'text',

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -459,8 +459,8 @@ class Curriculum extends OpenSearchBase
 
         return [
             'settings' => [
-                'number_of_shards' => 2,
-                'number_of_replicas' => 0,
+                'number_of_shards' => 1,
+                'number_of_replicas' => 1,
                 'default_pipeline' => 'curriculum',
             ],
             'mappings' => [

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -472,7 +472,7 @@ class Curriculum extends OpenSearchBase
             'settings' => [
                 'analysis' => self::getAnalyzers(),
                 'max_ngram_diff' =>  15,
-                'number_of_shards' => 1,
+                'number_of_shards' => 2,
                 'number_of_replicas' => 0,
                 'default_pipeline' => 'curriculum',
             ],

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -114,7 +114,7 @@ class LearningMaterials extends OpenSearchBase
     {
         return [
             'settings' => [
-                'number_of_shards' => 1,
+                'number_of_shards' => 5,
                 'number_of_replicas' => 0,
             ],
             'mappings' => [

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -9,9 +9,6 @@ use App\Entity\DTO\LearningMaterialDTO;
 use App\Service\Config;
 use App\Service\NonCachingIliosFileSystem;
 use OpenSearch\Client;
-use setasign\Fpdi\Fpdi;
-use setasign\Fpdi\FpdiException;
-use setasign\Fpdi\PdfParser\StreamReader;
 use InvalidArgumentException;
 use SplFileInfo;
 
@@ -144,6 +141,9 @@ class LearningMaterials extends OpenSearchBase
                         'attachment' => [
                             'field' => 'data',
                             'target_field' => 'material',
+                        ],
+                        'remove' => [
+                            'field' => 'data',
                         ],
                     ],
                 ],

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -111,8 +111,8 @@ class LearningMaterials extends OpenSearchBase
     {
         return [
             'settings' => [
-                'number_of_shards' => 5,
-                'number_of_replicas' => 0,
+                'number_of_shards' => 1,
+                'number_of_replicas' => 1,
             ],
             'mappings' => [
                 '_meta' => [

--- a/src/Service/Index/Manager.php
+++ b/src/Service/Index/Manager.php
@@ -45,6 +45,7 @@ class Manager extends OpenSearchBase
             'body' => Curriculum::getMapping(),
         ]);
 
+        $this->client->ingest()->putPipeline(Users::getPipeline());
         $this->client->ingest()->putPipeline(Curriculum::getPipeline());
         $this->client->ingest()->putPipeline(LearningMaterials::getPipeline());
         $this->client->indices()->create([

--- a/src/Service/Index/Mesh.php
+++ b/src/Service/Index/Mesh.php
@@ -93,7 +93,7 @@ class Mesh extends OpenSearchBase
         return [
             'settings' => [
                 'number_of_shards' => 1,
-                'number_of_replicas' => 0,
+                'number_of_replicas' => 1,
             ],
             'mappings' => [
                 '_meta' => [

--- a/src/Service/Index/Mesh.php
+++ b/src/Service/Index/Mesh.php
@@ -104,16 +104,16 @@ class Mesh extends OpenSearchBase
                     'annotation' => $txtTypeField,
                     'previousIndexing' => $txtTypeField,
                     'terms' => [
-                        'type' => 'keyword'
+                        'type' => 'keyword',
                     ],
                     'concepts' => [
-                        'type' => 'keyword'
+                        'type' => 'keyword',
                     ],
                     'scopeNotes' => $txtTypeField,
                     'casn1Names' => [
-                        'type' => 'keyword'
+                        'type' => 'keyword',
                     ],
-                ]
+                ],
             ],
         ];
     }

--- a/src/Service/Index/Mesh.php
+++ b/src/Service/Index/Mesh.php
@@ -79,13 +79,17 @@ class Mesh extends OpenSearchBase
             ];
         }, $descriptors);
 
-        $result = $this->doBulkIndex(self::INDEX, $input);
-        return !$result['errors'];
+        return $this->doBulkIndex(self::INDEX, $input);
     }
 
 
     public static function getMapping(): array
     {
+        $txtTypeField = [
+            'type' => 'text',
+            'analyzer' => 'english',
+        ];
+
         return [
             'settings' => [
                 'number_of_shards' => 1,
@@ -95,6 +99,21 @@ class Mesh extends OpenSearchBase
                 '_meta' => [
                     'version' => '1',
                 ],
+                'properties' => [
+                    'name' => $txtTypeField,
+                    'annotation' => $txtTypeField,
+                    'previousIndexing' => $txtTypeField,
+                    'terms' => [
+                        'type' => 'keyword'
+                    ],
+                    'concepts' => [
+                        'type' => 'keyword'
+                    ],
+                    'scopeNotes' => $txtTypeField,
+                    'casn1Names' => [
+                        'type' => 'keyword'
+                    ],
+                ]
             ],
         ];
     }

--- a/src/Service/Index/Users.php
+++ b/src/Service/Index/Users.php
@@ -6,6 +6,7 @@ namespace App\Service\Index;
 
 use App\Classes\OpenSearchBase;
 use App\Entity\DTO\UserDTO;
+use DateTime;
 use InvalidArgumentException;
 use Exception;
 
@@ -40,9 +41,7 @@ class Users extends OpenSearchBase
             'fullNameLastFirst' => $user->lastName . ', ' . $user->firstName . ' ' . $user->middleName,
         ], $users);
 
-        $result = $this->doBulkIndex(self::INDEX, $input);
-
-        return !$result['errors'];
+        return $this->doBulkIndex(self::INDEX, $input);
     }
 
     public function delete(int $id): bool
@@ -148,6 +147,7 @@ class Users extends OpenSearchBase
         return [
             'settings' => [
                 'analysis' => self::getAnalyzers(),
+                'default_pipeline' => 'users',
                 'max_ngram_diff' =>  15,
                 'number_of_shards' => 1,
                 'number_of_replicas' => 0,
@@ -247,6 +247,10 @@ class Users extends OpenSearchBase
                     'enabled' => [
                         'type' => 'boolean',
                     ],
+                    'ingestTime' => [
+                        'type' => 'date',
+                        'format' => 'date_optional_time||basic_date_time_no_millis||epoch_second||epoch_millis',
+                    ],
                 ],
             ],
         ];
@@ -279,6 +283,24 @@ class Users extends OpenSearchBase
                     'token_chars' => [
                         'letter',
                         'digit',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public static function getPipeline(): array
+    {
+        return [
+            'id' => 'users',
+            'body' => [
+                'description' => 'Set Ingest Time',
+                'processors' => [
+                    [
+                        'set' => [
+                            'field' => '_source.ingestTime',
+                            'value' => '{{_ingest.timestamp}}',
+                        ],
                     ],
                 ],
             ],

--- a/src/Service/Index/Users.php
+++ b/src/Service/Index/Users.php
@@ -150,7 +150,7 @@ class Users extends OpenSearchBase
                 'default_pipeline' => 'users',
                 'max_ngram_diff' =>  15,
                 'number_of_shards' => 1,
-                'number_of_replicas' => 0,
+                'number_of_replicas' => 1,
             ],
             'mappings' => [
                 '_meta' => [

--- a/tests/Command/Index/DropCommandTest.php
+++ b/tests/Command/Index/DropCommandTest.php
@@ -7,6 +7,8 @@ namespace App\Tests\Command\Index;
 use PHPUnit\Framework\Attributes\Group;
 use App\Command\Index\DropCommand;
 use App\Service\Index\Manager;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -20,13 +22,15 @@ class DropCommandTest extends KernelTestCase
 
     protected CommandTester $commandTester;
     protected m\MockInterface $indexManager;
+    protected m\MockInterface $entityManager;
 
     public function setUp(): void
     {
         parent::setUp();
         $this->indexManager = m::mock(Manager::class);
+        $this->entityManager = m::mock(EntityManagerInterface::class);
 
-        $command = new DropCommand($this->indexManager);
+        $command = new DropCommand($this->indexManager, $this->entityManager);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
@@ -41,6 +45,7 @@ class DropCommandTest extends KernelTestCase
     {
         parent::tearDown();
         unset($this->indexManager);
+        unset($this->entityManager);
         unset($this->commandTester);
     }
 
@@ -58,6 +63,11 @@ class DropCommandTest extends KernelTestCase
     public function testDropsWithForce(): void
     {
         $this->indexManager->shouldReceive('drop')->once();
+        $connection = m::mock(Connection::class);
+        $connection
+            ->shouldReceive('executeStatement')
+            ->with('DELETE FROM messenger_messages WHERE queue_name="default"');
+        $this->entityManager->shouldReceive('getConnection')->andReturn($connection);
 
         $this->commandTester->execute([
             '--force' => true,

--- a/tests/EventListener/IndexEntityChangesTest.php
+++ b/tests/EventListener/IndexEntityChangesTest.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\UnitOfWork;
 use Mockery as m;
 use stdClass;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -33,6 +34,8 @@ class IndexEntityChangesTest extends TestCase
 
     protected m\MockInterface $bus;
 
+    protected m\MockInterface $logger;
+
     protected IndexEntityChanges $indexEntityChanges;
 
     protected function setUp(): void
@@ -42,12 +45,14 @@ class IndexEntityChangesTest extends TestCase
         $this->meshIndex = m::mock(Mesh::class);
         $this->usersIndex = m::mock(Users::class);
         $this->bus = m::mock(MessageBusInterface::class);
+        $this->logger = m::mock(LoggerInterface::class);
         $this->indexEntityChanges = new IndexEntityChanges(
             $this->curriculumIndex,
             $this->learningMaterialIndex,
             $this->meshIndex,
             $this->usersIndex,
-            $this->bus
+            $this->bus,
+            $this->logger
         );
     }
 
@@ -111,7 +116,7 @@ class IndexEntityChangesTest extends TestCase
             ->withArgs(fn (UserIndexRequest $request) => in_array($userId, $request->getUserIds()))
             ->andReturn(new Envelope(new stdClass()))
             ->once();
-
+        $this->logger->shouldReceive('debug')->once();
         $this->indexEntityChanges->postUpdate($args);
     }
 }

--- a/tests/Service/Index/CurriculumTest.php
+++ b/tests/Service/Index/CurriculumTest.php
@@ -9,8 +9,9 @@ use App\Entity\DTO\CourseDTO;
 use App\Service\Config;
 use App\Service\Index\Curriculum;
 use App\Tests\TestCase;
-use DateTime;
 use OpenSearch\Client;
+use DateTime;
+use Exception;
 use InvalidArgumentException;
 use Mockery as m;
 
@@ -61,11 +62,11 @@ class CurriculumTest extends TestCase
     {
         $obj = new Curriculum($this->config, null);
         $mockCourse = m::mock(IndexableCourse::class);
-        $mockDto = m::mock(CourseDTO::class);
-        $mockDto->id = 11;
-        $mockCourse->courseDTO = $mockDto;
-        $mockCourse->shouldReceive('createIndexObjects')->andReturn([]);
-        $this->assertTrue($obj->index([$mockCourse], new DateTime()));
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            'Search is not configured, isEnabled() should be called before calling this method'
+        );
+        $obj->index([$mockCourse], new DateTime());
     }
 
     public function testIndexCourses(): void
@@ -87,6 +88,7 @@ class CurriculumTest extends TestCase
             ['id' => 2, 'courseFileLearningMaterialIds' => [], 'sessionFileLearningMaterialIds' => []],
             ['id' => 3, 'courseFileLearningMaterialIds' => [], 'sessionFileLearningMaterialIds' => []],
         ]);
+        $stamp = new DateTime();
 
         $stamp = new DateTime();
         $this->setupSkippable($stamp, [1, 2], []);
@@ -161,7 +163,6 @@ class CurriculumTest extends TestCase
 
     public function testIndexCourseWithNoSessions(): void
     {
-        $this->client = m::mock(Client::class);
         $obj = new Curriculum($this->config, $this->client);
         $course1 = m::mock(IndexableCourse::class);
         $mockDto = m::mock(CourseDTO::class);

--- a/tests/Service/Index/UsersTest.php
+++ b/tests/Service/Index/UsersTest.php
@@ -73,49 +73,35 @@ class UsersTest extends TestCase
         $user1 = $this->createUserDto(13);
         $user2 = $this->createUserDto(11);
 
-        $this->client->shouldReceive('bulk')->once()->with([
-            'body' => [
-                [
-                    'index' => [
-                        '_index' => Users::INDEX,
-                        '_id' => $user1->id,
-                    ],
-                ],
-                [
-                    'id' => $user1->id,
-                    'firstName' => $user1->firstName,
-                    'lastName' => $user1->lastName,
-                    'middleName' => $user1->middleName,
-                    'displayName' => $user1->displayName,
-                    'email' => $user1->email,
-                    'campusId' => $user1->campusId,
-                    'username' => $user1->username,
-                    'enabled' => $user1->enabled,
-                    'fullName' => '13 first 13 middle 13 last',
-                    'fullNameLastFirst' => '13 last, 13 first 13 middle',
-                ],
-                [
-                    'index' => [
-                        '_index' => Users::INDEX,
-                        '_id' => $user2->id,
-                    ],
-                ],
-                [
-                    'id' => $user2->id,
-                    'firstName' => $user2->firstName,
-                    'lastName' => $user2->lastName,
-                    'middleName' => $user2->middleName,
-                    'displayName' => $user2->displayName,
-                    'email' => $user2->email,
-                    'campusId' => $user2->campusId,
-                    'username' => $user2->username,
-                    'enabled' => $user2->enabled,
-                    'fullName' => '11 first 11 middle 11 last',
-                    'fullNameLastFirst' => '11 last, 11 first 11 middle',
-                ],
-            ],
-        ])->andReturn(['errors' => false, 'took' => 1, 'items' => []]);
+        $this->client->shouldReceive('bulk')->once()
+            ->with(m::capture($args))
+        ->andReturn(['errors' => false, 'took' => 1, 'items' => []]);
         $obj->index([$user1, $user2]);
+
+        $this->assertArrayHasKey('body', $args);
+        $this->assertEquals($args['body'][1]['id'], $user1->id);
+        $this->assertEquals($args['body'][1]['firstName'], $user1->firstName);
+        $this->assertEquals($args['body'][1]['lastName'], $user1->lastName);
+        $this->assertEquals($args['body'][1]['middleName'], $user1->middleName);
+        $this->assertEquals($args['body'][1]['displayName'], $user1->displayName);
+        $this->assertEquals($args['body'][1]['email'], $user1->email);
+        $this->assertEquals($args['body'][1]['campusId'], $user1->campusId);
+        $this->assertEquals($args['body'][1]['username'], $user1->username);
+        $this->assertEquals($args['body'][1]['enabled'], $user1->enabled);
+        $this->assertEquals($args['body'][1]['fullName'], '13 first 13 middle 13 last');
+        $this->assertEquals($args['body'][1]['fullNameLastFirst'], '13 last, 13 first 13 middle');
+
+        $this->assertEquals($args['body'][3]['id'], $user2->id);
+        $this->assertEquals($args['body'][3]['firstName'], $user2->firstName);
+        $this->assertEquals($args['body'][3]['lastName'], $user2->lastName);
+        $this->assertEquals($args['body'][3]['middleName'], $user2->middleName);
+        $this->assertEquals($args['body'][3]['displayName'], $user2->displayName);
+        $this->assertEquals($args['body'][3]['email'], $user2->email);
+        $this->assertEquals($args['body'][3]['campusId'], $user2->campusId);
+        $this->assertEquals($args['body'][3]['username'], $user2->username);
+        $this->assertEquals($args['body'][3]['enabled'], $user2->enabled);
+        $this->assertEquals($args['body'][3]['fullName'], '11 first 11 middle 11 last');
+        $this->assertEquals($args['body'][3]['fullNameLastFirst'], '11 last, 11 first 11 middle');
     }
 
     public function testSearchThrowsExceptionWhenNotConfigured(): void


### PR DESCRIPTION
Extracting a lot of the useful stuff in #5480 without the learning material index changes. I tried to salvage the original intent in commits, but several rebases and dropping LM commits made my only partially successful.

Along with preventing re-indexing of courses and users the biggest changes in here are in [e567861b4c3dc0085bfa85dca731ea64f1c3eb46] and [9a3b55dda8d43834787ffc1b2b91e3fae2a142c6] which are intended to improve results. This will need to be tested. These changes are nearly 5 years old at this point and include many things I thought were already merged.