### PR TITLE
Overwrite the ILIOS_STORAGE_S3_URL in docker

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -34,6 +34,7 @@ services:
       - ILIOS_SEARCH_HOST=http://opensearch:9200
       - ILIOS_REDIS_URL=redis://redis
       - ILIOS_FEATURE_DTO_CACHING=false
+      - ILIOS_STORAGE_S3_URL=false
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/ilios-storage
       - ILIOS_TIKA_URL=http://tika:9998
     volumes:
@@ -55,6 +56,7 @@ services:
       - ILIOS_ERROR_CAPTURE_ENABLED=false
       - ILIOS_SEARCH_HOST=http://opensearch:9200
       - ILIOS_REDIS_URL=redis://redis
+      - ILIOS_STORAGE_S3_URL=false
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/ilios-storage
       - ILIOS_TIKA_URL=http://tika:9998
     restart: always


### PR DESCRIPTION
For our docker containers we use a local file storage, just in case someone uses a production database with this value we should overwrite it here.