### PR TITLE
Create a Development Message Consumer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,6 +202,27 @@ ENTRYPOINT ["/entrypoint"]
 HEALTHCHECK NONE
 
 ###############################################################################
+# Development message consumer
+###############################################################################
+FROM consume-messages AS consume-messages-dev
+
+ENV APP_ENV=dev
+ENV APP_DEBUG=true
+
+COPY docker/fpm/symfony.dev.ini $PHP_INI_DIR/conf.d/symfony.ini
+COPY docker/fpm/xdebug-dev.ini $PHP_INI_DIR/conf.d/xdebug.ini
+
+RUN ln -sf "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+RUN set -eux; \
+    pecl install xdebug \
+    && docker-php-ext-enable xdebug; \
+    composer install --prefer-dist --no-progress --no-interaction; \
+    rm -f .env.local.php; \
+    composer run-script post-install-cmd; \
+    bin/console cache:warmup; \
+    sync
+
+###############################################################################
 # MySQL configured as needed for Ilios
 ###############################################################################
 FROM mysql:8-oracle AS mysql

--- a/compose.yaml
+++ b/compose.yaml
@@ -49,7 +49,7 @@ services:
   messages:
     build:
       context: .
-      target: consume-messages
+      target: consume-messages-dev
     environment:
       - ILIOS_DATABASE_URL=mysql://ilios:ilios@db/ilios
       - ILIOS_ERROR_CAPTURE_ENABLED=false
@@ -58,7 +58,7 @@ services:
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/ilios-storage
       - ILIOS_TIKA_URL=http://tika:9998
     restart: always
-    command: [ "--time-limit", "3600", "-vv"]
+    command: [ "--time-limit", "3600", "-vv" ]
     depends_on:
       - db
       - opensearch


### PR DESCRIPTION
In order to work with building message consumers we need a dev container that doesn't cache the PHP and prevent changes from showing up.