### PR TITLE
Improve Messenger Configuration for Indexing

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -3,11 +3,30 @@ framework:
     failure_transport: failed
     transports:
       # https://symfony.com/doc/current/messenger.html#transport-configuration
-      async:
+      async_priority_high:
         dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
         retry_strategy:
           # milliseconds delay, 30 seconds
           delay: 30000
+        options:
+          queue_name: high
+
+      async_priority_normal:
+        dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+        retry_strategy:
+          # milliseconds delay, 30 seconds
+          delay: 30000
+        options:
+          queue_name: normal
+
+      async_priority_low:
+        dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+        retry_strategy:
+          # milliseconds delay, 30 seconds
+          delay: 30000
+        options:
+          queue_name: low
+
       failed: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=failed'
 
     default_bus: messenger.bus.default

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -10,17 +10,6 @@ framework:
           delay: 30000
       failed: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=failed'
 
-    routing:
-       # Route your messages to the transports
-       'App\Message\CourseIndexRequest': async
-       'App\Message\UserIndexRequest': async
-       'App\Message\MeshDescriptorIndexRequest': async
-       'App\Message\LearningMaterialIndexRequest': async
-       'App\Message\LearningMaterialTextExtractionRequest': async
-       'App\Message\CourseDeleteRequest': async
-       'App\Message\SessionDeleteRequest': async
-       'App\Message\LearningMaterialDeleteRequest': async
-
     default_bus: messenger.bus.default
     buses:
       messenger.bus.default:

--- a/docker/messages-entrypoint
+++ b/docker/messages-entrypoint
@@ -12,4 +12,4 @@ echo "The search index is now ready and reachable"
 # use exec so the process is the container's PID 1 which will allow
 # signals (Kill, Quit, Term) to be passed to the process.
 # Also pass all arguments into it
-exec /srv/app/bin/console messenger:consume async "$@"
+exec /srv/app/bin/console messenger:consume async_priority_high async_priority_normal async_priority_low "$@"

--- a/docs/update.md
+++ b/docs/update.md
@@ -51,6 +51,14 @@ _NOTE:_ The steps below assume that file ownership of the deployed codebase belo
 
 ## Version-specific steps
 
+### Upgrading to Ilios 3.126.0
+
+Async messages (for indexing and extracting) have been split into priority queues. When consuming these messages you should do so in priority order:
+
+```bash
+bin/console messenger:consume async_priority_high async_priority_normal async_priority_low
+```
+
 ### Upgrading to Ilios 3.123.0
 
 The `ILIOS_SEARCH_HOSTS` has been renamed to `ILIOS_SEARCH_HOST` and will no longer accept a semi-colon seeperated list of hosts. Replace this is your configuration with a single host if you have search and indexing enabled.

