### PR TITLE
do not remove intl dev libs post-install, as this breaks php-intl.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*; \
     rm -rf /tmp/pear; \
     # remove the apt source files to save space
-    apt-get purge libldap2-dev zlib1g-dev libicu-dev -y; \
+    apt-get purge libldap2-dev zlib1g-dev  -y; \
     apt-get autoremove -y;
 
 ENV \
@@ -296,7 +296,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*; \
     rm -rf /tmp/pear; \
     # remove the apt source files to save space
-    apt-get purge libldap2-dev zlib1g-dev libicu-dev -y; \
+    apt-get purge libldap2-dev zlib1g-dev  -y; \
     apt-get autoremove -y;
 
 COPY ./docker/php.ini $PHP_INI_DIR


### PR DESCRIPTION
turns out removing this lib post-install is too aggressive.

fixes #6426 


to test:

```bash
docker compose up -d
docker exec -it ilios-php-1 /bin/bash
php -v  #observe that the intl-related warning is gone
php -m | grep intl # observe that `intl` is listed in the output
```

then do the same again with the messages container

```bash
docker exec -it ilios-messages-1 /bin/bash
php -v  #observe that the intl-related warning is gone
php -m | grep intl # observe that `intl` is listed in the output
```