### PR TITLE
Display Details That Trigger Warnings

### DIFF
--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -7,6 +7,7 @@
          colors="true"
          bootstrap="tests/bootstrap.php"
          cacheDirectory=".phpunit.cache"
+         displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <php>
         <ini name="display_errors" value="1" />


### PR DESCRIPTION
This seems useful and makes it far easier to debug when you cause a warning with code PHPUnit is executing.