### PR TITLE
Float MySQL Docker Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,7 +204,7 @@ HEALTHCHECK NONE
 ###############################################################################
 # MySQL configured as needed for Ilios
 ###############################################################################
-FROM mysql:8.0-oracle AS mysql
+FROM mysql:8-oracle AS mysql
 LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
 ENV MYSQL_RANDOM_ROOT_PASSWORD=yes
 COPY docker/mysql.cnf /etc/mysql/conf.d/ilios.cnf

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,7 +28,7 @@ services:
       context: .
       target: fpm-dev
     environment:
-      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=8.0
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios
       - ILIOS_REQUIRE_SECURE_CONNECTION=false
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_SEARCH_HOST=http://opensearch:9200
@@ -51,7 +51,7 @@ services:
       context: .
       target: consume-messages
     environment:
-      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=8.0
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_SEARCH_HOST=http://opensearch:9200
       - ILIOS_REDIS_URL=redis://redis

--- a/docs/docker-examples/docker-compose.demo.yml
+++ b/docs/docker-examples/docker-compose.demo.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - public:/srv/app/public
     environment:
-      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=8.0
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios
       - ILIOS_REQUIRE_SECURE_CONNECTION=false
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_SEARCH_HOST=http://opensearch
@@ -30,7 +30,7 @@ services:
   messages:
     image: ilios/consume-messages:v3
     environment:
-      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios?serverVersion=8.0
+      - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_SEARCH_HOST=http://opensearch
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/tmp


### PR DESCRIPTION
Docker images are available for v8 that stay up to date with the latest release which is better for our containers. I also discovered that, while it is required for a fresh install, serverVersion isn't needed when a database already exists. Which is the case when we use the demo DB. So I've removed it from those compose setups to make it easier to stay in sync.