### PR TITLE
updates doctrine-bundle symfony recipe to v3.0.

### DIFF
--- a/symfony.lock
+++ b/symfony.lock
@@ -70,12 +70,12 @@
         }
     },
     "doctrine/doctrine-bundle": {
-        "version": "2.14",
+        "version": "3.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
-            "version": "2.13",
-            "ref": "620b57f496f2e599a6015a9fa222c2ee0a32adcb"
+            "version": "3.0",
+            "ref": "86b1fbac469b8b1c05e5ff28a7a2cffcaacf5068"
         },
         "files": [
             "config/packages/doctrine.yaml",


### PR DESCRIPTION
no config changes, we already yanked the [no-op config options](https://github.com/doctrine/DoctrineBundle/blob/3.0.x/UPGRADE-3.0.md#no-op-configuration-options-removed) that became obsolete with Doctrine 3.0.



