### PR TITLE
Make Materials Searchable

### DIFF
--- a/src/Classes/OpenSearchBase.php
+++ b/src/Classes/OpenSearchBase.php
@@ -16,7 +16,6 @@ class OpenSearchBase
 
     protected int|string|null $uploadLimit = null;
 
-    protected const int COMPRESSION_FACTOR = 3;
     public const int SIZE_LIMIT = 5000;
     protected const string SCROLL_TIME = '10s';
 
@@ -136,7 +135,7 @@ class OpenSearchBase
             $item = $items[$i];
             $itemSize = strlen(json_encode($item, JSON_INVALID_UTF8_SUBSTITUTE));
             //upload limit multiplied for compression
-            if (($chunkSize + $itemSize) < $this->uploadLimit * self::COMPRESSION_FACTOR) {
+            if (($chunkSize + $itemSize) < $this->uploadLimit) {
                 //add the item and move on to the next one
                 $chunk[] = $item;
                 $i++;

--- a/src/Classes/OpenSearchBase.php
+++ b/src/Classes/OpenSearchBase.php
@@ -16,6 +16,10 @@ class OpenSearchBase
 
     protected int|string|null $uploadLimit = null;
 
+    protected const int COMPRESSION_FACTOR = 3;
+    public const int SIZE_LIMIT = 5000;
+    protected const string SCROLL_TIME = '10s';
+
     /**
      * Search constructor.
      */
@@ -132,7 +136,7 @@ class OpenSearchBase
             $item = $items[$i];
             $itemSize = strlen(json_encode($item, JSON_INVALID_UTF8_SUBSTITUTE));
             //upload limit multiplied for compression
-            if (($chunkSize + $itemSize) < $this->uploadLimit * 3) {
+            if (($chunkSize + $itemSize) < $this->uploadLimit * self::COMPRESSION_FACTOR) {
                 //add the item and move on to the next one
                 $chunk[] = $item;
                 $i++;
@@ -207,7 +211,7 @@ class OpenSearchBase
         if (!$this->enabled) {
             throw new Exception("Search is not configured, isEnabled() should be called before calling this method");
         }
-        $scroll = '10s';
+        $scroll = self::SCROLL_TIME;
         $params['scroll'] = $scroll;
         $response = $this->doSearch($params);
         $scrollId = $response['_scroll_id'];

--- a/src/Command/ExtractLearningMaterialsTextCommand.php
+++ b/src/Command/ExtractLearningMaterialsTextCommand.php
@@ -31,6 +31,12 @@ class ExtractLearningMaterialsTextCommand extends Command
 
         $this
             ->addOption(
+                'materials',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Comma-separated list list of materials to extract.',
+            )
+            ->addOption(
                 'overwrite',
                 null,
                 InputOption::VALUE_NONE,
@@ -42,6 +48,10 @@ class ExtractLearningMaterialsTextCommand extends Command
     {
         $overwrite = $input->getOption('overwrite');
         $allIds = $this->learningMaterialRepository->getFileLearningMaterialIds();
+        if ($input->getOption('materials')) {
+            $ids = explode(',', $input->getOption('materials'));
+            $allIds = array_intersect($allIds, $ids);
+        }
         $count = count($allIds);
         $chunks = array_chunk($allIds, LearningMaterialTextExtractionRequest::MAX_MATERIALS);
         foreach ($chunks as $ids) {

--- a/src/Command/ExtractLearningMaterialsTextCommand.php
+++ b/src/Command/ExtractLearningMaterialsTextCommand.php
@@ -8,7 +8,9 @@ use App\Message\LearningMaterialTextExtractionRequest;
 use App\Repository\LearningMaterialRepository;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -17,7 +19,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 #[AsCommand(
     name: 'ilios:extract-material-text',
-    description: 'Queue extraction of learning material text.'
+    description: 'Extract text from learning materials'
 )]
 class ExtractLearningMaterialsTextCommand extends Command
 {
@@ -26,17 +28,29 @@ class ExtractLearningMaterialsTextCommand extends Command
         protected MessageBusInterface $bus
     ) {
         parent::__construct();
+
+        $this
+            ->addOption(
+                'overwrite',
+                null,
+                InputOption::VALUE_NONE,
+                'Overwrite existing text.',
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $overwrite = $input->getOption('overwrite');
         $allIds = $this->learningMaterialRepository->getFileLearningMaterialIds();
         $count = count($allIds);
         $chunks = array_chunk($allIds, LearningMaterialTextExtractionRequest::MAX_MATERIALS);
         foreach ($chunks as $ids) {
-            $this->bus->dispatch(new LearningMaterialTextExtractionRequest($ids));
+            $this->bus->dispatch(new LearningMaterialTextExtractionRequest($ids, $overwrite));
         }
-        $output->writeln("<info>{$count} learning materials have been queued for text extraction.</info>");
+        $output->writeln("<info>{$count} learning materials have been queued for text extraction</info>");
+        if ($overwrite) {
+            $output->writeln('<comment>Existing text extractions for these materials will be overwritten</comment>');
+        }
 
         return Command::SUCCESS;
     }

--- a/src/Command/Index/CourseCommand.php
+++ b/src/Command/Index/CourseCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\Index;
+
+use App\Repository\CourseRepository;
+use App\Repository\LearningMaterialRepository;
+use App\Service\Index\Curriculum;
+use App\Service\Index\LearningMaterials;
+use Composer\Console\Input\InputArgument;
+use DateTime;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'ilios:index:course',
+    description: 'Extract and index a course by id'
+)]
+class CourseCommand extends Command
+{
+    public function __construct(
+        protected CourseRepository $courseRepository,
+        protected Curriculum $index,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                'courseId',
+                InputArgument::REQUIRED,
+                'The ID of the course to index.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->index->isEnabled()) {
+            $output->writeln("<comment>Indexing is not currently configured.</comment>");
+            return Command::FAILURE;
+        }
+        $id = $input->getArgument('courseId');
+        $indexes = $this->courseRepository->getCourseIndexesFor([$id]);
+        $this->index->index($indexes, new DateTime());
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/Index/DetectMissingCommand.php
+++ b/src/Command/Index/DetectMissingCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\Index;
+
+use App\Repository\LearningMaterialRepository;
+use App\Service\Index\LearningMaterials;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'ilios:index:detect-missing',
+    description: 'Find items that are missing in the index'
+)]
+class DetectMissingCommand extends Command
+{
+    public function __construct(
+        protected LearningMaterialRepository $learningMaterialRepository,
+        protected LearningMaterials $materialIndex,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->materialIndex->isEnabled()) {
+            $output->writeln("<comment>Indexing is not currently configured.</comment>");
+            return Command::FAILURE;
+        }
+        $materialsInIndex = $this->materialIndex->getAllIds();
+        $allIds = $this->learningMaterialRepository->getFileLearningMaterialIds();
+        $missing = array_diff($allIds, $materialsInIndex);
+        $count = count($missing);
+        if ($count) {
+            $list = implode(', ', $missing);
+            $output->writeln("<error>{$count} materials are missing from the index.</error>");
+            $output->writeln("<comment>Materials: {$list}</comment>");
+            return Command::FAILURE;
+        }
+
+        $output->writeln("<info>All materials are indexed.</info>");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Message/CourseIndexRequest.php
+++ b/src/Message/CourseIndexRequest.php
@@ -11,7 +11,7 @@ class CourseIndexRequest
 {
     private array $courseIds;
     private DateTime $createdAt;
-    public const int MAX_COURSES = 100;
+    public const int MAX_COURSES = 20;
 
     /**
      * CourseIndexRequest constructor.

--- a/src/Message/LearningMaterialIndexRequest.php
+++ b/src/Message/LearningMaterialIndexRequest.php
@@ -11,7 +11,7 @@ class LearningMaterialIndexRequest
     private array $ids;
     public const int MAX_MATERIALS = 10;
 
-    public function __construct(array $ids)
+    public function __construct(array $ids, protected bool $force = false)
     {
         $count = count($ids);
         if ($count > self::MAX_MATERIALS) {
@@ -29,5 +29,10 @@ class LearningMaterialIndexRequest
     public function getIds(): array
     {
         return $this->ids;
+    }
+
+    public function getForce(): bool
+    {
+        return $this->force;
     }
 }

--- a/src/Message/LearningMaterialTextExtractionRequest.php
+++ b/src/Message/LearningMaterialTextExtractionRequest.php
@@ -8,12 +8,11 @@ use InvalidArgumentException;
 
 class LearningMaterialTextExtractionRequest
 {
-    private array $learningMaterialIds;
     public const int MAX_MATERIALS = 50;
 
-    public function __construct(array $learningMaterialIds)
+    public function __construct(private readonly array $learningMaterialIds, private readonly bool $overwrite = false)
     {
-        $count = count($learningMaterialIds);
+        $count = count($this->learningMaterialIds);
         if ($count > self::MAX_MATERIALS) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -23,11 +22,15 @@ class LearningMaterialTextExtractionRequest
                 )
             );
         }
-        $this->learningMaterialIds = $learningMaterialIds;
     }
 
     public function getLearningMaterialIds(): array
     {
         return $this->learningMaterialIds;
+    }
+
+    public function getOverwrite(): bool
+    {
+        return $this->overwrite;
     }
 }

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -17,19 +17,12 @@ class LearningMaterialIndexHandler
     public function __construct(
         private LearningMaterials $learningMaterialsIndex,
         private LearningMaterialRepository $repository,
-        private NonCachingIliosFileSystem $fileSystem
     ) {
     }
 
     public function __invoke(LearningMaterialIndexRequest $message): void
     {
         $dtos = $this->repository->findDTOsBy(['id' => $message->getIds()]);
-        $materialsWithText = array_filter(
-            $dtos,
-            fn(LearningMaterialDTO $dto) => $this->fileSystem->checkIfLearningMaterialTextFileExists($dto->relativePath)
-        );
-        if ($materialsWithText !== []) {
-            $this->learningMaterialsIndex->index(array_values($materialsWithText));
-        }
+        $this->learningMaterialsIndex->index($dtos);
     }
 }

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -23,6 +23,6 @@ class LearningMaterialIndexHandler
     public function __invoke(LearningMaterialIndexRequest $message): void
     {
         $dtos = $this->repository->findDTOsBy(['id' => $message->getIds()]);
-        $this->learningMaterialsIndex->index($dtos);
+        $this->learningMaterialsIndex->index($dtos, $message->getForce());
     }
 }

--- a/src/MessageHandler/LearningMaterialTextExtractionHandler.php
+++ b/src/MessageHandler/LearningMaterialTextExtractionHandler.php
@@ -28,6 +28,9 @@ class LearningMaterialTextExtractionHandler
         foreach ($dtos as $dto) {
             $this->extractor->extract($dto, $overwrite);
         }
-        $this->bus->dispatch(new LearningMaterialIndexRequest($message->getLearningMaterialIds()));
+        $chunks = array_chunk($message->getLearningMaterialIds(), LearningMaterialIndexRequest::MAX_MATERIALS);
+        foreach ($chunks as $ids) {
+            $this->bus->dispatch(new LearningMaterialIndexRequest($ids));
+        }
     }
 }

--- a/src/MessageHandler/LearningMaterialTextExtractionHandler.php
+++ b/src/MessageHandler/LearningMaterialTextExtractionHandler.php
@@ -30,7 +30,7 @@ class LearningMaterialTextExtractionHandler
         }
         $chunks = array_chunk($message->getLearningMaterialIds(), LearningMaterialIndexRequest::MAX_MATERIALS);
         foreach ($chunks as $ids) {
-            $this->bus->dispatch(new LearningMaterialIndexRequest($ids));
+            $this->bus->dispatch(new LearningMaterialIndexRequest($ids, true));
         }
     }
 }

--- a/src/MessageHandler/LearningMaterialTextExtractionHandler.php
+++ b/src/MessageHandler/LearningMaterialTextExtractionHandler.php
@@ -24,8 +24,9 @@ class LearningMaterialTextExtractionHandler
     public function __invoke(LearningMaterialTextExtractionRequest $message): void
     {
         $dtos = $this->repository->findDTOsBy(['id' => $message->getLearningMaterialIds()]);
+        $overwrite = $message->getOverwrite();
         foreach ($dtos as $dto) {
-            $this->extractor->extract($dto);
+            $this->extractor->extract($dto, $overwrite);
         }
         $this->bus->dispatch(new LearningMaterialIndexRequest($message->getLearningMaterialIds()));
     }

--- a/src/Repository/CourseRepository.php
+++ b/src/Repository/CourseRepository.php
@@ -152,6 +152,19 @@ class CourseRepository extends ServiceEntityRepository implements
     }
 
     /**
+     * Get Ids for all courses with at least one session
+     */
+    public function getIdsForCoursesWithSessions(): array
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->select('c.id')->from(Session::class, 'x')
+            ->join('x.course', 'c')
+            ->distinct();
+
+        return array_map(fn(array $arr) => $arr['id'], $qb->getQuery()->getScalarResult());
+    }
+
+    /**
      * Finds all courses associated with a given user.
      * A user can be associated as either course director, learner or instructor with a given course.
      *

--- a/src/Repository/SessionRepository.php
+++ b/src/Repository/SessionRepository.php
@@ -79,6 +79,18 @@ class SessionRepository extends ServiceEntityRepository implements
         return $this->createSessionDTOs($qb->getQuery());
     }
 
+
+    /**
+     * Get all the IDs
+     */
+    public function getIds(): array
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->addSelect('x.id')->from(Session::class, 'x');
+
+        return array_map(fn(array $arr) => $arr['id'], $qb->getQuery()->getScalarResult());
+    }
+
     protected function findIdsBy(
         array $criteria,
         ?array $orderBy = null,

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -447,10 +447,6 @@ class Curriculum extends OpenSearchBase
                     'type' => 'text',
                     'analyzer' => 'spanish',
                 ],
-                'raw' => [
-                    'type' => 'text',
-                    'analyzer' => 'keyword',
-                ],
             ],
         ];
         $txtTypeFieldWithCompletion = $txtTypeField;

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -448,6 +448,24 @@ class Curriculum extends OpenSearchBase
         return array_unique($ids);
     }
 
