### PR TITLE
Drop PHP 8.3 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   ILIOS_FILE_SYSTEM_STORAGE_PATH: /tmp
   SYMFONY_DEPRECATIONS_HELPER: disabled=1
   MESSENGER_TRANSPORT_DSN: doctrine://default
-  minimum_php_version: 8.3
+  minimum_php_version: 8.4
   DOCKER_BUILDKIT: 1
 
   #token is tied to Jon's account on UCSF's SonarQube (type: project, name: ilios)
@@ -70,7 +70,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.4, 8.3]
+        php-version: [8.4]
 
     steps:
     - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.4, 8.3]
+        php-version: [8.4]
 
     steps:
     - uses: actions/checkout@v4
@@ -345,7 +345,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.4, 8.3]
+        php-version: [8.4]
 
     steps:
       - uses: actions/checkout@v4
@@ -364,7 +364,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.4, 8.3]
+        php-version: [8.4]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -12,7 +12,7 @@ env:
   ILIOS_FILE_SYSTEM_STORAGE_PATH: /tmp
   SYMFONY_DEPRECATIONS_HELPER: disabled=1
   MESSENGER_TRANSPORT_DSN: doctrine://default
-  minimum_php_version: 8.3
+  minimum_php_version: 8.4
   DOCKER_BUILDKIT: 1
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
 

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
-  minimum_php_version: 8.3
+  minimum_php_version: 8.4
 
 jobs:
   update:

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "description": "The \"Ilios Standard Edition\" distribution",
   "version": "3.124.0",
   "require": {
-    "php": ">= 8.3",
+    "php": ">= 8.4",
     "ext-apcu": "*",
     "ext-ctype": "*",
     "ext-curl": "*",
@@ -92,7 +92,7 @@
   },
   "config": {
     "platform": {
-      "php": "8.3"
+      "php": "8.4"
     },
     "preferred-install": {
       "*": "dist"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1780ae097a14f53eafc8833d925eb7d4",
+    "content-hash": "a047c3150481d04ba884a1af1c349770",
     "packages": [
         {
             "name": "async-aws/core",
@@ -15202,7 +15202,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 8.3",
+        "php": ">= 8.4",
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-curl": "*",
@@ -15218,7 +15218,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.3"
+        "php": "8.4"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/config/packages/monitor.yaml
+++ b/config/packages/monitor.yaml
@@ -6,7 +6,7 @@ liip_monitor:
       default:
         php_extensions: [apcu, mbstring, ldap, xml, dom, mysqlnd, pdo, zip, json, zlib, ctype, iconv]
         php_version:
-            "8.3": ">="
+            "8.4": ">="
         readable_directory: ["%kernel.cache_dir%"]
         writable_directory: ["%kernel.cache_dir%"]
       production:

--- a/docs/ilios_php_version_policy.md
+++ b/docs/ilios_php_version_policy.md
@@ -8,13 +8,13 @@ At any given time, the Ilios application will only be supported on the very late
 
 ### Policy Example
 
-For example, the current minimum version of PHP is v8.3. When PHP v8.4 is released, we will continue to ensure the Ilios code will work on PHP 8.3 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 8.4 going forward.
+For example, the current minimum version of PHP is v8.4. When PHP v8.5 is released, we will continue to ensure the Ilios code will work on PHP 8.4 for at least 90 days, and then, after that time has passed, we will only offer support for Ilios applications running on PHP 8.5 going forward.
 
 ## Currently Supported Versions of PHP
 
 Based on the policy above, Ilios is currently compatible with the following versions of PHP:
 
-* PHP 8.3
+* PHP 8.4
 
 ## Up-To-Date PHP Repositories for CentOS and RHEL
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ Ilios 3 uses a Symfony (PHP/SQL) backend to serve its API, so these tools and th
 
 * CentOS 7 - Any modern Linux should work, but we recommend Redhat (RHEL, CentOS, or Fedora) or Ubuntu
 * MySQL using the InnoDB database engine (v5.7 or later required, 8+ recommended)
-* PHP v8.3+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
+* PHP v8.4+ REQUIRED - In order to ensure the best security and performance of the application overall, we have adopted a policy of requiring the latest version of PHP for running Ilios. Please see [ilios_php_version_policy.md](docs/ilios_php_version_policy.md) for the latest information about the PHP version requirements for Ilios.
 
 NOTE: Several institutions have successfully deployed Ilios using Microsoft IIS on Windows as their webserver, but we do not recommend it as we do not have alot of experience with it ourselves and we've only ever support Ilios on Linux systems. That being said, if you MUST use IIS for Windows and are having trouble getting Ilios running properly, please contact the [Ilios Project Support Team](https://iliosproject.org) at [support@iliosproject.org](mailto:support@iliosproject.org) if you have any problems and we might be able to help you out!
 
@@ -74,7 +74,7 @@ All the steps below should be performed in the context of the user that runs you
     sudo -u apache git checkout tags/$(git fetch --tags; git describe --tags `git rev-list --tags --max-count=1`)
     ```
 
-5. Run the following command to build the packages and its dependencies. This step assumes you have PHP 8.3+ and Composer installed on your system:
+5. Run the following command to build the packages and its dependencies. This step assumes you have PHP 8.4+ and Composer installed on your system:
 
     ```bash
     sudo -u apache bin/setup

--- a/tests/Classes/AcademicYearTest.php
+++ b/tests/Classes/AcademicYearTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Classes;
 use App\Classes\AcademicYear;
 use App\Tests\TestCase;
 
-class AcademicYearTest extends TestCase
+final class AcademicYearTest extends TestCase
 {
     public function testConstructor(): void
     {

--- a/tests/Classes/IndexableCourseTest.php
+++ b/tests/Classes/IndexableCourseTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(IndexableCourse::class)]
-class IndexableCourseTest extends TestCase
+final class IndexableCourseTest extends TestCase
 {
     public function testCreateIndexObjects(): void
     {

--- a/tests/Classes/IndexableSessionTest.php
+++ b/tests/Classes/IndexableSessionTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(IndexableSession::class)]
-class IndexableSessionTest extends TestCase
+final class IndexableSessionTest extends TestCase
 {
     public function testCreateIndexObjects(): void
     {

--- a/tests/Classes/InflectorTest.php
+++ b/tests/Classes/InflectorTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 use App\Service\InflectorFactory;
 use PHPUnit\Framework\TestCase;
 
-class InflectorTest extends TestCase
+final class InflectorTest extends TestCase
 {
     #[Group('twice')]
     public function testInstanceInflection(): void

--- a/tests/Classes/LocalCachingFilesystemDecoratorTest.php
+++ b/tests/Classes/LocalCachingFilesystemDecoratorTest.php
@@ -14,7 +14,7 @@ use Mockery as m;
  * Class LocalCachingFilesystemDecoratorTest
  * @package App\Tests\Classes
  */
-class LocalCachingFilesystemDecoratorTest extends TestCase
+final class LocalCachingFilesystemDecoratorTest extends TestCase
 {
     private FilesystemOperator|m\MockInterface $cacheFileSystem;
     private FilesystemOperator|m\MockInterface $remoteFileSystem;

--- a/tests/Classes/MysqlMigrationTest.php
+++ b/tests/Classes/MysqlMigrationTest.php
@@ -18,7 +18,7 @@ use function iterator_to_array;
 use function str_starts_with;
 use function var_export;
 
-class MysqlMigrationTest extends WebTestCase
+final class MysqlMigrationTest extends WebTestCase
 {
     public function testConstructor(): void
     {

--- a/tests/Classes/PermissionMatrixTest.php
+++ b/tests/Classes/PermissionMatrixTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
  * Class PermissionMatrixTest
  */
 #[CoversClass(PermissionMatrix::class)]
-class PermissionMatrixTest extends TestCase
+final class PermissionMatrixTest extends TestCase
 {
     protected PermissionMatrix $permissionMatrix;
 

--- a/tests/Classes/SchoolEventTest.php
+++ b/tests/Classes/SchoolEventTest.php
@@ -17,7 +17,7 @@ use DateTime;
  * @package App\Tests\Classes
  */
 #[CoversClass(SchoolEvent::class)]
-class SchoolEventTest extends TestCase
+final class SchoolEventTest extends TestCase
 {
     protected SchoolEvent $schoolEvent;
 

--- a/tests/Classes/ServiceTokenUserTest.php
+++ b/tests/Classes/ServiceTokenUserTest.php
@@ -16,7 +16,7 @@ use Mockery as m;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[CoversClass(ServiceTokenUser::class)]
-class ServiceTokenUserTest extends TestCase
+final class ServiceTokenUserTest extends TestCase
 {
     protected m\MockInterface $mockServiceToken;
     protected ServiceTokenUser $serviceTokenUser;

--- a/tests/Classes/SessionUserTest.php
+++ b/tests/Classes/SessionUserTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
  * Class SessionUserTest
  */
 #[CoversClass(SessionUser::class)]
-class SessionUserTest extends TestCase
+final class SessionUserTest extends TestCase
 {
     protected m\MockInterface $iliosUser;
 

--- a/tests/Classes/UserEventTest.php
+++ b/tests/Classes/UserEventTest.php
@@ -18,7 +18,7 @@ use DateTime;
  */
 #[CoversClass(CalendarEvent::class)]
 #[CoversClass(UserEvent::class)]
-class UserEventTest extends TestCase
+final class UserEventTest extends TestCase
 {
     protected UserEvent $userEvent;
 

--- a/tests/Classes/UserMaterialTest.php
+++ b/tests/Classes/UserMaterialTest.php
@@ -14,7 +14,7 @@ use DateTime;
  * @package App\Tests\Classes
  */
 #[CoversClass(UserMaterial::class)]
-class UserMaterialTest extends TestCase
+final class UserMaterialTest extends TestCase
 {
     protected UserMaterial $userMaterial;
 

--- a/tests/Command/AddDirectoryUserCommandTest.php
+++ b/tests/Command/AddDirectoryUserCommandTest.php
@@ -25,7 +25,7 @@ use Mockery as m;
  * Class AddDirectoryUserCommandTest
  */
 #[Group('cli')]
-class AddDirectoryUserCommandTest extends KernelTestCase
+final class AddDirectoryUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -27,7 +27,7 @@ use Mockery as m;
  * Class AddNewStudentsToSchoolCommandTest
  */
 #[Group('cli')]
-class AddNewStudentsToSchoolCommandTest extends KernelTestCase
+final class AddNewStudentsToSchoolCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/AddRootUserCommandTest.php
+++ b/tests/Command/AddRootUserCommandTest.php
@@ -24,7 +24,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(AddRootUserCommand::class)]
-class AddRootUserCommandTest extends KernelTestCase
+final class AddRootUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  * Class AddUserCommandTest
  */
 #[Group('cli')]
-class AddUserCommandTest extends KernelTestCase
+final class AddUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/AuditLogExportCommandTest.php
+++ b/tests/Command/AuditLogExportCommandTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 #[Group('cli')]
 #[CoversClass(InstallFirstUserCommand::class)]
-class AuditLogExportCommandTest extends KernelTestCase
+final class AuditLogExportCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ChangePasswordCommandTest.php
+++ b/tests/Command/ChangePasswordCommandTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class ChangePasswordCommandTest extends KernelTestCase
+final class ChangePasswordCommandTest extends KernelTestCase
 {
     use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
 

--- a/tests/Command/ChangeUsernameCommandTest.php
+++ b/tests/Command/ChangeUsernameCommandTest.php
@@ -23,7 +23,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class ChangeUsernameCommandTest extends KernelTestCase
+final class ChangeUsernameCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/CleanupS3FilesystemCacheCommandTest.php
+++ b/tests/Command/CleanupS3FilesystemCacheCommandTest.php
@@ -23,7 +23,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class CleanupS3FilesystemCacheCommandTest extends KernelTestCase
+final class CleanupS3FilesystemCacheCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/CleanupStringsCommandTest.php
+++ b/tests/Command/CleanupStringsCommandTest.php
@@ -39,7 +39,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 #[Group('cli')]
 #[CoversClass(CleanupStringsCommand::class)]
-class CleanupStringsCommandTest extends KernelTestCase
+final class CleanupStringsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/CreateServiceTokenCommandTest.php
+++ b/tests/Command/CreateServiceTokenCommandTest.php
@@ -28,7 +28,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(CreateServiceTokenCommand::class)]
-class CreateServiceTokenCommandTest extends KernelTestCase
+final class CreateServiceTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/CreateUserTokenCommandTest.php
+++ b/tests/Command/CreateUserTokenCommandTest.php
@@ -22,7 +22,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class CreateUserTokenCommandTest extends KernelTestCase
+final class CreateUserTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/DeleteServiceTokenCommandTest.php
+++ b/tests/Command/DeleteServiceTokenCommandTest.php
@@ -21,7 +21,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(DeleteServiceTokenCommand::class)]
-class DeleteServiceTokenCommandTest extends KernelTestCase
+final class DeleteServiceTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/DisableServiceTokenCommandTest.php
+++ b/tests/Command/DisableServiceTokenCommandTest.php
@@ -21,7 +21,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(DisableServiceTokenCommand::class)]
-class DisableServiceTokenCommandTest extends KernelTestCase
+final class DisableServiceTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/EnableServiceTokenCommandTest.php
+++ b/tests/Command/EnableServiceTokenCommandTest.php
@@ -21,7 +21,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(EnableServiceTokenCommand::class)]
-class EnableServiceTokenCommandTest extends KernelTestCase
+final class EnableServiceTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ExtractLearningMaterialsTextCommandTest.php
+++ b/tests/Command/ExtractLearningMaterialsTextCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[Group('cli')]
-class ExtractLearningMaterialsTextCommandTest extends KernelTestCase
+final class ExtractLearningMaterialsTextCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/FindUserCommandTest.php
+++ b/tests/Command/FindUserCommandTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class FindUserCommandTest extends KernelTestCase
+final class FindUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
+++ b/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\File\File;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
+final class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ImportDefaultDataCommandTest.php
+++ b/tests/Command/ImportDefaultDataCommandTest.php
@@ -38,7 +38,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(ImportDefaultDataCommand::class)]
-class ImportDefaultDataCommandTest extends KernelTestCase
+final class ImportDefaultDataCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ImportMeshUniverseCommandAcceptanceTest.php
+++ b/tests/Command/ImportMeshUniverseCommandAcceptanceTest.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 #[Group('cli')]
 #[CoversClass(ImportMeshUniverseCommand::class)]
-class ImportMeshUniverseCommandAcceptanceTest extends KernelTestCase
+final class ImportMeshUniverseCommandAcceptanceTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ImportMeshUniverseCommandTest.php
+++ b/tests/Command/ImportMeshUniverseCommandTest.php
@@ -24,7 +24,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(ImportMeshUniverseCommand::class)]
-class ImportMeshUniverseCommandTest extends KernelTestCase
+final class ImportMeshUniverseCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/Index/CourseCommandTest.php
+++ b/tests/Command/Index/CourseCommandTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Command\Index;
 
+use App\Classes\IndexableCourse;
 use App\Command\Index\CourseCommand;
 use App\Repository\CourseRepository;
 use App\Service\Index\Curriculum;
-use App\Tests\Classes\IndexableCourseTest;
 use DateTime;
 use PHPUnit\Framework\Attributes\Group;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
 #[Group('cli')]
-class CourseCommandTest extends KernelTestCase
+final class CourseCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 
@@ -53,7 +53,7 @@ class CourseCommandTest extends KernelTestCase
     public function testExecute(): void
     {
         $this->index->shouldReceive('isEnabled')->once()->andReturn(true);
-        $c = m::mock(IndexableCourseTest::class);
+        $c = m::mock(IndexableCourse::class);
         $this->repository->shouldReceive('getCourseIndexesFor')->once()->with([13])->andReturn([$c]);
         $this->index->shouldReceive('index')
             ->once()

--- a/tests/Command/Index/CreateCommandTest.php
+++ b/tests/Command/Index/CreateCommandTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
 #[Group('cli')]
-class CreateCommandTest extends KernelTestCase
+final class CreateCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/Index/DetectMissingCommandTest.php
+++ b/tests/Command/Index/DetectMissingCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
 #[Group('cli')]
-class DetectMissingCommandTest extends KernelTestCase
+final class DetectMissingCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/Index/DropCommandTest.php
+++ b/tests/Command/Index/DropCommandTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
 #[Group('cli')]
-class DropCommandTest extends KernelTestCase
+final class DropCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/Index/MaterialCommandTest.php
+++ b/tests/Command/Index/MaterialCommandTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
 #[Group('cli')]
-class MaterialCommandTest extends KernelTestCase
+final class MaterialCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/InstallFirstUserCommandTest.php
+++ b/tests/Command/InstallFirstUserCommandTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  * Class InstallFirstUserCommandTest
  */
 #[Group('cli')]
-class InstallFirstUserCommandTest extends KernelTestCase
+final class InstallFirstUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/InvalidateUserTokenCommandTest.php
+++ b/tests/Command/InvalidateUserTokenCommandTest.php
@@ -23,7 +23,7 @@ use DateTime;
  * Class InvalidateUserTokenCommandTest
  */
 #[Group('cli')]
-class InvalidateUserTokenCommandTest extends KernelTestCase
+final class InvalidateUserTokenCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ListConfigValuesCommandTest.php
+++ b/tests/Command/ListConfigValuesCommandTest.php
@@ -21,7 +21,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class ListConfigValuesCommandTest extends KernelTestCase
+final class ListConfigValuesCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ListRootUsersCommandTest.php
+++ b/tests/Command/ListRootUsersCommandTest.php
@@ -22,7 +22,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(ListRootUsersCommand::class)]
-class ListRootUsersCommandTest extends KernelTestCase
+final class ListRootUsersCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ListSchoolConfigValuesCommandTest.php
+++ b/tests/Command/ListSchoolConfigValuesCommandTest.php
@@ -22,7 +22,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class ListSchoolConfigValuesCommandTest extends KernelTestCase
+final class ListSchoolConfigValuesCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ListServiceTokensCommandTest.php
+++ b/tests/Command/ListServiceTokensCommandTest.php
@@ -23,7 +23,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(ListServiceTokensCommand::class)]
-class ListServiceTokensCommandTest extends KernelTestCase
+final class ListServiceTokensCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
+++ b/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\File\File;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
+final class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/RemoveRootUserCommandTest.php
+++ b/tests/Command/RemoveRootUserCommandTest.php
@@ -24,7 +24,7 @@ use Mockery as m;
  */
 #[Group('cli')]
 #[CoversClass(RemoveRootUserCommand::class)]
-class RemoveRootUserCommandTest extends KernelTestCase
+final class RemoveRootUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/RolloverCourseCommandTest.php
+++ b/tests/Command/RolloverCourseCommandTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
  * Class RolloverCourseCommandTest
  */
 #[Group('cli')]
-class RolloverCourseCommandTest extends KernelTestCase
+final class RolloverCourseCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
+++ b/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
@@ -21,7 +21,7 @@ use Mockery as m;
  * Class RolloverCurriculumInventoryReportCommandTest
  */
 #[Group('cli')]
-class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
+final class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SendChangeAlertsCommandTest.php
+++ b/tests/Command/SendChangeAlertsCommandTest.php
@@ -48,7 +48,7 @@ use Twig\Environment;
  */
 #[Group('cli')]
 #[CoversClass(Command::class)]
-class SendChangeAlertsCommandTest extends KernelTestCase
+final class SendChangeAlertsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SendTeachingRemindersCommandTest.php
+++ b/tests/Command/SendTeachingRemindersCommandTest.php
@@ -43,7 +43,7 @@ use Symfony\Component\Mailer\MailerInterface;
  */
 #[Group('cli')]
 #[CoversClass(SendTeachingRemindersCommand::class)]
-class SendTeachingRemindersCommandTest extends KernelTestCase
+final class SendTeachingRemindersCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SendTestEmailCommandTest.php
+++ b/tests/Command/SendTestEmailCommandTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Mime\Email;
  */
 #[Group('cli')]
 #[CoversClass(SendChangeAlertsCommand::class)]
-class SendTestEmailCommandTest extends KernelTestCase
+final class SendTestEmailCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SetConfigValueCommandTest.php
+++ b/tests/Command/SetConfigValueCommandTest.php
@@ -20,7 +20,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class SetConfigValueCommandTest extends KernelTestCase
+final class SetConfigValueCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SetSchoolConfigValueCommandTest.php
+++ b/tests/Command/SetSchoolConfigValueCommandTest.php
@@ -22,7 +22,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class SetSchoolConfigValueCommandTest extends KernelTestCase
+final class SetSchoolConfigValueCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SetupAuthenticationCommandTest.php
+++ b/tests/Command/SetupAuthenticationCommandTest.php
@@ -18,7 +18,7 @@ use Mockery as m;
  * Class SetupAuthenticationCommandTest
  */
 #[Group('cli')]
-class SetupAuthenticationCommandTest extends KernelTestCase
+final class SetupAuthenticationCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SyncAllUsersCommandTest.php
+++ b/tests/Command/SyncAllUsersCommandTest.php
@@ -24,7 +24,7 @@ use Mockery as m;
  * Class SyncAllUsersCommandTest
  */
 #[Group('cli')]
-class SyncAllUsersCommandTest extends KernelTestCase
+final class SyncAllUsersCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SyncFormerStudentsCommandTest.php
+++ b/tests/Command/SyncFormerStudentsCommandTest.php
@@ -24,7 +24,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class SyncFormerStudentsCommandTest extends KernelTestCase
+final class SyncFormerStudentsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SyncStudentStatusCommandTest.php
+++ b/tests/Command/SyncStudentStatusCommandTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Mockery as m;
 
 #[Group('cli')]
-class SyncStudentStatusCommandTest extends KernelTestCase
+final class SyncStudentStatusCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/SyncUserCommandTest.php
+++ b/tests/Command/SyncUserCommandTest.php
@@ -26,7 +26,7 @@ use Mockery as m;
  * Class SyncUserCommandTest
  */
 #[Group('cli')]
-class SyncUserCommandTest extends KernelTestCase
+final class SyncUserCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/ValidateLearningMaterialPathsCommandTest.php
+++ b/tests/Command/ValidateLearningMaterialPathsCommandTest.php
@@ -20,7 +20,7 @@ use Mockery as m;
  * @package App\Tests\Command
  */
 #[Group('cli')]
-class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
+final class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/WaitForDatabaseCommandTest.php
+++ b/tests/Command/WaitForDatabaseCommandTest.php
@@ -18,7 +18,7 @@ use Mockery as m;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 #[Group('cli')]
-class WaitForDatabaseCommandTest extends KernelTestCase
+final class WaitForDatabaseCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Command/WaitForIndexCommandTest.php
+++ b/tests/Command/WaitForIndexCommandTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 #[Group('cli')]
-class WaitForIndexCommandTest extends KernelTestCase
+final class WaitForIndexCommandTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -17,7 +17,7 @@ use App\Tests\Traits\TestableJsonController;
  * General API tests.
  */
 #[Group('controller')]
-class ApiControllerTest extends WebTestCase
+final class ApiControllerTest extends WebTestCase
 {
     use TestableJsonController;
 

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -26,7 +26,7 @@ use function var_export;
 
 #[Group('controller')]
 #[CoversClass(AuthController::class)]
-class AuthControllerTest extends WebTestCase
+final class AuthControllerTest extends WebTestCase
 {
     use TestableJsonController;
     use GetUrlTrait;

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Group('controller')]
 #[CoversClass(ConfigController::class)]
-class ConfigControllerTest extends WebTestCase
+final class ConfigControllerTest extends WebTestCase
 {
     use TestableJsonController;
 

--- a/tests/Controller/CurriculumInventoryDownloadControllerTest.php
+++ b/tests/Controller/CurriculumInventoryDownloadControllerTest.php
@@ -26,7 +26,7 @@ use App\Tests\Traits\TestableJsonController;
 
 #[Group('controller')]
 #[CoversClass(CurriculumInventoryDownloadController::class)]
-class CurriculumInventoryDownloadControllerTest extends WebTestCase
+final class CurriculumInventoryDownloadControllerTest extends WebTestCase
 {
     use TestableJsonController;
     use GetUrlTrait;

--- a/tests/Controller/DirectoryControllerTest.php
+++ b/tests/Controller/DirectoryControllerTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 #[Group('controller')]
 #[CoversClass(DirectoryController::class)]
-class DirectoryControllerTest extends TestCase
+final class DirectoryControllerTest extends TestCase
 {
     protected DirectoryController $directoryController;
     protected m\MockInterface $mockTokenStorage;

--- a/tests/Controller/DownloadControllerTest.php
+++ b/tests/Controller/DownloadControllerTest.php
@@ -26,7 +26,7 @@ use App\Tests\Traits\TestableJsonController;
 
 #[Group('controller')]
 #[CoversClass(DownloadController::class)]
-class DownloadControllerTest extends WebTestCase
+final class DownloadControllerTest extends WebTestCase
 {
     use TestableJsonController;
     use GetUrlTrait;

--- a/tests/Controller/ErrorControllerTest.php
+++ b/tests/Controller/ErrorControllerTest.php
@@ -17,7 +17,7 @@ use App\Tests\Traits\TestableJsonController;
 
 #[Group('controller')]
 #[CoversClass(ErrorController::class)]
-class ErrorControllerTest extends WebTestCase
+final class ErrorControllerTest extends WebTestCase
 {
     use TestableJsonController;
 

--- a/tests/Controller/IcsControllerTest.php
+++ b/tests/Controller/IcsControllerTest.php
@@ -25,7 +25,7 @@ use App\Tests\Traits\TestableJsonController;
 
 #[Group('controller')]
 #[CoversClass(IcsController::class)]
-class IcsControllerTest extends WebTestCase
+final class IcsControllerTest extends WebTestCase
 {
     use TestableJsonController;
     use GetUrlTrait;

--- a/tests/Controller/IndexControllerTest.php
+++ b/tests/Controller/IndexControllerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 #[Group('controller')]
 #[CoversClass(IndexController::class)]
-class IndexControllerTest extends WebTestCase
+final class IndexControllerTest extends WebTestCase
 {
     use MockeryPHPUnitIntegration;
 
@@ -46,8 +46,8 @@ class IndexControllerTest extends WebTestCase
         foreach ($this->testFiles as $path) {
             $this->fileSystem->remove($path);
         }
-        unset($this->fs);
         unset($this->fileSystem);
+        unset($this->testFiles);
     }
 
     public function testIndex(): void

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 #[Group('controller')]
 #[CoversClass(SearchController::class)]
-class SearchControllerTest extends TestCase
+final class SearchControllerTest extends TestCase
 {
     protected SearchController $controller;
     protected m\MockInterface $mockCurriculumSearch;

--- a/tests/Controller/UploadControllerTest.php
+++ b/tests/Controller/UploadControllerTest.php
@@ -19,7 +19,7 @@ use App\Tests\Traits\TestableJsonController;
 
 #[Group('controller')]
 #[CoversClass(UploadController::class)]
-class UploadControllerTest extends WebTestCase
+final class UploadControllerTest extends WebTestCase
 {
     use TestableJsonController;
 

--- a/tests/DataLoader/AamcMethodData.php
+++ b/tests/DataLoader/AamcMethodData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\AamcMethodDTO;
 
-class AamcMethodData extends AbstractDataLoader
+final class AamcMethodData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/AamcPcrsData.php
+++ b/tests/DataLoader/AamcPcrsData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\AamcPcrsDTO;
 
-class AamcPcrsData extends AbstractDataLoader
+final class AamcPcrsData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/AamcResourceTypeData.php
+++ b/tests/DataLoader/AamcResourceTypeData.php
@@ -9,7 +9,7 @@ use App\Entity\DTO\AamcResourceTypeDTO;
 /**
  * Class AamcResourceTypeData
  */
-class AamcResourceTypeData extends AbstractDataLoader
+final class AamcResourceTypeData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/AlertChangeTypeData.php
+++ b/tests/DataLoader/AlertChangeTypeData.php
@@ -7,7 +7,7 @@ namespace App\Tests\DataLoader;
 use App\Entity\AlertChangeTypeInterface;
 use App\Entity\DTO\AlertChangeTypeDTO;
 
-class AlertChangeTypeData extends AbstractDataLoader
+final class AlertChangeTypeData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/AlertData.php
+++ b/tests/DataLoader/AlertData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\AlertDTO;
 
-class AlertData extends AbstractDataLoader
+final class AlertData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/ApplicationConfigData.php
+++ b/tests/DataLoader/ApplicationConfigData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\ApplicationConfigDTO;
 
-class ApplicationConfigData extends AbstractDataLoader
+final class ApplicationConfigData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/AssessmentOptionData.php
+++ b/tests/DataLoader/AssessmentOptionData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\AssessmentOptionDTO;
 
-class AssessmentOptionData extends AbstractDataLoader
+final class AssessmentOptionData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/AuditLogData.php
+++ b/tests/DataLoader/AuditLogData.php
@@ -11,7 +11,7 @@ use Exception;
 /**
  * Class AuditLogData
  */
-class AuditLogData extends AbstractDataLoader
+final class AuditLogData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/AuthenticationData.php
+++ b/tests/DataLoader/AuthenticationData.php
@@ -8,7 +8,7 @@ use App\Entity\DTO\AuthenticationDTO;
 use DateTime;
 use Exception;
 
-class AuthenticationData extends AbstractDataLoader
+final class AuthenticationData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CohortData.php
+++ b/tests/DataLoader/CohortData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\CohortDTO;
 
-class CohortData extends AbstractDataLoader
+final class CohortData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CompetencyData.php
+++ b/tests/DataLoader/CompetencyData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\CompetencyDTO;
 
-class CompetencyData extends AbstractDataLoader
+final class CompetencyData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CourseClerkshipTypeData.php
+++ b/tests/DataLoader/CourseClerkshipTypeData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\CourseClerkshipTypeDTO;
 
-class CourseClerkshipTypeData extends AbstractDataLoader
+final class CourseClerkshipTypeData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CourseData.php
+++ b/tests/DataLoader/CourseData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\CourseDTO;
 
-class CourseData extends AbstractDataLoader
+final class CourseData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CourseLearningMaterialData.php
+++ b/tests/DataLoader/CourseLearningMaterialData.php
@@ -7,7 +7,7 @@ namespace App\Tests\DataLoader;
 use App\Entity\DTO\CourseLearningMaterialDTO;
 use DateTime;
 
-class CourseLearningMaterialData extends AbstractDataLoader
+final class CourseLearningMaterialData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CourseObjectiveData.php
+++ b/tests/DataLoader/CourseObjectiveData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\CourseObjectiveDTO;
 
-class CourseObjectiveData extends AbstractDataLoader
+final class CourseObjectiveData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CurriculumInventoryAcademicLevelData.php
+++ b/tests/DataLoader/CurriculumInventoryAcademicLevelData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\CurriculumInventoryAcademicLevelDTO;
 
-class CurriculumInventoryAcademicLevelData extends AbstractDataLoader
+final class CurriculumInventoryAcademicLevelData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CurriculumInventoryExportData.php
+++ b/tests/DataLoader/CurriculumInventoryExportData.php
@@ -7,7 +7,7 @@ namespace App\Tests\DataLoader;
 use App\Entity\DTO\CurriculumInventoryExportDTO;
 use Exception;
 
-class CurriculumInventoryExportData extends AbstractDataLoader
+final class CurriculumInventoryExportData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CurriculumInventoryInstitutionData.php
+++ b/tests/DataLoader/CurriculumInventoryInstitutionData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\CurriculumInventoryInstitutionDTO;
 
-class CurriculumInventoryInstitutionData extends AbstractDataLoader
+final class CurriculumInventoryInstitutionData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CurriculumInventoryReportData.php
+++ b/tests/DataLoader/CurriculumInventoryReportData.php
@@ -7,7 +7,7 @@ namespace App\Tests\DataLoader;
 use App\Entity\DTO\CurriculumInventoryReportDTO;
 use DateTime;
 
-class CurriculumInventoryReportData extends AbstractDataLoader
+final class CurriculumInventoryReportData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CurriculumInventorySequenceBlockData.php
+++ b/tests/DataLoader/CurriculumInventorySequenceBlockData.php
@@ -8,7 +8,7 @@ use App\Entity\CurriculumInventorySequenceBlockInterface;
 use App\Entity\DTO\CurriculumInventorySequenceBlockDTO;
 use DateTime;
 
-class CurriculumInventorySequenceBlockData extends AbstractDataLoader
+final class CurriculumInventorySequenceBlockData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/CurriculumInventorySequenceData.php
+++ b/tests/DataLoader/CurriculumInventorySequenceData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\CurriculumInventorySequenceDTO;
 
-class CurriculumInventorySequenceData extends AbstractDataLoader
+final class CurriculumInventorySequenceData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/IlmSessionData.php
+++ b/tests/DataLoader/IlmSessionData.php
@@ -7,7 +7,7 @@ namespace App\Tests\DataLoader;
 use App\Entity\DTO\IlmSessionDTO;
 use DateTime;
 
-class IlmSessionData extends AbstractDataLoader
+final class IlmSessionData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/IngestionExceptionData.php
+++ b/tests/DataLoader/IngestionExceptionData.php
@@ -7,7 +7,7 @@ namespace App\Tests\DataLoader;
 use App\Entity\DTO\IngestionExceptionDTO;
 use Exception;
 
-class IngestionExceptionData extends AbstractDataLoader
+final class IngestionExceptionData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/InstructorGroupData.php
+++ b/tests/DataLoader/InstructorGroupData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\InstructorGroupDTO;
 
-class InstructorGroupData extends AbstractDataLoader
+final class InstructorGroupData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/LearnerGroupData.php
+++ b/tests/DataLoader/LearnerGroupData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\LearnerGroupDTO;
 
-class LearnerGroupData extends AbstractDataLoader
+final class LearnerGroupData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/LearningMaterialData.php
+++ b/tests/DataLoader/LearningMaterialData.php
@@ -8,7 +8,7 @@ use App\Entity\DTO\LearningMaterialDTO;
 use App\Entity\LearningMaterialStatusInterface;
 use Exception;
 
-class LearningMaterialData extends AbstractDataLoader
+final class LearningMaterialData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/LearningMaterialStatusData.php
+++ b/tests/DataLoader/LearningMaterialStatusData.php
@@ -7,7 +7,7 @@ namespace App\Tests\DataLoader;
 use App\Entity\DTO\LearningMaterialStatusDTO;
 use App\Entity\LearningMaterialStatusInterface;
 
-class LearningMaterialStatusData extends AbstractDataLoader
+final class LearningMaterialStatusData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/LearningMaterialUserRoleData.php
+++ b/tests/DataLoader/LearningMaterialUserRoleData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\LearningMaterialUserRoleDTO;
 
-class LearningMaterialUserRoleData extends AbstractDataLoader
+final class LearningMaterialUserRoleData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/MeshConceptData.php
+++ b/tests/DataLoader/MeshConceptData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\MeshConceptDTO;
 
-class MeshConceptData extends AbstractDataLoader
+final class MeshConceptData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/MeshDescriptorData.php
+++ b/tests/DataLoader/MeshDescriptorData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\MeshDescriptorDTO;
 
-class MeshDescriptorData extends AbstractDataLoader
+final class MeshDescriptorData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/MeshPreviousIndexingData.php
+++ b/tests/DataLoader/MeshPreviousIndexingData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\MeshPreviousIndexingDTO;
 
-class MeshPreviousIndexingData extends AbstractDataLoader
+final class MeshPreviousIndexingData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/MeshQualifierData.php
+++ b/tests/DataLoader/MeshQualifierData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\MeshQualifierDTO;
 
-class MeshQualifierData extends AbstractDataLoader
+final class MeshQualifierData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/MeshTermData.php
+++ b/tests/DataLoader/MeshTermData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\MeshTermDTO;
 
-class MeshTermData extends AbstractDataLoader
+final class MeshTermData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/MeshTreeData.php
+++ b/tests/DataLoader/MeshTreeData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\MeshTreeDTO;
 
-class MeshTreeData extends AbstractDataLoader
+final class MeshTreeData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/OfferingData.php
+++ b/tests/DataLoader/OfferingData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\OfferingDTO;
 
-class OfferingData extends AbstractDataLoader
+final class OfferingData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/PendingUserUpdateData.php
+++ b/tests/DataLoader/PendingUserUpdateData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\PendingUserUpdateDTO;
 
-class PendingUserUpdateData extends AbstractDataLoader
+final class PendingUserUpdateData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/ProgramData.php
+++ b/tests/DataLoader/ProgramData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\ProgramDTO;
 
-class ProgramData extends AbstractDataLoader
+final class ProgramData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/ProgramYearData.php
+++ b/tests/DataLoader/ProgramYearData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\ProgramYearDTO;
 
-class ProgramYearData extends AbstractDataLoader
+final class ProgramYearData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/ProgramYearObjectiveData.php
+++ b/tests/DataLoader/ProgramYearObjectiveData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\ProgramYearObjectiveDTO;
 
-class ProgramYearObjectiveData extends AbstractDataLoader
+final class ProgramYearObjectiveData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/ReportData.php
+++ b/tests/DataLoader/ReportData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\ReportDTO;
 
-class ReportData extends AbstractDataLoader
+final class ReportData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/SchoolConfigData.php
+++ b/tests/DataLoader/SchoolConfigData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\SchoolConfigDTO;
 
-class SchoolConfigData extends AbstractDataLoader
+final class SchoolConfigData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/SchoolData.php
+++ b/tests/DataLoader/SchoolData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\SchoolDTO;
 
-class SchoolData extends AbstractDataLoader
+final class SchoolData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/ServiceTokenData.php
+++ b/tests/DataLoader/ServiceTokenData.php
@@ -8,7 +8,7 @@ use DateInterval;
 use DateTime;
 use Exception;
 
-class ServiceTokenData extends AbstractDataLoader
+final class ServiceTokenData extends AbstractDataLoader
 {
     public const int ENABLED_SERVICE_TOKEN_ID = 1;
     public const int EXPIRED_SERVICE_TOKEN_ID = 2;

--- a/tests/DataLoader/SessionData.php
+++ b/tests/DataLoader/SessionData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\SessionDTO;
 
-class SessionData extends AbstractDataLoader
+final class SessionData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/SessionLearningMaterialData.php
+++ b/tests/DataLoader/SessionLearningMaterialData.php
@@ -7,7 +7,7 @@ namespace App\Tests\DataLoader;
 use App\Entity\DTO\SessionLearningMaterialDTO;
 use DateTime;
 
-class SessionLearningMaterialData extends AbstractDataLoader
+final class SessionLearningMaterialData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/SessionObjectiveData.php
+++ b/tests/DataLoader/SessionObjectiveData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\SessionObjectiveDTO;
 
-class SessionObjectiveData extends AbstractDataLoader
+final class SessionObjectiveData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/SessionTypeData.php
+++ b/tests/DataLoader/SessionTypeData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\SessionTypeDTO;
 
-class SessionTypeData extends AbstractDataLoader
+final class SessionTypeData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/TermData.php
+++ b/tests/DataLoader/TermData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\TermDTO;
 
-class TermData extends AbstractDataLoader
+final class TermData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/UserData.php
+++ b/tests/DataLoader/UserData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\UserDTO;
 
-class UserData extends AbstractDataLoader
+final class UserData extends AbstractDataLoader
 {
     public const int ROOT_USER_ID = 2;
 

--- a/tests/DataLoader/UserRoleData.php
+++ b/tests/DataLoader/UserRoleData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\UserRoleDTO;
 
-class UserRoleData extends AbstractDataLoader
+final class UserRoleData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/UserSessionMaterialStatusData.php
+++ b/tests/DataLoader/UserSessionMaterialStatusData.php
@@ -7,7 +7,7 @@ namespace App\Tests\DataLoader;
 use App\Entity\DTO\UserSessionMaterialStatusDTO;
 use App\Entity\UserSessionMaterialStatusInterface;
 
-class UserSessionMaterialStatusData extends AbstractDataLoader
+final class UserSessionMaterialStatusData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DataLoader/VocabularyData.php
+++ b/tests/DataLoader/VocabularyData.php
@@ -6,7 +6,7 @@ namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\VocabularyDTO;
 
-class VocabularyData extends AbstractDataLoader
+final class VocabularyData extends AbstractDataLoader
 {
     protected function getData(): array
     {

--- a/tests/DependencyInjection/PrefixSeedCompilerPassTest.php
+++ b/tests/DependencyInjection/PrefixSeedCompilerPassTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 #[CoversClass(PrefixSeedCompilerPass::class)]
-class PrefixSeedCompilerPassTest extends TestCase
+final class PrefixSeedCompilerPassTest extends TestCase
 {
     protected m\MockInterface $config;
     protected PrefixSeedCompilerPass $pass;

--- a/tests/Endpoints/AamcMethodTest.php
+++ b/tests/Endpoints/AamcMethodTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadSessionTypeData;
  * AamcMethod API endpoint Test.
  */
 #[Group('api_1')]
-class AamcMethodTest extends AbstractReadWriteEndpoint
+final class AamcMethodTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'aamcMethods';
     protected bool $enableDeleteTestsWithServiceToken = false;

--- a/tests/Endpoints/AamcPcrsTest.php
+++ b/tests/Endpoints/AamcPcrsTest.php
@@ -13,7 +13,7 @@ use App\Tests\Fixture\LoadCompetencyData;
  * AamcPcrses API endpoint Test.
  */
 #[Group('api_5')]
-class AamcPcrsTest extends AbstractReadWriteEndpoint
+final class AamcPcrsTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'aamcPcrses';
     protected bool $enableDeleteTestsWithServiceToken = false;

--- a/tests/Endpoints/AamcResourceTypeTest.php
+++ b/tests/Endpoints/AamcResourceTypeTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadTermData;
  * AamcResourceType API endpoint Test.
  */
 #[Group('api_3')]
-class AamcResourceTypeTest extends AbstractReadWriteEndpoint
+final class AamcResourceTypeTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'aamcResourceTypes';
     protected bool $enableDeleteTestsWithServiceToken = false;

--- a/tests/Endpoints/AbstractEndpoint.php
+++ b/tests/Endpoints/AbstractEndpoint.php
@@ -40,10 +40,10 @@ abstract class AbstractEndpoint extends WebTestCase
 
     protected string $apiVersion = 'v3';
     protected string $testName;
-    protected KernelBrowser $kernelBrowser;
-    protected AbstractDatabaseTool $databaseTool;
+    final protected KernelBrowser $kernelBrowser;
+    final protected AbstractDatabaseTool $databaseTool;
     private Inflector $inflector;
-    protected ReferenceRepository $fixtures;
+    final protected ReferenceRepository $fixtures;
 
     public function setUp(): void
     {

--- a/tests/Endpoints/AcademicYearTest.php
+++ b/tests/Endpoints/AcademicYearTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
  * AamcMethod API endpoint Test.
  */
 #[Group('api_5')]
-class AcademicYearTest extends AbstractReadEndpoint
+final class AcademicYearTest extends AbstractReadEndpoint
 {
     protected string $testName = 'academicYears';
 

--- a/tests/Endpoints/ApplicationConfigTest.php
+++ b/tests/Endpoints/ApplicationConfigTest.php
@@ -11,7 +11,7 @@ use App\Tests\Fixture\LoadApplicationConfigData;
  * ApplicationConfig API endpoint Test.
  */
 #[Group('api_3')]
-class ApplicationConfigTest extends AbstractReadWriteEndpoint
+final class ApplicationConfigTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'applicationConfigs';
     protected bool $isGraphQLTestable = false;

--- a/tests/Endpoints/AssessmentOptionTest.php
+++ b/tests/Endpoints/AssessmentOptionTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadSessionTypeData;
  * AssessmentOption API endpoint Test.
  */
 #[Group('api_4')]
-class AssessmentOptionTest extends AbstractReadWriteEndpoint
+final class AssessmentOptionTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'assessmentOptions';
     protected bool $enableDeleteTestsWithServiceToken = false;

--- a/tests/Endpoints/AuthenticationTest.php
+++ b/tests/Endpoints/AuthenticationTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Authentication API endpoint Test.
  */
 #[Group('api_5')]
-class AuthenticationTest extends AbstractReadWriteEndpoint
+final class AuthenticationTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'authentications';
     protected bool $isGraphQLTestable = false;

--- a/tests/Endpoints/CohortTest.php
+++ b/tests/Endpoints/CohortTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Cohort API endpoint Test.
  */
 #[Group('api_2')]
-class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterface
+final class CohortTest extends AbstractReadEndpoint implements PutEndpointTestInterface
 {
     use PutEndpointTestable;
 

--- a/tests/Endpoints/CompetencyTest.php
+++ b/tests/Endpoints/CompetencyTest.php
@@ -21,7 +21,7 @@ use App\Tests\Fixture\LoadSessionObjectiveData;
  * Competency API endpoint Test.
  */
 #[Group('api_5')]
-class CompetencyTest extends AbstractReadWriteEndpoint
+final class CompetencyTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'competencies';
 

--- a/tests/Endpoints/CourseClerkshipTypeTest.php
+++ b/tests/Endpoints/CourseClerkshipTypeTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadCourseData;
  * CourseClerkshipType API endpoint Test.
  */
 #[Group('api_4')]
-class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
+final class CourseClerkshipTypeTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'courseClerkshipTypes';
     protected bool $enableDeleteTestsWithServiceToken = false;

--- a/tests/Endpoints/CourseLearningMaterialTest.php
+++ b/tests/Endpoints/CourseLearningMaterialTest.php
@@ -17,7 +17,7 @@ use function is_null;
  * CourseLearningMaterial API endpoint Test.
  */
 #[Group('api_1')]
-class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
+final class CourseLearningMaterialTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'courseLearningMaterials';
 

--- a/tests/Endpoints/CourseObjectiveTest.php
+++ b/tests/Endpoints/CourseObjectiveTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
  * CourseObjectiveTest API endpoint Test.
  */
 #[Group('api_1')]
-class CourseObjectiveTest extends AbstractReadWriteEndpoint
+final class CourseObjectiveTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'courseObjectives';
 

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Course API endpoint Test.
  */
 #[Group('api_2')]
-class CourseTest extends AbstractReadWriteEndpoint
+final class CourseTest extends AbstractReadWriteEndpoint
 {
     use QEndpointTrait;
 

--- a/tests/Endpoints/CurrentSessionTest.php
+++ b/tests/Endpoints/CurrentSessionTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 use App\Tests\Traits\TestableJsonController;
 
 #[Group('api_3')]
-class CurrentSessionTest extends WebTestCase
+final class CurrentSessionTest extends WebTestCase
 {
     use TestableJsonController;
     use GetUrlTrait;

--- a/tests/Endpoints/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/Endpoints/CurriculumInventoryAcademicLevelTest.php
@@ -15,7 +15,7 @@ use App\Tests\Fixture\LoadProgramData;
  * CurriculumInventoryAcademicLevel API endpoint Test.
  */
 #[Group('api_4')]
-class CurriculumInventoryAcademicLevelTest extends AbstractReadEndpoint
+final class CurriculumInventoryAcademicLevelTest extends AbstractReadEndpoint
 {
     protected string $testName =  'curriculumInventoryAcademicLevels';
 

--- a/tests/Endpoints/CurriculumInventoryExportTest.php
+++ b/tests/Endpoints/CurriculumInventoryExportTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
  * This is a POST only endpoint so that is all we will test
  */
 #[Group('api_1')]
-class CurriculumInventoryExportTest extends AbstractEndpoint
+final class CurriculumInventoryExportTest extends AbstractEndpoint
 {
     protected string $testName =  'curriculumInventoryExports';
 

--- a/tests/Endpoints/CurriculumInventoryInstitutionTest.php
+++ b/tests/Endpoints/CurriculumInventoryInstitutionTest.php
@@ -13,7 +13,7 @@ use App\Tests\Fixture\LoadSchoolData;
  * CurriculumInventoryInstitution API endpoint Test.
  */
 #[Group('api_2')]
-class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
+final class CurriculumInventoryInstitutionTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'curriculumInventoryInstitutions';
 

--- a/tests/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/Endpoints/CurriculumInventoryReportTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
  * CurriculumInventoryReport API endpoint Test.
  */
 #[Group('api_5')]
-class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
+final class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'curriculumInventoryReports';
 

--- a/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceBlockTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
  * CurriculumInventorySequenceBlock API endpoint Test.
  */
 #[Group('api_4')]
-class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
+final class CurriculumInventorySequenceBlockTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'curriculumInventorySequenceBlocks';
 

--- a/tests/Endpoints/CurriculumInventorySequenceTest.php
+++ b/tests/Endpoints/CurriculumInventorySequenceTest.php
@@ -13,7 +13,7 @@ use App\Tests\Fixture\LoadCurriculumInventorySequenceData;
  * CurriculumInventorySequence API endpoint Test.
  */
 #[Group('api_1')]
-class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
+final class CurriculumInventorySequenceTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'curriculumInventorySequences';
 

--- a/tests/Endpoints/IlmSessionTest.php
+++ b/tests/Endpoints/IlmSessionTest.php
@@ -15,7 +15,7 @@ use DateTimeZone;
  * IlmSession API endpoint Test.
  */
 #[Group('api_3')]
-class IlmSessionTest extends AbstractReadWriteEndpoint
+final class IlmSessionTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'ilmSessions';
 

--- a/tests/Endpoints/IngestionExceptionTest.php
+++ b/tests/Endpoints/IngestionExceptionTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
  * IngestionException API endpoint Test.
  */
 #[Group('api_4')]
-class IngestionExceptionTest extends AbstractReadEndpoint
+final class IngestionExceptionTest extends AbstractReadEndpoint
 {
     protected string $testName =  'ingestionExceptions';
     protected bool $isGraphQLTestable = false;

--- a/tests/Endpoints/InstructorGroupTest.php
+++ b/tests/Endpoints/InstructorGroupTest.php
@@ -19,7 +19,7 @@ use App\Tests\Fixture\LoadUserData;
  * InstructorGroup API endpoint Test.
  */
 #[Group('api_1')]
-class InstructorGroupTest extends AbstractReadWriteEndpoint
+final class InstructorGroupTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'instructorGroups';
 

--- a/tests/Endpoints/LearnerGroupTest.php
+++ b/tests/Endpoints/LearnerGroupTest.php
@@ -17,7 +17,7 @@ use App\Tests\Fixture\LoadVocabularyData;
  * LearnerGroup API endpoint Test.
  */
 #[Group('api_2')]
-class LearnerGroupTest extends AbstractReadWriteEndpoint
+final class LearnerGroupTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'learnerGroups';
 

--- a/tests/Endpoints/LearningMaterialStatusTest.php
+++ b/tests/Endpoints/LearningMaterialStatusTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadLearningMaterialStatusData;
  * LearningMaterialStatus API endpoint Test.
  */
 #[Group('api_3')]
-class LearningMaterialStatusTest extends AbstractReadEndpoint
+final class LearningMaterialStatusTest extends AbstractReadEndpoint
 {
     protected string $testName =  'learningMaterialStatuses';
 

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 #[Group('api_4')]
 #[CoversClass(LearningMaterials::class)]
-class LearningMaterialTest extends AbstractReadWriteEndpoint
+final class LearningMaterialTest extends AbstractReadWriteEndpoint
 {
     use QEndpointTrait;
 

--- a/tests/Endpoints/LearningMaterialUserRoleTest.php
+++ b/tests/Endpoints/LearningMaterialUserRoleTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadLearningMaterialUserRoleData;
  * LearningMaterialUserRole API endpoint Test.
  */
 #[Group('api_1')]
-class LearningMaterialUserRoleTest extends AbstractReadEndpoint
+final class LearningMaterialUserRoleTest extends AbstractReadEndpoint
 {
     protected string $testName =  'learningMaterialUserRoles';
 

--- a/tests/Endpoints/MeshConceptTest.php
+++ b/tests/Endpoints/MeshConceptTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadMeshTermData;
  * MeshConcept API endpoint Test.
  */
 #[Group('api_5')]
-class MeshConceptTest extends AbstractMeshEndpoint
+final class MeshConceptTest extends AbstractMeshEndpoint
 {
     protected string $testName =  'meshConcepts';
 

--- a/tests/Endpoints/MeshDescriptorTest.php
+++ b/tests/Endpoints/MeshDescriptorTest.php
@@ -24,7 +24,7 @@ use App\Tests\QEndpointTrait;
  * MeshDescriptor API endpoint Test.
  */
 #[Group('api_3')]
-class MeshDescriptorTest extends AbstractMeshEndpoint
+final class MeshDescriptorTest extends AbstractMeshEndpoint
 {
     use QEndpointTrait;
 

--- a/tests/Endpoints/MeshPreviousIndexingTest.php
+++ b/tests/Endpoints/MeshPreviousIndexingTest.php
@@ -15,7 +15,7 @@ use App\Tests\Fixture\LoadSessionLearningMaterialData;
  * MeshPreviousIndexing API endpoint Test.
  */
 #[Group('api_4')]
-class MeshPreviousIndexingTest extends AbstractMeshEndpoint
+final class MeshPreviousIndexingTest extends AbstractMeshEndpoint
 {
     protected string $testName =  'meshPreviousIndexings';
 

--- a/tests/Endpoints/MeshQualifierTest.php
+++ b/tests/Endpoints/MeshQualifierTest.php
@@ -11,7 +11,7 @@ use App\Tests\Fixture\LoadMeshQualifierData;
  * MeshQualifier API endpoint Test.
  */
 #[Group('api_1')]
-class MeshQualifierTest extends AbstractMeshEndpoint
+final class MeshQualifierTest extends AbstractMeshEndpoint
 {
     protected string $testName =  'meshQualifiers';
 

--- a/tests/Endpoints/MeshTermTest.php
+++ b/tests/Endpoints/MeshTermTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadMeshTermData;
  * MeshTerm API endpoint Test.
  */
 #[Group('api_3')]
-class MeshTermTest extends AbstractMeshEndpoint
+final class MeshTermTest extends AbstractMeshEndpoint
 {
     protected string $testName =  'meshTerms';
 

--- a/tests/Endpoints/MeshTreeTest.php
+++ b/tests/Endpoints/MeshTreeTest.php
@@ -11,7 +11,7 @@ use App\Tests\Fixture\LoadMeshTreeData;
  * MeshTree API endpoint Test.
  */
 #[Group('api_4')]
-class MeshTreeTest extends AbstractMeshEndpoint
+final class MeshTreeTest extends AbstractMeshEndpoint
 {
     protected string $testName =  'meshTrees';
 

--- a/tests/Endpoints/OfferingTest.php
+++ b/tests/Endpoints/OfferingTest.php
@@ -26,7 +26,7 @@ use Doctrine\ORM\EntityManager;
  * Offering API endpoint Test.
  */
 #[Group('api_1')]
-class OfferingTest extends AbstractReadWriteEndpoint
+final class OfferingTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'offerings';
     protected bool $skipDates = false;

--- a/tests/Endpoints/PendingUserUpdateTest.php
+++ b/tests/Endpoints/PendingUserUpdateTest.php
@@ -12,7 +12,9 @@ use App\Tests\Endpoints\PutEndpointTestInterface as PutEndpointInterface;
  * PendingUserUpdate API endpoint Test.
  */
 #[Group('api_3')]
-class PendingUserUpdateTest extends AbstractReadEndpoint implements PutEndpointInterface, DeleteEndpointTestInterface
+final class PendingUserUpdateTest extends AbstractReadEndpoint implements
+    PutEndpointInterface,
+    DeleteEndpointTestInterface
 {
     use PutEndpointTestable;
     use DeleteEndpointTestable;

--- a/tests/Endpoints/ProgramTest.php
+++ b/tests/Endpoints/ProgramTest.php
@@ -17,7 +17,7 @@ use App\Tests\Fixture\LoadTermData;
  * Program API endpoint Test.
  */
 #[Group('api_1')]
-class ProgramTest extends AbstractReadWriteEndpoint
+final class ProgramTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'programs';
 

--- a/tests/Endpoints/ProgramYearObjectiveTest.php
+++ b/tests/Endpoints/ProgramYearObjectiveTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
  * ProgramYearObjectiveTest API endpoint Test.
  */
 #[Group('api_2')]
-class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
+final class ProgramYearObjectiveTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'programYearObjectives';
 

--- a/tests/Endpoints/ProgramYearTest.php
+++ b/tests/Endpoints/ProgramYearTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 #[Group('api_3')]
 #[CoversClass(ProgramYears::class)]
-class ProgramYearTest extends AbstractReadWriteEndpoint
+final class ProgramYearTest extends AbstractReadWriteEndpoint
 {
     protected string $testName = 'programYears';
 

--- a/tests/Endpoints/ReportTest.php
+++ b/tests/Endpoints/ReportTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadUserData;
  * Report API endpoint Test.
  */
 #[Group('api_4')]
-class ReportTest extends AbstractReadWriteEndpoint
+final class ReportTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'reports';
     protected bool $enableGetTestsWithServiceToken = false;

--- a/tests/Endpoints/SchoolConfigTest.php
+++ b/tests/Endpoints/SchoolConfigTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadSchoolData;
  * SchoolConfig API endpoint Test.
  */
 #[Group('api_5')]
-class SchoolConfigTest extends AbstractReadWriteEndpoint
+final class SchoolConfigTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'schoolConfigs';
     protected bool $isGraphQLTestable = false;

--- a/tests/Endpoints/SchoolTest.php
+++ b/tests/Endpoints/SchoolTest.php
@@ -19,7 +19,7 @@ use App\Tests\Fixture\LoadSessionTypeData;
  * School API endpoint Test.
  */
 #[Group('api_5')]
-class SchoolTest extends AbstractReadWriteEndpoint
+final class SchoolTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'schools';
 

--- a/tests/Endpoints/SchooleventsTest.php
+++ b/tests/Endpoints/SchooleventsTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
  * SchooleventsTest API endpoint Test.
  */
 #[Group('api_2')]
-class SchooleventsTest extends AbstractEndpoint
+final class SchooleventsTest extends AbstractEndpoint
 {
     protected function getFixtures(): array
     {

--- a/tests/Endpoints/SessionLearningMaterialTest.php
+++ b/tests/Endpoints/SessionLearningMaterialTest.php
@@ -20,7 +20,7 @@ use function is_null;
  * SessionLearningMaterial API endpoint Test.
  */
 #[Group('api_1')]
-class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
+final class SessionLearningMaterialTest extends AbstractReadWriteEndpoint
 {
     protected string $testName = 'sessionLearningMaterials';
 

--- a/tests/Endpoints/SessionObjectiveTest.php
+++ b/tests/Endpoints/SessionObjectiveTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
  * SessionObjectiveTest API endpoint Test.
  */
 #[Group('api_3')]
-class SessionObjectiveTest extends AbstractReadWriteEndpoint
+final class SessionObjectiveTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'sessionObjectives';
 

--- a/tests/Endpoints/SessionTest.php
+++ b/tests/Endpoints/SessionTest.php
@@ -23,7 +23,7 @@ use App\Tests\QEndpointTrait;
  * Session API endpoint Test.
  */
 #[Group('api_2')]
-class SessionTest extends AbstractReadWriteEndpoint
+final class SessionTest extends AbstractReadWriteEndpoint
 {
     use QEndpointTrait;
 

--- a/tests/Endpoints/SessionTypeTest.php
+++ b/tests/Endpoints/SessionTypeTest.php
@@ -29,7 +29,7 @@ use App\Tests\Fixture\LoadVocabularyData;
  * SessionType API endpoint Test.
  */
 #[Group('api_3')]
-class SessionTypeTest extends AbstractReadWriteEndpoint
+final class SessionTypeTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'sessionTypes';
 

--- a/tests/Endpoints/TermTest.php
+++ b/tests/Endpoints/TermTest.php
@@ -26,7 +26,7 @@ use App\Tests\Fixture\LoadVocabularyData;
  * Term API endpoint Test.
  */
 #[Group('api_4')]
-class TermTest extends AbstractReadWriteEndpoint
+final class TermTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'terms';
 

--- a/tests/Endpoints/UserRoleTest.php
+++ b/tests/Endpoints/UserRoleTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadUserRoleData;
  * UserRole API endpoint Test.
  */
 #[Group('api_4')]
-class UserRoleTest extends AbstractReadEndpoint
+final class UserRoleTest extends AbstractReadEndpoint
 {
     protected string $testName =  'userRoles';
     protected bool $isGraphQLTestable = false;

--- a/tests/Endpoints/UserSessionMaterialStatusTest.php
+++ b/tests/Endpoints/UserSessionMaterialStatusTest.php
@@ -12,7 +12,7 @@ use App\Tests\Fixture\LoadUserSessionMaterialStatusData;
  * UserSessionMaterialStatusTest API endpoint Test.
  */
 #[Group('api_1')]
-class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
+final class UserSessionMaterialStatusTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'userSessionMaterialStatuses';
     protected bool $enableGetTestsWithServiceToken = false;

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpFoundation\Response;
  * User API endpoint Test.
  */
 #[Group('api_1')]
-class UserTest extends AbstractReadWriteEndpoint
+final class UserTest extends AbstractReadWriteEndpoint
 {
     use QEndpointTrait;
 

--- a/tests/Endpoints/UsereventTest.php
+++ b/tests/Endpoints/UsereventTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpFoundation\Response;
  * UsereventTest API endpoint Test.
  */
 #[Group('api_1')]
-class UsereventTest extends AbstractEndpoint
+final class UsereventTest extends AbstractEndpoint
 {
     protected function getFixtures(): array
     {

--- a/tests/Endpoints/UsermaterialsTest.php
+++ b/tests/Endpoints/UsermaterialsTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
  * UsermaterialsTest API endpoint Test.
  */
 #[Group('api_3')]
-class UsermaterialsTest extends AbstractEndpoint
+final class UsermaterialsTest extends AbstractEndpoint
 {
     protected function getFixtures(): array
     {

--- a/tests/Endpoints/VocabularyTest.php
+++ b/tests/Endpoints/VocabularyTest.php
@@ -13,7 +13,7 @@ use App\Tests\Fixture\LoadVocabularyData;
  *
  */
 #[Group('api_2')]
-class VocabularyTest extends AbstractReadWriteEndpoint
+final class VocabularyTest extends AbstractReadWriteEndpoint
 {
     protected string $testName =  'vocabularies';
 

--- a/tests/Entity/AamcMethodTest.php
+++ b/tests/Entity/AamcMethodTest.php
@@ -13,7 +13,7 @@ use App\Entity\AamcMethod;
  */
 #[Group('model')]
 #[CoversClass(AamcMethod::class)]
-class AamcMethodTest extends EntityBase
+final class AamcMethodTest extends EntityBase
 {
     protected AamcMethod $object;
 

--- a/tests/Entity/AamcPcrsTest.php
+++ b/tests/Entity/AamcPcrsTest.php
@@ -13,7 +13,7 @@ use App\Entity\AamcPcrs;
  */
 #[Group('model')]
 #[CoversClass(AamcPcrs::class)]
-class AamcPcrsTest extends EntityBase
+final class AamcPcrsTest extends EntityBase
 {
     protected AamcPcrs $object;
 

--- a/tests/Entity/AamcResourceTypeTest.php
+++ b/tests/Entity/AamcResourceTypeTest.php
@@ -13,7 +13,7 @@ use App\Entity\AamcResourceType;
  */
 #[Group('model')]
 #[CoversClass(AamcResourceType::class)]
-class AamcResourceTypeTest extends EntityBase
+final class AamcResourceTypeTest extends EntityBase
 {
     protected AamcResourceType $object;
 

--- a/tests/Entity/AlertChangeTypeTest.php
+++ b/tests/Entity/AlertChangeTypeTest.php
@@ -13,7 +13,7 @@ use App\Entity\AlertChangeType;
  */
 #[Group('model')]
 #[CoversClass(AlertChangeType::class)]
-class AlertChangeTypeTest extends EntityBase
+final class AlertChangeTypeTest extends EntityBase
 {
     protected AlertChangeType $object;
 

--- a/tests/Entity/AlertTest.php
+++ b/tests/Entity/AlertTest.php
@@ -13,7 +13,7 @@ use App\Entity\Alert;
  */
 #[Group('model')]
 #[CoversClass(Alert::class)]
-class AlertTest extends EntityBase
+final class AlertTest extends EntityBase
 {
     protected Alert $object;
 

--- a/tests/Entity/ApplicationConfigTest.php
+++ b/tests/Entity/ApplicationConfigTest.php
@@ -13,7 +13,7 @@ use App\Entity\ApplicationConfig;
  */
 #[Group('model')]
 #[CoversClass(ApplicationConfig::class)]
-class ApplicationConfigTest extends EntityBase
+final class ApplicationConfigTest extends EntityBase
 {
     protected ApplicationConfig $object;
 

--- a/tests/Entity/AssessmentOptionTest.php
+++ b/tests/Entity/AssessmentOptionTest.php
@@ -13,7 +13,7 @@ use App\Entity\AssessmentOption;
  */
 #[Group('model')]
 #[CoversClass(AssessmentOption::class)]
-class AssessmentOptionTest extends EntityBase
+final class AssessmentOptionTest extends EntityBase
 {
     protected AssessmentOption $object;
 

--- a/tests/Entity/AuditLogTest.php
+++ b/tests/Entity/AuditLogTest.php
@@ -15,7 +15,7 @@ use function method_exists;
  */
 #[Group('model')]
 #[CoversClass(AuditLog::class)]
-class AuditLogTest extends EntityBase
+final class AuditLogTest extends EntityBase
 {
     protected AuditLog $object;
 

--- a/tests/Entity/AuthenticationTest.php
+++ b/tests/Entity/AuthenticationTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(Authentication::class)]
-class AuthenticationTest extends EntityBase
+final class AuthenticationTest extends EntityBase
 {
     protected Authentication $object;
 

--- a/tests/Entity/CohortTest.php
+++ b/tests/Entity/CohortTest.php
@@ -16,7 +16,7 @@ use App\Entity\School;
  */
 #[Group('model')]
 #[CoversClass(Cohort::class)]
-class CohortTest extends EntityBase
+final class CohortTest extends EntityBase
 {
     protected Cohort $object;
 

--- a/tests/Entity/CompetencyTest.php
+++ b/tests/Entity/CompetencyTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(Competency::class)]
-class CompetencyTest extends EntityBase
+final class CompetencyTest extends EntityBase
 {
     protected Competency $object;
 

--- a/tests/Entity/CourseClerkshipTypeTest.php
+++ b/tests/Entity/CourseClerkshipTypeTest.php
@@ -13,7 +13,7 @@ use App\Entity\CourseClerkshipType;
  */
 #[Group('model')]
 #[CoversClass(CourseClerkshipType::class)]
-class CourseClerkshipTypeTest extends EntityBase
+final class CourseClerkshipTypeTest extends EntityBase
 {
     protected CourseClerkshipType $object;
 

--- a/tests/Entity/CourseLearningMaterialTest.php
+++ b/tests/Entity/CourseLearningMaterialTest.php
@@ -16,7 +16,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(CourseLearningMaterial::class)]
-class CourseLearningMaterialTest extends EntityBase
+final class CourseLearningMaterialTest extends EntityBase
 {
     protected CourseLearningMaterial $object;
 

--- a/tests/Entity/CourseObjectiveTest.php
+++ b/tests/Entity/CourseObjectiveTest.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 #[Group('model')]
 #[CoversClass(CourseObjective::class)]
-class CourseObjectiveTest extends EntityBase
+final class CourseObjectiveTest extends EntityBase
 {
     protected CourseObjective $object;
 

--- a/tests/Entity/CourseTest.php
+++ b/tests/Entity/CourseTest.php
@@ -20,7 +20,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(Course::class)]
-class CourseTest extends EntityBase
+final class CourseTest extends EntityBase
 {
     protected Course $object;
 

--- a/tests/Entity/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/Entity/CurriculumInventoryAcademicLevelTest.php
@@ -13,7 +13,7 @@ use App\Entity\CurriculumInventoryAcademicLevel;
  */
 #[Group('model')]
 #[CoversClass(CurriculumInventoryAcademicLevel::class)]
-class CurriculumInventoryAcademicLevelTest extends EntityBase
+final class CurriculumInventoryAcademicLevelTest extends EntityBase
 {
     protected CurriculumInventoryAcademicLevel $object;
 

--- a/tests/Entity/CurriculumInventoryExportTest.php
+++ b/tests/Entity/CurriculumInventoryExportTest.php
@@ -13,7 +13,7 @@ use App\Entity\CurriculumInventoryExport;
  */
 #[Group('model')]
 #[CoversClass(CurriculumInventoryExport::class)]
-class CurriculumInventoryExportTest extends EntityBase
+final class CurriculumInventoryExportTest extends EntityBase
 {
     protected CurriculumInventoryExport $object;
 

--- a/tests/Entity/CurriculumInventoryInstitutionTest.php
+++ b/tests/Entity/CurriculumInventoryInstitutionTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(CurriculumInventoryInstitution::class)]
-class CurriculumInventoryInstitutionTest extends EntityBase
+final class CurriculumInventoryInstitutionTest extends EntityBase
 {
     protected CurriculumInventoryInstitution $object;
 

--- a/tests/Entity/CurriculumInventoryReportTest.php
+++ b/tests/Entity/CurriculumInventoryReportTest.php
@@ -16,7 +16,7 @@ use DateTime;
  */
 #[Group('model')]
 #[CoversClass(CurriculumInventoryReport::class)]
-class CurriculumInventoryReportTest extends EntityBase
+final class CurriculumInventoryReportTest extends EntityBase
 {
     protected CurriculumInventoryReport $object;
 

--- a/tests/Entity/CurriculumInventorySequenceBlockTest.php
+++ b/tests/Entity/CurriculumInventorySequenceBlockTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(CurriculumInventorySequenceBlock::class)]
-class CurriculumInventorySequenceBlockTest extends EntityBase
+final class CurriculumInventorySequenceBlockTest extends EntityBase
 {
     protected CurriculumInventorySequenceBlock $object;
 

--- a/tests/Entity/CurriculumInventorySequenceTest.php
+++ b/tests/Entity/CurriculumInventorySequenceTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(CurriculumInventorySequence::class)]
-class CurriculumInventorySequenceTest extends EntityBase
+final class CurriculumInventorySequenceTest extends EntityBase
 {
     protected CurriculumInventorySequence $object;
 

--- a/tests/Entity/DTO/LearningMaterialDTOTest.php
+++ b/tests/Entity/DTO/LearningMaterialDTOTest.php
@@ -16,7 +16,7 @@ use DateTime;
  */
 #[Group('model')]
 #[CoversClass(LearningMaterialDTO::class)]
-class LearningMaterialDTOTest extends TestCase
+final class LearningMaterialDTOTest extends TestCase
 {
     protected LearningMaterialDTO $dto;
 

--- a/tests/Entity/IlmSessionTest.php
+++ b/tests/Entity/IlmSessionTest.php
@@ -15,7 +15,7 @@ use DateTime;
  */
 #[Group('model')]
 #[CoversClass(IlmSession::class)]
-class IlmSessionTest extends EntityBase
+final class IlmSessionTest extends EntityBase
 {
     protected IlmSession $object;
 

--- a/tests/Entity/IngestionExceptionTest.php
+++ b/tests/Entity/IngestionExceptionTest.php
@@ -13,7 +13,7 @@ use App\Entity\IngestionException;
  */
 #[Group('model')]
 #[CoversClass(IngestionException::class)]
-class IngestionExceptionTest extends EntityBase
+final class IngestionExceptionTest extends EntityBase
 {
     protected IngestionException $object;
 

--- a/tests/Entity/InstructorGroupTest.php
+++ b/tests/Entity/InstructorGroupTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(InstructorGroup::class)]
-class InstructorGroupTest extends EntityBase
+final class InstructorGroupTest extends EntityBase
 {
     protected InstructorGroup $object;
 

--- a/tests/Entity/LearnerGroupTest.php
+++ b/tests/Entity/LearnerGroupTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(LearnerGroup::class)]
-class LearnerGroupTest extends EntityBase
+final class LearnerGroupTest extends EntityBase
 {
     protected LearnerGroup $object;
 

--- a/tests/Entity/LearningMaterialStatusTest.php
+++ b/tests/Entity/LearningMaterialStatusTest.php
@@ -13,7 +13,7 @@ use App\Entity\LearningMaterialStatus;
  */
 #[Group('model')]
 #[CoversClass(LearningMaterialStatus::class)]
-class LearningMaterialStatusTest extends EntityBase
+final class LearningMaterialStatusTest extends EntityBase
 {
     protected LearningMaterialStatus $object;
 

--- a/tests/Entity/LearningMaterialTest.php
+++ b/tests/Entity/LearningMaterialTest.php
@@ -23,7 +23,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(LearningMaterial::class)]
-class LearningMaterialTest extends EntityBase
+final class LearningMaterialTest extends EntityBase
 {
     protected LearningMaterial $object;
 

--- a/tests/Entity/LearningMaterialUserRoleTest.php
+++ b/tests/Entity/LearningMaterialUserRoleTest.php
@@ -13,7 +13,7 @@ use App\Entity\LearningMaterialUserRole;
  */
 #[Group('model')]
 #[CoversClass(LearningMaterialUserRole::class)]
-class LearningMaterialUserRoleTest extends EntityBase
+final class LearningMaterialUserRoleTest extends EntityBase
 {
     protected LearningMaterialUserRole $object;
 

--- a/tests/Entity/MeshConceptTest.php
+++ b/tests/Entity/MeshConceptTest.php
@@ -14,7 +14,7 @@ use DateTime;
  */
 #[Group('model')]
 #[CoversClass(MeshConcept::class)]
-class MeshConceptTest extends EntityBase
+final class MeshConceptTest extends EntityBase
 {
     protected MeshConcept $object;
 

--- a/tests/Entity/MeshDescriptorTest.php
+++ b/tests/Entity/MeshDescriptorTest.php
@@ -20,7 +20,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(MeshDescriptor::class)]
-class MeshDescriptorTest extends EntityBase
+final class MeshDescriptorTest extends EntityBase
 {
     protected MeshDescriptor $object;
 

--- a/tests/Entity/MeshPreviousIndexingTest.php
+++ b/tests/Entity/MeshPreviousIndexingTest.php
@@ -13,7 +13,7 @@ use App\Entity\MeshPreviousIndexing;
  */
 #[Group('model')]
 #[CoversClass(MeshPreviousIndexing::class)]
-class MeshPreviousIndexingTest extends EntityBase
+final class MeshPreviousIndexingTest extends EntityBase
 {
     protected MeshPreviousIndexing $object;
 

--- a/tests/Entity/MeshQualifierTest.php
+++ b/tests/Entity/MeshQualifierTest.php
@@ -14,7 +14,7 @@ use DateTime;
  */
 #[Group('model')]
 #[CoversClass(MeshQualifier::class)]
-class MeshQualifierTest extends EntityBase
+final class MeshQualifierTest extends EntityBase
 {
     protected MeshQualifier $object;
 

--- a/tests/Entity/MeshTermTest.php
+++ b/tests/Entity/MeshTermTest.php
@@ -14,7 +14,7 @@ use DateTime;
  */
 #[Group('model')]
 #[CoversClass(MeshTerm::class)]
-class MeshTermTest extends EntityBase
+final class MeshTermTest extends EntityBase
 {
     protected MeshTerm $object;
 

--- a/tests/Entity/MeshTreeTest.php
+++ b/tests/Entity/MeshTreeTest.php
@@ -13,7 +13,7 @@ use App\Entity\MeshTree;
  */
 #[Group('model')]
 #[CoversClass(MeshTree::class)]
-class MeshTreeTest extends EntityBase
+final class MeshTreeTest extends EntityBase
 {
     protected MeshTree $object;
 

--- a/tests/Entity/OfferingTest.php
+++ b/tests/Entity/OfferingTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(Offering::class)]
-class OfferingTest extends EntityBase
+final class OfferingTest extends EntityBase
 {
     protected Offering $object;
 

--- a/tests/Entity/PendingUserUpdateTest.php
+++ b/tests/Entity/PendingUserUpdateTest.php
@@ -14,7 +14,7 @@ use App\Entity\User;
  */
 #[Group('model')]
 #[CoversClass(PendingUserUpdate::class)]
-class PendingUserUpdateTest extends EntityBase
+final class PendingUserUpdateTest extends EntityBase
 {
     protected PendingUserUpdate $object;
 

--- a/tests/Entity/ProgramTest.php
+++ b/tests/Entity/ProgramTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(Program::class)]
-class ProgramTest extends EntityBase
+final class ProgramTest extends EntityBase
 {
     protected Program $object;
 

--- a/tests/Entity/ProgramYearObjectiveTest.php
+++ b/tests/Entity/ProgramYearObjectiveTest.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 #[Group('model')]
 #[CoversClass(ProgramYearObjective::class)]
-class ProgramYearObjectiveTest extends EntityBase
+final class ProgramYearObjectiveTest extends EntityBase
 {
     protected ProgramYearObjective $object;
 

--- a/tests/Entity/ProgramYearTest.php
+++ b/tests/Entity/ProgramYearTest.php
@@ -17,7 +17,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(ProgramYear::class)]
-class ProgramYearTest extends EntityBase
+final class ProgramYearTest extends EntityBase
 {
     protected ProgramYear $object;
 

--- a/tests/Entity/ReportTest.php
+++ b/tests/Entity/ReportTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(Report::class)]
-class ReportTest extends EntityBase
+final class ReportTest extends EntityBase
 {
     protected Report $object;
 

--- a/tests/Entity/SchoolConfigTest.php
+++ b/tests/Entity/SchoolConfigTest.php
@@ -14,7 +14,7 @@ use App\Entity\SchoolConfig;
  */
 #[Group('model')]
 #[CoversClass(SchoolConfig::class)]
-class SchoolConfigTest extends EntityBase
+final class SchoolConfigTest extends EntityBase
 {
     protected SchoolConfig $object;
 

--- a/tests/Entity/SchoolTest.php
+++ b/tests/Entity/SchoolTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(School::class)]
-class SchoolTest extends EntityBase
+final class SchoolTest extends EntityBase
 {
     protected School $object;
 

--- a/tests/Entity/ServiceTokenTest.php
+++ b/tests/Entity/ServiceTokenTest.php
@@ -11,7 +11,7 @@ use DateTime;
 
 #[Group('model')]
 #[CoversClass(ServiceToken::class)]
-class ServiceTokenTest extends EntityBase
+final class ServiceTokenTest extends EntityBase
 {
     protected ServiceToken $object;
 

--- a/tests/Entity/SessionLearningMaterialTest.php
+++ b/tests/Entity/SessionLearningMaterialTest.php
@@ -16,7 +16,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(SessionLearningMaterial::class)]
-class SessionLearningMaterialTest extends EntityBase
+final class SessionLearningMaterialTest extends EntityBase
 {
     protected SessionLearningMaterial $object;
 

--- a/tests/Entity/SessionObjectiveTest.php
+++ b/tests/Entity/SessionObjectiveTest.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 #[Group('model')]
 #[CoversClass(SessionObjective::class)]
-class SessionObjectiveTest extends EntityBase
+final class SessionObjectiveTest extends EntityBase
 {
     protected SessionObjective $object;
 

--- a/tests/Entity/SessionTest.php
+++ b/tests/Entity/SessionTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(Session::class)]
-class SessionTest extends EntityBase
+final class SessionTest extends EntityBase
 {
     protected Session $object;
 

--- a/tests/Entity/SessionTypeTest.php
+++ b/tests/Entity/SessionTypeTest.php
@@ -16,7 +16,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(SessionType::class)]
-class SessionTypeTest extends EntityBase
+final class SessionTypeTest extends EntityBase
 {
     protected SessionType $object;
 

--- a/tests/Entity/TermTest.php
+++ b/tests/Entity/TermTest.php
@@ -17,7 +17,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(Term::class)]
-class TermTest extends EntityBase
+final class TermTest extends EntityBase
 {
     protected Term $object;
 

--- a/tests/Entity/UserRoleTest.php
+++ b/tests/Entity/UserRoleTest.php
@@ -13,7 +13,7 @@ use App\Entity\UserRole;
  */
 #[Group('model')]
 #[CoversClass(UserRole::class)]
-class UserRoleTest extends EntityBase
+final class UserRoleTest extends EntityBase
 {
     protected UserRole $object;
 

--- a/tests/Entity/UserSessionMaterialStatusTest.php
+++ b/tests/Entity/UserSessionMaterialStatusTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
 
 #[Group('model')]
 #[CoversClass(UserSessionMaterialStatus::class)]
-class UserSessionMaterialStatusTest extends EntityBase
+final class UserSessionMaterialStatusTest extends EntityBase
 {
     protected UserSessionMaterialStatus $object;
 

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 #[Group('model')]
 #[CoversClass(User::class)]
-class UserTest extends EntityBase
+final class UserTest extends EntityBase
 {
     protected User $object;
 

--- a/tests/Entity/VocabularyTest.php
+++ b/tests/Entity/VocabularyTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  */
 #[Group('model')]
 #[CoversClass(Vocabulary::class)]
-class VocabularyTest extends EntityBase
+final class VocabularyTest extends EntityBase
 {
     protected Vocabulary $object;
 

--- a/tests/EventListener/IndexEntityChangesTest.php
+++ b/tests/EventListener/IndexEntityChangesTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[CoversClass(IndexEntityChanges::class)]
-class IndexEntityChangesTest extends TestCase
+final class IndexEntityChangesTest extends TestCase
 {
     protected m\MockInterface $curriculumIndex;
     protected m\MockInterface $learningMaterialIndex;

--- a/tests/Fixture/LoadAamcMethodData.php
+++ b/tests/Fixture/LoadAamcMethodData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAamcMethodData extends AbstractFixture implements ORMFixtureInterface
+final class LoadAamcMethodData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected AamcMethodData $data)
     {

--- a/tests/Fixture/LoadAamcPcrsData.php
+++ b/tests/Fixture/LoadAamcPcrsData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAamcPcrsData extends AbstractFixture implements ORMFixtureInterface
+final class LoadAamcPcrsData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected AamcPcrsData $data)
     {

--- a/tests/Fixture/LoadAamcResourceTypeData.php
+++ b/tests/Fixture/LoadAamcResourceTypeData.php
@@ -10,7 +10,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use App\Entity\AamcResourceType;
 
-class LoadAamcResourceTypeData extends AbstractFixture implements ORMFixtureInterface
+final class LoadAamcResourceTypeData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected AamcResourceTypeData $data)
     {

--- a/tests/Fixture/LoadAlertChangeTypeData.php
+++ b/tests/Fixture/LoadAlertChangeTypeData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAlertChangeTypeData extends AbstractFixture implements ORMFixtureInterface
+final class LoadAlertChangeTypeData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected AlertChangeTypeData $data)
     {

--- a/tests/Fixture/LoadAlertData.php
+++ b/tests/Fixture/LoadAlertData.php
@@ -14,7 +14,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAlertData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadAlertData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected AlertData $data)
     {

--- a/tests/Fixture/LoadApplicationConfigData.php
+++ b/tests/Fixture/LoadApplicationConfigData.php
@@ -10,7 +10,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use App\Entity\ApplicationConfig;
 
-class LoadApplicationConfigData extends AbstractFixture implements ORMFixtureInterface
+final class LoadApplicationConfigData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected ApplicationConfigData $data)
     {

--- a/tests/Fixture/LoadAssessmentOptionData.php
+++ b/tests/Fixture/LoadAssessmentOptionData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAssessmentOptionData extends AbstractFixture implements ORMFixtureInterface
+final class LoadAssessmentOptionData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected AssessmentOptionData $data)
     {

--- a/tests/Fixture/LoadAuditLogData.php
+++ b/tests/Fixture/LoadAuditLogData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAuditLogData extends AbstractFixture implements ORMFixtureInterface
+final class LoadAuditLogData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected AuditLogData $data)
     {

--- a/tests/Fixture/LoadAuthenticationData.php
+++ b/tests/Fixture/LoadAuthenticationData.php
@@ -14,7 +14,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
-class LoadAuthenticationData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadAuthenticationData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(
         protected UserPasswordHasherInterface $passwordHasher,

--- a/tests/Fixture/LoadCohortData.php
+++ b/tests/Fixture/LoadCohortData.php
@@ -12,7 +12,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCohortData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadCohortData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected CohortData $data)
     {

--- a/tests/Fixture/LoadCompetencyData.php
+++ b/tests/Fixture/LoadCompetencyData.php
@@ -13,7 +13,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCompetencyData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadCompetencyData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected CompetencyData $data)
     {

--- a/tests/Fixture/LoadCourseClerkshipTypeData.php
+++ b/tests/Fixture/LoadCourseClerkshipTypeData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCourseClerkshipTypeData extends AbstractFixture implements ORMFixtureInterface
+final class LoadCourseClerkshipTypeData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected CourseClerkshipTypeData $data)
     {

--- a/tests/Fixture/LoadCourseData.php
+++ b/tests/Fixture/LoadCourseData.php
@@ -18,7 +18,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCourseData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadCourseData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected CourseData $data)
     {

--- a/tests/Fixture/LoadCourseLearningMaterialData.php
+++ b/tests/Fixture/LoadCourseLearningMaterialData.php
@@ -15,7 +15,9 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCourseLearningMaterialData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadCourseLearningMaterialData extends AbstractFixture implements
+    ORMFixtureInterface,
+    DependentFixtureInterface
 {
     public function __construct(protected CourseLearningMaterialData $data)
     {

--- a/tests/Fixture/LoadCourseObjectiveData.php
+++ b/tests/Fixture/LoadCourseObjectiveData.php
@@ -16,7 +16,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCourseObjectiveData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadCourseObjectiveData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected CourseObjectiveData $data)
     {

--- a/tests/Fixture/LoadCurriculumInventoryAcademicLevelData.php
+++ b/tests/Fixture/LoadCurriculumInventoryAcademicLevelData.php
@@ -12,7 +12,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCurriculumInventoryAcademicLevelData extends AbstractFixture implements
+final class LoadCurriculumInventoryAcademicLevelData extends AbstractFixture implements
     ORMFixtureInterface,
     DependentFixtureInterface
 {

--- a/tests/Fixture/LoadCurriculumInventoryExportData.php
+++ b/tests/Fixture/LoadCurriculumInventoryExportData.php
@@ -13,7 +13,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCurriculumInventoryExportData extends AbstractFixture implements
+final class LoadCurriculumInventoryExportData extends AbstractFixture implements
     ORMFixtureInterface,
     DependentFixtureInterface
 {

--- a/tests/Fixture/LoadCurriculumInventoryInstitutionData.php
+++ b/tests/Fixture/LoadCurriculumInventoryInstitutionData.php
@@ -12,7 +12,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCurriculumInventoryInstitutionData extends AbstractFixture implements
+final class LoadCurriculumInventoryInstitutionData extends AbstractFixture implements
     ORMFixtureInterface,
     DependentFixtureInterface
 {

--- a/tests/Fixture/LoadCurriculumInventoryReportData.php
+++ b/tests/Fixture/LoadCurriculumInventoryReportData.php
@@ -13,7 +13,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCurriculumInventoryReportData extends AbstractFixture implements
+final class LoadCurriculumInventoryReportData extends AbstractFixture implements
     ORMFixtureInterface,
     DependentFixtureInterface
 {

--- a/tests/Fixture/LoadCurriculumInventorySequenceBlockData.php
+++ b/tests/Fixture/LoadCurriculumInventorySequenceBlockData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCurriculumInventorySequenceBlockData extends AbstractFixture implements
+final class LoadCurriculumInventorySequenceBlockData extends AbstractFixture implements
     ORMFixtureInterface,
     DependentFixtureInterface
 {

--- a/tests/Fixture/LoadCurriculumInventorySequenceData.php
+++ b/tests/Fixture/LoadCurriculumInventorySequenceData.php
@@ -12,7 +12,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCurriculumInventorySequenceData extends AbstractFixture implements
+final class LoadCurriculumInventorySequenceData extends AbstractFixture implements
     ORMFixtureInterface,
     DependentFixtureInterface
 {

--- a/tests/Fixture/LoadIlmSessionData.php
+++ b/tests/Fixture/LoadIlmSessionData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadIlmSessionData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadIlmSessionData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected IlmSessionData $data)
     {

--- a/tests/Fixture/LoadIngestionExceptionData.php
+++ b/tests/Fixture/LoadIngestionExceptionData.php
@@ -12,7 +12,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadIngestionExceptionData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadIngestionExceptionData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected IngestionExceptionData $data)
     {

--- a/tests/Fixture/LoadInstructorGroupData.php
+++ b/tests/Fixture/LoadInstructorGroupData.php
@@ -13,7 +13,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadInstructorGroupData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadInstructorGroupData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected InstructorGroupData $data)
     {

--- a/tests/Fixture/LoadLearnerGroupData.php
+++ b/tests/Fixture/LoadLearnerGroupData.php
@@ -14,7 +14,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadLearnerGroupData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadLearnerGroupData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected LearnerGroupData $data)
     {

--- a/tests/Fixture/LoadLearningMaterialData.php
+++ b/tests/Fixture/LoadLearningMaterialData.php
@@ -16,7 +16,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\Filesystem\Filesystem;
 
-class LoadLearningMaterialData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadLearningMaterialData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public const string TEST_FILE_PATH = __DIR__ . '/FakeTestFiles/TESTFILE.txt';
 

--- a/tests/Fixture/LoadLearningMaterialStatusData.php
+++ b/tests/Fixture/LoadLearningMaterialStatusData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadLearningMaterialStatusData extends AbstractFixture implements ORMFixtureInterface
+final class LoadLearningMaterialStatusData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected LearningMaterialStatusData $data)
     {

--- a/tests/Fixture/LoadLearningMaterialUserRoleData.php
+++ b/tests/Fixture/LoadLearningMaterialUserRoleData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadLearningMaterialUserRoleData extends AbstractFixture implements ORMFixtureInterface
+final class LoadLearningMaterialUserRoleData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected LearningMaterialUserRoleData $data)
     {

--- a/tests/Fixture/LoadMeshConceptData.php
+++ b/tests/Fixture/LoadMeshConceptData.php
@@ -12,7 +12,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadMeshConceptData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadMeshConceptData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected MeshConceptData $data)
     {

--- a/tests/Fixture/LoadMeshDescriptorData.php
+++ b/tests/Fixture/LoadMeshDescriptorData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadMeshDescriptorData extends AbstractFixture implements ORMFixtureInterface
+final class LoadMeshDescriptorData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected MeshDescriptorData $data)
     {

--- a/tests/Fixture/LoadMeshPreviousIndexingData.php
+++ b/tests/Fixture/LoadMeshPreviousIndexingData.php
@@ -12,7 +12,9 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadMeshPreviousIndexingData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadMeshPreviousIndexingData extends AbstractFixture implements
+    ORMFixtureInterface,
+    DependentFixtureInterface
 {
     public function __construct(protected MeshPreviousIndexingData $data)
     {

--- a/tests/Fixture/LoadMeshQualifierData.php
+++ b/tests/Fixture/LoadMeshQualifierData.php
@@ -12,7 +12,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadMeshQualifierData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadMeshQualifierData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected MeshQualifierData $data)
     {

--- a/tests/Fixture/LoadMeshTermData.php
+++ b/tests/Fixture/LoadMeshTermData.php
@@ -12,7 +12,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadMeshTermData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadMeshTermData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected MeshTermData $data)
     {

--- a/tests/Fixture/LoadMeshTreeData.php
+++ b/tests/Fixture/LoadMeshTreeData.php
@@ -12,7 +12,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 
-class LoadMeshTreeData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadMeshTreeData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected MeshTreeData $data)
     {

--- a/tests/Fixture/LoadOfferingData.php
+++ b/tests/Fixture/LoadOfferingData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadOfferingData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadOfferingData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected OfferingData $data)
     {

--- a/tests/Fixture/LoadPendingUserUpdateData.php
+++ b/tests/Fixture/LoadPendingUserUpdateData.php
@@ -12,7 +12,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadPendingUserUpdateData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadPendingUserUpdateData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected PendingUserUpdateData $data)
     {

--- a/tests/Fixture/LoadProgramData.php
+++ b/tests/Fixture/LoadProgramData.php
@@ -12,7 +12,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadProgramData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadProgramData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected ProgramData $data)
     {

--- a/tests/Fixture/LoadProgramYearData.php
+++ b/tests/Fixture/LoadProgramYearData.php
@@ -14,7 +14,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadProgramYearData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadProgramYearData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected ProgramYearData $data)
     {

--- a/tests/Fixture/LoadProgramYearObjectiveData.php
+++ b/tests/Fixture/LoadProgramYearObjectiveData.php
@@ -15,7 +15,9 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadProgramYearObjectiveData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadProgramYearObjectiveData extends AbstractFixture implements
+    ORMFixtureInterface,
+    DependentFixtureInterface
 {
     public function __construct(protected ProgramYearObjectiveData $data)
     {

--- a/tests/Fixture/LoadReportData.php
+++ b/tests/Fixture/LoadReportData.php
@@ -13,7 +13,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadReportData extends AbstractFixture implements
+final class LoadReportData extends AbstractFixture implements
     ORMFixtureInterface,
     DependentFixtureInterface
 {

--- a/tests/Fixture/LoadSchoolConfigData.php
+++ b/tests/Fixture/LoadSchoolConfigData.php
@@ -12,7 +12,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use App\Entity\SchoolConfig;
 
-class LoadSchoolConfigData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadSchoolConfigData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected SchoolConfigData $data)
     {

--- a/tests/Fixture/LoadSchoolData.php
+++ b/tests/Fixture/LoadSchoolData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadSchoolData extends AbstractFixture implements ORMFixtureInterface
+final class LoadSchoolData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected SchoolData $data)
     {

--- a/tests/Fixture/LoadServiceTokenData.php
+++ b/tests/Fixture/LoadServiceTokenData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadServiceTokenData extends AbstractFixture implements ORMFixtureInterface
+final class LoadServiceTokenData extends AbstractFixture implements ORMFixtureInterface
 {
     public const string REFERENCE_KEY_PREFIX = 'serviceTokens';
 

--- a/tests/Fixture/LoadSessionData.php
+++ b/tests/Fixture/LoadSessionData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadSessionData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadSessionData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected SessionData $data)
     {

--- a/tests/Fixture/LoadSessionLearningMaterialData.php
+++ b/tests/Fixture/LoadSessionLearningMaterialData.php
@@ -15,7 +15,9 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadSessionLearningMaterialData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadSessionLearningMaterialData extends AbstractFixture implements
+    ORMFixtureInterface,
+    DependentFixtureInterface
 {
     public function __construct(protected SessionLearningMaterialData $data)
     {

--- a/tests/Fixture/LoadSessionObjectiveData.php
+++ b/tests/Fixture/LoadSessionObjectiveData.php
@@ -14,7 +14,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadSessionObjectiveData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadSessionObjectiveData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected SessionObjectiveData $data)
     {

--- a/tests/Fixture/LoadSessionTypeData.php
+++ b/tests/Fixture/LoadSessionTypeData.php
@@ -14,7 +14,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadSessionTypeData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadSessionTypeData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected SessionTypeData $data)
     {

--- a/tests/Fixture/LoadTermData.php
+++ b/tests/Fixture/LoadTermData.php
@@ -13,7 +13,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadTermData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadTermData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected TermData $data)
     {

--- a/tests/Fixture/LoadUserData.php
+++ b/tests/Fixture/LoadUserData.php
@@ -17,7 +17,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadUserData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadUserData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected UserData $data)
     {

--- a/tests/Fixture/LoadUserRoleData.php
+++ b/tests/Fixture/LoadUserRoleData.php
@@ -10,7 +10,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadUserRoleData extends AbstractFixture implements ORMFixtureInterface
+final class LoadUserRoleData extends AbstractFixture implements ORMFixtureInterface
 {
     public function __construct(protected UserRoleData $data)
     {

--- a/tests/Fixture/LoadUserSessionMaterialStatusData.php
+++ b/tests/Fixture/LoadUserSessionMaterialStatusData.php
@@ -13,7 +13,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadUserSessionMaterialStatusData extends AbstractFixture implements
+final class LoadUserSessionMaterialStatusData extends AbstractFixture implements
     ORMFixtureInterface,
     DependentFixtureInterface
 {

--- a/tests/Fixture/LoadVocabularyData.php
+++ b/tests/Fixture/LoadVocabularyData.php
@@ -12,7 +12,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadVocabularyData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+final class LoadVocabularyData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
 {
     public function __construct(protected VocabularyData $data)
     {

--- a/tests/Helper/TestQuestionHelper.php
+++ b/tests/Helper/TestQuestionHelper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\Question;
  * Solution from https://github.com/symfony/symfony/issues/19463#issuecomment-322782602
  *
  */
-class TestQuestionHelper extends QuestionHelper
+final class TestQuestionHelper extends QuestionHelper
 {
     public function ask(InputInterface $input, OutputInterface $output, Question $question): mixed
     {

--- a/tests/Message/CourseDeleteRequestTest.php
+++ b/tests/Message/CourseDeleteRequestTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Message;
 use App\Message\CourseDeleteRequest;
 use App\Tests\TestCase;
 
-class CourseDeleteRequestTest extends TestCase
+final class CourseDeleteRequestTest extends TestCase
 {
     public function testItWorks(): void
     {

--- a/tests/Message/LearningMaterialDeleteRequestTest.php
+++ b/tests/Message/LearningMaterialDeleteRequestTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Message;
 use App\Message\LearningMaterialDeleteRequest;
 use App\Tests\TestCase;
 
-class LearningMaterialDeleteRequestTest extends TestCase
+final class LearningMaterialDeleteRequestTest extends TestCase
 {
     public function testItWorks(): void
     {

--- a/tests/Message/LearningMaterialIndexRequestTest.php
+++ b/tests/Message/LearningMaterialIndexRequestTest.php
@@ -8,7 +8,7 @@ use App\Message\LearningMaterialIndexRequest;
 use App\Tests\TestCase;
 use Exception;
 
-class LearningMaterialIndexRequestTest extends TestCase
+final class LearningMaterialIndexRequestTest extends TestCase
 {
     public function testMaximumValues(): void
     {

--- a/tests/Message/LearningMaterialTextExtractionRequestTest.php
+++ b/tests/Message/LearningMaterialTextExtractionRequestTest.php
@@ -8,7 +8,7 @@ use App\Message\LearningMaterialTextExtractionRequest;
 use App\Tests\TestCase;
 use Exception;
 
-class LearningMaterialTextExtractionRequestTest extends TestCase
+final class LearningMaterialTextExtractionRequestTest extends TestCase
 {
     public function testMaximumValues(): void
     {

--- a/tests/Message/SessionDeleteRequestTest.php
+++ b/tests/Message/SessionDeleteRequestTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Message;
 use App\Message\SessionDeleteRequest;
 use App\Tests\TestCase;
 
-class SessionDeleteRequestTest extends TestCase
+final class SessionDeleteRequestTest extends TestCase
 {
     public function testItWorks(): void
     {

--- a/tests/MessageHandler/CourseDeleteHandlerTest.php
+++ b/tests/MessageHandler/CourseDeleteHandlerTest.php
@@ -10,7 +10,7 @@ use App\Service\Index\Curriculum;
 use App\Tests\TestCase;
 use Mockery as m;
 
-class CourseDeleteHandlerTest extends TestCase
+final class CourseDeleteHandlerTest extends TestCase
 {
     protected m\MockInterface|Curriculum $curriculum;
 

--- a/tests/MessageHandler/LearningMaterialDeleteHandlerTest.php
+++ b/tests/MessageHandler/LearningMaterialDeleteHandlerTest.php
@@ -10,7 +10,7 @@ use App\Service\Index\LearningMaterials;
 use App\Tests\TestCase;
 use Mockery as m;
 
-class LearningMaterialDeleteHandlerTest extends TestCase
+final class LearningMaterialDeleteHandlerTest extends TestCase
 {
     protected m\MockInterface|LearningMaterials $index;
 

--- a/tests/MessageHandler/LearningMaterialIndexHandlerTest.php
+++ b/tests/MessageHandler/LearningMaterialIndexHandlerTest.php
@@ -13,7 +13,7 @@ use App\Service\NonCachingIliosFileSystem;
 use App\Tests\TestCase;
 use Mockery as m;
 
-class LearningMaterialIndexHandlerTest extends TestCase
+final class LearningMaterialIndexHandlerTest extends TestCase
 {
     protected m\MockInterface|LearningMaterials $index;
     protected m\MockInterface|LearningMaterialRepository $repository;

--- a/tests/MessageHandler/LearningMaterialTextExtractionHandlerTest.php
+++ b/tests/MessageHandler/LearningMaterialTextExtractionHandlerTest.php
@@ -16,7 +16,7 @@ use stdClass;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-class LearningMaterialTextExtractionHandlerTest extends TestCase
+final class LearningMaterialTextExtractionHandlerTest extends TestCase
 {
     protected m\MockInterface|LearningMaterialTextExtractor $extractor;
     protected m\MockInterface|LearningMaterialRepository $repository;

--- a/tests/MessageHandler/SessionDeleteHandlerTest.php
+++ b/tests/MessageHandler/SessionDeleteHandlerTest.php
@@ -10,7 +10,7 @@ use App\Service\Index\Curriculum;
 use App\Tests\TestCase;
 use Mockery as m;
 
-class SessionDeleteHandlerTest extends TestCase
+final class SessionDeleteHandlerTest extends TestCase
 {
     protected m\MockInterface|Curriculum $curriculum;
 

--- a/tests/RelationshipVoter/AamcMethodTest.php
+++ b/tests/RelationshipVoter/AamcMethodTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class AamcMethodTest extends AbstractBase
+final class AamcMethodTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/AamcPcrsTest.php
+++ b/tests/RelationshipVoter/AamcPcrsTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class AamcPcrsTest extends AbstractBase
+final class AamcPcrsTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/AamcResourceTypeTest.php
+++ b/tests/RelationshipVoter/AamcResourceTypeTest.php
@@ -12,7 +12,7 @@ use App\Tests\RelationshipVoter\AbstractBase;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class AamcResourceTypeTest extends AbstractBase
+final class AamcResourceTypeTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/AbstractBase.php
+++ b/tests/RelationshipVoter/AbstractBase.php
@@ -15,8 +15,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 abstract class AbstractBase extends TestCase
 {
-    protected m\MockInterface $permissionChecker;
-    protected Voter $voter;
+    final protected m\MockInterface $permissionChecker;
+    final protected Voter $voter;
 
     /**
      * Remove all mock objects

--- a/tests/RelationshipVoter/ApplicationConfigDTOTest.php
+++ b/tests/RelationshipVoter/ApplicationConfigDTOTest.php
@@ -11,7 +11,7 @@ use App\Entity\DTO\ApplicationConfigDTO;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class ApplicationConfigDTOTest extends AbstractBase
+final class ApplicationConfigDTOTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/ApplicationConfigTest.php
+++ b/tests/RelationshipVoter/ApplicationConfigTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class ApplicationConfigTest extends AbstractBase
+final class ApplicationConfigTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/AssessmentOptionTest.php
+++ b/tests/RelationshipVoter/AssessmentOptionTest.php
@@ -11,7 +11,7 @@ use App\Entity\AssessmentOptionInterface;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class AssessmentOptionTest extends AbstractBase
+final class AssessmentOptionTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/AuthenticationTest.php
+++ b/tests/RelationshipVoter/AuthenticationTest.php
@@ -13,7 +13,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class AuthenticationTest extends AbstractBase
+final class AuthenticationTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CohortTest.php
+++ b/tests/RelationshipVoter/CohortTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CohortTest extends AbstractBase
+final class CohortTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CompetencyTest.php
+++ b/tests/RelationshipVoter/CompetencyTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CompetencyTest extends AbstractBase
+final class CompetencyTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CourseClerkshipTypeTest.php
+++ b/tests/RelationshipVoter/CourseClerkshipTypeTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CourseClerkshipTypeTest extends AbstractBase
+final class CourseClerkshipTypeTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CourseLearningMaterialTest.php
+++ b/tests/RelationshipVoter/CourseLearningMaterialTest.php
@@ -13,7 +13,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CourseLearningMaterialTest extends AbstractBase
+final class CourseLearningMaterialTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CourseTest.php
+++ b/tests/RelationshipVoter/CourseTest.php
@@ -13,7 +13,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CourseTest extends AbstractBase
+final class CourseTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CurriculumInventoryAcademicLevelTest.php
+++ b/tests/RelationshipVoter/CurriculumInventoryAcademicLevelTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CurriculumInventoryAcademicLevelTest extends AbstractBase
+final class CurriculumInventoryAcademicLevelTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CurriculumInventoryExportTest.php
+++ b/tests/RelationshipVoter/CurriculumInventoryExportTest.php
@@ -13,7 +13,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CurriculumInventoryExportTest extends AbstractBase
+final class CurriculumInventoryExportTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CurriculumInventoryInstitutionTest.php
+++ b/tests/RelationshipVoter/CurriculumInventoryInstitutionTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CurriculumInventoryInstitutionTest extends AbstractBase
+final class CurriculumInventoryInstitutionTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CurriculumInventoryReportTest.php
+++ b/tests/RelationshipVoter/CurriculumInventoryReportTest.php
@@ -13,7 +13,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CurriculumInventoryReportTest extends AbstractBase
+final class CurriculumInventoryReportTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CurriculumInventorySequenceBlockTest.php
+++ b/tests/RelationshipVoter/CurriculumInventorySequenceBlockTest.php
@@ -14,7 +14,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CurriculumInventorySequenceBlockTest extends AbstractBase
+final class CurriculumInventorySequenceBlockTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/CurriculumInventorySequenceTest.php
+++ b/tests/RelationshipVoter/CurriculumInventorySequenceTest.php
@@ -14,7 +14,7 @@ use App\Entity\School;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CurriculumInventorySequenceTest extends AbstractBase
+final class CurriculumInventorySequenceTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
+++ b/tests/RelationshipVoter/ElevatedPermissionsViewDTOVoterTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
  * @package App\Tests\RelationshipVoter
  */
 #[CoversClass(Voter::class)]
-class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
+final class ElevatedPermissionsViewDTOVoterTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
+++ b/tests/RelationshipVoter/GreenlightViewDtoVoterTest.php
@@ -53,7 +53,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
  * @package App\Tests\RelationshipVoter
  */
 #[CoversClass(Voter::class)]
-class GreenlightViewDtoVoterTest extends AbstractBase
+final class GreenlightViewDtoVoterTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/IlmSessionTest.php
+++ b/tests/RelationshipVoter/IlmSessionTest.php
@@ -14,7 +14,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class IlmSessionTest extends AbstractBase
+final class IlmSessionTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/IngestionExceptionTest.php
+++ b/tests/RelationshipVoter/IngestionExceptionTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class IngestionExceptionTest extends AbstractBase
+final class IngestionExceptionTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/InstructorGroupTest.php
+++ b/tests/RelationshipVoter/InstructorGroupTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class InstructorGroupTest extends AbstractBase
+final class InstructorGroupTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/LearnerGroupDTOVoterTest.php
+++ b/tests/RelationshipVoter/LearnerGroupDTOVoterTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
  * @package App\Tests\RelationshipVoter
  */
 #[CoversClass(LearnerGroupDTOVoter::class)]
-class LearnerGroupDTOVoterTest extends AbstractBase
+final class LearnerGroupDTOVoterTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/LearnerGroupTest.php
+++ b/tests/RelationshipVoter/LearnerGroupTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class LearnerGroupTest extends AbstractBase
+final class LearnerGroupTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/LearningMaterialStatusTest.php
+++ b/tests/RelationshipVoter/LearningMaterialStatusTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class LearningMaterialStatusTest extends AbstractBase
+final class LearningMaterialStatusTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/LearningMaterialTest.php
+++ b/tests/RelationshipVoter/LearningMaterialTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class LearningMaterialTest extends AbstractBase
+final class LearningMaterialTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/MeshTest.php
+++ b/tests/RelationshipVoter/MeshTest.php
@@ -17,7 +17,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class MeshTest extends AbstractBase
+final class MeshTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/OfferingTest.php
+++ b/tests/RelationshipVoter/OfferingTest.php
@@ -14,7 +14,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class OfferingTest extends AbstractBase
+final class OfferingTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/PendingUserUpdateTest.php
+++ b/tests/RelationshipVoter/PendingUserUpdateTest.php
@@ -13,7 +13,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class PendingUserUpdateTest extends AbstractBase
+final class PendingUserUpdateTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/ProgramTest.php
+++ b/tests/RelationshipVoter/ProgramTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class ProgramTest extends AbstractBase
+final class ProgramTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/ProgramYearTest.php
+++ b/tests/RelationshipVoter/ProgramYearTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class ProgramYearTest extends AbstractBase
+final class ProgramYearTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/ReportDTOVoterTest.php
+++ b/tests/RelationshipVoter/ReportDTOVoterTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
  * @package App\Tests\RelationshipVoter
  */
 #[CoversClass(ReportDTOVoter::class)]
-class ReportDTOVoterTest extends AbstractBase
+final class ReportDTOVoterTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/ReportTest.php
+++ b/tests/RelationshipVoter/ReportTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class ReportTest extends AbstractBase
+final class ReportTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/SchoolConfigTest.php
+++ b/tests/RelationshipVoter/SchoolConfigTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class SchoolConfigTest extends AbstractBase
+final class SchoolConfigTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/SchoolEventTest.php
+++ b/tests/RelationshipVoter/SchoolEventTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class SchoolEventTest extends AbstractBase
+final class SchoolEventTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/SchoolTest.php
+++ b/tests/RelationshipVoter/SchoolTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class SchoolTest extends AbstractBase
+final class SchoolTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/SessionLearningMaterialDTOVoterTest.php
+++ b/tests/RelationshipVoter/SessionLearningMaterialDTOVoterTest.php
@@ -13,7 +13,7 @@ use DateTime;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class SessionLearningMaterialDTOVoterTest extends AbstractBase
+final class SessionLearningMaterialDTOVoterTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/SessionLearningMaterialTest.php
+++ b/tests/RelationshipVoter/SessionLearningMaterialTest.php
@@ -16,7 +16,7 @@ use DateTime;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class SessionLearningMaterialTest extends AbstractBase
+final class SessionLearningMaterialTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/SessionTest.php
+++ b/tests/RelationshipVoter/SessionTest.php
@@ -13,7 +13,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class SessionTest extends AbstractBase
+final class SessionTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/SessionTypeTest.php
+++ b/tests/RelationshipVoter/SessionTypeTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class SessionTypeTest extends AbstractBase
+final class SessionTypeTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/TemporaryFileSystemTest.php
+++ b/tests/RelationshipVoter/TemporaryFileSystemTest.php
@@ -11,7 +11,7 @@ use App\Service\TemporaryFileSystem;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class TemporaryFileSystemTest extends AbstractBase
+final class TemporaryFileSystemTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/TermTest.php
+++ b/tests/RelationshipVoter/TermTest.php
@@ -13,7 +13,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class TermTest extends AbstractBase
+final class TermTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/UserDTOVoterTest.php
+++ b/tests/RelationshipVoter/UserDTOVoterTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
  * @package App\Tests\RelationshipVoter
  */
 #[CoversClass(UserDTOVoter::class)]
-class UserDTOVoterTest extends AbstractBase
+final class UserDTOVoterTest extends AbstractBase
 {
     protected UserDTOVoter $dto;
 

--- a/tests/RelationshipVoter/UserEventTest.php
+++ b/tests/RelationshipVoter/UserEventTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class UserEventTest extends AbstractBase
+final class UserEventTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/UserMaterialTest.php
+++ b/tests/RelationshipVoter/UserMaterialTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class UserMaterialTest extends AbstractBase
+final class UserMaterialTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/UserRoleTest.php
+++ b/tests/RelationshipVoter/UserRoleTest.php
@@ -11,7 +11,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class UserRoleTest extends AbstractBase
+final class UserRoleTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/UserSessionMaterialStatusDTOVoterTest.php
+++ b/tests/RelationshipVoter/UserSessionMaterialStatusDTOVoterTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
  * @package App\Tests\RelationshipVoter
  */
 #[CoversClass(UserSessionMaterialStatusDTOVoter::class)]
-class UserSessionMaterialStatusDTOVoterTest extends AbstractBase
+final class UserSessionMaterialStatusDTOVoterTest extends AbstractBase
 {
     protected UserSessionMaterialStatusDTOVoter $dto;
 

--- a/tests/RelationshipVoter/UserSessionMaterialStatusTest.php
+++ b/tests/RelationshipVoter/UserSessionMaterialStatusTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class UserSessionMaterialStatusTest extends AbstractBase
+final class UserSessionMaterialStatusTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/UserTest.php
+++ b/tests/RelationshipVoter/UserTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class UserTest extends AbstractBase
+final class UserTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/RelationshipVoter/VocabularyTest.php
+++ b/tests/RelationshipVoter/VocabularyTest.php
@@ -12,7 +12,7 @@ use App\Service\SessionUserPermissionChecker;
 use Mockery as m;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class VocabularyTest extends AbstractBase
+final class VocabularyTest extends AbstractBase
 {
     public function setUp(): void
     {

--- a/tests/Repository/AamcMethodRepositoryTest.php
+++ b/tests/Repository/AamcMethodRepositoryTest.php
@@ -12,7 +12,7 @@ use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-class AamcMethodRepositoryTest extends KernelTestCase
+final class AamcMethodRepositoryTest extends KernelTestCase
 {
     protected ReferenceRepository $fixtures;
     protected AamcMethodRepository $repository;

--- a/tests/Security/JsonWebTokenAuthenticatorTest.php
+++ b/tests/Security/JsonWebTokenAuthenticatorTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use UnexpectedValueException;
 
 #[CoversClass(JsonWebTokenAuthenticator::class)]
-class JsonWebTokenAuthenticatorTest extends TestCase
+final class JsonWebTokenAuthenticatorTest extends TestCase
 {
     protected m\MockInterface $routerMock;
     protected m\MockInterface $jsonWebTokenManagerMock;

--- a/tests/Service/AcademicYearFactoryTest.php
+++ b/tests/Service/AcademicYearFactoryTest.php
@@ -9,7 +9,7 @@ use App\Service\Config;
 use App\Tests\TestCase;
 use Mockery as m;
 
-class AcademicYearFactoryTest extends TestCase
+final class AcademicYearFactoryTest extends TestCase
 {
     protected m\MockInterface $config;
     protected AcademicYearFactory $factory;

--- a/tests/Service/ApiRequestParserTest.php
+++ b/tests/Service/ApiRequestParserTest.php
@@ -21,7 +21,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 #[CoversClass(ApiRequestParser::class)]
-class ApiRequestParserTest extends KernelTestCase
+final class ApiRequestParserTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Service/ApiResponseBuilderTest.php
+++ b/tests/Service/ApiResponseBuilderTest.php
@@ -10,7 +10,7 @@ use App\Tests\TestCase;
 use Mockery as m;
 use Symfony\Component\Serializer\SerializerInterface;
 
-class ApiResponseBuilderTest extends TestCase
+final class ApiResponseBuilderTest extends TestCase
 {
     private ApiResponseBuilder $obj;
 

--- a/tests/Service/AuthenticationFactoryTest.php
+++ b/tests/Service/AuthenticationFactoryTest.php
@@ -14,7 +14,7 @@ use Exception;
 use Mockery as m;
 use App\Service\AuthenticationFactory;
 
-class AuthenticationFactoryTest extends TestCase
+final class AuthenticationFactoryTest extends TestCase
 {
     protected m\MockInterface $config;
     protected m\MockInterface $cas;

--- a/tests/Service/ChangeAlertHandlerTest.php
+++ b/tests/Service/ChangeAlertHandlerTest.php
@@ -26,7 +26,7 @@ use App\Tests\TestCase;
  * @package App\Tests\Service
  */
 #[CoversClass(ChangeAlertHandler::class)]
-class ChangeAlertHandlerTest extends TestCase
+final class ChangeAlertHandlerTest extends TestCase
 {
     protected m\MockInterface $mockAlertRepository;
     protected m\MockInterface $mockAlertChangeTypeRepository;

--- a/tests/Service/ConfigTest.php
+++ b/tests/Service/ConfigTest.php
@@ -13,7 +13,7 @@ use App\Tests\TestCase;
  * Class LoggerQueueTest
  * @package App\Tests\Classes
  */
-class ConfigTest extends TestCase
+final class ConfigTest extends TestCase
 {
     public function testPullsFromENVFirst(): void
     {

--- a/tests/Service/CourseRolloverTest.php
+++ b/tests/Service/CourseRolloverTest.php
@@ -54,7 +54,7 @@ use Mockery as m;
 /**
  * Class CourseRolloverTest
  */
-class CourseRolloverTest extends TestCase
+final class CourseRolloverTest extends TestCase
 {
     protected m\MockInterface $courseRepository;
     protected m\MockInterface $learningMaterialRepository;

--- a/tests/Service/CurriculumInventory/Export/AggregatorTest.php
+++ b/tests/Service/CurriculumInventory/Export/AggregatorTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
  * @package App\Tests\Service\CurriculumInventory\Export
  */
 #[CoversClass(Aggregator::class)]
-class AggregatorTest extends TestCase
+final class AggregatorTest extends TestCase
 {
     protected m\MockInterface $manager;
     protected m\MockInterface $institutionRepository;

--- a/tests/Service/CurriculumInventory/Export/XmlPrinterTest.php
+++ b/tests/Service/CurriculumInventory/Export/XmlPrinterTest.php
@@ -25,7 +25,7 @@ use DateTime;
  * @package App\Tests\Service\CurriculumInventory\Export
  */
 #[CoversClass(XmlPrinter::class)]
-class XmlPrinterTest extends TestCase
+final class XmlPrinterTest extends TestCase
 {
     protected XmlPrinter $printer;
 

--- a/tests/Service/CurriculumInventory/ExporterTest.php
+++ b/tests/Service/CurriculumInventory/ExporterTest.php
@@ -16,7 +16,7 @@ use Mockery as m;
  * Class ExporterTest
  */
 #[CoversClass(Exporter::class)]
-class ExporterTest extends TestCase
+final class ExporterTest extends TestCase
 {
     public function testPrint(): void
     {

--- a/tests/Service/CurriculumInventory/ManagerTest.php
+++ b/tests/Service/CurriculumInventory/ManagerTest.php
@@ -17,7 +17,7 @@ use App\Tests\TestCase;
  * @package App\Tests\Service\CurriculumInventory
  */
 #[CoversClass(Manager::class)]
-class ManagerTest extends TestCase
+final class ManagerTest extends TestCase
 {
     protected m\MockInterface $repository;
     protected Manager $manager;

--- a/tests/Service/CurriculumInventory/ReportRolloverTest.php
+++ b/tests/Service/CurriculumInventory/ReportRolloverTest.php
@@ -31,7 +31,7 @@ use function count;
  * Class ReportRolloverTest
  */
 #[CoversClass(ReportRollover::class)]
-class ReportRolloverTest extends TestCase
+final class ReportRolloverTest extends TestCase
 {
     protected MockInterface $reportRepository;
     protected MockInterface $academicLevelRepository;

--- a/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
+++ b/tests/Service/CurriculumInventory/VerificationPreviewBuilderTest.php
@@ -26,7 +26,7 @@ use Mockery\MockInterface;
  * @package App\Tests\Service\CurriculumInventory
  */
 #[CoversClass(VerificationPreviewBuilder::class)]
-class VerificationPreviewBuilderTest extends TestCase
+final class VerificationPreviewBuilderTest extends TestCase
 {
     protected VerificationPreviewBuilder $builder;
     protected MockInterface $methodRepository;

--- a/tests/Service/DefaultDataImporterTest.php
+++ b/tests/Service/DefaultDataImporterTest.php
@@ -15,7 +15,7 @@ use Mockery as m;
  * @package App\Tests\Service
  */
 #[CoversClass(DefaultDataImporter::class)]
-class DefaultDataImporterTest extends TestCase
+final class DefaultDataImporterTest extends TestCase
 {
     protected m\MockInterface $repository;
     protected m\MockInterface $loader;

--- a/tests/Service/DefaultDataLoaderTest.php
+++ b/tests/Service/DefaultDataLoaderTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
  * @package App\Tests\Service
  */
 #[CoversClass(DefaultDataLoader::class)]
-class DefaultDataLoaderTest extends KernelTestCase
+final class DefaultDataLoaderTest extends KernelTestCase
 {
     protected string $projectRootDir;
 

--- a/tests/Service/DefaultPermissionMatrixTest.php
+++ b/tests/Service/DefaultPermissionMatrixTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
  * @package App\Tests\Service
  */
 #[CoversClass(DefaultPermissionMatrix::class)]
-class DefaultPermissionMatrixTest extends TestCase
+final class DefaultPermissionMatrixTest extends TestCase
 {
     protected DefaultPermissionMatrix $permissionMatrix;
     protected SchoolDTO $schoolDTO;

--- a/tests/Service/DirectoryTest.php
+++ b/tests/Service/DirectoryTest.php
@@ -12,7 +12,7 @@ use App\Service\Directory;
 use App\Tests\TestCase;
 
 #[CoversClass(Directory::class)]
-class DirectoryTest extends TestCase
+final class DirectoryTest extends TestCase
 {
     protected m\MockInterface $ldapManager;
     protected m\MockInterface $config;

--- a/tests/Service/EndpointResponseNamerTest.php
+++ b/tests/Service/EndpointResponseNamerTest.php
@@ -12,7 +12,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 #[CoversClass(EndpointResponseNamer::class)]
-class EndpointResponseNamerTest extends KernelTestCase
+final class EndpointResponseNamerTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Service/EntityMetadataTest.php
+++ b/tests/Service/EntityMetadataTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Contracts\Cache\CacheInterface;
 
 #[CoversClass(EntityMetadata::class)]
-class EntityMetadataTest extends KernelTestCase
+final class EntityMetadataTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Service/EntityRepositoryLookupTest.php
+++ b/tests/Service/EntityRepositoryLookupTest.php
@@ -19,7 +19,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 #[CoversClass(EntityRepositoryLookup::class)]
-class EntityRepositoryLookupTest extends KernelTestCase
+final class EntityRepositoryLookupTest extends KernelTestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Service/FilesystemFactoryTest.php
+++ b/tests/Service/FilesystemFactoryTest.php
@@ -12,7 +12,7 @@ use Exception;
 use League\Flysystem\FilesystemOperator;
 use Mockery as m;
 
-class FilesystemFactoryTest extends TestCase
+final class FilesystemFactoryTest extends TestCase
 {
     private m\MockInterface|Config $config;
     private FilesystemFactory $filesystemFactory;

--- a/tests/Service/FormAuthenticationTest.php
+++ b/tests/Service/FormAuthenticationTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-class FormAuthenticationTest extends TestCase
+final class FormAuthenticationTest extends TestCase
 {
     protected m\MockInterface $authenticationRepository;
     protected m\MockInterface $userRepository;

--- a/tests/Service/IliosFileSystemTest.php
+++ b/tests/Service/IliosFileSystemTest.php
@@ -13,7 +13,7 @@ use App\Service\IliosFileSystem;
 use App\Tests\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class IliosFileSystemTest extends TestCase
+final class IliosFileSystemTest extends TestCase
 {
     private IliosFileSystem $iliosFileSystem;
     private m\MockInterface $fileSystemMock;

--- a/tests/Service/Index/CurriculumTest.php
+++ b/tests/Service/Index/CurriculumTest.php
@@ -15,7 +15,7 @@ use Exception;
 use InvalidArgumentException;
 use Mockery as m;
 
-class CurriculumTest extends TestCase
+final class CurriculumTest extends TestCase
 {
     private m\MockInterface $client;
     private m\MockInterface $config;

--- a/tests/Service/Index/LearningMaterialsTest.php
+++ b/tests/Service/Index/LearningMaterialsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Service\Index;
 
 use App\Classes\OpenSearchBase;
+use App\Entity\DTO\CourseDTO;
 use App\Entity\DTO\LearningMaterialDTO;
 use App\Service\Config;
 use App\Service\Index\LearningMaterials;
@@ -15,7 +16,7 @@ use Exception;
 use InvalidArgumentException;
 use Mockery as m;
 
-class LearningMaterialsTest extends TestCase
+final class LearningMaterialsTest extends TestCase
 {
     private m\MockInterface | Client $client;
     private m\MockInterface | Config $config;
@@ -54,7 +55,7 @@ class LearningMaterialsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $courses = [
             m::mock(LearningMaterialDTO::class),
-            m::mock(self::class),
+            m::mock(CourseDTO::class),
             m::mock(LearningMaterialDTO::class),
         ];
         $obj->index($courses);

--- a/tests/Service/Index/MeshTest.php
+++ b/tests/Service/Index/MeshTest.php
@@ -12,7 +12,7 @@ use Exception;
 use Ilios\MeSH\Model\Descriptor;
 use Mockery as m;
 
-class MeshTest extends TestCase
+final class MeshTest extends TestCase
 {
     private m\MockInterface $client;
     private m\MockInterface $config;

--- a/tests/Service/Index/UsersTest.php
+++ b/tests/Service/Index/UsersTest.php
@@ -14,7 +14,7 @@ use Exception;
 use InvalidArgumentException;
 use Mockery as m;
 
-class UsersTest extends TestCase
+final class UsersTest extends TestCase
 {
     private m\MockInterface $client;
     private m\MockInterface $config;

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -19,7 +19,7 @@ use Mockery as m;
 use App\Service\JsonWebTokenManager;
 
 #[CoversClass(JsonWebTokenManager::class)]
-class JsonWebTokenManagerTest extends TestCase
+final class JsonWebTokenManagerTest extends TestCase
 {
     protected JsonWebTokenManager $obj;
     protected m\MockInterface $permissionChecker;

--- a/tests/Service/LdapAuthenticationTest.php
+++ b/tests/Service/LdapAuthenticationTest.php
@@ -17,7 +17,7 @@ use Mockery as m;
 use App\Service\LdapAuthentication;
 use Symfony\Component\HttpFoundation\Request;
 
-class LdapAuthenticationTest extends TestCase
+final class LdapAuthenticationTest extends TestCase
 {
     protected m\MockInterface $authRepository;
     protected m\MockInterface $jwtManager;

--- a/tests/Service/LearningMaterialTextExtractorTest.php
+++ b/tests/Service/LearningMaterialTextExtractorTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\File;
 use Vaites\ApacheTika\Client;
 
-class LearningMaterialTextExtractorTest extends TestCase
+final class LearningMaterialTextExtractorTest extends TestCase
 {
     public const string TEST_FILE_PATH = __DIR__ . '/FakeTestFiles/LearningMaterialTextExtractor_TEST.txt';
     private LearningMaterialTextExtractor $extractor;

--- a/tests/Service/LoggerQueueTest.php
+++ b/tests/Service/LoggerQueueTest.php
@@ -13,7 +13,7 @@ use App\Tests\TestCase;
 /**
  * Class LoggerQueueTest
  */
-class LoggerQueueTest extends TestCase
+final class LoggerQueueTest extends TestCase
 {
     public function testFlush(): void
     {

--- a/tests/Service/MeshDescriptorSetTransmogrifierTest.php
+++ b/tests/Service/MeshDescriptorSetTransmogrifierTest.php
@@ -19,7 +19,7 @@ use Ilios\MeSH\Model\Term;
  * Class MeshDescriptorSetTransmogrifierTest
  */
 #[CoversClass(MeshDescriptorSetTransmogrifier::class)]
-class MeshDescriptorSetTransmogrifierTest extends TestCase
+final class MeshDescriptorSetTransmogrifierTest extends TestCase
 {
     protected MeshDescriptorSetTransmogrifier $transmogrifier;
 

--- a/tests/Service/NonCachingIliosFileSystemTest.php
+++ b/tests/Service/NonCachingIliosFileSystemTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use App\Service\IliosFileSystem;
 use App\Tests\TestCase;
 
-class NonCachingIliosFileSystemTest extends TestCase
+final class NonCachingIliosFileSystemTest extends TestCase
 {
     private NonCachingIliosFileSystem $iliosFileSystem;
     private m\MockInterface $fileSystem;

--- a/tests/Service/ServiceTokenUserProviderTest.php
+++ b/tests/Service/ServiceTokenUserProviderTest.php
@@ -17,7 +17,7 @@ use Mockery as m;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 
 #[CoversClass(ServiceTokenUserProvider::class)]
-class ServiceTokenUserProviderTest extends TestCase
+final class ServiceTokenUserProviderTest extends TestCase
 {
     protected ServiceTokenUserProvider $provider;
     protected m\MockInterface $repositoryMock;

--- a/tests/Service/SessionUserPermissionCheckerTest.php
+++ b/tests/Service/SessionUserPermissionCheckerTest.php
@@ -22,7 +22,7 @@ use Mockery as m;
  * @package App\Tests\Service
  */
 #[CoversClass(SessionUserPermissionChecker::class)]
-class SessionUserPermissionCheckerTest extends TestCase
+final class SessionUserPermissionCheckerTest extends TestCase
 {
     protected SessionUserPermissionChecker $permissionChecker;
     protected m\MockInterface $permissionMatrix;

--- a/tests/Service/SessionUserProviderTest.php
+++ b/tests/Service/SessionUserProviderTest.php
@@ -21,7 +21,7 @@ use Mockery as m;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 
 #[CoversClass(SessionUserProvider::class)]
-class SessionUserProviderTest extends TestCase
+final class SessionUserProviderTest extends TestCase
 {
     protected SessionUserProvider $provider;
     protected m\MockInterface $repositoryMock;

--- a/tests/Service/ShibbolethAuthenticationTest.php
+++ b/tests/Service/ShibbolethAuthenticationTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ServerBag;
 
-class ShibbolethAuthenticationTest extends TestCase
+final class ShibbolethAuthenticationTest extends TestCase
 {
     protected m\MockInterface $authenticationRepository;
     protected m\MockInterface $jwtManager;

--- a/tests/Service/TemporaryFileSystemTest.php
+++ b/tests/Service/TemporaryFileSystemTest.php
@@ -10,7 +10,7 @@ use App\Service\TemporaryFileSystem;
 use App\Tests\TestCase;
 use Symfony\Component\HttpFoundation\File\File;
 
-class TemporaryFileSystemTest extends TestCase
+final class TemporaryFileSystemTest extends TestCase
 {
     private TemporaryFileSystem $tempFileSystem;
     private m\MockInterface $mockFileSystem;
@@ -42,7 +42,7 @@ class TemporaryFileSystemTest extends TestCase
     {
         parent::tearDown();
         unset($this->mockFileSystem);
-        unset($this->iliosFileSystem);
+        unset($this->tempFileSystem);
 
         $fs = new SymfonyFileSystem();
         $fs->remove($this->fakeTestFileDir);

--- a/tests/Service/TikaFactoryTest.php
+++ b/tests/Service/TikaFactoryTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 use Vaites\ApacheTika\Client;
 use Vaites\ApacheTika\Clients\WebClient;
 
-class TikaFactoryTest extends TestCase
+final class TikaFactoryTest extends TestCase
 {
     protected m\MockInterface|Config $config;
 

--- a/tests/ServiceTokenVoter/AbstractBase.php
+++ b/tests/ServiceTokenVoter/AbstractBase.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 abstract class AbstractBase extends TestCase
 {
-    protected Voter $voter;
+    final protected Voter $voter;
 
     public function tearDown(): void
     {

--- a/tests/ServiceTokenVoter/CohortTest.php
+++ b/tests/ServiceTokenVoter/CohortTest.php
@@ -12,7 +12,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\Cohort as Voter;
 use Mockery as m;
 
-class CohortTest extends AbstractReadWriteBase
+final class CohortTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/CompetencyTest.php
+++ b/tests/ServiceTokenVoter/CompetencyTest.php
@@ -10,7 +10,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\Competency as Voter;
 use Mockery as m;
 
-class CompetencyTest extends AbstractReadWriteBase
+final class CompetencyTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/CourseLearningMaterialTest.php
+++ b/tests/ServiceTokenVoter/CourseLearningMaterialTest.php
@@ -11,7 +11,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\CourseLearningMaterial as Voter;
 use Mockery as m;
 
-class CourseLearningMaterialTest extends AbstractReadWriteBase
+final class CourseLearningMaterialTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/CourseObjectiveTest.php
+++ b/tests/ServiceTokenVoter/CourseObjectiveTest.php
@@ -11,7 +11,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\CourseObjective as Voter;
 use Mockery as m;
 
-class CourseObjectiveTest extends AbstractReadWriteBase
+final class CourseObjectiveTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/CourseTest.php
+++ b/tests/ServiceTokenVoter/CourseTest.php
@@ -10,7 +10,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\Course as Voter;
 use Mockery as m;
 
-class CourseTest extends AbstractReadWriteBase
+final class CourseTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/CurriculumInventoryExportTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventoryExportTest.php
@@ -11,7 +11,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\CurriculumInventoryExport as Voter;
 use Mockery as m;
 
-class CurriculumInventoryExportTest extends AbstractReadWriteBase
+final class CurriculumInventoryExportTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/CurriculumInventoryInstitutionTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventoryInstitutionTest.php
@@ -10,7 +10,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\CurriculumInventoryInstitution as Voter;
 use Mockery as m;
 
-class CurriculumInventoryInstitutionTest extends AbstractReadWriteBase
+final class CurriculumInventoryInstitutionTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/CurriculumInventoryReportTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventoryReportTest.php
@@ -10,7 +10,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\CurriculumInventoryReport as Voter;
 use Mockery as m;
 
-class CurriculumInventoryReportTest extends AbstractReadWriteBase
+final class CurriculumInventoryReportTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/CurriculumInventorySequenceBlockTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventorySequenceBlockTest.php
@@ -11,7 +11,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\CurriculumInventorySequenceBlock as Voter;
 use Mockery as m;
 
-class CurriculumInventorySequenceBlockTest extends AbstractReadWriteBase
+final class CurriculumInventorySequenceBlockTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/CurriculumInventorySequenceTest.php
+++ b/tests/ServiceTokenVoter/CurriculumInventorySequenceTest.php
@@ -11,7 +11,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\CurriculumInventorySequence as Voter;
 use Mockery as m;
 
-class CurriculumInventorySequenceTest extends AbstractReadWriteBase
+final class CurriculumInventorySequenceTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/GreenlightViewDTOVoterTest.php
+++ b/tests/ServiceTokenVoter/GreenlightViewDTOVoterTest.php
@@ -50,7 +50,7 @@ use App\Entity\DTO\UserRoleDTO;
 use App\Entity\DTO\VocabularyDTO;
 use App\ServiceTokenVoter\GreenlightViewDTOVoter;
 
-class GreenlightViewDTOVoterTest extends AbstractReadonlyBase
+final class GreenlightViewDTOVoterTest extends AbstractReadonlyBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/IlmSessionTest.php
+++ b/tests/ServiceTokenVoter/IlmSessionTest.php
@@ -12,7 +12,7 @@ use App\Entity\SessionInterface;
 use App\ServiceTokenVoter\IlmSession as Voter;
 use Mockery as m;
 
-class IlmSessionTest extends AbstractReadWriteBase
+final class IlmSessionTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/InstructorGroupTest.php
+++ b/tests/ServiceTokenVoter/InstructorGroupTest.php
@@ -10,7 +10,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\InstructorGroup as Voter;
 use Mockery as m;
 
-class InstructorGroupTest extends AbstractReadWriteBase
+final class InstructorGroupTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/LearnerGroupTest.php
+++ b/tests/ServiceTokenVoter/LearnerGroupTest.php
@@ -11,7 +11,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\LearnerGroup as Voter;
 use Mockery as m;
 
-class LearnerGroupTest extends AbstractReadWriteBase
+final class LearnerGroupTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/OfferingTest.php
+++ b/tests/ServiceTokenVoter/OfferingTest.php
@@ -12,7 +12,7 @@ use App\Entity\SessionInterface;
 use App\ServiceTokenVoter\Offering as Voter;
 use Mockery as m;
 
-class OfferingTest extends AbstractReadWriteBase
+final class OfferingTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/PendingUserUpdateTest.php
+++ b/tests/ServiceTokenVoter/PendingUserUpdateTest.php
@@ -11,7 +11,7 @@ use App\Entity\UserInterface;
 use App\ServiceTokenVoter\PendingUserUpdate as Voter;
 use Mockery as m;
 
-class PendingUserUpdateTest extends AbstractReadWriteBase
+final class PendingUserUpdateTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/ProgramTest.php
+++ b/tests/ServiceTokenVoter/ProgramTest.php
@@ -10,7 +10,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\Program as Voter;
 use Mockery as m;
 
-class ProgramTest extends AbstractReadWriteBase
+final class ProgramTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/ProgramYearObjectiveTest.php
+++ b/tests/ServiceTokenVoter/ProgramYearObjectiveTest.php
@@ -12,7 +12,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\ProgramYearObjective as Voter;
 use Mockery as m;
 
-class ProgramYearObjectiveTest extends AbstractReadWriteBase
+final class ProgramYearObjectiveTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/ProgramYearTest.php
+++ b/tests/ServiceTokenVoter/ProgramYearTest.php
@@ -11,7 +11,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\ProgramYear as Voter;
 use Mockery as m;
 
-class ProgramYearTest extends AbstractReadWriteBase
+final class ProgramYearTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/ReadonlyEntityVoterTest.php
+++ b/tests/ServiceTokenVoter/ReadonlyEntityVoterTest.php
@@ -24,7 +24,7 @@ use App\Entity\UserInterface;
 use App\Entity\UserRoleInterface;
 use App\ServiceTokenVoter\ReadonlyEntityVoter as Voter;
 
-class ReadonlyEntityVoterTest extends AbstractReadonlyBase
+final class ReadonlyEntityVoterTest extends AbstractReadonlyBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/SchoolTest.php
+++ b/tests/ServiceTokenVoter/SchoolTest.php
@@ -9,7 +9,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\School as Voter;
 use Mockery as m;
 
-class SchoolTest extends AbstractReadWriteBase
+final class SchoolTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/SessionLearningMaterialTest.php
+++ b/tests/ServiceTokenVoter/SessionLearningMaterialTest.php
@@ -12,7 +12,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\SessionLearningMaterial as Voter;
 use Mockery as m;
 
-class SessionLearningMaterialTest extends AbstractReadWriteBase
+final class SessionLearningMaterialTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/SessionObjectiveTest.php
+++ b/tests/ServiceTokenVoter/SessionObjectiveTest.php
@@ -12,7 +12,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\SessionObjective as Voter;
 use Mockery as m;
 
-class SessionObjectiveTest extends AbstractReadWriteBase
+final class SessionObjectiveTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/SessionTest.php
+++ b/tests/ServiceTokenVoter/SessionTest.php
@@ -11,7 +11,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\Session as Voter;
 use Mockery as m;
 
-class SessionTest extends AbstractReadWriteBase
+final class SessionTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/SessionTypeTest.php
+++ b/tests/ServiceTokenVoter/SessionTypeTest.php
@@ -10,7 +10,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\SessionType as Voter;
 use Mockery as m;
 
-class SessionTypeTest extends AbstractReadWriteBase
+final class SessionTypeTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/TermTest.php
+++ b/tests/ServiceTokenVoter/TermTest.php
@@ -11,7 +11,7 @@ use App\Entity\VocabularyInterface;
 use App\ServiceTokenVoter\Term as Voter;
 use Mockery as m;
 
-class TermTest extends AbstractReadWriteBase
+final class TermTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/ServiceTokenVoter/VocabularyTest.php
+++ b/tests/ServiceTokenVoter/VocabularyTest.php
@@ -10,7 +10,7 @@ use App\Entity\SchoolInterface;
 use App\ServiceTokenVoter\Vocabulary as Voter;
 use Mockery as m;
 
-class VocabularyTest extends AbstractReadWriteBase
+final class VocabularyTest extends AbstractReadWriteBase
 {
     public function setUp(): void
     {

--- a/tests/Traits/CohortsEntityTest.php
+++ b/tests/Traits/CohortsEntityTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 
 #[CoversTrait(CohortsEntity::class)]
-class CohortsEntityTest extends TestCase
+final class CohortsEntityTest extends TestCase
 {
     private object $traitObject;
     public function setUp(): void

--- a/tests/Traits/CompetenciesEntityTest.php
+++ b/tests/Traits/CompetenciesEntityTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 
 #[CoversTrait(CompetenciesEntity::class)]
-class CompetenciesEntityTest extends TestCase
+final class CompetenciesEntityTest extends TestCase
 {
     private object $traitObject;
     public function setUp(): void

--- a/tests/Traits/ConceptsEntityTest.php
+++ b/tests/Traits/ConceptsEntityTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 
 #[CoversTrait(ConceptsEntity::class)]
-class ConceptsEntityTest extends TestCase
+final class ConceptsEntityTest extends TestCase
 {
     private object $traitObject;
     public function setUp(): void

--- a/tests/Traits/CoursesEntityTest.php
+++ b/tests/Traits/CoursesEntityTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 
 #[CoversTrait(CoursesEntity::class)]
-class CoursesEntityTest extends TestCase
+final class CoursesEntityTest extends TestCase
 {
     private object $traitObject;
     public function setUp(): void

--- a/tests/Traits/IlmSessionsEntityTest.php
+++ b/tests/Traits/IlmSessionsEntityTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 
 #[CoversTrait(IlmSessionsEntity::class)]
-class IlmSessionsEntityTest extends TestCase
+final class IlmSessionsEntityTest extends TestCase
 {
     private object $traitObject;
     public function setUp(): void

--- a/tests/Traits/LearningMaterialsEntityTest.php
+++ b/tests/Traits/LearningMaterialsEntityTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 
 #[CoversTrait(LearningMaterialsEntity::class)]
-class LearningMaterialsEntityTest extends TestCase
+final class LearningMaterialsEntityTest extends TestCase
 {
     private object $traitObject;
     public function setUp(): void

--- a/tests/Traits/ProgramYearsEntityTest.php
+++ b/tests/Traits/ProgramYearsEntityTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 
 #[CoversTrait(ProgramYearsEntity::class)]
-class ProgramYearsEntityTest extends TestCase
+final class ProgramYearsEntityTest extends TestCase
 {
     private object $traitObject;
     public function setUp(): void

--- a/tests/Traits/ProgramsEntityTest.php
+++ b/tests/Traits/ProgramsEntityTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 
 #[CoversTrait(ProgramsEntity::class)]
-class ProgramsEntityTest extends TestCase
+final class ProgramsEntityTest extends TestCase
 {
     private object $traitObject;
     public function setUp(): void

--- a/tests/Traits/UsersEntityTest.php
+++ b/tests/Traits/UsersEntityTest.php
@@ -12,7 +12,7 @@ use App\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 
 #[CoversTrait(UsersEntity::class)]
-class UsersEntityTest extends TestCase
+final class UsersEntityTest extends TestCase
 {
     private object $traitObject;
     public function setUp(): void


### PR DESCRIPTION
In accordance with our version policy, we now only support PHP 8.4.0 and above.