### PR TITLE
Update phpunit/phpunit Recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     - name: install dependencies
       run: composer install --no-interaction --prefer-dist
     - name: Run Tests
-      run: vendor/bin/phpunit --coverage-clover build/coverage.xml
+      run: bin/phpunit --coverage-clover build/coverage.xml
     - name: Archive Coverage Report
       uses: actions/upload-artifact@v4
       with:
@@ -138,9 +138,9 @@ jobs:
     - name: install dependencies
       run: composer install --no-interaction --prefer-dist
     - name: First Run
-      run: vendor/bin/phpunit --group twice
+      run: bin/phpunit --group twice
     - name: Second Run
-      run: vendor/bin/phpunit --group twice
+      run: bin/phpunit --group twice
 
   build_containers:
     name: Build ${{ matrix.image }} (${{ matrix.arch }})

--- a/.github/workflows/future-php.yml
+++ b/.github/workflows/future-php.yml
@@ -28,7 +28,7 @@ jobs:
     - name: install dependencies
       run: composer install --no-interaction --prefer-dist
     - name: Run Tests
-      run: vendor/bin/phpunit
+      run: bin/phpunit
     - uses: act10ns/slack@v2.1.0
       with:
         status: ${{ job.status }}

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install dependencies
         run: composer install --no-interaction --prefer-dist
       - name: create coverage
-        run: vendor/bin/phpunit --coverage-xml=build/coverage --log-junit=build/coverage/phpunit.junit.xml
+        run: bin/phpunit --coverage-xml=build/coverage --log-junit=build/coverage/phpunit.junit.xml
       - name: infection
         run: vendor/bin/infection --coverage=build/coverage
       - name: Upload artifact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ In order to get your changes accepted you will need do:
 
 ### Running Tests
 
-1. vendor/bin/phpunit
+1. bin/phpunit
 2. vendor/bin/phpcs
 
 ### Commit Message

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,6 @@
     "symfony/browser-kit": "@stable",
     "symfony/css-selector": "@stable",
     "symfony/debug-bundle": "@stable",
-    "symfony/phpunit-bridge": "@stable",
     "symfony/stopwatch": "@stable",
     "symfony/web-profiler-bundle": "@stable"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5a37865d4465af5c6583816b83a916f",
+    "content-hash": "d8aac9bfbbd8ee1fb6b7982cf86811f7",
     "packages": [
         {
             "name": "async-aws/core",
@@ -14820,88 +14820,6 @@
             "time": "2025-03-05T10:15:41+00:00"
         },
         {
-            "name": "symfony/phpunit-bridge",
-            "version": "v7.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "2eabda563921f21cbce1d1e3247b3c36568905e6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/2eabda563921f21cbce1d1e3247b3c36568905e6",
-                "reference": "2eabda563921f21cbce1d1e3247b3c36568905e6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<7.5|9.1.2"
-            },
-            "require-dev": {
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/error-handler": "^5.4|^6.4|^7.0",
-                "symfony/polyfill-php81": "^1.27"
-            },
-            "bin": [
-                "bin/simple-phpunit"
-            ],
-            "type": "symfony-bridge",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/sebastianbergmann/phpunit",
-                    "name": "phpunit/phpunit"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Bridge\\PhpUnit\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/",
-                    "/bin/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v7.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-05-23T07:26:30+00:00"
-        },
-        {
             "name": "symfony/web-profiler-bundle",
             "version": "v7.3.0",
             "source": {
@@ -15201,7 +15119,6 @@
         "symfony/mailgun-mailer": 0,
         "symfony/messenger": 0,
         "symfony/monolog-bundle": 0,
-        "symfony/phpunit-bridge": 0,
         "symfony/postmark-mailer": 0,
         "symfony/property-access": 0,
         "symfony/property-info": 0,

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -30,6 +30,12 @@
         <include>
             <directory>src</directory>
         </include>
+
+        <deprecationTrigger>
+            <method>Doctrine\Deprecations\Deprecation::trigger</method>
+            <method>Doctrine\Deprecations\Deprecation::delegateTriggerToBackend</method>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
     </source>
 
     <extensions>

--- a/symfony.lock
+++ b/symfony.lock
@@ -61,7 +61,13 @@
         "version": "2.12.1"
     },
     "doctrine/deprecations": {
-        "version": "v0.5.3"
+        "version": "1.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "87424683adc81d7dc305eefec1fced883084aab9"
+        }
     },
     "doctrine/doctrine-bundle": {
         "version": "2.14",
@@ -365,15 +371,16 @@
         "version": "5.0.3"
     },
     "phpunit/phpunit": {
-        "version": "12.1",
+        "version": "12.2",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
-            "version": "10.0",
-            "ref": "bb22cf8d8c554a623b427d5f3416b538f5525233"
+            "version": "11.1",
+            "ref": "c6658a60fc9d594805370eacdf542c3d6b5c0869"
         },
         "files": [
             ".env.test",
+            "bin/phpunit",
             "phpunit.dist.xml",
             "tests/bootstrap.php"
         ]
@@ -724,21 +731,6 @@
     },
     "symfony/password-hasher": {
         "version": "v5.3.0"
-    },
-    "symfony/phpunit-bridge": {
-        "version": "7.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "main",
-            "version": "6.3",
-            "ref": "a411a0480041243d97382cac7984f7dce7813c08"
-        },
-        "files": [
-            ".env.test",
-            "bin/phpunit",
-            "phpunit.xml.dist",
-            "tests/bootstrap.php"
-        ]
     },
     "symfony/polyfill-intl-grapheme": {
         "version": "v1.20.0"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,7 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (method_exists(Dotenv::class, 'bootEnv')) {
+if (class_exists(Dotenv::class)) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,4 +4,10 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+if (method_exists(Dotenv::class, 'bootEnv')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+}
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}


### PR DESCRIPTION
This is the new symfony flex recipe for phpunit 12, it drops the bridge in favor of the internal deprecation handler in PHPUnit and takes ownership of bin/phpunit which is now being used in all of our jobs.

As part of the change to for this recipe a new doctrine/deprecations recipe was added as well. I've included it in this change as it's related and it modifies the PHPUnit configuration as well.