### PR TITLE
Extend Tika Extraction Timeout

### DIFF
--- a/src/Service/LearningMaterialTextExtractor.php
+++ b/src/Service/LearningMaterialTextExtractor.php
@@ -71,6 +71,8 @@ class LearningMaterialTextExtractor
                 //this document can't be processed by tika
                 //we don't want to keep trying, so we store the filename as the text
                 $this->iliosFileSystem->storeLearningMaterialText($dto->relativePath, $dto->filename);
+            } else {
+                throw $exception;
             }
         } finally {
             if (file_exists($tmpFile->getRealPath())) {

--- a/src/Service/TikaFactory.php
+++ b/src/Service/TikaFactory.php
@@ -12,7 +12,7 @@ class TikaFactory
     {
         $url = $config->get('tika_url');
         if ($url) {
-            return Client::prepare($url, null, [CURLOPT_TIMEOUT => 30]);
+            return Client::prepare($url, null, [CURLOPT_TIMEOUT => 120]);
         }
 
         return null;


### PR DESCRIPTION
This value was too low for some of our materials. In addition we were swallowing the exception emitted by the Tika client when this happened so we weren't getting good logs for the messenger tasks.

Fixes #6507