### PR TITLE
Use New zstd Compression Codec

### DIFF
--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -646,6 +646,7 @@ class Curriculum extends OpenSearchBase
                 'number_of_replicas' => 1,
                 'default_pipeline' => 'curriculum',
                 'index' => [
+                    'codec' => 'zstd',
                     'analysis' => [
                         'analyzer' => [
                             'trigram' => $trigramAnalyzer,

--- a/src/Service/Index/LearningMaterials.php
+++ b/src/Service/Index/LearningMaterials.php
@@ -240,6 +240,9 @@ class LearningMaterials extends OpenSearchBase
             'settings' => [
                 'number_of_shards' => 1,
                 'number_of_replicas' => 1,
+                'codec' => 'zstd',
+                // maximum compression as we don't search this index by anything other than id
+                'codec.compression_level' => 6,
             ],
             'mappings' => [
                 '_meta' => [

--- a/src/Service/Index/Mesh.php
+++ b/src/Service/Index/Mesh.php
@@ -94,6 +94,7 @@ class Mesh extends OpenSearchBase
             'settings' => [
                 'number_of_shards' => 1,
                 'number_of_replicas' => 1,
+                'codec' => 'zstd',
             ],
             'mappings' => [
                 '_meta' => [

--- a/src/Service/Index/Users.php
+++ b/src/Service/Index/Users.php
@@ -151,6 +151,7 @@ class Users extends OpenSearchBase
                 'max_ngram_diff' =>  15,
                 'number_of_shards' => 1,
                 'number_of_replicas' => 1,
+                'codec' => 'zstd',
             ],
             'mappings' => [
                 '_meta' => [


### PR DESCRIPTION
This is available in OpenSearch now and provides a much better value of disk storage and performance, reducing storage by a significant amount.

Original:
<img width="1444" height="661" alt="Screenshot 2025-09-09 at 10 05 23 PM" src="https://github.com/user-attachments/assets/81a0cd90-09b8-4d93-8415-6e128b82db64" />

New Codec:
<img width="1427" height="646" alt="Screenshot 2025-09-10 at 10 36 23 AM" src="https://github.com/user-attachments/assets/70dd9684-3df2-4111-b23c-bdb49f067d3e" />
