### PR TITLE
Replace Deprecated Add Command

### DIFF
--- a/tests/Command/AddDirectoryUserCommandTest.php
+++ b/tests/Command/AddDirectoryUserCommandTest.php
@@ -51,7 +51,7 @@ final class AddDirectoryUserCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/AddNewStudentsToSchoolCommandTest.php
+++ b/tests/Command/AddNewStudentsToSchoolCommandTest.php
@@ -56,7 +56,7 @@ final class AddNewStudentsToSchoolCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/AddRootUserCommandTest.php
+++ b/tests/Command/AddRootUserCommandTest.php
@@ -39,7 +39,7 @@ final class AddRootUserCommandTest extends KernelTestCase
         $command = new AddRootUserCommand($this->userRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -58,7 +58,7 @@ final class AddUserCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
 
         // Override the question helper to fix testing issue with hidden password input

--- a/tests/Command/AuditLogExportCommandTest.php
+++ b/tests/Command/AuditLogExportCommandTest.php
@@ -44,7 +44,7 @@ final class AuditLogExportCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $command = new AuditLogExportCommand($this->logger, $this->auditLogRepository);
-        $application->add($command);
+        $application->addCommands([$command]);
         $command = $application->find($command->getName());
         $this->commandTester = new CommandTester($command);
     }

--- a/tests/Command/ChangePasswordCommandTest.php
+++ b/tests/Command/ChangePasswordCommandTest.php
@@ -52,7 +52,7 @@ final class ChangePasswordCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
 
         // Override the question helper to fix testing issue with hidden password input

--- a/tests/Command/ChangeUsernameCommandTest.php
+++ b/tests/Command/ChangeUsernameCommandTest.php
@@ -42,7 +42,7 @@ final class ChangeUsernameCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/CleanupS3FilesystemCacheCommandTest.php
+++ b/tests/Command/CleanupS3FilesystemCacheCommandTest.php
@@ -44,7 +44,7 @@ final class CleanupS3FilesystemCacheCommandTest extends KernelTestCase
         $command = new CleanupS3FilesystemCacheCommand($factory, $this->diskSpace);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/CleanupStringsCommandTest.php
+++ b/tests/Command/CleanupStringsCommandTest.php
@@ -83,7 +83,7 @@ final class CleanupStringsCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/CreateServiceTokenCommandTest.php
+++ b/tests/Command/CreateServiceTokenCommandTest.php
@@ -50,7 +50,7 @@ final class CreateServiceTokenCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/CreateUserTokenCommandTest.php
+++ b/tests/Command/CreateUserTokenCommandTest.php
@@ -39,7 +39,7 @@ final class CreateUserTokenCommandTest extends KernelTestCase
         $command = new CreateUserTokenCommand($this->userRepository, $this->jwtManager);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/DeleteServiceTokenCommandTest.php
