### PR TITLE
Skip Indexing Materials When Disabled

### DIFF
--- a/src/Command/Index/MaterialCommand.php
+++ b/src/Command/Index/MaterialCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command\Index;
 
 use App\Repository\LearningMaterialRepository;
+use App\Service\Config;
 use App\Service\Index\LearningMaterials;
 use Composer\Console\Input\InputArgument;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -21,6 +22,7 @@ class MaterialCommand extends Command
     public function __construct(
         protected LearningMaterialRepository $learningMaterialRepository,
         protected LearningMaterials $index,
+        protected readonly Config $config,
     ) {
         parent::__construct();
     }
@@ -39,6 +41,10 @@ class MaterialCommand extends Command
     {
         if (!$this->index->isEnabled()) {
             $output->writeln("<comment>Indexing is not currently configured.</comment>");
+            return Command::FAILURE;
+        }
+        if ($this->config->get('learningMaterialsDisabled')) {
+            $output->writeln("<comment>Learning Materials are disabled on this instance.</comment>");
             return Command::FAILURE;
         }
         $id = $input->getArgument('materialId');

--- a/src/Command/Index/UpdateCommand.php
+++ b/src/Command/Index/UpdateCommand.php
@@ -12,6 +12,7 @@ use App\Repository\CourseRepository;
 use App\Repository\LearningMaterialRepository;
 use App\Repository\MeshDescriptorRepository;
 use App\Repository\UserRepository;
+use App\Service\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -33,6 +34,7 @@ class UpdateCommand extends Command
         protected MeshDescriptorRepository $descriptorRepository,
         protected LearningMaterialRepository $learningMaterialRepository,
         protected MessageBusInterface $bus,
+        protected readonly Config $config,
     ) {
         parent::__construct();
     }
