### PR TITLE
Improved Failed Index Message Handling

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -3,7 +3,11 @@ framework:
     failure_transport: failed
     transports:
       # https://symfony.com/doc/current/messenger.html#transport-configuration
-      async: '%env(MESSENGER_TRANSPORT_DSN)%'
+      async:
+        dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+        retry_strategy:
+          # milliseconds delay, 30 seconds
+          delay: 30000
       failed: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=failed'
 
     routing:

--- a/src/MessageHandler/CourseIndexHandler.php
+++ b/src/MessageHandler/CourseIndexHandler.php
@@ -8,19 +8,33 @@ use App\Message\CourseIndexRequest;
 use App\Repository\CourseRepository;
 use App\Service\Index\Curriculum;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Throwable;
 
 #[AsMessageHandler]
 class CourseIndexHandler
 {
     public function __construct(
-        private Curriculum $curriculumIndex,
-        private CourseRepository $courseRepository
+        private readonly Curriculum $curriculumIndex,
+        private readonly CourseRepository $courseRepository,
+        private readonly MessageBusInterface $bus,
     ) {
     }
 
     public function __invoke(CourseIndexRequest $message): void
     {
         $indexes = $this->courseRepository->getCourseIndexesFor($message->getCourseIds());
-        $this->curriculumIndex->index($indexes, $message->getCreatedAt());
+        try {
+            $this->curriculumIndex->index($indexes, $message->getCreatedAt());
+        } catch (Throwable $t) {
+            if (count($message->getCourseIds()) <= 1) {
+                throw $t;
+            } else {
+                //split up the failed handling into individual requests
+                foreach ($message->getCourseIds() as $courseId) {
+                    $this->bus->dispatch(new CourseIndexRequest([$courseId]));
+                }
+            }
+        }
     }
 }

--- a/tests/MessageHandler/CourseIndexHandlerTest.php
+++ b/tests/MessageHandler/CourseIndexHandlerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MessageHandler;
+
+use App\Classes\IndexableCourse;
+use App\Message\CourseIndexRequest;
+use App\MessageHandler\CourseIndexHandler;
+use App\Repository\CourseRepository;
+use App\Service\Index\Curriculum;
+use App\Tests\TestCase;
+use Mockery as m;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class CourseIndexHandlerTest extends TestCase
+{
+    protected m\MockInterface|Curriculum $index;
+    protected m\MockInterface|CourseRepository $repository;
+    protected m\MockInterface|MessageBusInterface $bus;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->index = m::mock(Curriculum::class);
+        $this->repository = m::mock(CourseRepository::class);
+        $this->bus = m::mock(MessageBusInterface::class);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->index);
+        unset($this->repository);
+        unset($this->bus);
+    }
+
+    public function testInvoke(): void
+    {
+        $firstCourse = m::mock(IndexableCourse::class);
+        $secondCourse = m::mock(IndexableCourse::class);
+        $handler = new CourseIndexHandler($this->index, $this->repository, $this->bus);
+        $request = new CourseIndexRequest([6, 24]);
+
+        $this->repository->shouldReceive(('getCourseIndexesFor'))
+            ->once()
+            ->with([6, 24])
+            ->andReturn([
+                $firstCourse,
+                $secondCourse,
+            ]);
+
+        $this->index
+            ->shouldReceive('index')
+            ->once()
+            ->withArgs(function (array $courses) use ($firstCourse, $secondCourse) {
+                $this->assertCount(2, $courses);
+                $this->assertContains($firstCourse, $courses);
+                $this->assertContains($secondCourse, $courses);
+
+                $this->assertEquals([$firstCourse, $secondCourse], $courses);
+
+                return true;
+            });
+
+        $handler->__invoke($request);
+    }
+}


### PR DESCRIPTION
Slightly modified the retry failure settings, but the main thrust of this change is to split up courses that fail to index as a group into smaller individual parts.