### PR TITLE
Enqueue Index Deletes

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -13,6 +13,9 @@ framework:
        'App\Message\MeshDescriptorIndexRequest': async
        'App\Message\LearningMaterialIndexRequest': async
        'App\Message\LearningMaterialTextExtractionRequest': async
+       'App\Message\CourseDeleteRequest': async
+       'App\Message\SessionDeleteRequest': async
+       'App\Message\LearningMaterialDeleteRequest': async
 
     default_bus: messenger.bus.default
     buses:

--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -9,8 +9,11 @@ use App\Entity\CourseInterface;
 use App\Entity\LearningMaterialInterface;
 use App\Entity\SessionInterface;
 use App\Entity\UserInterface;
+use App\Message\CourseDeleteRequest;
 use App\Message\CourseIndexRequest;
+use App\Message\LearningMaterialDeleteRequest;
 use App\Message\LearningMaterialTextExtractionRequest;
+use App\Message\SessionDeleteRequest;
 use App\Message\UserIndexRequest;
 use App\Service\Index\Curriculum;
 use App\Service\Index\LearningMaterials;
@@ -105,16 +108,16 @@ class IndexEntityChanges
         }
 
         if ($entity instanceof CourseInterface) {
-            $this->curriculumIndex->deleteCourse($entity->getId());
+            $this->bus->dispatch(new CourseDeleteRequest($entity->getId()));
         }
 
         if ($entity instanceof SessionInterface) {
-            $this->curriculumIndex->deleteSession($entity->getId());
-            return; //don't re-index our just removed session
+            $this->bus->dispatch(new SessionDeleteRequest($entity->getId()));
+            return; //don't re-index our just removed session as an IndexableCoursesEntity
         }
 
         if ($entity instanceof LearningMaterialInterface) {
-            $this->learningMaterialsIndex->delete($entity->getId());
+            $this->bus->dispatch(new LearningMaterialDeleteRequest($entity->getId()));
         }
 
         if ($entity instanceof IndexableCoursesEntityInterface) {

--- a/src/Message/CourseDeleteRequest.php
+++ b/src/Message/CourseDeleteRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+class CourseDeleteRequest
+{
+    public function __construct(private readonly int $courseId)
+    {
+    }
+
+    public function getCourseId(): int
+    {
+        return $this->courseId;
+    }
+}

--- a/src/Message/LearningMaterialDeleteRequest.php
+++ b/src/Message/LearningMaterialDeleteRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+class LearningMaterialDeleteRequest
+{
+    public function __construct(private readonly int $learningMaterialId)
+    {
+    }
+
+    public function getLearningMaterialId(): int
+    {
+        return $this->learningMaterialId;
+    }
+}

--- a/src/Message/SessionDeleteRequest.php
+++ b/src/Message/SessionDeleteRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+class SessionDeleteRequest
+{
+    public function __construct(private readonly int $sessionId)
+    {
+    }
+
+    public function getSessionId(): int
+    {
+        return $this->sessionId;
+    }
+}

--- a/src/MessageHandler/CourseDeleteHandler.php
+++ b/src/MessageHandler/CourseDeleteHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\CourseDeleteRequest;
+use App\Service\Index\Curriculum;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class CourseDeleteHandler
+{
+    public function __construct(
+        private readonly Curriculum $curriculumIndex
+    ) {
+    }
+
+    public function __invoke(CourseDeleteRequest $message): void
+    {
+        $this->curriculumIndex->deleteCourse($message->getCourseId());
+    }
+}

--- a/src/MessageHandler/LearningMaterialDeleteHandler.php
+++ b/src/MessageHandler/LearningMaterialDeleteHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\LearningMaterialDeleteRequest;
+use App\Service\Index\LearningMaterials;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class LearningMaterialDeleteHandler
+{
+    public function __construct(
+        private readonly LearningMaterials $learningMaterialIndex,
+    ) {
+    }
+
+    public function __invoke(LearningMaterialDeleteRequest $message): void
+    {
+        $this->learningMaterialIndex->delete($message->getLearningMaterialId());
+    }
+}

--- a/src/MessageHandler/SessionDeleteHandler.php
+++ b/src/MessageHandler/SessionDeleteHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\SessionDeleteRequest;
+use App\Service\Index\Curriculum;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class SessionDeleteHandler
+{
+    public function __construct(
+        private readonly Curriculum $curriculumIndex
+    ) {
+    }
+
+    public function __invoke(SessionDeleteRequest $message): void
+    {
+        $this->curriculumIndex->deleteSession($message->getSessionId());
+    }
+}

--- a/tests/Message/CourseDeleteRequestTest.php
+++ b/tests/Message/CourseDeleteRequestTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Message;
+
+use App\Message\CourseDeleteRequest;
+use App\Tests\TestCase;
+
+class CourseDeleteRequestTest extends TestCase
+{
+    public function testItWorks(): void
+    {
+        $id = 42;
+        $request = new CourseDeleteRequest($id);
+        $this->assertSame($id, $request->getCourseId());
+    }
+}

--- a/tests/Message/LearningMaterialDeleteRequestTest.php
+++ b/tests/Message/LearningMaterialDeleteRequestTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Message;
+
+use App\Message\LearningMaterialDeleteRequest;
+use App\Tests\TestCase;
+
+class LearningMaterialDeleteRequestTest extends TestCase
+{
+    public function testItWorks(): void
+    {
+        $id = 42;
+        $request = new LearningMaterialDeleteRequest($id);
+        $this->assertSame($id, $request->getLearningMaterialId());
+    }
+}

--- a/tests/Message/SessionDeleteRequestTest.php
+++ b/tests/Message/SessionDeleteRequestTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Message;
+
+use App\Message\SessionDeleteRequest;
+use App\Tests\TestCase;
+
+class SessionDeleteRequestTest extends TestCase
+{
+    public function testItWorks(): void
+    {
+        $id = 42;
+        $request = new SessionDeleteRequest($id);
+        $this->assertSame($id, $request->getSessionId());
+    }
+}

--- a/tests/MessageHandler/CourseDeleteHandlerTest.php
+++ b/tests/MessageHandler/CourseDeleteHandlerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MessageHandler;
+
+use App\Message\CourseDeleteRequest;
+use App\MessageHandler\CourseDeleteHandler;
+use App\Service\Index\Curriculum;
+use App\Tests\TestCase;
+use Mockery as m;
+
+class CourseDeleteHandlerTest extends TestCase
+{
+    protected m\MockInterface|Curriculum $curriculum;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->curriculum = m::mock(Curriculum::class);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->curriculum);
+    }
+
+    public function testInvoke(): void
+    {
+        $handler = new CourseDeleteHandler($this->curriculum);
+        $request = new CourseDeleteRequest(24);
+
+        $this->curriculum
+            ->shouldReceive('deleteCourse')
+            ->once()
+            ->with(24);
+
+        $handler->__invoke($request);
+    }
+}

