### PR TITLE
Remove Integer Fields from Match Query

### DIFF
--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -298,10 +298,8 @@ class Curriculum extends OpenSearchBase
             'sessionLearningMaterialAttachments',
         ];
         $keywordFields = [
-            'courseId',
             'courseYear',
             'courseMeshDescriptorIds',
-            'sessionId',
             'sessionType',
             'sessionMeshDescriptorIds',
         ];


### PR DESCRIPTION
Changed these field types to improve indexing, but they cannot be queried using a match query as they are integers now. For now I've removed them entirely from the curriculum search in order to restore functionality.

Fixes #6281