### PR TITLE
rm explicitly declared dependency on symfony/property-info

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,6 @@
     "symfony/monolog-bundle": "@stable",
     "symfony/postmark-mailer": "@stable",
     "symfony/property-access": "@stable",
-    "symfony/property-info": "@stable",
     "symfony/requirements-checker": "@stable",
     "symfony/runtime": "@stable",
     "symfony/security-bundle": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89c16a3caa353c569a1b5a71487d0b8a",
+    "content-hash": "8248896a60bd773936997d12de143b02",
     "packages": [
         {
             "name": "async-aws/core",
@@ -15124,10 +15124,15 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "firebase/php-jwt": 0,
+        "mockery/mockery": 0,
+        "squizlabs/php_codesniffer": 0,
         "symfony/amazon-mailer": 0,
         "symfony/apache-pack": 0,
         "symfony/asset": 0,
+        "symfony/browser-kit": 0,
         "symfony/console": 0,
+        "symfony/css-selector": 0,
+        "symfony/debug-bundle": 0,
         "symfony/doctrine-messenger": 0,
         "symfony/dotenv": 0,
         "symfony/flex": 0,
@@ -15142,23 +15147,17 @@
         "symfony/monolog-bundle": 0,
         "symfony/postmark-mailer": 0,
         "symfony/property-access": 0,
-        "symfony/property-info": 0,
         "symfony/requirements-checker": 0,
         "symfony/runtime": 0,
         "symfony/security-bundle": 0,
         "symfony/sendgrid-mailer": 0,
         "symfony/serializer": 0,
+        "symfony/stopwatch": 0,
         "symfony/twig-bundle": 0,
         "symfony/validator": 0,
         "symfony/web-link": 0,
-        "symfony/yaml": 0,
-        "mockery/mockery": 0,
-        "squizlabs/php_codesniffer": 0,
-        "symfony/browser-kit": 0,
-        "symfony/css-selector": 0,
-        "symfony/debug-bundle": 0,
-        "symfony/stopwatch": 0,
-        "symfony/web-profiler-bundle": 0
+        "symfony/web-profiler-bundle": 0,
+        "symfony/yaml": 0
     },
     "prefer-stable": false,
     "prefer-lowest": false,
@@ -15177,9 +15176,9 @@
         "ext-xmlwriter": "*",
         "ext-zlib": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
some dependencies, like the api docs bundle, continue to require this package. but we don't need to declare this dependency explicitly since we're not using it directly.

refs #6307 