+    public function getAllSessionIds(): array
+    {
+        $params = [
+            'index' => self::INDEX,
+            'body' => [
+                'query' => [
+                    'match_all' => new stdClass(),
+                ],
+                '_source' => ['sessionId'],
+            ],
+            'size' => 5000,
+        ];
+
+        $results = $this->doScrollSearch($params);
+        $ids = array_map(fn ($item) => $item['_source']['sessionId'], $results);
+        return array_unique($ids);
+    }
+
     public static function getMapping(): array
     {
         $txtTypeField = [

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -440,7 +440,7 @@ class Curriculum extends OpenSearchBase
                 ],
                 '_source' => ['courseId'],
             ],
-            'size' => 5000,
+            'size' => self::SIZE_LIMIT,
         ];
 
         $results = $this->doScrollSearch($params);
@@ -458,7 +458,7 @@ class Curriculum extends OpenSearchBase
                 ],
                 '_source' => ['sessionId'],
             ],
-            'size' => 5000,
+            'size' => self::SIZE_LIMIT,
         ];
 
         $results = $this->doScrollSearch($params);

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -185,7 +185,7 @@ class Curriculum extends OpenSearchBase
         if (!empty($learningMaterialIds)) {
             $params = [
                 'index' => LearningMaterials::INDEX,
-                'size' => 10000,
+                'size' => 25,
                 'body' => [
                     'query' => [
                         'terms' => [
@@ -199,9 +199,9 @@ class Curriculum extends OpenSearchBase
                     ],
                 ],
             ];
-            $results = $this->doSearch($params);
+            $results = $this->doScrollSearch($params);
 
-            $materialsById = array_reduce($results['hits']['hits'], function (array $carry, array $hit) {
+            $materialsById = array_reduce($results, function (array $carry, array $hit) {
                 $result = $hit['_source'];
                 $id = $result['learningMaterialId'];
                 $carry[$id][] = $result['contents'];

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -9,6 +9,7 @@ use App\Classes\IndexableCourse;
 use DateTime;
 use Exception;
 use InvalidArgumentException;
+use stdClass;
 
 class Curriculum extends OpenSearchBase
 {
@@ -427,6 +428,24 @@ class Curriculum extends OpenSearchBase
             'autocomplete' => $autocompleteSuggestions,
             'courses' => $courses,
         ];
+    }
+
+    public function getAllCourseIds(): array
+    {
+        $params = [
+            'index' => self::INDEX,
+            'body' => [
+                'query' => [
+                    'match_all' => new stdClass(),
+                ],
+                '_source' => ['courseId'],
+            ],
+            'size' => 5000,
+        ];
+
+        $results = $this->doScrollSearch($params);
+        $ids = array_map(fn ($item) => $item['_source']['courseId'], $results);
+        return array_unique($ids);
     }
 
     public static function getMapping(): array

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -192,8 +192,9 @@ class Curriculum extends OpenSearchBase
                         ],
                     ],
                     "_source" => [
+                        'id',
                         'learningMaterialId',
-                        'material.content',
+                        'contents',
                     ],
                 ],
             ];
@@ -202,10 +203,7 @@ class Curriculum extends OpenSearchBase
             $materialsById = array_reduce($results['hits']['hits'], function (array $carry, array $hit) {
                 $result = $hit['_source'];
                 $id = $result['learningMaterialId'];
-
-                if (array_key_exists('material', $result)) {
-                    $carry[$id][] = $result['material']['content'];
-                }
+                $carry[$id][] = $result['contents'];
 
                 return $carry;
             }, []);

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -184,6 +184,7 @@ class Curriculum extends OpenSearchBase
         if (!empty($learningMaterialIds)) {
             $params = [
                 'index' => LearningMaterials::INDEX,
+                'size' => 10000,
                 'body' => [
                     'query' => [
                         'terms' => [

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -138,11 +138,11 @@ class LearningMaterials extends OpenSearchBase
                     'learningMaterialId' => [
                         'terms' => [
                             'field' => 'learningMaterialId',
-                            'size' => 10000,
+                            'size' => self::SIZE_LIMIT,
                         ],
                     ],
                 ],
-                'size' => 0,
+                'size' => self::SIZE_LIMIT,
             ],
         ];
         $results = $this->doSearch($params);
@@ -160,7 +160,7 @@ class LearningMaterials extends OpenSearchBase
                 ],
                 '_source' => ['learningMaterialId'],
             ],
-            'size' => 5000,
+            'size' => self::SIZE_LIMIT,
         ];
 
         $results = $this->doScrollSearch($params);

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -69,7 +69,7 @@ class LearningMaterials extends OpenSearchBase
                         'title' => $lm->title,
                         'description' => $lm->description,
                         'filename' => $lm->filename,
