### PR TITLE
Rewrite of DetectMissing Command

### DIFF
--- a/src/Command/Index/DetectMissingCommand.php
+++ b/src/Command/Index/DetectMissingCommand.php
@@ -57,14 +57,18 @@ class DetectMissingCommand extends Command
     {
         $materialsInIndex = $this->materialIndex->getAllIds();
         $allIds = $this->learningMaterialRepository->getFileLearningMaterialIds();
-        return array_diff($allIds, $materialsInIndex);
+        return array_values(
+            array_diff($allIds, $materialsInIndex)
+        );
     }
 
     protected function checkSessions(): array
     {
         $sessionsInIndex = $this->curriculumIndex->getAllSessionIds();
         $allIds = $this->sessionRepository->getIds();
-        return array_diff($allIds, $sessionsInIndex);
+        return array_values(
+            array_diff($allIds, $sessionsInIndex)
+        );
     }
 
     protected function displayResults(

--- a/src/Command/Index/DetectMissingCommand.php
+++ b/src/Command/Index/DetectMissingCommand.php
@@ -51,7 +51,11 @@ class DetectMissingCommand extends Command
 
         if ($missingMaterials) {
             $io->title('Missing Materials (' . count($missingMaterials) . ')');
-            $io->listing($missingMaterials);
+            $count = count($missingMaterials);
+            $io->listing(array_slice($missingMaterials, 0, 10));
+            if ($count > 10) {
+                $io->warning('and ' . $count - 10 . ' additional materials.');
+            }
         }
 
         $coursesWithMissingSessions = [];
@@ -82,12 +86,17 @@ class DetectMissingCommand extends Command
 
                 return ["{$item['title']} ({$item['courseId']})", $sessions];
             }, $coursesWithMissingSessions);
+
+            $count = count($tableRows);
             $io->title('Missing Sessions (' . count($missingSessions) . ')');
             $table = new Table($output);
             $table->setStyle('compact');
             $table->setHeaders(['Course', 'Missing Sessions']);
-            $table->setRows($tableRows);
+            $table->setRows(array_slice($tableRows, 0, 10));
             $table->render();
+            if ($count > 10) {
+                $io->warning('and ' . $count - 10 . ' additional courses.');
+            }
         }
 
         $io->newLine();

--- a/src/Command/Index/DetectMissingCommand.php
+++ b/src/Command/Index/DetectMissingCommand.php
@@ -27,7 +27,7 @@ class DetectMissingCommand extends Command
 {
     public function __construct(
         protected readonly LearningMaterialRepository $learningMaterialRepository,
-        protected readonly CourseREpository $courseRepository,
+        protected readonly CourseRepository $courseRepository,
         protected readonly SessionRepository $sessionRepository,
         protected readonly LearningMaterials $materialIndex,
         protected readonly Curriculum $curriculumIndex,

--- a/src/Repository/SessionRepository.php
+++ b/src/Repository/SessionRepository.php
@@ -340,4 +340,16 @@ class SessionRepository extends ServiceEntityRepository implements
         return (int) $this->getEntityManager()->createQuery('SELECT COUNT(s.id) FROM App\Entity\Session s')
             ->getSingleScalarResult();
     }
+
+    public function getCoursesForSessionIds(array $ids): array
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->select('s.id as sessionId, c.id as courseId, c.title as courseTitle')
+            ->from(Session::class, 's')
+            ->leftJoin('s.course', 'c')
+            ->where('s.id in (:ids)')
+            ->setParameter(':ids', $ids);
+
+        return $qb->getQuery()->getResult();
+    }
 }

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -486,14 +486,21 @@ class Curriculum extends OpenSearchBase
                 'query' => [
                     'match_all' => new stdClass(),
                 ],
-                '_source' => ['courseId'],
+                'aggs' => [
+                    'courseId' => [
+                        'terms' => [
+                            'field' => 'courseId',
+                            'size' => 10000,
+                        ],
+                    ],
+                ],
+                'size' => 0,
             ],
-            'size' => self::SIZE_LIMIT,
         ];
+        $results = $this->doSearch($params);
+        $courseIds = array_column($results['aggregations']['courseId']['buckets'], 'key');
 
-        $results = $this->doScrollSearch($params);
-        $ids = array_map(fn ($item) => $item['_source']['courseId'], $results);
-        return array_unique($ids);
+        return array_map('intval', $courseIds);
     }
 
     public function getAllSessionIds(): array

