### PR TITLE
Update Lock File When Tagging Version

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -36,6 +36,7 @@ jobs:
     - name: Increment version
       run: |
         composer config version ${{ env.new_tag }}
+        composer update --lock
         git commit -a -m "Bump Ilios version to ${{ env.new_tag }}"
     - name: Tag Version
       run: git tag v${{ env.new_tag }} -m "Tagging the ${{ env.new_tag }} ${{ github.event.inputs.releaseType }} release"


### PR DESCRIPTION
The `composer config` command only updates `composer.json` and not the lock file. Running update with the `--lock` option should update the lock file without updating any packages.