### PR TITLE
Stop Splitting Materials

### DIFF
--- a/tests/Service/Index/LearningMaterialsTest.php
+++ b/tests/Service/Index/LearningMaterialsTest.php
@@ -114,11 +114,11 @@ class LearningMaterialsTest extends TestCase
                 [
                     'index' => [
                         '_index' => LearningMaterials::INDEX,
-                        '_id' => 'lm_0_1',
+                        '_id' => 'lm_1',
                     ],
                 ],
                 [
-                    'id' => 'lm_0_1',
+                    'id' => 'lm_1',
                     'learningMaterialId' => 1,
                     'title' => 'first title',
                     'description' => 'first description',
@@ -128,11 +128,11 @@ class LearningMaterialsTest extends TestCase
                 [
                     'index' => [
                         '_index' => LearningMaterials::INDEX,
-                        '_id' => 'lm_0_2',
+                        '_id' => 'lm_2',
                     ],
                 ],
                 [
-                    'id' => 'lm_0_2',
+                    'id' => 'lm_2',
                     'learningMaterialId' => 2,
                     'title' => 'second title',
                     'description' => 'second description',
@@ -179,11 +179,11 @@ class LearningMaterialsTest extends TestCase
                 [
                     'index' => [
                         '_index' => LearningMaterials::INDEX,
-                        '_id' => 'lm_0_2',
+                        '_id' => 'lm_2',
                     ],
                 ],
                 [
-                    'id' => 'lm_0_2',
+                    'id' => 'lm_2',
                     'learningMaterialId' => 2,
                     'title' => 'second title',
                     'description' => 'second description',
@@ -240,11 +240,11 @@ class LearningMaterialsTest extends TestCase
                     [
                         'index' => [
                             '_index' => LearningMaterials::INDEX,
-                            '_id' => 'lm_0_1',
+                            '_id' => 'lm_1',
                         ],
                     ],
                     [
-                        'id' => 'lm_0_1',
+                        'id' => 'lm_1',
                         'learningMaterialId' => 1,
                         'title' => 'first title',
                         'description' => 'first description',
@@ -254,11 +254,11 @@ class LearningMaterialsTest extends TestCase
                     [
                         'index' => [
                             '_index' => LearningMaterials::INDEX,
-                            '_id' => 'lm_0_2',
+                            '_id' => 'lm_2',
                         ],
                     ],
                     [
-                        'id' => 'lm_0_2',
+                        'id' => 'lm_2',
                         'learningMaterialId' => 2,
                         'title' => 'second title',
                         'description' => 'second description',


### PR DESCRIPTION
This is an unnecessary extra step, once converted to text and compressed no materials in our very large sample are over a few megabytes. We can go ahead and index them as is.