-                        'contents' => $this->cleanMaterialText($string),
+                        'contents' => $this->cleanMaterialText($lm->id, $string),
                     ];
                 }
 
@@ -81,16 +81,34 @@ class LearningMaterials extends OpenSearchBase
         return $this->doBulkIndex(self::INDEX, $input);
     }
 
-    protected function cleanMaterialText(string $str): string
+    protected function cleanMaterialText(int $id, string $str): string
     {
         //remove punctuation
         $str = preg_replace('/[\p{P}]/u', '', $str);
+        if ($str === null) {
+            throw new Exception(
+                "Unable to clean material #{$id}, error: " .
+                preg_last_error_msg()
+            );
+        }
 
         //remove symbols, keeping letters, numbers, and spaces
         $str = preg_replace('/[^\p{L}\p{N}\s]/u', '', $str);
+        if ($str === null) {
+            throw new Exception(
+                "Unable to clean material #{$id}, error: " .
+                preg_last_error_msg()
+            );
+        }
 
         //remove extra spaces
         $str = preg_replace('/\s+/u', ' ', $str);
+        if ($str === null) {
+            throw new Exception(
+                "Unable to clean material #{$id}, error: " .
+                preg_last_error_msg()
+            );
+        }
 
         return trim($str);
     }

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -61,7 +61,11 @@ class LearningMaterials extends OpenSearchBase
                 $path =  $this->nonCachingIliosFileSystem->getLearningMaterialTextPath($lm->relativePath);
                 $contents = $this->nonCachingIliosFileSystem->getFileContents($path);
 
