### PR TITLE
Remove Unused Opensearch Plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -251,7 +251,6 @@ RUN /bin/bash /fetch-demo-database.sh
 ###############################################################################
 FROM opensearchproject/opensearch:2 AS opensearch
 LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
-RUN bin/opensearch-plugin install -b ingest-attachment
 
 ###############################################################################
 # Setup redis with needed config


### PR DESCRIPTION
We're now parsing materials with tikka directly as the POST size limits on AWS wouldn't work with our materials. We don't need this plugin anymore in our opensearch image.