### PR TITLE
Split Large Materials

### DIFF
--- a/tests/Service/Index/LearningMaterialsTest.php
+++ b/tests/Service/Index/LearningMaterialsTest.php
@@ -113,11 +113,11 @@ class LearningMaterialsTest extends TestCase
                 [
                     'index' => [
                         '_index' => LearningMaterials::INDEX,
-                        '_id' => 'lm_1',
+                        '_id' => 'lm_0_1',
                     ],
                 ],
                 [
-                    'id' => 'lm_1',
+                    'id' => 'lm_0_1',
                     'learningMaterialId' => 1,
                     'title' => 'first title',
                     'description' => 'first description',
@@ -127,11 +127,11 @@ class LearningMaterialsTest extends TestCase
                 [
                     'index' => [
                         '_index' => LearningMaterials::INDEX,
-                        '_id' => 'lm_2',
+                        '_id' => 'lm_0_2',
                     ],
                 ],
                 [
-                    'id' => 'lm_2',
+                    'id' => 'lm_0_2',
                     'learningMaterialId' => 2,
                     'title' => 'second title',
                     'description' => 'second description',
@@ -177,11 +177,11 @@ class LearningMaterialsTest extends TestCase
                 [
                     'index' => [
                         '_index' => LearningMaterials::INDEX,
-                        '_id' => 'lm_2',
+                        '_id' => 'lm_0_2',
                     ],
                 ],
                 [
-                    'id' => 'lm_2',
+                    'id' => 'lm_0_2',
                     'learningMaterialId' => 2,
                     'title' => 'second title',
                     'description' => 'second description',
@@ -237,11 +237,11 @@ class LearningMaterialsTest extends TestCase
                 [
                     'index' => [
                         '_index' => LearningMaterials::INDEX,
-                        '_id' => 'lm_1',
+                        '_id' => 'lm_0_1',
                     ],
                 ],
                 [
-                    'id' => 'lm_1',
+                    'id' => 'lm_0_1',
                     'learningMaterialId' => 1,
                     'title' => 'first title',
                     'description' => 'first description',
@@ -251,11 +251,11 @@ class LearningMaterialsTest extends TestCase
                 [
                     'index' => [
                         '_index' => LearningMaterials::INDEX,
-                        '_id' => 'lm_2',
+                        '_id' => 'lm_0_2',
                     ],
                 ],
                 [
-                    'id' => 'lm_2',
+                    'id' => 'lm_0_2',
                     'learningMaterialId' => 2,
                     'title' => 'second title',
                     'description' => 'second description',


### PR DESCRIPTION
To ensure they can be indexed split large materials into multiple chunks and attach them material ID to each one. This may have a small effect on the results, but it ensures that all the data is in the index and can be found.

Fixes #6122