### PR TITLE
Handle Empty LM Text Extraction Better

### DIFF
--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -54,6 +54,12 @@ class LearningMaterialTextExtractor
         try {
             $raw = $this->client->getText($tmpFile->getRealPath());
             $text = $this->cleanText($raw);
+
+            //when extraction is successful, but no data is returned we store the filename as the text
+            //this prevents re-extracting or having errors during indexing
+            if (empty($text)) {
+                $text = $dto->filename;
+            }
             $this->iliosFileSystem->storeLearningMaterialText($dto->relativePath, $text);
         } catch (Exception $exception) {
             if (

--- a/tests/Service/LearningMaterialTextExtractorTest.php
+++ b/tests/Service/LearningMaterialTextExtractorTest.php
@@ -232,4 +232,46 @@ final class LearningMaterialTextExtractorTest extends TestCase
         $this->extractor->extract($dto, true);
         $this->assertFalse(file_exists(self::TEST_FILE_PATH));
     }
+
+    public function testEmptyExtractionStoresFileName(): void
+    {
+        $dto = m::mock(LearningMaterialDTO::class);
+        $dto->relativePath = 'dir/lm/13/13/ts';
+        $dto->filename = 'empty-scanned.pdf';
+        $dto->mimetype = 'test/pdf';
+        $this->nonCachingFileSystem
+            ->shouldReceive('checkLearningMaterialRelativePath')
+            ->with($dto->relativePath)
+            ->once()
+            ->andReturn(true);
+        $this->nonCachingFileSystem
+            ->shouldReceive('getFileContents')
+            ->with($dto->relativePath)
+            ->once()
+            ->andReturn('lm-contents');
+        $tmpFile = new File(self::TEST_FILE_PATH);
+        $this->temporaryFileSystem
+            ->shouldReceive('createFile')
+            ->with('lm-contents')
+            ->once()
+            ->andReturn($tmpFile);
+        $this->tikaClient
+            ->shouldReceive('getText')
+            ->once()
+            ->with(self::TEST_FILE_PATH)
+            ->andReturn('');
+        $this->fileSystem
+            ->shouldReceive('checkIfLearningMaterialTextFileExists')
+            ->once()
+            ->with($dto->relativePath)
+            ->andReturn(false);
+        $this->fileSystem
+            ->shouldReceive('storeLearningMaterialText')
+            ->once()
+            ->with($dto->relativePath, $dto->filename)
+            ->andReturn('lm-text-path');
+        $this->assertTrue(file_exists(self::TEST_FILE_PATH));
+        $this->extractor->extract($dto, false);
+        $this->assertFalse(file_exists(self::TEST_FILE_PATH));
+    }
 }


### PR DESCRIPTION
When a material can't be extracted, but there are no errors tika will return and empty string. This can also happen when the extracted text only contains junk. In that case we need to store something to prevent errors when we try and read an empty file.

Fixes #6421