### PR TITLE
Add Command to Rotate File Tokens

### DIFF
--- a/src/Command/RotateFileAccessTokensCommand.php
+++ b/src/Command/RotateFileAccessTokensCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\CurriculumInventoryReportRepository;
+use App\Repository\LearningMaterialRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Regnerate File Access Tokens
+ * Invalidates all existing tokens and generates new ones which is useful if you want to prevent accessing old files
+ * or in case of a breach and you want to protect the files.
+ */
+#[AsCommand(
+    name: 'ilios:rotate-tokens',
+    description: 'Regenerates access tokens for materials and curriculum inventory reports.',
+)]
+class RotateFileAccessTokensCommand extends Command
+{
+    private const int QUERY_LIMIT = 500;
+
+    public function __construct(
+        protected readonly EntityManagerInterface $em,
+        protected readonly LearningMaterialRepository $learningMaterialRepository,
+        protected readonly CurriculumInventoryReportRepository $reportRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->rotateReportTokens($output);
+        $this->rotateMaterialTokens($output);
+
+        return Command::SUCCESS;
+    }
+
+    protected function rotateMaterialTokens(OutputInterface $output): void
+    {
+        $ids = $this->learningMaterialRepository->getFileLearningMaterialIds();
+        $progress = new ProgressBar($output, count($ids));
+        $progress->setRedrawFrequency(208);
+        $output->writeln("<info>Rotating Learning Material Tokens...</info>");
+        $progress->start();
+
+        $chunks = array_chunk($ids, self::QUERY_LIMIT);
+        $modifiedMaterials = [];
+        foreach ($chunks as $ids) {
+            $materials = $this->learningMaterialRepository->findBy(['id' => $ids]);
+            foreach ($materials as $lm) {
+                $originalToken = $lm->getToken();
+                $lm->generateToken();
+                $newToken = $lm->getToken();
+                $this->learningMaterialRepository->update($lm, false);
+                $progress->advance();
+                $modifiedMaterials[] = [
+                    $lm->getId(),
+                    $originalToken,
+                    $newToken,
+                ];
+            }
+
+            $this->em->flush();
+            $this->em->clear();
+        }
+
+        $progress->finish();
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Material ID', 'Original Token', 'New Token'])
+            ->setRows($modifiedMaterials)
+        ;
+        $table->render();
+    }
+
+    protected function rotateReportTokens(OutputInterface $output): void
+    {
+
+        $output->writeln("<info>Rotating CI Report Tokens...</info>");
+
+        $modifiedReports = [];
+        $reports = $this->reportRepository->findAll();
+        foreach ($reports as $report) {
+            $originalToken = $report->getToken();
+            $report->generateToken();
+            $newToken = $report->getToken();
+            $this->reportRepository->update($report, false);
+            $modifiedReports[] = [
+                $report->getId(),
+                $originalToken,
+                $newToken,
+            ];
+        }
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Report ID', 'Original Token', 'New Token'])
+            ->setRows($modifiedReports)
+        ;
+        $table->render();
+    }
+}

--- a/tests/Command/RotateFileAccessTokensCommandTest.php
+++ b/tests/Command/RotateFileAccessTokensCommandTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\RotateFileAccessTokensCommand;
+use App\Entity\CurriculumInventoryReportInterface;
+use App\Repository\CurriculumInventoryReportRepository;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\CoversClass;
+use App\Entity\LearningMaterialInterface;
+use App\Repository\LearningMaterialRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+#[Group('cli')]
+#[CoversClass(RotateFileAccessTokensCommand::class)]
+final class RotateFileAccessTokensCommandTest extends KernelTestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected m\MockInterface $em;
+    protected m\MockInterface $learningMaterialRepository;
+    protected m\MockInterface $reportRepository;
+    protected CommandTester $commandTester;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->learningMaterialRepository = m::mock(LearningMaterialRepository::class);
+        $this->reportRepository = m::mock(CurriculumInventoryReportRepository::class);
+        $this->em = m::mock(EntityManagerInterface::class);
+
+        $command = new RotateFileAccessTokensCommand(
+            $this->em,
+            $this->learningMaterialRepository,
+            $this->reportRepository,
+        );
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->add($command);
+        $commandInApp = $application->find($command->getName());
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->em);
+        unset($this->learningMaterialRepository);
+        unset($this->reportRepository);
+    }
+
+    public function testRun(): void
+    {
+        $report = m::mock(CurriculumInventoryReportInterface::class);
+        $report->shouldReceive('getId')->andReturn(11);
+        $report->shouldReceive('getToken')->once()->andReturn('original report token');
+        $report->shouldReceive('generateToken');
+        $report->shouldReceive('getToken')->once()->andReturn('new report token');
+        $lm = m::mock(LearningMaterialInterface::class);
+        $lm->shouldReceive('getId')->andReturn(22);
+        $lm->shouldReceive('getToken')->once()->andReturn('original material token');
+        $lm->shouldReceive('generateToken');
+        $lm->shouldReceive('getToken')->once()->andReturn('new material token');
+
+        $this->reportRepository->shouldReceive('findAll')->andReturn([$report]);
+        $this->learningMaterialRepository->shouldReceive('getFileLearningMaterialIds')->andReturn([22]);
+        $this->learningMaterialRepository->shouldReceive('findBy')->with(['id' => [22]])->andReturn([$lm]);
+
+        $this->reportRepository->shouldReceive('update')->with($report, false);
+        $this->learningMaterialRepository->shouldReceive('update')->with($lm, false);
+
+
+        $this->em->shouldReceive('flush')->times(2);
+        $this->em->shouldReceive('clear')->times(2);
+        $this->commandTester->execute([]);
+
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('11        | original report token | new report token', $output);
+        $this->assertStringContainsString('22          | original material token | new material token', $output);
+    }
+}


### PR DESCRIPTION
These tokens are used as direct links to learning materials and curriculum reports and they bypass any other authentication. As such they may need to be rotated from time to time.