-                $strings = str_split($contents, $singleMaterialMaximumSize);
+                if ($contents) {
+                    $strings = str_split($contents, $singleMaterialMaximumSize);
+                } else {
+                    $strings = [''];
+                }
                 foreach ($strings as $key => $string) {
                     $carry[] = [
                         'id' => 'lm_' . $key . '_' . $lm->id,

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -11,6 +11,7 @@ use App\Service\NonCachingIliosFileSystem;
 use Exception;
 use OpenSearch\Client;
 use InvalidArgumentException;
+use stdClass;
 
 class LearningMaterials extends OpenSearchBase
 {
@@ -147,6 +148,23 @@ class LearningMaterials extends OpenSearchBase
         $results = $this->doSearch($params);
 
         return  array_column($results['aggregations']['learningMaterialId']['buckets'], 'key');
+    }
+
+    public function getAllIds(): array
+    {
+        $params = [
+            'index' => self::INDEX,
+            'body' => [
+                'query' => [
+                    'match_all' => new stdClass(),
+                ],
+                '_source' => ['learningMaterialId'],
+            ],
+            'size' => 5000,
+        ];
+
+        $results = $this->doScrollSearch($params);
+        return array_map(fn ($item) => $item['_source']['learningMaterialId'], $results);
     }
 
     public function delete(int $id): bool

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -69,7 +69,7 @@ class LearningMaterials extends OpenSearchBase
                         'title' => $lm->title,
                         'description' => $lm->description,
                         'filename' => $lm->filename,
-                        'contents' => $string,
+                        'contents' => $this->cleanMaterialText($string),
                     ];
                 }
 
@@ -79,6 +79,20 @@ class LearningMaterials extends OpenSearchBase
         );
 
         return $this->doBulkIndex(self::INDEX, $input);
+    }
+
+    protected function cleanMaterialText(string $str): string
+    {
+        //remove punctuation
+        $str = preg_replace('/[\p{P}]/u', '', $str);
+
+        //remove symbols, keeping letters, numbers, and spaces
+        $str = preg_replace('/[^\p{L}\p{N}\s]/u', '', $str);
+
+        //remove extra spaces
+        $str = preg_replace('/\s+/u', ' ', $str);
+
+        return trim($str);
     }
 
     protected function alreadyIndexedMaterials(array $ids): array

--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -110,9 +110,6 @@ class LearningMaterialTextExtractor
         //back to an array, that is cleaner now and can be filtered some more
         $arr = json_decode($text, true);
 
-        //keep lines that have a letter, number, or space in them
-        $arr = preg_grep('/[a-z0-9\s]+/', $arr);
-
         //remove any lines that contain *only* quotes, exclamation points, or double quotes
         $arr = preg_grep('/[\'"!]+/', $arr, PREG_GREP_INVERT);
 

--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -26,7 +26,7 @@ class LearningMaterialTextExtractor
         }
     }
 
