### PR TITLE
Add Messenger Migration

### DIFF
--- a/migrations/Version20260105000000.php
+++ b/migrations/Version20260105000000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilios\Migrations;
+
+use App\Classes\MysqlMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260105000000 extends MysqlMigration
+{
+    public function getDescription(): string
+    {
+        return 'Migrate messenger messages to new schema';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_75EA56E016BA31DB ON messenger_messages');
+        $this->addSql('DROP INDEX IDX_75EA56E0FB7336F0 ON messenger_messages');
+        $this->addSql('DROP INDEX IDX_75EA56E0E3BD61CE ON messenger_messages');
+        $this->addSql('CREATE INDEX IDX_75EA56E0FB7336F0E3BD61CE16BA31DBBF396750 ON messenger_messages (queue_name, available_at, delivered_at, id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_75EA56E0FB7336F0E3BD61CE16BA31DBBF396750 ON messenger_messages');
+        $this->addSql('CREATE INDEX IDX_75EA56E016BA31DB ON messenger_messages (delivered_at)');
+        $this->addSql('CREATE INDEX IDX_75EA56E0FB7336F0 ON messenger_messages (queue_name)');
+        $this->addSql('CREATE INDEX IDX_75EA56E0E3BD61CE ON messenger_messages (available_at)');
+    }
+}


### PR DESCRIPTION
The latest update to symfony's doctrine messenger 7.3.9 has a new schema for the messages table.