### PR TITLE
updates symfony/monolog-bundle recipe to v4.0

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -10,14 +10,6 @@ when@dev:
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug
                 channels: ["!event"]
-            # uncomment to get logging in your browser
-            # you may have to allow bigger header sizes in your Web server configuration
-            #firephp:
-            #    type: firephp
-            #    level: info
-            #chromephp:
-            #    type: chromephp
-            #    level: info
             console:
                 type: console
                 process_psr_3_messages: false
@@ -45,6 +37,7 @@ when@prod:
                 action_level: error
                 handler: nested
                 excluded_http_codes: [404, 405]
+                channels: ["!deprecation"]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
             nested:
                 type: stream

--- a/symfony.lock
+++ b/symfony.lock
@@ -716,12 +716,12 @@
         "version": "v5.2.0"
     },
     "symfony/monolog-bundle": {
-        "version": "3.10",
+        "version": "4.0",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "3.7",
-            "ref": "aff23899c4440dd995907613c1dd709b6f59503f"
+            "ref": "1b9efb10c54cb51c713a9391c9300ff8bceda459"
         },
         "files": [
             "config/packages/monolog.yaml"


### PR DESCRIPTION
see the referenced PRs in the captured output below for details.


```bash
$ composer recipes:update symfony/monolog-bundle
  Updating recipe for symfony/monolog-bundle...

                        
   Yes! Recipe updated! 
                        

  Run git status or git diff --cached to see the changes.
  When you're ready, commit these changes like normal.

  * [symfony/monolog-bundle] Don't log deprecations twice in prod (PR https://github.com/symfony/recipes/pull/1454)
  * [Monolog] Remove commented code to log in the browser (PR https://github.com/symfony/recipes/pull/1475)
```