--- a/tests/Command/Index/DetectMissingCommandTest.php
+++ b/tests/Command/Index/DetectMissingCommandTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Command\Index;
 
+use App\Classes\IndexableCourse;
 use App\Command\Index\DetectMissingCommand;
+use App\Entity\DTO\LearningMaterialDTO;
 use App\Repository\CourseRepository;
 use App\Repository\LearningMaterialRepository;
 use App\Repository\SessionRepository;
@@ -125,5 +127,58 @@ final class DetectMissingCommandTest extends KernelTestCase
             '/Our Missing Course \(33\) 1 /',
             $output
         );
+    }
+    public function testReIndexMaterials(): void
+    {
+        $this->materialIndex->shouldReceive('isEnabled')->once()->andReturn(true);
+
+        $this->materialIndex->shouldReceive('getAllIds')->once()->andReturn([13]);
+        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([13, 14]);
+
+        $this->curriculumIndex->shouldReceive('getAllSessionIds')->once()->andReturn([]);
+        $this->sessionRepository->shouldReceive('getIds')->once()->andReturn([]);
+
+        $this->sessionRepository->shouldNotReceive('getCoursesForSessionIds');
+
+        $dto = m::mock(LearningMaterialDTO::class);
+        $this->learningMaterialRepository->shouldReceive('findDTOsBy')->once()
+            ->with(['id' => [14]])
+            ->andReturn([$dto]);
+
+        $this->materialIndex->shouldReceive('index')->once()->with([$dto])->andReturn(true);
+
+        $this->commandTester->setInputs(['yes']);
+        $this->commandTester->execute([]);
+    }
+    public function testReIndexCourses(): void
+    {
+        $this->materialIndex->shouldReceive('isEnabled')->once()->andReturn(true);
+
+        $this->materialIndex->shouldReceive('getAllIds')->once()->andReturn([]);
+        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([]);
+
+        $this->curriculumIndex->shouldReceive('getAllSessionIds')->once()->andReturn([22]);
+        $this->sessionRepository->shouldReceive('getIds')->once()->andReturn([1, 22]);
+
+        $this->sessionRepository
+            ->shouldReceive('getCoursesForSessionIds')->once()
+            ->with([1])
+            ->andReturn([
+                [
+                    'courseId' => 33,
+                    'courseTitle' => 'Our Missing Course',
+                    'sessionId' => 1,
+                ],
+            ]);
+
+        $c = m::mock(IndexableCourse::class);
+        $this->courseRepository->shouldReceive('getCourseIndexesFor')->once()
+            ->with([33])
+            ->andReturn([$c]);
+
+        $this->curriculumIndex->shouldReceive('index')->once()->andReturn(true);
+
+        $this->commandTester->setInputs(['yes']);
+        $this->commandTester->execute([]);
     }
 }

--- a/tests/Repository/SessionRepositoryTest.php
+++ b/tests/Repository/SessionRepositoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\Session;
+use App\Repository\SessionRepository;
+use App\Tests\Fixture\LoadSessionData;
+use Doctrine\Common\DataFixtures\ReferenceRepository;
+use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class SessionRepositoryTest extends KernelTestCase
+{
+    protected ReferenceRepository $fixtures;
+    protected SessionRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $databaseToot = self::$kernel->getContainer()->get(DatabaseToolCollection::class)->get();
+        $executor = $databaseToot->loadFixtures([
+            LoadSessionData::class,
+        ]);
+        $this->fixtures = $executor->getReferenceRepository();
+
+        $entityManager = self::$kernel->getContainer()->get('doctrine')->getManager();
+        /** @var SessionRepository $repository */
+        $repository = $entityManager->getRepository(Session::class);
+        $this->repository = $repository;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->fixtures);
+        unset($this->repository);
+    }
+
+    public function testFindById(): void
+    {
+        $entity = $this->repository->findOneBy(['id' => 1]);
+        $this->assertNotNull($entity);
+        $this->assertInstanceOf(Session::class, $entity);
+        $this->assertSame(1, $entity->getId());
+        $this->assertSame('session1Title', $entity->getTitle());
+    }
+
+    public function testGetCoursesForSessionIds(): void
+    {
+        $arr = $this->repository->getCoursesForSessionIds([2, 3]);
+        $this->assertCount(2, $arr);
+        $this->assertSame([
+            'sessionId' => 2,
+            'courseId' => 1,
+            'courseTitle' => 'firstCourse',
+        ], $arr[0]);
+        $this->assertSame([
+            'sessionId' => 3,
+            'courseId' => 2,
+            'courseTitle' => 'course 2',
+        ], $arr[1]);
+    }
+}

