### PR TITLE
Docker Opensearch Cluster

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -87,6 +87,7 @@ services:
       - node.name=opensearch
       - cluster.initial_cluster_manager_nodes=opensearch,opensearch-node2
       - discovery.seed_hosts=opensearch,opensearch-node2
+      - "OPENSEARCH_JAVA_OPTS=-Xms1600m -Xmx1600m"
     ports:
       - "9200:9200"
 
@@ -100,6 +101,7 @@ services:
       - node.name=opensearch-node2
       - cluster.initial_cluster_manager_nodes=opensearch,opensearch-node2
       - discovery.seed_hosts=opensearch,opensearch-node2
+      - "OPENSEARCH_JAVA_OPTS=-Xms1600m -Xmx1600m"
 
   redis:
     build:


### PR DESCRIPTION
More similar to our production environment and easier to diagnose and
debug query performance.

Mainly opening PR for reference. I'm not convinced we need this for development as it didn't show the same slow fetch phase performance as we have in production anyway.