### PR TITLE
Declare LOCK_DSN in Containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ MAILER_DSN=null://null \
 ILIOS_LOCALE=en \
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt \
 ILIOS_REQUIRE_SECURE_CONNECTION=false \
+LOCK_DSN=flock \
 MESSENGER_TRANSPORT_DSN=doctrine://default
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
@@ -317,6 +318,7 @@ ILIOS_DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db" \
 ILIOS_LOCALE=en \
 ILIOS_SECRET=ThisTokenIsNotSoSecretChangeIt \
 ILIOS_REQUIRE_SECURE_CONNECTION=false \
+LOCK_DSN=flock \
 MESSENGER_TRANSPORT_DSN=doctrine://default
 
 WORKDIR /var/www/ilios

--- a/src/Monitor/RequiredENV.php
+++ b/src/Monitor/RequiredENV.php
@@ -16,6 +16,7 @@ class RequiredENV implements CheckInterface
         'ILIOS_LOCALE',
         'ILIOS_SECRET',
         'MAILER_DSN',
+        'LOCK_DSN',
     ];
     private const string INSTRUCTIONS_URL = 'https://github.com/ilios/ilios/blob/master/docs/env_vars_and_config.md';
     private const string UPDATE_URL = 'https://github.com/ilios/ilios/blob/master/docs/update.md';


### PR DESCRIPTION
This has been part of symfony for a long time, but recently not having it declared has caused major issues. Adding it to our containers and to the health check.