### PR TITLE
Add console-command container to Dockerfile to allow one-and-done console commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -339,3 +339,12 @@ USER root
 ENTRYPOINT ["php-apache-entrypoint"]
 CMD ["apache2-foreground"]
 EXPOSE 80
+
+###############################################################################
+# Multi-purpose container to run a single Ilios console command and then exit
+###############################################################################
+FROM php-base AS console-command
+WORKDIR /srv/app
+COPY docker/console-command-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/console-command-entrypoint.sh
+++ b/docker/console-command-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# ilios/console-command
+# runs a single Ilios console command and exits
+# 
+# usage: docker run -e ENTRYPOINT="bin/console [COMMAND]" yourimage
+
+if [ -z "$ENTRYPOINT" ]; then
+  echo "Please supply entrypoint argument as ENTRYPOINT env var."
+  exit 1
+else
+  cd /srv/app || exit 2
+  exec sh -c "$ENTRYPOINT"
+fi
+


### PR DESCRIPTION
resolves #6518 