### PR TITLE
Optimize Curriculum Search Fetch

### DIFF
--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -51,29 +51,29 @@ class Curriculum extends OpenSearchBase
             'index' => self::INDEX,
             'body' => [
                 'suggest' => $suggest,
-                "_source" => [
-                    'courseId',
-                    'courseTitle',
-                    'courseYear',
-                    'sessionId',
-                    'sessionTitle',
-                    'school',
-                ],
-                'collapse' => [
-                    'field' => 'courseId',
-                    'inner_hits' => [
-                        'name' => 'sessions',
-                        'size' => 5,
-                        'sort' => ['_score'],
-                    ],
-                ],
-                'sort' => '_score',
-                'size' => 25,
-                'min_score' => 25,
             ],
         ];
 
         if (!$onlySuggest) {
+            $params['body']['_source'] = [
+                'courseId',
+                'courseTitle',
+                'courseYear',
+                'sessionId',
+                'sessionTitle',
+                'school',
+            ];
+            $params['body']['collapse'] = [
+                'field' => 'courseId',
+                'inner_hits' => [
+                    'name' => 'sessions',
+                    'size' => 5,
+                    'sort' => ['_score'],
+                ],
+            ];
+            $params['body']['sort'] = '_score';
+            $params['body']['size'] = 25;
+            $params['body']['min_score'] = 25;
             $params['body']['query'] = $this->buildCurriculumSearch($query);
         }
 


### PR DESCRIPTION
Performance in the fetch phase of search isn't good enough. This seems to be caused by pulling too many results. Getting deep into what we can do with search what I've done is limit to 25 courses worth of data by combining all the results by their course ID and then including the sessions that go with that course. This limits the results, but can result in some less-relevant seeming results so I also applied some logic to have courses that are closer to today rank higher.

Wip:
- [ ] Test on stage, see if this helps
- [ ] See how results feel to users

Next Steps:
Need to allow users to page forward through results until the end, but this required some API additions that we'd like to hold off on if possible until we get our current LM search work released.