### PR TITLE
Reduce What we Store in the Curriculum Index

### DIFF
--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -18,6 +18,15 @@ class Curriculum extends OpenSearchBase
     public const string INDEX = 'ilios-curriculum';
     public const string SESSION_ID_PREFIX = 'session_';
 
+    public const array SOURCE_FIELDS = [
+        'courseId',
+        'courseTitle',
+        'courseYear',
+        'sessionId',
+        'sessionTitle',
+        'school',
+    ];
+
     public function __construct(
         private readonly CourseRepository $courseRepository,
         protected readonly Config $config,
@@ -40,14 +49,7 @@ class Curriculum extends OpenSearchBase
         $params = [
             'index' => self::INDEX,
             'body' => [
-                '_source' => [
-                    'courseId',
-                    'courseTitle',
-                    'courseYear',
-                    'sessionId',
-                    'sessionTitle',
-                    'school',
-                ],
+                '_source' => self::SOURCE_FIELDS,
                 'collapse' => [
                     'field' => 'courseId',
                     'inner_hits' => [
@@ -658,7 +660,10 @@ class Curriculum extends OpenSearchBase
             ],
             'mappings' => [
                 '_meta' => [
-                    'version' => '2',
+                    'version' => '3',
+                ],
+                '_source' => [
+                  'includes' => self::SOURCE_FIELDS,
                 ],
                 'properties' => [
                     'courseId' => [


### PR DESCRIPTION
The _source field isn't needed for search, it's purpose it to allow us to get data from the original document. For curriculum search we don't use any of this data, we only use the bare minimum needed to display the results. By only storing this data for the source we reduce the index size significantly and make search much faster.