### PR TITLE
Improve Material DTO Build Query

### DIFF
--- a/src/Entity/DTO/LearningMaterialDTO.php
+++ b/src/Entity/DTO/LearningMaterialDTO.php
@@ -219,6 +219,9 @@ class LearningMaterialDTO
     public function __construct(
         int $id,
         string $title,
+        int $userRole,
+        int $status,
+        int $owningUser,
         ?string $description,
         DateTime $uploadDate,
         ?string $originalAuthor,
@@ -234,6 +237,9 @@ class LearningMaterialDTO
     ) {
         $this->id = $id;
         $this->title = $title;
+        $this->userRole = $userRole;
+        $this->status = $status;
+        $this->owningUser = $owningUser;
         $this->description = $description;
         $this->uploadDate = $uploadDate;
         $this->originalAuthor = $originalAuthor;

--- a/src/Service/LearningMaterialDecoratorFactory.php
+++ b/src/Service/LearningMaterialDecoratorFactory.php
@@ -36,6 +36,9 @@ class LearningMaterialDecoratorFactory
         $dto = new LearningMaterialDTO(
             $learningMaterial->getId(),
             $learningMaterial->getTitle(),
+            $learningMaterial->getUserRole()->getId(),
+            $learningMaterial->getStatus()->getId(),
+            $learningMaterial->getOwningUser()->getId(),
             $learningMaterial->getDescription(),
             $learningMaterial->getUploadDate(),
             $learningMaterial->getOriginalAuthor(),
@@ -49,9 +52,6 @@ class LearningMaterialDecoratorFactory
             $learningMaterial->getToken(),
             $learningMaterial->getRelativePath()
         );
-        $dto->userRole = $learningMaterial->getUserRole()->getId();
-        $dto->owningUser = $learningMaterial->getOwningUser()->getId();
-        $dto->status = $learningMaterial->getStatus()->getId();
         $dto->courseLearningMaterials = $learningMaterial->getCourseLearningMaterials()->map(
             fn(Stringable $courseLearningMaterial) => (string) $courseLearningMaterial
         )->toArray();

--- a/tests/Entity/DTO/LearningMaterialDTOTest.php
+++ b/tests/Entity/DTO/LearningMaterialDTOTest.php
@@ -26,6 +26,9 @@ final class LearningMaterialDTOTest extends TestCase
         $this->dto = new LearningMaterialDTO(
             1,
             'title',
+            1,
+            1,
+            1,
             null,
             new DateTime(),
             null,


### PR DESCRIPTION
Instead of joining the extra data we need for a material DTO we can use doctrine's IDENTITY function in the DQL to get the join keys as part of the initial query. This allows us to skip the second query entirely and the very costly joins. Results in a [substantial speedup](https://blackfire.io/profiles/compare/b99feb97-2e9f-48d5-b87c-1b42b622ff0f/graph) for the API endpoint we use to get the data for all the sessions in a course.

<img width="550" height="290" alt="Screenshot 2025-09-15 at 11 40 09 PM" src="https://github.com/user-attachments/assets/4d728ae9-c1ad-4abb-a2d1-d08519fff4f1" />


This is best seen on courses with many materials such as [Airways, Blood and Circulation 
2025 - 2026](https://demo.iliosproject.org/courses/2327).