### PR TITLE
Reduce Development Message Consumers

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -60,9 +60,6 @@ services:
       - ILIOS_FILE_SYSTEM_STORAGE_PATH=/ilios-storage
       - ILIOS_TIKA_URL=http://tika:9998
     restart: always
-    deploy:
-      mode: replicated
-      replicas: 3
     command: [ "--time-limit", "3600", "-vv" ]
     depends_on:
       - db


### PR DESCRIPTION
Having multiple consumers seems to overwhelm the docker database, reducing this back to one for an improved indexing experience in local development.