### PR TITLE
explicitly sets escape character to the current default value.

### DIFF
--- a/src/Command/SendTeachingRemindersCommand.php
+++ b/src/Command/SendTeachingRemindersCommand.php
@@ -120,7 +120,7 @@ class SendTeachingRemindersCommand extends Command
             $from = new Address($sender, $senderName);
         }
         if ($schools) {
-            $schoolIds = array_map('intval', str_getcsv($schools));
+            $schoolIds = array_map('intval', str_getcsv($schools, escape: "\\"));
         } else {
             $schoolIds = $this->schoolRepository->getIds();
         }

--- a/tests/Endpoints/ProgramYearTest.php
+++ b/tests/Endpoints/ProgramYearTest.php
@@ -222,7 +222,10 @@ final class ProgramYearTest extends AbstractReadWriteEndpoint
             ],
         ];
 
-        $actual = array_map('str_getcsv', explode(PHP_EOL, trim($response->getContent())));
+        $actual = array_map(
+            fn ($content) => str_getcsv($content, escape: "\\"),
+            explode(PHP_EOL, trim($response->getContent()))
+        );
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertStringStartsWith('text/csv', $response->headers->get('Content-Type'));
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
refs #6335 

as of PHP 8.4.0, depending on the default value is deprecated.

please see https://www.php.net/manual/en/function.str-getcsv.php for further details.

