### PR TITLE
Use ISO Year in Rollover

### DIFF
--- a/src/Service/CourseRollover.php
+++ b/src/Service/CourseRollover.php
@@ -321,7 +321,7 @@ class CourseRollover
         if (!$newCourseStartDate) {
             $isoWeekOrdinal = (int) $origCourseStartDate->format('W');
             $isoDayOrdinal = (int) $origCourseStartDate->format('N');
-            $yearDiff = (int) $origCourseStartDate->format('Y') - $origAcademicYear;
+            $yearDiff = (int) $origCourseStartDate->format('o') - $origAcademicYear;
 
             $diffedYear = $newAcademicYear + $yearDiff;
             $newCourseStartDate = new DateTime();


### PR DESCRIPTION
When we calculate the correct date from the academic year we need to use the ISO year as we're expecting that when we set the new course dates. Usually this is the same as the calendar year expect in the week transitioning between years.

Fixes #6764