### PR TITLE
rm direct dependency on phpdocumentor/reflection-docblock package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     "nelmio/cors-bundle": "^2.0",
     "opensearch-project/opensearch-php": "^2.0",
     "pear/archive_tar": "^1.4",
-    "phpdocumentor/reflection-docblock": "^6.0",
     "psr/log": "^3.0.0",
     "sentry/sentry-symfony": "^5.0",
     "swagger-api/swagger-ui": "^5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "730b6a7bf23dba7b9d4c2aa700860708",
+    "content-hash": "edc1369cda82eff3036d425c7058477a",
     "packages": [
         {
             "name": "async-aws/core",


### PR DESCRIPTION
we don't need it.

refs #6803

this package was first introduced with this PR #3591