### PR TITLE
Remove the dispatch.bus Configuration

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -26,15 +26,6 @@ framework:
           - doctrine_ping_connection
           # After handling, the Doctrine connection is closed
           - doctrine_close_connection
-      dispatch.bus:
-        default_middleware: false
-        middleware:
-            - validation
-            - add_bus_name_stamp_middleware: ['messenger.bus.default']
-            - dispatch_after_current_bus
-            - failed_message_processing_middleware
-            - send_message
-            - handle_message
 
 when@test:
    framework:

--- a/src/EventListener/IndexEntityChanges.php
+++ b/src/EventListener/IndexEntityChanges.php
@@ -34,9 +34,6 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 class IndexEntityChanges
 {
-    /**
-     * ACHTUNG!!! Do NOT change the name of $bus it tells the dependency injection system what bus to inject!!!
-     */
     public function __construct(
         protected Curriculum $curriculumIndex,
         protected LearningMaterials $learningMaterialsIndex,


### PR DESCRIPTION
This was added to work around issues with the doctrine middleware on the default bus, however it fell out of use accidentally during a codemod and appears to no longer be needed. Removing as well as the related code comments.