### PR TITLE
Improve ReIndex Performance for Courses

### DIFF
--- a/src/Command/Index/CourseCommand.php
+++ b/src/Command/Index/CourseCommand.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command\Index;
 
-use App\Repository\CourseRepository;
-use App\Repository\LearningMaterialRepository;
 use App\Service\Index\Curriculum;
-use App\Service\Index\LearningMaterials;
 use Composer\Console\Input\InputArgument;
 use DateTime;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -22,7 +19,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CourseCommand extends Command
 {
     public function __construct(
-        protected CourseRepository $courseRepository,
         protected Curriculum $index,
     ) {
         parent::__construct();
@@ -45,8 +41,7 @@ class CourseCommand extends Command
             return Command::FAILURE;
         }
         $id = $input->getArgument('courseId');
-        $indexes = $this->courseRepository->getCourseIndexesFor([$id]);
-        $this->index->index($indexes, new DateTime());
+        $this->index->index([$id], new DateTime());
 
         return Command::SUCCESS;
     }

--- a/src/Command/Index/DetectMissingCommand.php
+++ b/src/Command/Index/DetectMissingCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Command\Index;
 
-use App\Repository\CourseRepository;
 use App\Repository\LearningMaterialRepository;
 use App\Repository\SessionRepository;
 use App\Service\Index\Curriculum;
@@ -27,7 +26,6 @@ class DetectMissingCommand extends Command
 {
     public function __construct(
         protected readonly LearningMaterialRepository $learningMaterialRepository,
-        protected readonly CourseRepository $courseRepository,
         protected readonly SessionRepository $sessionRepository,
         protected readonly LearningMaterials $materialIndex,
         protected readonly Curriculum $curriculumIndex,
@@ -153,12 +151,10 @@ class DetectMissingCommand extends Command
         }
         $progressBar->advance();
         if ($courses) {
-            $indexObjects = $this->courseRepository->getCourseIndexesFor(
-                array_column($courses, 'courseId')
-            );
             $progressBar->advance();
-            foreach ($indexObjects as $indexObject) {
-                $this->curriculumIndex->index([$indexObject], new DateTime());
+            $ids = array_column($courses, 'courseId');
+            foreach ($ids as $id) {
+                $this->curriculumIndex->index([$id], new DateTime());
                 $progressBar->advance();
             }
         }

--- a/src/MessageHandler/CourseIndexHandler.php
+++ b/src/MessageHandler/CourseIndexHandler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\MessageHandler;
 
 use App\Message\CourseIndexRequest;
-use App\Repository\CourseRepository;
 use App\Service\Index\Curriculum;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -16,16 +15,14 @@ class CourseIndexHandler
 {
     public function __construct(
         private readonly Curriculum $curriculumIndex,
-        private readonly CourseRepository $courseRepository,
         private readonly MessageBusInterface $bus,
     ) {
     }
 
     public function __invoke(CourseIndexRequest $message): void
     {
-        $indexes = $this->courseRepository->getCourseIndexesFor($message->getCourseIds());
         try {
-            $this->curriculumIndex->index($indexes, $message->getCreatedAt());
+            $this->curriculumIndex->index($message->getCourseIds(), $message->getCreatedAt());
         } catch (Throwable $t) {
             if (count($message->getCourseIds()) <= 1) {
                 throw $t;


### PR DESCRIPTION
When a course has been indexed more recently than the queued message we don't need to index it again. Before we were loading the data for indexing in the handler, but this meant loading it for every course even those that would be skipped. Instead We now pass a list of course IDs into the indexer, check for duplicates, and re-index if needed.

This is especially important now that learning material indexing triggers all courses to get re-indexed. So on an initial load every course could be indexed many many times.

WIP:
- [ ] Update tests