-    public function extract(LearningMaterialDTO $dto): void
+    public function extract(LearningMaterialDTO $dto, bool $overwrite): void
     {
         if (!$this->isEnabled()) {
             return;
@@ -42,7 +42,7 @@ class LearningMaterialTextExtractor
             return;
         }
 
-        if ($this->iliosFileSystem->checkIfLearningMaterialTextFileExists($dto->relativePath)) {
+        if (!$overwrite && $this->iliosFileSystem->checkIfLearningMaterialTextFileExists($dto->relativePath)) {
             //this LM has already been extracted
             return;
         }

--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -9,6 +9,7 @@ use App\Exception\LearningMaterialTextExtractorException;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
 use Vaites\ApacheTika\Client;
+use Normalizer;
 
 class LearningMaterialTextExtractor
 {
@@ -88,6 +89,11 @@ class LearningMaterialTextExtractor
      */
     private function cleanText(string $text): string
     {
+        if (class_exists(Normalizer::class)) {
+            //clean up the text a bit making it easier to parse later
+            $text = Normalizer::normalize($text, Normalizer::FORM_C);
+        }
+
         //split into lines, it's easier to work with each line and filter it in or out
         $arr = preg_split('/\r\n|\r|\n/', $text);
 

--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -51,18 +51,6 @@ class LearningMaterialTextExtractor
         $contents = $this->fileSystem->getFileContents($dto->relativePath);
         $tmpFile = $this->temporaryFileSystem->createFile($contents);
 
-        if (!$this->client->isMIMETypeSupported($dto->mimetype)) {
-            if (!function_exists('mime_content_type')) {
-                return;
-            }
-            //re-check the mime type of the file using PHP, sometimes we have a bad mime type
-            $mimeType = mime_content_type($tmpFile->getRealPath());
-            if (!$this->client->isMIMETypeSupported($mimeType)) {
-                //not the type of file tika can extract
-                return;
-            }
-        }
-
         try {
             $raw = $this->client->getText($tmpFile->getRealPath());
             $text = $this->cleanText($raw);

--- a/tests/Command/ExtractLearningMaterialsTextCommandTest.php
+++ b/tests/Command/ExtractLearningMaterialsTextCommandTest.php
@@ -96,4 +96,25 @@ class ExtractLearningMaterialsTextCommandTest extends KernelTestCase
             $output
         );
     }
+
+    public function testExtractWithMaterialFilter(): void
+    {
+        $this->repository->shouldReceive('getFileLearningMaterialIds')->andReturn([1, 4, 99]);
+        $this->bus
+            ->shouldReceive('dispatch')
+            ->withArgs(
+                fn (LearningMaterialTextExtractionRequest $r) =>
+                    $r->getLearningMaterialIds() === [4] &&
+                    $r->getOverwrite() === false
+            )
+            ->andReturn(new Envelope(new stdClass()))
+            ->once();
+        $this->commandTester->execute(['--materials' => '3,4,81']);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/1 learning materials have been queued for text extraction/',
+            $output
+        );
+    }
 }

--- a/tests/Command/ExtractLearningMaterialsTextCommandTest.php
+++ b/tests/Command/ExtractLearningMaterialsTextCommandTest.php
@@ -56,14 +56,43 @@ class ExtractLearningMaterialsTextCommandTest extends KernelTestCase
         $this->repository->shouldReceive('getFileLearningMaterialIds')->andReturn([1, 4]);
         $this->bus
             ->shouldReceive('dispatch')
-            ->withArgs(fn (LearningMaterialTextExtractionRequest $r) => $r->getLearningMaterialIds() === [1, 4])
+            ->withArgs(
+                fn (LearningMaterialTextExtractionRequest $r) =>
+                    $r->getLearningMaterialIds() === [1, 4] &&
+                    $r->getOverwrite() === false
+            )
             ->andReturn(new Envelope(new stdClass()))
             ->once();
         $this->commandTester->execute([]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertMatchesRegularExpression(
-            '/2 learning materials have been queued for text extraction./',
+            '/2 learning materials have been queued for text extraction/',
+            $output
+        );
+    }
+
+    public function testExtractWithOverwrite(): void
+    {
+        $this->repository->shouldReceive('getFileLearningMaterialIds')->andReturn([1, 4]);
+        $this->bus
+            ->shouldReceive('dispatch')
+            ->withArgs(
+                fn (LearningMaterialTextExtractionRequest $r) =>
+                    $r->getLearningMaterialIds() === [1, 4] &&
+                    $r->getOverwrite() === true
+            )
+            ->andReturn(new Envelope(new stdClass()))
+            ->once();
+        $this->commandTester->execute(['--overwrite' => true]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/2 learning materials have been queued for text extraction/',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/Existing text extractions for these materials will be overwritten/',
             $output
         );
     }

--- a/tests/Command/Index/CourseCommandTest.php
+++ b/tests/Command/Index/CourseCommandTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command\Index;
+
+use App\Command\Index\CourseCommand;
+use App\Repository\CourseRepository;
+use App\Service\Index\Curriculum;
+use App\Tests\Classes\IndexableCourseTest;
+use DateTime;
+use PHPUnit\Framework\Attributes\Group;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+#[Group('cli')]
+class CourseCommandTest extends KernelTestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected CommandTester $commandTester;
+    protected m\MockInterface | CourseRepository $repository;
+    protected m\MockInterface | Curriculum $index;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = m::mock(CourseRepository::class);
+        $this->index = m::mock(Curriculum::class);
+
+        $command = new CourseCommand($this->repository, $this->index);
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->add($command);
+        $commandInApp = $application->find($command->getName());
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->repository);
+        unset($this->index);
+        unset($this->commandTester);
+    }
+
+    public function testExecute(): void
+    {
+        $this->index->shouldReceive('isEnabled')->once()->andReturn(true);
+        $c = m::mock(IndexableCourseTest::class);
+        $this->repository->shouldReceive('getCourseIndexesFor')->once()->with([13])->andReturn([$c]);
+        $this->index->shouldReceive('index')
+            ->once()
+            ->withArgs(
+                fn (array $a, DateTime $dateTime) => $c === $a[0] && $dateTime->diff(new DateTime())->days === 0
+            );
+        $this->commandTester->execute(['courseId' => 13]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testExecuteWithIndexDisabled(): void
+    {
+        $this->index->shouldReceive('isEnabled')->once()->andReturn(false);
+        $this->index->shouldNotReceive('index');
+
+        $this->commandTester->execute(['courseId' => 1]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/Indexing is not currently configured./',
+            $output
+        );
+    }
+}

--- a/tests/Command/Index/DetectMissingCommandTest.php
+++ b/tests/Command/Index/DetectMissingCommandTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\Command\Index;
 
 use App\Command\Index\DetectMissingCommand;
+use App\Repository\CourseRepository;
 use App\Repository\LearningMaterialRepository;
+use App\Service\Index\Curriculum;
 use App\Service\Index\LearningMaterials;
 use PHPUnit\Framework\Attributes\Group;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -20,16 +22,25 @@ class DetectMissingCommandTest extends KernelTestCase
     use MockeryPHPUnitIntegration;
 
     protected CommandTester $commandTester;
-    protected m\MockInterface | LearningMaterialRepository $repository;
+    protected m\MockInterface | LearningMaterialRepository $learningMaterialRepository;
     protected m\MockInterface | LearningMaterials $materialIndex;
+    protected m\MockInterface | CourseRepository $courseRepository;
+    protected m\MockInterface | Curriculum $curriculumIndex;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->repository = m::mock(LearningMaterialRepository::class);
+        $this->learningMaterialRepository = m::mock(LearningMaterialRepository::class);
         $this->materialIndex = m::mock(LearningMaterials::class);
+        $this->courseRepository = m::mock(CourseRepository::class);
+        $this->curriculumIndex = m::mock(Curriculum::class);
 
-        $command = new DetectMissingCommand($this->repository, $this->materialIndex);
+        $command = new DetectMissingCommand(
+            $this->learningMaterialRepository,
+            $this->courseRepository,
+            $this->materialIndex,
+            $this->curriculumIndex,
+        );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->add($command);
@@ -43,8 +54,10 @@ class DetectMissingCommandTest extends KernelTestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->repository);
+        unset($this->learningMaterialRepository);
         unset($this->materialIndex);
+        unset($this->courseRepository);
+        unset($this->curriculumIndex);
         unset($this->commandTester);
     }
 
@@ -52,6 +65,9 @@ class DetectMissingCommandTest extends KernelTestCase
     {
         $this->materialIndex->shouldReceive('isEnabled')->once()->andReturn(false);
         $this->materialIndex->shouldNotReceive('getAllIds');
+        $this->curriculumIndex->shouldNotReceive('getAllCourseIds');
+        $this->learningMaterialRepository->shouldNotReceive('getFileLearningMaterialIds');
+        $this->courseRepository->shouldNotReceive('getIdsForCoursesWithSessions');
 
         $this->commandTester->execute([]);
 
@@ -64,8 +80,13 @@ class DetectMissingCommandTest extends KernelTestCase
     public function testExecuteWithIndexEnabled(): void
     {
         $this->materialIndex->shouldReceive('isEnabled')->once()->andReturn(true);
+
         $this->materialIndex->shouldReceive('getAllIds')->once()->andReturn([13]);
-        $this->repository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([13, 14]);
+        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([13, 14]);
+
+        $this->curriculumIndex->shouldReceive('getAllCourseIds')->once()->andReturn([11]);
+        $this->courseRepository->shouldReceive('getIdsForCoursesWithSessions')->once()->andReturn([11, 33]);
+
 
         $this->commandTester->execute([]);
 
@@ -76,6 +97,14 @@ class DetectMissingCommandTest extends KernelTestCase
         );
         $this->assertMatchesRegularExpression(
             '/Materials: 14/',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/1 courses are missing from the index/',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/Courses: 33/',
             $output
         );
     }

