### PR TITLE
Prevent Indexing Non File Materials

### DIFF
--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -59,7 +59,7 @@ class IndexEntityChanges
             $this->indexUser($entity->getUser());
         }
 
-        if ($entity instanceof LearningMaterialInterface) {
+        if ($entity instanceof LearningMaterialInterface && $entity->getFilename()) {
             $this->bus->dispatch(new LearningMaterialTextExtractionRequest([$entity->getId()]));
         }
 
@@ -84,7 +84,7 @@ class IndexEntityChanges
             $this->indexUser($entity->getUser());
         }
 
-        if ($entity instanceof LearningMaterialInterface) {
+        if ($entity instanceof LearningMaterialInterface && $entity->getFilename()) {
             $this->indexLearningMaterial($entity);
         }
 
@@ -155,7 +155,9 @@ class IndexEntityChanges
     {
         if ($this->learningMaterialsIndex->isEnabled()) {
             $this->logger->debug('Indexing Material ' . $lm->getId());
-            $this->bus->dispatch(new LearningMaterialIndexRequest([$lm->getId()]));
+            if ($lm->getFilename()) {
+                $this->bus->dispatch(new LearningMaterialIndexRequest([$lm->getId()]));
+            }
         }
     }
 }

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -40,6 +40,14 @@ class LearningMaterials extends OpenSearchBase
                     )
                 );
             }
+            if (!$material->relativePath) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'Material %d has no relative path and cannot be indexed, probably not a file type material.',
+                        $material->id,
+                    )
+                );
+            }
         }
 
         $ids = array_map(fn (LearningMaterialDTO $dto) => $dto->id, $materials);

--- a/tests/Service/Index/LearningMaterialsTest.php
+++ b/tests/Service/Index/LearningMaterialsTest.php
@@ -53,12 +53,32 @@ final class LearningMaterialsTest extends TestCase
     {
         $obj = new LearningMaterials($this->fs, $this->config, $this->client);
         $this->expectException(InvalidArgumentException::class);
-        $courses = [
-            m::mock(LearningMaterialDTO::class),
+        $goodMock1 = m::mock(LearningMaterialDTO::class);
+        $goodMock1->relativePath = 'trouble';
+        $goodMock2 = m::mock(LearningMaterialDTO::class);
+        $goodMock2->relativePath = 'skiziks';
+        $materials = [
+            $goodMock1,
             m::mock(CourseDTO::class),
-            m::mock(LearningMaterialDTO::class),
+            $goodMock2,
         ];
-        $obj->index($courses);
+        $obj->index($materials);
+    }
+
+    public function testIndexThrowsWhenNotAFileTypeMaterial(): void
+    {
+        $obj = new LearningMaterials($this->fs, $this->config, $this->client);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Material 56 has no relative path and cannot be indexed, probably not a file type material.'
+        );
+        $goodMock =  m::mock(LearningMaterialDTO::class);
+        $goodMock->relativePath = 'foo';
+        $badMock = m::mock(LearningMaterialDTO::class);
+        $badMock->relativePath = null;
+        $badMock->id = 56;
+        $materials = [$goodMock, $badMock,];
+        $obj->index($materials);
     }
 
     public function testIndexThrowsWithoutSearch(): void


### PR DESCRIPTION
We were sending indexing requests for all materials on save, limit this to just files and add a nice exception if this gets messed up in the future.

Fixes #6222