--- a/src/Message/CourseDeleteRequest.php
+++ b/src/Message/CourseDeleteRequest.php
@@ -6,7 +6,7 @@ namespace App\Message;
 
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
-#[AsMessage('async')]
+#[AsMessage('async_priority_normal')]
 class CourseDeleteRequest
 {
     public function __construct(private readonly int $courseId)

--- a/src/Message/CourseDeleteRequest.php
+++ b/src/Message/CourseDeleteRequest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Message;
 
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage('async')]
 class CourseDeleteRequest
 {
     public function __construct(private readonly int $courseId)

--- a/src/Message/CourseIndexRequest.php
+++ b/src/Message/CourseIndexRequest.php
@@ -6,7 +6,9 @@ namespace App\Message;
 
 use DateTime;
 use InvalidArgumentException;
+use Symfony\Component\Messenger\Attribute\AsMessage;
 
+#[AsMessage('async')]
 class CourseIndexRequest
 {
     private array $courseIds;

--- a/src/Message/CourseIndexRequest.php
+++ b/src/Message/CourseIndexRequest.php
@@ -8,7 +8,7 @@ use DateTime;
 use InvalidArgumentException;
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
-#[AsMessage('async')]
+#[AsMessage('async_priority_low')]
 class CourseIndexRequest
 {
     private array $courseIds;

--- a/src/Message/LearningMaterialDeleteRequest.php
+++ b/src/Message/LearningMaterialDeleteRequest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Message;
 
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage('async')]
 class LearningMaterialDeleteRequest
 {
     public function __construct(private readonly int $learningMaterialId)

--- a/src/Message/LearningMaterialDeleteRequest.php
+++ b/src/Message/LearningMaterialDeleteRequest.php
@@ -6,7 +6,7 @@ namespace App\Message;
 
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
-#[AsMessage('async')]
+#[AsMessage('async_priority_normal')]
 class LearningMaterialDeleteRequest
 {
     public function __construct(private readonly int $learningMaterialId)

--- a/src/Message/LearningMaterialIndexRequest.php
+++ b/src/Message/LearningMaterialIndexRequest.php
@@ -7,7 +7,7 @@ namespace App\Message;
 use InvalidArgumentException;
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
-#[AsMessage('async')]
+#[AsMessage('async_priority_normal')]
 class LearningMaterialIndexRequest
 {
     private array $ids;

--- a/src/Message/LearningMaterialIndexRequest.php
+++ b/src/Message/LearningMaterialIndexRequest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Message;
 
 use InvalidArgumentException;
+use Symfony\Component\Messenger\Attribute\AsMessage;
 
+#[AsMessage('async')]
 class LearningMaterialIndexRequest
 {
     private array $ids;

--- a/src/Message/LearningMaterialTextExtractionRequest.php
+++ b/src/Message/LearningMaterialTextExtractionRequest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Message;
 
 use InvalidArgumentException;
+use Symfony\Component\Messenger\Attribute\AsMessage;
 
+#[AsMessage('async')]
 class LearningMaterialTextExtractionRequest
 {
     public const int MAX_MATERIALS = 50;

--- a/src/Message/LearningMaterialTextExtractionRequest.php
+++ b/src/Message/LearningMaterialTextExtractionRequest.php
@@ -7,7 +7,7 @@ namespace App\Message;
 use InvalidArgumentException;
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
-#[AsMessage('async')]
+#[AsMessage('async_priority_high')]
 class LearningMaterialTextExtractionRequest
 {
     public const int MAX_MATERIALS = 50;

--- a/src/Message/MeshDescriptorIndexRequest.php
+++ b/src/Message/MeshDescriptorIndexRequest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Message;
 
 use InvalidArgumentException;
+use Symfony\Component\Messenger\Attribute\AsMessage;
 
+#[AsMessage('async')]
 class MeshDescriptorIndexRequest
 {
     private array $descriptorIds;

--- a/src/Message/MeshDescriptorIndexRequest.php
+++ b/src/Message/MeshDescriptorIndexRequest.php
@@ -7,7 +7,7 @@ namespace App\Message;
 use InvalidArgumentException;
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
-#[AsMessage('async')]
+#[AsMessage('async_priority_normal')]
 class MeshDescriptorIndexRequest
 {
     private array $descriptorIds;

--- a/src/Message/SessionDeleteRequest.php
+++ b/src/Message/SessionDeleteRequest.php
@@ -6,7 +6,7 @@ namespace App\Message;
 
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
-#[AsMessage('async')]
+#[AsMessage('async_priority_normal')]
 class SessionDeleteRequest
 {
     public function __construct(private readonly int $sessionId)

--- a/src/Message/SessionDeleteRequest.php
+++ b/src/Message/SessionDeleteRequest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Message;
 
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage('async')]
 class SessionDeleteRequest
 {
     public function __construct(private readonly int $sessionId)

--- a/src/Message/UserIndexRequest.php
+++ b/src/Message/UserIndexRequest.php
@@ -7,7 +7,7 @@ namespace App\Message;
 use InvalidArgumentException;
 use Symfony\Component\Messenger\Attribute\AsMessage;
 
-#[AsMessage('async')]
+#[AsMessage('async_priority_normal')]
 class UserIndexRequest
 {
     private array $userIds;

--- a/src/Message/UserIndexRequest.php
+++ b/src/Message/UserIndexRequest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Message;
 
 use InvalidArgumentException;
+use Symfony\Component\Messenger\Attribute\AsMessage;
 
+#[AsMessage('async')]
 class UserIndexRequest
 {
     private array $userIds;

--- a/src/MessageHandler/LearningMaterialTextExtractionHandler.php
+++ b/src/MessageHandler/LearningMaterialTextExtractionHandler.php
@@ -9,7 +9,9 @@ use App\Message\LearningMaterialTextExtractionRequest;
 use App\Repository\LearningMaterialRepository;
 use App\Service\LearningMaterialTextExtractor;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
 
 #[AsMessageHandler]
 class LearningMaterialTextExtractionHandler
@@ -30,7 +32,10 @@ class LearningMaterialTextExtractionHandler
         }
         $chunks = array_chunk($message->getLearningMaterialIds(), LearningMaterialIndexRequest::MAX_MATERIALS);
         foreach ($chunks as $ids) {
-            $this->bus->dispatch(new LearningMaterialIndexRequest($ids, true));
+            $this->bus->dispatch(
+                new Envelope(new LearningMaterialIndexRequest($ids, true))
+                    ->with(new DispatchAfterCurrentBusStamp()),
+            );
         }
     }
 }

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -13,7 +13,9 @@ use App\Service\NonCachingIliosFileSystem;
 use Exception;
 use OpenSearch\Client;
 use InvalidArgumentException;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
 
 class LearningMaterials extends OpenSearchBase
 {
@@ -94,7 +96,10 @@ class LearningMaterials extends OpenSearchBase
         $associatedCourses = $this->learningMaterialRepository->getCourseIdsForMaterials($ids);
         $chunks = array_chunk($associatedCourses, CourseIndexRequest::MAX_COURSES);
         foreach ($chunks as $ids) {
-            $this->bus->dispatch(new CourseIndexRequest($ids));
+            $this->bus->dispatch(
+                new Envelope(new CourseIndexRequest($ids))
+                    ->with(new DispatchAfterCurrentBusStamp()),
+            );
         }
 
         return true;

--- a/tests/Command/Index/DropCommandTest.php
+++ b/tests/Command/Index/DropCommandTest.php
@@ -66,7 +66,10 @@ final class DropCommandTest extends KernelTestCase
         $connection = m::mock(Connection::class);
         $connection
             ->shouldReceive('executeStatement')
-            ->with('DELETE FROM messenger_messages WHERE queue_name="default"');
+            ->with(
+                'DELETE FROM messenger_messages WHERE body REGEXP ' .
+                "'CourseIndexRequest|LearningMaterialIndexRequest|UserIndexRequest|MeshDescriptorIndexRequest'"
+            );
         $this->entityManager->shouldReceive('getConnection')->andReturn($connection);
 
         $this->commandTester->execute([

--- a/tests/MessageHandler/LearningMaterialTextExtractionHandlerTest.php
+++ b/tests/MessageHandler/LearningMaterialTextExtractionHandlerTest.php
@@ -55,7 +55,7 @@ final class LearningMaterialTextExtractionHandlerTest extends TestCase
 
         $this->bus
             ->shouldReceive('dispatch')
-            ->withArgs(fn (LearningMaterialIndexRequest $request) => in_array(6, $request->getIds()))
+            ->withArgs(fn (Envelope $env) => in_array(6, $env->getMessage()->getIds()))
             ->andReturn(new Envelope(new stdClass()))
             ->once();
 
@@ -87,8 +87,8 @@ final class LearningMaterialTextExtractionHandlerTest extends TestCase
         $this->bus
             ->shouldReceive('dispatch')
             ->withArgs(
-                fn (LearningMaterialIndexRequest $request) =>
-                array_diff($request->getIds(), $ids) === [] && $request->getForce()
+                fn (Envelope $env) =>
+                array_diff($env->getMessage()->getIds(), $ids) === [] && $env->getMessage()->getForce()
             )
             ->andReturn(new Envelope(new stdClass()))
         ->times(3);

--- a/tests/Service/Index/LearningMaterialsTest.php
+++ b/tests/Service/Index/LearningMaterialsTest.php
@@ -180,7 +180,7 @@ final class LearningMaterialsTest extends TestCase
             ->once()->with([1, 2])->andReturn([6, 24, 2005]);
         $this->bus
             ->shouldReceive('dispatch')
-            ->withArgs(fn (CourseIndexRequest $request) => $request->getCourseIds() === [6, 24, 2005])
+            ->withArgs(fn (Envelope $env) => $env->getMessage()->getCourseIds() === [6, 24, 2005])
             ->andReturn(new Envelope(new stdClass()))
             ->once();
         $obj->index([$mockDto, $mockDto2]);


### PR DESCRIPTION
Using a combination of middleware and splitting the transports this ensures everything gets consumed in the right order. It does complicate running the message consumer, but this feels ok to me for the result.