--- a/tests/Command/Index/DetectMissingCommandTest.php
+++ b/tests/Command/Index/DetectMissingCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command\Index;
+
+use App\Command\Index\DetectMissingCommand;
+use App\Repository\LearningMaterialRepository;
+use App\Service\Index\LearningMaterials;
+use PHPUnit\Framework\Attributes\Group;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+#[Group('cli')]
+class DetectMissingCommandTest extends KernelTestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected CommandTester $commandTester;
+    protected m\MockInterface | LearningMaterialRepository $repository;
+    protected m\MockInterface | LearningMaterials $materialIndex;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = m::mock(LearningMaterialRepository::class);
+        $this->materialIndex = m::mock(LearningMaterials::class);
+
+        $command = new DetectMissingCommand($this->repository, $this->materialIndex);
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->add($command);
+        $commandInApp = $application->find($command->getName());
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->repository);
+        unset($this->materialIndex);
+        unset($this->commandTester);
+    }
+
+    public function testExecuteeWithIndexDisabled(): void
+    {
+        $this->materialIndex->shouldReceive('isEnabled')->once()->andReturn(false);
+        $this->materialIndex->shouldNotReceive('getAllIds');
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/Indexing is not currently configured./',
+            $output
+        );
+    }
+    public function testExecuteWithIndexEnabled(): void
+    {
+        $this->materialIndex->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->materialIndex->shouldReceive('getAllIds')->once()->andReturn([13]);
+        $this->repository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([13, 14]);
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/1 materials are missing from the index/',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/Materials: 14/',
+            $output
+        );
+    }
+}

--- a/tests/Message/LearningMaterialIndexRequestTest.php
+++ b/tests/Message/LearningMaterialIndexRequestTest.php
@@ -23,4 +23,16 @@ class LearningMaterialIndexRequestTest extends TestCase
         $request = new LearningMaterialIndexRequest($arr);
         $this->assertEquals($arr, $request->getIds());
     }
+
+    public function testGetForce(): void
+    {
+        $request = new LearningMaterialIndexRequest([1]);
+        $this->assertFalse($request->getForce());
+
+        $request = new LearningMaterialIndexRequest([1], true);
+        $this->assertTrue($request->getForce());
+
+        $request = new LearningMaterialIndexRequest([1], false);
+        $this->assertFalse($request->getForce());
+    }
 }

--- a/tests/Message/LearningMaterialTextExtractionRequestTest.php
+++ b/tests/Message/LearningMaterialTextExtractionRequestTest.php
@@ -16,4 +16,12 @@ class LearningMaterialTextExtractionRequestTest extends TestCase
         $arr = array_fill(0, 100, '');
         new LearningMaterialTextExtractionRequest($arr);
     }
+
+    public function testConstructor(): void
+    {
+        $arr = [1, 2, 3];
+        $request = new LearningMaterialTextExtractionRequest($arr);
+        $this->assertEquals($arr, $request->getLearningMaterialIds());
+        $this->assertFalse($request->getOverwrite());
+    }
 }

--- a/tests/MessageHandler/LearningMaterialTextExtractionHandlerTest.php
+++ b/tests/MessageHandler/LearningMaterialTextExtractionHandlerTest.php
@@ -86,7 +86,10 @@ class LearningMaterialTextExtractionHandlerTest extends TestCase
 
         $this->bus
             ->shouldReceive('dispatch')
-            ->withArgs(fn (LearningMaterialIndexRequest $request) => array_diff($request->getIds(), $ids) === [])
+            ->withArgs(
+                fn (LearningMaterialIndexRequest $request) =>
+                array_diff($request->getIds(), $ids) === [] && $request->getForce()
+            )
             ->andReturn(new Envelope(new stdClass()))
         ->times(3);
 

--- a/tests/MessageHandler/LearningMaterialTextExtractionHandlerTest.php
+++ b/tests/MessageHandler/LearningMaterialTextExtractionHandlerTest.php
@@ -51,7 +51,7 @@ class LearningMaterialTextExtractionHandlerTest extends TestCase
 
         $this->extractor
             ->shouldReceive('extract')
-            ->with($dto1);
+            ->with($dto1, false);
 
         $this->bus
             ->shouldReceive('dispatch')

--- a/tests/Service/Index/CurriculumTest.php
+++ b/tests/Service/Index/CurriculumTest.php
@@ -217,6 +217,61 @@ class CurriculumTest extends TestCase
         ])->andReturn(['errors' => false, 'took' => 1, "aggregations" => ["courseId" => ["buckets" => $ids]]]);
     }
 
+    public function testGetAllCourseIds(): void
+    {
+        $obj = new Curriculum($this->config, $this->client);
+        $this->client->shouldReceive('search')->once()->andReturn([
+            'hits' => [
+                'hits' => [
+                    ['_source' => ['courseId' => 1]],
+                    ['_source' => ['courseId' => 2]],
+                ],
+            ],
+            '_scroll_id' => '123',
+        ]);
+        $this->client->shouldReceive('scroll')->once()->andReturn(['hits' => ['hits' => []]]);
+        $this->client->shouldReceive('clearScroll')->once();
+        $courseIds = $obj->getAllCourseIds();
+        $this->assertCount(2, $courseIds);
+        $this->assertEquals([1, 2], $courseIds);
+    }
+
+    public function testGetAllSessionIds(): void
+    {
+        $obj = new Curriculum($this->config, $this->client);
+        $this->client->shouldReceive('search')->once()->andReturn([
+            'hits' => [
+                'hits' => [
+                    ['_source' => ['sessionId' => 1]],
+                    ['_source' => ['sessionId' => 2]],
+                ],
+            ],
+            '_scroll_id' => '123',
+        ]);
+        $this->client->shouldReceive('scroll')->once()->andReturn(['hits' => ['hits' => []]]);
+        $this->client->shouldReceive('clearScroll')->once();
+        $ids = $obj->getAllSessionIds();
+        $this->assertCount(2, $ids);
+        $this->assertEquals([1, 2], $ids);
+    }
+
+    public function testGetMapping(): void
+    {
+        $obj = new Curriculum($this->config, $this->client);
+        $mapping = $obj->getMapping();
+        $this->assertArrayHasKey('settings', $mapping);
+        $this->assertArrayHasKey('mappings', $mapping);
+    }
+
+    public function testGetPipeline(): void
+    {
+        $obj = new Curriculum($this->config, $this->client);
+        $pipeline = $obj->getPipeline();
+        $this->assertArrayHasKey('id', $pipeline);
+        $this->assertArrayHasKey('body', $pipeline);
+        $this->assertEquals('curriculum', $pipeline['id']);
+    }
+
     protected function validateRequest(
         string $method,
         string $uri,

--- a/tests/Service/Index/LearningMaterialsTest.php
+++ b/tests/Service/Index/LearningMaterialsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Service\Index;
 
+use App\Classes\OpenSearchBase;
 use App\Entity\DTO\LearningMaterialDTO;
 use App\Service\Config;
 use App\Service\Index\LearningMaterials;
@@ -291,11 +292,11 @@ class LearningMaterialsTest extends TestCase
                     'learningMaterialId' => [
                         'terms' => [
                             'field' => 'learningMaterialId',
-                            'size' => 10000,
+                            'size' => OpenSearchBase::SIZE_LIMIT,
                         ],
                     ],
                 ],