--- a/tests/Service/Index/CurriculumTest.php
+++ b/tests/Service/Index/CurriculumTest.php
@@ -310,17 +310,17 @@ final class CurriculumTest extends TestCase
     public function testGetAllCourseIds(): void
     {
         $obj = new Curriculum($this->config, $this->client);
+        //$results['aggregations']['courseId']['buckets']
         $this->client->shouldReceive('search')->once()->andReturn([
-            'hits' => [
-                'hits' => [
-                    ['_source' => ['courseId' => 1]],
-                    ['_source' => ['courseId' => 2]],
+            'aggregations' => [
+                'courseId' => [
+                    'buckets' => [
+                        ['key' => 1],
+                        ['key' => 2],
+                    ],
                 ],
             ],
-            '_scroll_id' => '123',
         ]);
-        $this->client->shouldReceive('scroll')->once()->andReturn(['hits' => ['hits' => []]]);
-        $this->client->shouldReceive('clearScroll')->once();
         $courseIds = $obj->getAllCourseIds();
         $this->assertCount(2, $courseIds);
         $this->assertEquals([1, 2], $courseIds);
@@ -330,16 +330,33 @@ final class CurriculumTest extends TestCase
     {
         $obj = new Curriculum($this->config, $this->client);
         $this->client->shouldReceive('search')->once()->andReturn([
-            'hits' => [
-                'hits' => [
-                    ['_source' => ['sessionId' => 1]],
-                    ['_source' => ['sessionId' => 2]],
+            'aggregations' => [
+                'sessionId' => [
+                    'buckets' => [
+                        ['key' => 1],
+                        ['key' => 2],
+                    ],
                 ],
             ],
-            '_scroll_id' => '123',
+            'hits' => [
+                'total' => [
+                    'value' => 2,
+                ],
+            ],
         ]);
-        $this->client->shouldReceive('scroll')->once()->andReturn(['hits' => ['hits' => []]]);
-        $this->client->shouldReceive('clearScroll')->once();
+        $this->client->shouldReceive('search')->once()->andReturn([
+            'aggregations' => [
+                'sessionId' => [
+                    'buckets' => [
+                    ],
+                ],
+            ],
+            'hits' => [
+                'total' => [
+                    'value' => 0,
+                ],
+            ],
+        ]);
         $ids = $obj->getAllSessionIds();
         $this->assertCount(2, $ids);
         $this->assertEquals([1, 2], $ids);

--- a/tests/Service/Index/LearningMaterialsTest.php
+++ b/tests/Service/Index/LearningMaterialsTest.php
@@ -354,17 +354,35 @@ final class LearningMaterialsTest extends TestCase
     public function testGetAllIds(): void
     {
         $obj = new LearningMaterials($this->fs, $this->bus, $this->repository, $this->config, $this->client);
+
         $this->client->shouldReceive('search')->once()->andReturn([
-            'hits' => [
-                'hits' => [
-                    ['_source' => ['learningMaterialId' => 1]],
-                    ['_source' => ['learningMaterialId' => 2]],
+            'aggregations' => [
+                'learningMaterialId' => [
+                    'buckets' => [
+                        ['key' => 1],
+                        ['key' => 2],
+                    ],
                 ],
             ],
-            '_scroll_id' => '123',
+            'hits' => [
+                'total' => [
+                    'value' => 2,
+                ],
+            ],
         ]);
-        $this->client->shouldReceive('scroll')->once()->andReturn(['hits' => ['hits' => []]]);
-        $this->client->shouldReceive('clearScroll')->once();
+        $this->client->shouldReceive('search')->once()->andReturn([
+            'aggregations' => [
+                'learningMaterialId' => [
+                    'buckets' => [
+                    ],
+                ],
+            ],
+            'hits' => [
+                'total' => [
+                    'value' => 0,
+                ],
+            ],
+        ]);
         $ids = $obj->getAllIds();
         $this->assertCount(2, $ids);
         $this->assertEquals([1, 2], $ids);


### PR DESCRIPTION
Fixes #6258 

The scroll API we were using wasn't working here, I found a way to *very* quickly get all the ids using aggregators and then fixed the display output of the command itself and added an option to index anything that is detected as missing. This did require a change to the way we index courses and sessions. I had the IDs as keywords, but they need to be integers in order to use a range filter on them (which is the only way I could find to ensure we get every single sessions and course as we aggregate the ids).