--- a/tests/MessageHandler/LearningMaterialDeleteHandlerTest.php
+++ b/tests/MessageHandler/LearningMaterialDeleteHandlerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MessageHandler;
+
+use App\Message\LearningMaterialDeleteRequest;
+use App\MessageHandler\LearningMaterialDeleteHandler;
+use App\Service\Index\LearningMaterials;
+use App\Tests\TestCase;
+use Mockery as m;
+
+class LearningMaterialDeleteHandlerTest extends TestCase
+{
+    protected m\MockInterface|LearningMaterials $index;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->index = m::mock(LearningMaterials::class);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->index);
+    }
+
+    public function testInvoke(): void
+    {
+        $handler = new LearningMaterialDeleteHandler($this->index);
+        $request = new LearningMaterialDeleteRequest(6);
+
+        $this->index
+            ->shouldReceive('delete')
+            ->once()
+            ->with(6);
+
+        $handler->__invoke($request);
+    }
+}

--- a/tests/MessageHandler/SessionDeleteHandlerTest.php
+++ b/tests/MessageHandler/SessionDeleteHandlerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MessageHandler;
+
+use App\Message\SessionDeleteRequest;
+use App\MessageHandler\SessionDeleteHandler;
+use App\Service\Index\Curriculum;
+use App\Tests\TestCase;
+use Mockery as m;
+
+class SessionDeleteHandlerTest extends TestCase
+{
+    protected m\MockInterface|Curriculum $curriculum;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->curriculum = m::mock(Curriculum::class);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->curriculum);
+    }
+
+    public function testInvoke(): void
+    {
+        $handler = new SessionDeleteHandler($this->curriculum);
+        $request = new SessionDeleteRequest(24);
+
+        $this->curriculum
+            ->shouldReceive('deleteSession')
+            ->once()
+            ->with(24);
+
+        $handler->__invoke($request);
+    }
+}


### PR DESCRIPTION
Doing these instantly can mean the delete request lands before the index request (as in deleting a freshly created session). Because the indexing request is in the queue things that have been deleted can still be found in the index making for a confusing search experience.

Fixes #6060