-                'size' => 0,
+                'size' => OpenSearchBase::SIZE_LIMIT,
             ],
         ])->andReturn(['errors' => false, 'took' => 1, "aggregations" => [
             "learningMaterialId" => ["buckets" => $ids],

--- a/tests/Service/Index/LearningMaterialsTest.php
+++ b/tests/Service/Index/LearningMaterialsTest.php
@@ -302,6 +302,26 @@ class LearningMaterialsTest extends TestCase
         ]]);
     }
 
+
+    public function testGetAllIds(): void
+    {
+        $obj = new LearningMaterials($this->fs, $this->config, $this->client);
+        $this->client->shouldReceive('search')->once()->andReturn([
+            'hits' => [
+                'hits' => [
+                    ['_source' => ['learningMaterialId' => 1]],
+                    ['_source' => ['learningMaterialId' => 2]],
+                ],
+            ],
+            '_scroll_id' => '123',
+        ]);
+        $this->client->shouldReceive('scroll')->once()->andReturn(['hits' => ['hits' => []]]);
+        $this->client->shouldReceive('clearScroll')->once();
+        $ids = $obj->getAllIds();
+        $this->assertCount(2, $ids);
+        $this->assertEquals([1, 2], $ids);
+    }
+
     public function testGetMapping(): void
     {
         $obj = new LearningMaterials($this->fs, $this->config, $this->client);

--- a/tests/Service/Index/UsersTest.php
+++ b/tests/Service/Index/UsersTest.php
@@ -73,35 +73,45 @@ class UsersTest extends TestCase
         $user1 = $this->createUserDto(13);
         $user2 = $this->createUserDto(11);
 
-        $this->client->shouldReceive('bulk')->once()
-            ->with(m::capture($args))
+        $this->client->shouldReceive('request')->withArgs(function ($method, $uri, $data) use ($user1, $user2) {
+            $this->assertEquals('POST', $method);
+            $this->assertEquals('/_bulk', $uri);
+            $this->assertArrayHasKey('body', $data);
+            $this->assertArrayHasKey('options', $data);
+            $this->assertEquals(['headers' => ['Content-Encoding' => 'gzip']], $data['options']);
+            $body = gzdecode($data['body']);
+            $arr = array_map(fn ($item) => json_decode($item, true), explode("\n", $body));
+            $filtered = array_filter($arr, 'is_array');
+            $this->assertCount(4, $filtered);
+
+            $this->assertEquals($filtered[1]['id'], $user1->id);
+            $this->assertEquals($filtered[1]['firstName'], $user1->firstName);
+            $this->assertEquals($filtered[1]['lastName'], $user1->lastName);
+            $this->assertEquals($filtered[1]['middleName'], $user1->middleName);
+            $this->assertEquals($filtered[1]['displayName'], $user1->displayName);
+            $this->assertEquals($filtered[1]['email'], $user1->email);
+            $this->assertEquals($filtered[1]['campusId'], $user1->campusId);
+            $this->assertEquals($filtered[1]['username'], $user1->username);
+            $this->assertEquals($filtered[1]['enabled'], $user1->enabled);
+            $this->assertEquals($filtered[1]['fullName'], '13 first 13 middle 13 last');
+            $this->assertEquals($filtered[1]['fullNameLastFirst'], '13 last, 13 first 13 middle');
+
+            $this->assertEquals($filtered[3]['id'], $user2->id);
+            $this->assertEquals($filtered[3]['firstName'], $user2->firstName);
+            $this->assertEquals($filtered[3]['lastName'], $user2->lastName);
+            $this->assertEquals($filtered[3]['middleName'], $user2->middleName);
+            $this->assertEquals($filtered[3]['displayName'], $user2->displayName);
+            $this->assertEquals($filtered[3]['email'], $user2->email);
+            $this->assertEquals($filtered[3]['campusId'], $user2->campusId);
+            $this->assertEquals($filtered[3]['username'], $user2->username);
+            $this->assertEquals($filtered[3]['enabled'], $user2->enabled);
+            $this->assertEquals($filtered[3]['fullName'], '11 first 11 middle 11 last');
+            $this->assertEquals($filtered[3]['fullNameLastFirst'], '11 last, 11 first 11 middle');
+
+            return true;
+        })
         ->andReturn(['errors' => false, 'took' => 1, 'items' => []]);
         $obj->index([$user1, $user2]);
-
-        $this->assertArrayHasKey('body', $args);
-        $this->assertEquals($args['body'][1]['id'], $user1->id);
-        $this->assertEquals($args['body'][1]['firstName'], $user1->firstName);
-        $this->assertEquals($args['body'][1]['lastName'], $user1->lastName);
-        $this->assertEquals($args['body'][1]['middleName'], $user1->middleName);
-        $this->assertEquals($args['body'][1]['displayName'], $user1->displayName);
-        $this->assertEquals($args['body'][1]['email'], $user1->email);
-        $this->assertEquals($args['body'][1]['campusId'], $user1->campusId);
-        $this->assertEquals($args['body'][1]['username'], $user1->username);
-        $this->assertEquals($args['body'][1]['enabled'], $user1->enabled);
-        $this->assertEquals($args['body'][1]['fullName'], '13 first 13 middle 13 last');
-        $this->assertEquals($args['body'][1]['fullNameLastFirst'], '13 last, 13 first 13 middle');
-
-        $this->assertEquals($args['body'][3]['id'], $user2->id);
-        $this->assertEquals($args['body'][3]['firstName'], $user2->firstName);
-        $this->assertEquals($args['body'][3]['lastName'], $user2->lastName);
-        $this->assertEquals($args['body'][3]['middleName'], $user2->middleName);
-        $this->assertEquals($args['body'][3]['displayName'], $user2->displayName);
-        $this->assertEquals($args['body'][3]['email'], $user2->email);
-        $this->assertEquals($args['body'][3]['campusId'], $user2->campusId);
-        $this->assertEquals($args['body'][3]['username'], $user2->username);
-        $this->assertEquals($args['body'][3]['enabled'], $user2->enabled);
-        $this->assertEquals($args['body'][3]['fullName'], '11 first 11 middle 11 last');
-        $this->assertEquals($args['body'][3]['fullNameLastFirst'], '11 last, 11 first 11 middle');
     }
 
     public function testSearchThrowsExceptionWhenNotConfigured(): void

--- a/tests/Service/Index/UsersTest.php
+++ b/tests/Service/Index/UsersTest.php
@@ -84,29 +84,29 @@ class UsersTest extends TestCase
             $filtered = array_filter($arr, 'is_array');
             $this->assertCount(4, $filtered);
 
