### PR TITLE
Index Courses After Materials

### DIFF
--- a/src/Repository/LearningMaterialRepository.php
+++ b/src/Repository/LearningMaterialRepository.php
@@ -335,4 +335,30 @@ class LearningMaterialRepository extends ServiceEntityRepository implements DTOR
         $ids = array_column($results, 'id');
         return array_map('intval', $ids);
     }
+
+    /**
+     * Get the IDs for all courses attached to materials
+     * @return int[]
+     */
+    public function getCourseIdsForMaterials(array $ids): array
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->select('c.id')->from(LearningMaterial::class, 'x')
+            ->leftJoin('x.courseLearningMaterials', 'cm')
+            ->leftJoin('cm.course', 'c')
+            ->where('x.id IN (:ids)')
+            ->setParameter(':ids', $ids);
+        $courseIds = array_column($qb->getQuery()->getScalarResult(), 'id');
+
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->select('c.id')->from(LearningMaterial::class, 'x')
+            ->leftJoin('x.sessionLearningMaterials', 'sm')
+            ->leftJoin('sm.session', 's')
+            ->leftJoin('s.course', 'c')
+            ->where('x.id IN (:ids)')
+            ->setParameter(':ids', $ids);
+        $sessionCourseIds = array_column($qb->getQuery()->getScalarResult(), 'id');
+
+        return array_unique(array_merge($courseIds, $sessionCourseIds));
+    }
 }

--- a/src/Repository/LearningMaterialRepository.php
+++ b/src/Repository/LearningMaterialRepository.php
@@ -359,6 +359,13 @@ class LearningMaterialRepository extends ServiceEntityRepository implements DTOR
             ->setParameter(':ids', $ids);
         $sessionCourseIds = array_column($qb->getQuery()->getScalarResult(), 'id');
 
-        return array_unique(array_merge($courseIds, $sessionCourseIds));
+        //re-index the array of unique course ids, with all nulls removed
+        return array_values(
+            array_unique(
+                array_filter(
+                    array_merge($courseIds, $sessionCourseIds)
+                )
+            )
+        );
     }
 }

--- a/tests/Repository/LearningMaterialsRepositoryTest.php
+++ b/tests/Repository/LearningMaterialsRepositoryTest.php
@@ -6,7 +6,9 @@ namespace App\Tests\Repository;
 
 use App\Entity\LearningMaterial;
 use App\Repository\LearningMaterialRepository;
+use App\Tests\Fixture\LoadCourseLearningMaterialData;
 use App\Tests\Fixture\LoadLearningMaterialData;
+use App\Tests\Fixture\LoadSessionLearningMaterialData;
 use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\Persistence\ObjectRepository;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
@@ -23,7 +25,9 @@ final class LearningMaterialsRepositoryTest extends KernelTestCase
 
         $databaseToot = self::$kernel->getContainer()->get(DatabaseToolCollection::class)->get();
         $executor = $databaseToot->loadFixtures([
+            LoadCourseLearningMaterialData::class,
             LoadLearningMaterialData::class,
+            LoadSessionLearningMaterialData::class,
         ]);
         $this->fixtures = $executor->getReferenceRepository();
 
@@ -47,5 +51,14 @@ final class LearningMaterialsRepositoryTest extends KernelTestCase
         $this->assertInstanceOf(LearningMaterial::class, $entity);
         $this->assertSame(1, $entity->getId());
         $this->assertSame('firstlmtitle', $entity->getTitle());
+    }
+
+    public function testGetCourseIdsForMaterials(): void
+    {
+        $ids = $this->repository->getCourseIdsForMaterials([2, 3]);
+        $this->assertCount(2, $ids);
+        $this->assertContains(1, $ids);
+        $this->assertContains(2, $ids);
+        $this->assertSame([1, 2], $ids);
     }
 }

--- a/tests/Repository/LearningMaterialsRepositoryTest.php
+++ b/tests/Repository/LearningMaterialsRepositoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\LearningMaterial;
+use App\Repository\LearningMaterialRepository;
+use App\Tests\Fixture\LoadLearningMaterialData;
+use Doctrine\Common\DataFixtures\ReferenceRepository;
+use Doctrine\Persistence\ObjectRepository;
+use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class LearningMaterialsRepositoryTest extends KernelTestCase
+{
+    protected ReferenceRepository $fixtures;
+    protected LearningMaterialRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $databaseToot = self::$kernel->getContainer()->get(DatabaseToolCollection::class)->get();
+        $executor = $databaseToot->loadFixtures([
+            LoadLearningMaterialData::class,
+        ]);
+        $this->fixtures = $executor->getReferenceRepository();
+
+        $entityManager = self::$kernel->getContainer()->get('doctrine')->getManager();
+        /** @var LearningMaterialRepository $repository */
+        $repository = $entityManager->getRepository(LearningMaterial::class);
+        $this->repository = $repository;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->fixtures);
+        unset($this->repository);
+    }
+
+    public function testFindById(): void
+    {
+        $entity = $this->repository->findOneBy(['id' => 1]);
+        $this->assertNotNull($entity);
+        $this->assertInstanceOf(LearningMaterial::class, $entity);
+        $this->assertSame(1, $entity->getId());
+        $this->assertSame('firstlmtitle', $entity->getTitle());
+    }
+}


### PR DESCRIPTION
After a material is indexed grab all the courses it's associated with and re-index them as well to ensure the contents of the material are attached to the course.

Fixes #6226