### PR TITLE
Remove the Minimum Search Score

### DIFF
--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -65,7 +65,6 @@ class Curriculum extends OpenSearchBase
 
         $params['body']['query']['function_score'] = [
             'query' => $this->buildCurriculumSearch($query, $schools, $years),
-            'min_score' => 50,
         ];
         $params['body']['aggs']['courses']['cardinality']['field'] = 'courseId';
 


### PR DESCRIPTION
This number as way too high and was removing otherwise good matches, especially unique single words in large sessions. It doesn't seem to be required at all and I'm getting good results and performance.