-            $this->assertEquals($filtered[1]['id'], $user1->id);
-            $this->assertEquals($filtered[1]['firstName'], $user1->firstName);
-            $this->assertEquals($filtered[1]['lastName'], $user1->lastName);
-            $this->assertEquals($filtered[1]['middleName'], $user1->middleName);
-            $this->assertEquals($filtered[1]['displayName'], $user1->displayName);
-            $this->assertEquals($filtered[1]['email'], $user1->email);
-            $this->assertEquals($filtered[1]['campusId'], $user1->campusId);
-            $this->assertEquals($filtered[1]['username'], $user1->username);
-            $this->assertEquals($filtered[1]['enabled'], $user1->enabled);
-            $this->assertEquals($filtered[1]['fullName'], '13 first 13 middle 13 last');
-            $this->assertEquals($filtered[1]['fullNameLastFirst'], '13 last, 13 first 13 middle');
+            $this->assertEquals($user1->id, $filtered[1]['id']);
+            $this->assertEquals($user1->firstName, $filtered[1]['firstName']);
+            $this->assertEquals($user1->lastName, $filtered[1]['lastName']);
+            $this->assertEquals($user1->middleName, $filtered[1]['middleName']);
+            $this->assertEquals($user1->displayName, $filtered[1]['displayName']);
+            $this->assertEquals($user1->email, $filtered[1]['email']);
+            $this->assertEquals($user1->campusId, $filtered[1]['campusId']);
+            $this->assertEquals($user1->username, $filtered[1]['username']);
+            $this->assertEquals($user1->enabled, $filtered[1]['enabled']);
+            $this->assertEquals('13 first 13 middle 13 last', $filtered[1]['fullName']);
+            $this->assertEquals('13 last, 13 first 13 middle', $filtered[1]['fullNameLastFirst']);
 
-            $this->assertEquals($filtered[3]['id'], $user2->id);
-            $this->assertEquals($filtered[3]['firstName'], $user2->firstName);
-            $this->assertEquals($filtered[3]['lastName'], $user2->lastName);
-            $this->assertEquals($filtered[3]['middleName'], $user2->middleName);
-            $this->assertEquals($filtered[3]['displayName'], $user2->displayName);
-            $this->assertEquals($filtered[3]['email'], $user2->email);
-            $this->assertEquals($filtered[3]['campusId'], $user2->campusId);
-            $this->assertEquals($filtered[3]['username'], $user2->username);
-            $this->assertEquals($filtered[3]['enabled'], $user2->enabled);
-            $this->assertEquals($filtered[3]['fullName'], '11 first 11 middle 11 last');
-            $this->assertEquals($filtered[3]['fullNameLastFirst'], '11 last, 11 first 11 middle');
+            $this->assertEquals($user2->id, $filtered[3]['id']);
+            $this->assertEquals($user2->firstName, $filtered[3]['firstName']);
+            $this->assertEquals($user2->lastName, $filtered[3]['lastName']);
+            $this->assertEquals($user2->middleName, $filtered[3]['middleName']);
+            $this->assertEquals($user2->displayName, $filtered[3]['displayName']);
+            $this->assertEquals($user2->email, $filtered[3]['email']);
+            $this->assertEquals($user2->campusId, $filtered[3]['campusId']);
+            $this->assertEquals($user2->username, $filtered[3]['username']);
+            $this->assertEquals($user2->enabled, $filtered[3]['enabled']);
+            $this->assertEquals('11 first 11 middle 11 last', $filtered[3]['fullName']);
+            $this->assertEquals('11 last, 11 first 11 middle', $filtered[3]['fullNameLastFirst']);
 
             return true;
         })

--- a/tests/Service/LearningMaterialTextExtractorTest.php
+++ b/tests/Service/LearningMaterialTextExtractorTest.php
@@ -95,12 +95,6 @@ class LearningMaterialTextExtractorTest extends TestCase
             ->once()
             ->with(self::TEST_FILE_PATH)
             ->andReturn('lm-text');
-        $this->tikaClient
-            ->shouldReceive('isMimeTypeSupported')
-            ->once()
-            ->with('test/pdf')
-            ->andReturn(true);
-
         $this->fileSystem
             ->shouldReceive('checkIfLearningMaterialTextFileExists')
             ->once()
@@ -124,31 +118,12 @@ class LearningMaterialTextExtractorTest extends TestCase
         $this->extractor->extract($dto, false);
     }
 
-    public function testNonFileLm(): void
-    {
-        $dto = m::mock(LearningMaterialDTO::class);
-        $dto->filename = 't.txt';
-        $dto->mimetype = 'test/pdf';
-        $this->tikaClient
-            ->shouldReceive('isMimeTypeSupported')
-            ->once()
-            ->with('test/pdf')
-            ->andReturn(false);
-        $this->extractor->extract($dto, false);
-    }
-
     public function testFileAlreadyExists(): void
     {
         $dto = m::mock(LearningMaterialDTO::class);
         $dto->relativePath = 'dir/lm/24/24jj';
         $dto->filename = 'jayden.pdf';
         $dto->mimetype = 'test/pdf';
-        $this->tikaClient
-            ->shouldReceive('isMimeTypeSupported')
-            ->once()
-            ->with('test/pdf')
-            ->andReturn(true);
-
         $this->fileSystem
             ->shouldReceive('checkIfLearningMaterialTextFileExists')
             ->once()
@@ -170,12 +145,6 @@ class LearningMaterialTextExtractorTest extends TestCase
             ->once()
             ->andReturn(false);
         $tmpFile = new File(self::TEST_FILE_PATH);
-        $this->tikaClient
-            ->shouldReceive('isMimeTypeSupported')
-            ->once()
-            ->with('test/pdf')
-            ->andReturn(true);
-
         $this->fileSystem
             ->shouldReceive('checkIfLearningMaterialTextFileExists')
             ->once()
@@ -211,12 +180,6 @@ class LearningMaterialTextExtractorTest extends TestCase
             ->once()
             ->with(self::TEST_FILE_PATH)
             ->andThrow(Exception::class, 'Unprocessable document', 422);
-        $this->tikaClient
-            ->shouldReceive('isMimeTypeSupported')
-            ->once()
-            ->with('test/pdf')
-            ->andReturn(true);
-
         $this->fileSystem
             ->shouldReceive('checkIfLearningMaterialTextFileExists')
             ->once()
@@ -259,12 +222,6 @@ class LearningMaterialTextExtractorTest extends TestCase
             ->once()
             ->with(self::TEST_FILE_PATH)
             ->andReturn('lm-text');
-        $this->tikaClient
-            ->shouldReceive('isMimeTypeSupported')
-            ->once()
-            ->with('test/pdf')
-            ->andReturn(true);
-
         $this->fileSystem->shouldNotReceive('checkIfLearningMaterialTextFileExists');
         $this->fileSystem
             ->shouldReceive('storeLearningMaterialText')


### PR DESCRIPTION
Course and session materials are indexed into their own index, and then extracted during session indexing and included for search. This is made possible by good cleaning of the material text, and compression of the data to stay within common open search limits. 
wip:
- [x] need to validate some failures with re:indexing I'm seeing (These errors are from LMs on my local that needed to go through text extraction again)
- [x] need to test on stage
- [x] need to validate that all materials and sessions ended up in the index when it is re:run.