### PR TITLE
updates symfony recipe for messenger bundle to v7.3

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -3,6 +3,10 @@ framework:
     failure_transport: failed
     transports:
       # https://symfony.com/doc/current/messenger.html#transport-configuration
+      # async: '%env(MESSENGER_TRANSPORT_DSN)%'
+      # failed: 'doctrine://default?queue_name=failed'
+      sync: 'sync://'
+
       async_priority_high:
         dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
         retry_strategy:

--- a/symfony.lock
+++ b/symfony.lock
@@ -695,12 +695,12 @@
         }
     },
     "symfony/messenger": {
-        "version": "6.3",
+        "version": "7.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "6.0",
-            "ref": "ba1ac4e919baba5644d31b57a3284d6ba12d52ee"
+            "ref": "d8936e2e2230637ef97e5eecc0eea074eecae58b"
         },
         "files": [
             "config/packages/messenger.yaml"


### PR DESCRIPTION
i'm excluding this recipe change https://github.com/symfony/recipes/commit/575539a43738ab5c8c56d0edd0fb0969c45b0023

~~since i'm not sure if we want to turn on synchronous message processing or not. see https://symfony.com/doc/current/messenger.html#handling-messages-synchronously for details.~~

this turns on synchronous message processing.
    
see https://symfony.com/doc/current/messenger.html#handling-messages-synchronously for details.
