### PR TITLE
Replace Opensearch Exception

### DIFF
--- a/src/Classes/OpenSearchBase.php
+++ b/src/Classes/OpenSearchBase.php
@@ -7,7 +7,7 @@ namespace App\Classes;
 use App\Service\Config;
 use Exception;
 use OpenSearch\Client;
-use OpenSearch\Common\Exceptions\Missing404Exception;
+use OpenSearch\Exception\NotFoundHttpException;
 
 class OpenSearchBase
 {
@@ -69,7 +69,7 @@ class OpenSearchBase
         }
         try {
             return $this->client->delete($params);
-        } catch (Missing404Exception) {
+        } catch (NotFoundHttpException) {
             return ['result' => 'deleted'];
         }
     }
@@ -81,7 +81,7 @@ class OpenSearchBase
         }
         try {
             return $this->client->deleteByQuery($params);
-        } catch (Missing404Exception) {
+        } catch (NotFoundHttpException) {
             return ['failures' => []];
         }
     }


### PR DESCRIPTION
This fixes the immediate issue in #6060 as this exception wasn't getting trapped so it was bubbling up and blocking the delete. I'm leaving the issue open however because the session not being in the index yet doesn't mean it won't be in very soon so we need to enqueue these deletes as well. Saving that for another PR.