@@ -71,6 +73,10 @@ class UpdateCommand extends Command
 
     protected function queueLearningMaterials(OutputInterface $output): void
     {
+        if ($this->config->get('learningMaterialsDisabled')) {
+            $output->writeln("<info>Learning Materials are disabled on this instance.</info>");
+            return;
+        }
         $allIds = $this->learningMaterialRepository->getFileLearningMaterialIds();
         $count = count($allIds);
         $chunks = array_chunk($allIds, LearningMaterialIndexRequest::MAX_MATERIALS);

--- a/src/MessageHandler/LearningMaterialIndexHandler.php
+++ b/src/MessageHandler/LearningMaterialIndexHandler.php
@@ -4,25 +4,27 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
-use App\Entity\DTO\LearningMaterialDTO;
 use App\Message\LearningMaterialIndexRequest;
 use App\Repository\LearningMaterialRepository;
+use App\Service\Config;
 use App\Service\Index\LearningMaterials;
-use App\Service\NonCachingIliosFileSystem;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
 class LearningMaterialIndexHandler
 {
     public function __construct(
-        private LearningMaterials $learningMaterialsIndex,
-        private LearningMaterialRepository $repository,
+        private readonly LearningMaterials $learningMaterialsIndex,
+        private readonly LearningMaterialRepository $repository,
+        private readonly Config $config,
     ) {
     }
 
     public function __invoke(LearningMaterialIndexRequest $message): void
     {
-        $dtos = $this->repository->findDTOsBy(['id' => $message->getIds()]);
-        $this->learningMaterialsIndex->index($dtos, $message->getForce());
+        if (!$this->config->get('learningMaterialsDisabled')) {
+            $dtos = $this->repository->findDTOsBy(['id' => $message->getIds()]);
+            $this->learningMaterialsIndex->index($dtos, $message->getForce());
+        }
     }
 }

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -20,7 +20,7 @@ class Curriculum extends OpenSearchBase
 
     public function __construct(
         private readonly CourseRepository $courseRepository,
-        Config $config,
+        protected readonly Config $config,
         ?Client $client = null
     ) {
         parent::__construct($config, $client);
@@ -203,6 +203,9 @@ class Curriculum extends OpenSearchBase
      */
     protected function getMaterialContentsByIds(array $learningMaterialIds): array
     {
+        if ($this->config->get('learningMaterialsDisabled')) {
+            return [];
+        }
         sort($learningMaterialIds);
         $materialsById = [];
         if (!empty($learningMaterialIds)) {

--- a/tests/Command/Index/UpdateCommandTest.php
+++ b/tests/Command/Index/UpdateCommandTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command\Index;
+
+use App\Command\Index\UpdateCommand;
+use App\Message\CourseIndexRequest;
+use App\Message\LearningMaterialIndexRequest;
+use App\Message\MeshDescriptorIndexRequest;
+use App\Message\UserIndexRequest;
+use App\Repository\CourseRepository;
+use App\Repository\LearningMaterialRepository;
+use App\Repository\MeshDescriptorRepository;
+use App\Repository\UserRepository;
+use App\Service\Config;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\Group;
+use stdClass;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Mockery as m;
+
+#[Group('cli')]
+final class UpdateCommandTest extends KernelTestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected CommandTester $commandTester;
+    protected m\MockInterface|UserRepository $userRepository;
+    protected m\MockInterface|CourseRepository $courseRepository;
+    protected m\MockInterface|MeshDescriptorRepository $descriptorRepository;
+    protected m\MockInterface|LearningMaterialRepository $learningMaterialRepository;
+    protected m\MockInterface|MessageBusInterface $messageBus;
+    protected m\MockInterface|Config $config;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->userRepository = m::mock(UserRepository::class);
+        $this->courseRepository = m::mock(CourseRepository::class);
+        $this->descriptorRepository = m::mock(MeshDescriptorRepository::class);
+        $this->learningMaterialRepository = m::mock(LearningMaterialRepository::class);
+        $this->messageBus = m::mock(MessageBusInterface::class);
+        $this->config = m::mock(Config::class);
+
+        $command = new UpdateCommand(
+            $this->userRepository,
+            $this->courseRepository,
+            $this->descriptorRepository,
+            $this->learningMaterialRepository,
+            $this->messageBus,
+            $this->config
+        );
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->add($command);
+        $commandInApp = $application->find($command->getName());
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->userRepository);
+        unset($this->courseRepository);
+        unset($this->descriptorRepository);
+        unset($this->learningMaterialRepository);
+        unset($this->messageBus);
+        unset($this->config);
+        unset($this->commandTester);
+    }
+
+    public function testQueuesUsers(): void
+    {
+        $userIds = [1, 2, 3, 4, 5];
+        $this->userRepository->shouldReceive('getIds')->once()->andReturn($userIds);
+        $this->courseRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->descriptorRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([]);
+        $this->config->shouldReceive('get')->with('learningMaterialsDisabled')->once()->andReturn(false);
+
+        $this->messageBus->shouldReceive('dispatch')
+            ->once()
+            ->with(m::on(function (UserIndexRequest $message) use ($userIds) {
+                return $message->getUserIds() === $userIds;
+            }))
+            ->andReturn(new Envelope(new stdClass()));
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/5 users have been queued for indexing./',
+            $output
+        );
+    }
+
+    public function testQueuesCourses(): void
+    {
+        $courseIds = [1, 2, 3];
+        $this->userRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->courseRepository->shouldReceive('getIds')->once()->andReturn($courseIds);
+        $this->descriptorRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([]);
+        $this->config->shouldReceive('get')->with('learningMaterialsDisabled')->once()->andReturn(false);
+
+        $this->messageBus->shouldReceive('dispatch')
+            ->once()
+            ->with(m::on(function (CourseIndexRequest $message) use ($courseIds) {
+                return $message->getCourseIds() === $courseIds;
+            }))
+            ->andReturn(new Envelope(new stdClass()));
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/3 courses have been queued for indexing./',
+            $output
+        );
+    }
+
+    public function testQueuesLearningMaterials(): void
+    {
+        $learningMaterialIds = [1, 2, 3, 4];
+        $this->userRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->courseRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->descriptorRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->learningMaterialRepository
+            ->shouldReceive('getFileLearningMaterialIds')
+            ->once()
+            ->andReturn($learningMaterialIds);
+        $this->config->shouldReceive('get')->with('learningMaterialsDisabled')->once()->andReturn(false);
+
+        $this->messageBus->shouldReceive('dispatch')
+            ->once()
+            ->with(m::on(function (LearningMaterialIndexRequest $message) use ($learningMaterialIds) {
+                return $message->getIds() === $learningMaterialIds;
+            }))
+            ->andReturn(new Envelope(new stdClass()));
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/4 learning materials have been queued for indexing./',
+            $output
+        );
+    }
+
+    public function testQueuesMeshDescriptors(): void
+    {
+        $descriptorIds = [1, 2];
+        $this->userRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->courseRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->descriptorRepository->shouldReceive('getIds')->once()->andReturn($descriptorIds);
+        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->once()->andReturn([]);
+        $this->config->shouldReceive('get')->with('learningMaterialsDisabled')->once()->andReturn(false);
+
+        $this->messageBus->shouldReceive('dispatch')
+            ->once()
+            ->with(m::on(function (MeshDescriptorIndexRequest $message) use ($descriptorIds) {
+                return $message->getDescriptorIds() === $descriptorIds;
+            }))
+            ->andReturn(new Envelope(new stdClass()));
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/2 descriptors have been queued for indexing./',
+            $output
+        );
+    }
+
+    public function testSkipsLearningMaterialsWhenDisabled(): void
+    {
+        $this->userRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->courseRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->descriptorRepository->shouldReceive('getIds')->once()->andReturn([]);
+        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->never();
+        $this->config->shouldReceive('get')->with('learningMaterialsDisabled')->once()->andReturn(true);
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertMatchesRegularExpression(
+            '/Learning Materials are disabled on this instance./',
+            $output
+        );
+    }
+}


### PR DESCRIPTION
For instances, such as our demo environment, we have a configuration option that disables materials. If that is set we can avoid a significant amount of work by disabling indexing for those materials as well.

Fixes #6288