+++ b/tests/Command/DeleteServiceTokenCommandTest.php
@@ -35,7 +35,7 @@ final class DeleteServiceTokenCommandTest extends KernelTestCase
         $command = new DeleteServiceTokenCommand($this->serviceTokenRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/DisableServiceTokenCommandTest.php
+++ b/tests/Command/DisableServiceTokenCommandTest.php
@@ -35,7 +35,7 @@ final class DisableServiceTokenCommandTest extends KernelTestCase
         $command = new DisableServiceTokenCommand($this->serviceTokenRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/EnableServiceTokenCommandTest.php
+++ b/tests/Command/EnableServiceTokenCommandTest.php
@@ -35,7 +35,7 @@ final class EnableServiceTokenCommandTest extends KernelTestCase
         $command = new EnableServiceTokenCommand($this->serviceTokenRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/ExtractLearningMaterialsTextCommandTest.php
+++ b/tests/Command/ExtractLearningMaterialsTextCommandTest.php
@@ -35,7 +35,7 @@ final class ExtractLearningMaterialsTextCommandTest extends KernelTestCase
         $command = new ExtractLearningMaterialsTextCommand($this->repository, $this->bus);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/FindUserCommandTest.php
+++ b/tests/Command/FindUserCommandTest.php
@@ -33,7 +33,7 @@ final class FindUserCommandTest extends KernelTestCase
         $command = new FindUserCommand($this->directory);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
+++ b/tests/Command/FixLearningMaterialMimeTypesCommandTest.php
@@ -46,7 +46,7 @@ final class FixLearningMaterialMimeTypesCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/ImportDefaultDataCommandTest.php
+++ b/tests/Command/ImportDefaultDataCommandTest.php
@@ -102,7 +102,7 @@ final class ImportDefaultDataCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/ImportMeshUniverseCommandAcceptanceTest.php
+++ b/tests/Command/ImportMeshUniverseCommandAcceptanceTest.php
@@ -63,7 +63,7 @@ final class ImportMeshUniverseCommandAcceptanceTest extends KernelTestCase
 
         $command = new ImportMeshUniverseCommand($meshParser, $this->meshDescriptorRepository, $meshIndex);
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/ImportMeshUniverseCommandTest.php
+++ b/tests/Command/ImportMeshUniverseCommandTest.php
@@ -43,7 +43,7 @@ final class ImportMeshUniverseCommandTest extends KernelTestCase
         $command = new ImportMeshUniverseCommand($this->meshParser, $this->descriptorRepository, $this->meshIndex);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/Index/CourseCommandTest.php
+++ b/tests/Command/Index/CourseCommandTest.php
@@ -30,7 +30,7 @@ final class CourseCommandTest extends KernelTestCase
         $command = new CourseCommand($this->index);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/Index/CreateCommandTest.php
+++ b/tests/Command/Index/CreateCommandTest.php
@@ -29,7 +29,7 @@ final class CreateCommandTest extends KernelTestCase
         $command = new CreateCommand($this->indexManager);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/Index/DetectMissingCommandTest.php
+++ b/tests/Command/Index/DetectMissingCommandTest.php
@@ -47,7 +47,7 @@ final class DetectMissingCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/Index/DropCommandTest.php
+++ b/tests/Command/Index/DropCommandTest.php
@@ -33,7 +33,7 @@ final class DropCommandTest extends KernelTestCase
         $command = new DropCommand($this->indexManager, $this->entityManager);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/Index/MaterialCommandTest.php
+++ b/tests/Command/Index/MaterialCommandTest.php
@@ -36,7 +36,7 @@ final class MaterialCommandTest extends KernelTestCase
         $command = new MaterialCommand($this->repository, $this->index, $this->config);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/Index/UpdateCommandTest.php
+++ b/tests/Command/Index/UpdateCommandTest.php
@@ -57,7 +57,7 @@ final class UpdateCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/InstallFirstUserCommandTest.php
+++ b/tests/Command/InstallFirstUserCommandTest.php
@@ -56,7 +56,7 @@ final class InstallFirstUserCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/InvalidateUserTokenCommandTest.php
+++ b/tests/Command/InvalidateUserTokenCommandTest.php
@@ -40,7 +40,7 @@ final class InvalidateUserTokenCommandTest extends KernelTestCase
         $command = new InvalidateUserTokenCommand($this->userRepository, $this->authenticationRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/ListConfigValuesCommandTest.php
+++ b/tests/Command/ListConfigValuesCommandTest.php
@@ -40,7 +40,7 @@ final class ListConfigValuesCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/ListRootUsersCommandTest.php
+++ b/tests/Command/ListRootUsersCommandTest.php
@@ -37,7 +37,7 @@ final class ListRootUsersCommandTest extends KernelTestCase
         $command = new ListRootUsersCommand($this->userRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/ListSchoolConfigValuesCommandTest.php
+++ b/tests/Command/ListSchoolConfigValuesCommandTest.php
@@ -38,7 +38,7 @@ final class ListSchoolConfigValuesCommandTest extends KernelTestCase
         $command = new ListSchoolConfigValuesCommand($this->schoolRepository, $this->schoolConfigRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/ListServiceTokensCommandTest.php
+++ b/tests/Command/ListServiceTokensCommandTest.php
@@ -37,7 +37,7 @@ final class ListServiceTokensCommandTest extends KernelTestCase
         $command = new ListServiceTokensCommand($this->serviceTokenRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
+++ b/tests/Command/MigrateIlios2LearningMaterialsCommandTest.php
@@ -47,7 +47,7 @@ final class MigrateIlios2LearningMaterialsCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/RemoveRootUserCommandTest.php
+++ b/tests/Command/RemoveRootUserCommandTest.php
@@ -39,7 +39,7 @@ final class RemoveRootUserCommandTest extends KernelTestCase
         $command = new RemoveRootUserCommand($this->userRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/RolloverCourseCommandTest.php
+++ b/tests/Command/RolloverCourseCommandTest.php
@@ -34,7 +34,7 @@ final class RolloverCourseCommandTest extends KernelTestCase
         $command = new RolloverCourseCommand($this->service);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
+++ b/tests/Command/RolloverCurriculumInventoryReportCommandTest.php
@@ -37,7 +37,7 @@ final class RolloverCurriculumInventoryReportCommandTest extends KernelTestCase
         $command = new RolloverCurriculumInventoryReportCommand($this->reportRepository, $this->service);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/RotateFileAccessTokensCommandTest.php
+++ b/tests/Command/RotateFileAccessTokensCommandTest.php
@@ -43,7 +43,7 @@ final class RotateFileAccessTokensCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/SendChangeAlertsCommandTest.php
+++ b/tests/Command/SendChangeAlertsCommandTest.php
@@ -88,7 +88,7 @@ final class SendChangeAlertsCommandTest extends KernelTestCase
             $fs,
             sys_get_temp_dir()
         );
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/SendTeachingRemindersCommandTest.php
+++ b/tests/Command/SendTeachingRemindersCommandTest.php
@@ -81,7 +81,7 @@ final class SendTeachingRemindersCommandTest extends KernelTestCase
             $this->fs,
             $this->testDir
         );
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/SendTestEmailCommandTest.php
+++ b/tests/Command/SendTestEmailCommandTest.php
@@ -41,7 +41,7 @@ final class SendTestEmailCommandTest extends KernelTestCase
         $command = new SendTestEmailCommand(
             $this->mailer
         );
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/SetConfigValueCommandTest.php
+++ b/tests/Command/SetConfigValueCommandTest.php
@@ -34,7 +34,7 @@ final class SetConfigValueCommandTest extends KernelTestCase
         $command = new SetConfigValueCommand($this->applicationConfigRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/SetSchoolConfigValueCommandTest.php
+++ b/tests/Command/SetSchoolConfigValueCommandTest.php
@@ -38,7 +38,7 @@ final class SetSchoolConfigValueCommandTest extends KernelTestCase
         $command = new SetSchoolConfigValueCommand($this->schoolRepository, $this->schoolConfigRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/SetupAuthenticationCommandTest.php
+++ b/tests/Command/SetupAuthenticationCommandTest.php
@@ -35,7 +35,7 @@ final class SetupAuthenticationCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/SyncAllUsersCommandTest.php
+++ b/tests/Command/SyncAllUsersCommandTest.php
@@ -53,7 +53,7 @@ final class SyncAllUsersCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
         $this->pendingUserUpdateRepository->shouldReceive('removeAllPendingUserUpdates')->once();

--- a/tests/Command/SyncFormerStudentsCommandTest.php
+++ b/tests/Command/SyncFormerStudentsCommandTest.php
@@ -43,7 +43,7 @@ final class SyncFormerStudentsCommandTest extends KernelTestCase
         $command = new SyncFormerStudentsCommand($this->userRepository, $this->userRoleRepository, $this->directory);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/SyncStudentStatusCommandTest.php
+++ b/tests/Command/SyncStudentStatusCommandTest.php
@@ -38,7 +38,7 @@ final class SyncStudentStatusCommandTest extends KernelTestCase
         $command = new SyncStudentStatusCommand($this->userRepository, $this->userRoleRepository, $this->directory);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/SyncUserCommandTest.php
+++ b/tests/Command/SyncUserCommandTest.php
@@ -52,7 +52,7 @@ final class SyncUserCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/ValidateLearningMaterialPathsCommandTest.php
+++ b/tests/Command/ValidateLearningMaterialPathsCommandTest.php
@@ -40,7 +40,7 @@ final class ValidateLearningMaterialPathsCommandTest extends KernelTestCase
         );
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/WaitForDatabaseCommandTest.php
+++ b/tests/Command/WaitForDatabaseCommandTest.php
@@ -32,7 +32,7 @@ final class WaitForDatabaseCommandTest extends KernelTestCase
         $command = new WaitForDatabaseCommand($this->entityManager);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }

--- a/tests/Command/WaitForIndexCommandTest.php
+++ b/tests/Command/WaitForIndexCommandTest.php
@@ -36,7 +36,7 @@ final class WaitForIndexCommandTest extends KernelTestCase
         $command = new WaitForIndexCommand($this->client, $this->indexManager);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommands([$command]);
         $commandInApp = $application->find($command->getName());
         $this->commandTester = new CommandTester($commandInApp);
     }


### PR DESCRIPTION
This is deprecated in symfony 7.4, the new addCommands syntax is the drop in replacement and available now.