### PR TITLE
Stop Sleeping When indexing

### DIFF
--- a/src/Classes/OpenSearchBase.php
+++ b/src/Classes/OpenSearchBase.php
@@ -184,8 +184,6 @@ class OpenSearchBase
                 $results['errors'] = true;
             }
             $results['items'] = array_merge($results['items'], $rhett['items']);
-            //allow search time to catch up https://github.com/opensearch-project/opensearch-php/blob/9457c505e9bce68ca81932a461159517635aeba1/USER_GUIDE.md?plain=1#L139-L140
-            sleep(2);
         }
 
         if ($results['errors']) {


### PR DESCRIPTION
This was added as an attempt to fix persistent issues in our indexing, but it doesn't seem to be doing anything. The sleep we referenced in the guide was between a create and update transaction and possibly wasn't helpful here at all.

Refs #4704