### PR TITLE
Sleep Between Indexing

### DIFF
--- a/src/Command/Index/UpdateCommand.php
+++ b/src/Command/Index/UpdateCommand.php
@@ -40,8 +40,11 @@ class UpdateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->queueUsers($output);
+        sleep(2);
         $this->queueLearningMaterials($output);
+        sleep(2);
         $this->queueCourses($output);
+        sleep(2);
         $this->queueMesh($output);
 
         return Command::SUCCESS;


### PR DESCRIPTION
Order is important here for performance, we want to index every material before we index a single course. Without the sleep it is possible for the first courses we add to the queue to have the same available_at timestamp as the last materials and some random number will get picked to index in the wrong order. Sleeping ensures there is at least a full second between the timestamps.