### PR TITLE
Deprioritize Catch All Route

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
     "slevomat/coding-standard": "~8.0",
     "squizlabs/php_codesniffer": "@stable",
     "symfony/browser-kit": "7.4.*",
+    "symfony/css-selector": "7.4.*",
     "symfony/debug-bundle": "7.4.*",
     "symfony/stopwatch": "7.4.*",
     "symfony/web-profiler-bundle": "7.4.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c6a28ee410cdf1cb1ff29a7724b9841",
+    "content-hash": "edc1369cda82eff3036d425c7058477a",
     "packages": [
         {
             "name": "async-aws/core",
@@ -15137,6 +15137,75 @@
             "time": "2026-01-13T10:40:19+00:00"
         },
         {
+            "name": "symfony/css-selector",
+            "version": "v7.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "ab862f478513e7ca2fe9ec117a6f01a8da6e1135"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ab862f478513e7ca2fe9ec117a6f01a8da6e1135",
+                "reference": "ab862f478513e7ca2fe9ec117a6f01a8da6e1135",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Converts CSS selectors to XPath expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/v7.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-10-30T13:39:42+00:00"
+        },
+        {
             "name": "symfony/debug-bundle",
             "version": "v7.4.0",
             "source": {
@@ -15594,5 +15663,5 @@
     "platform-overrides": {
         "php": "8.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -46,6 +46,7 @@ class IndexController extends AbstractController
             'fileName' => null,
         ],
         methods: ['GET'],
+        priority: -1,
     )]
     public function index(Request $request): Response
     {

--- a/tests/Routing/HealthRouteTest.php
+++ b/tests/Routing/HealthRouteTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Routing;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class HealthRouteTest extends WebTestCase
+{
+    public function testSomething(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/ilios/health/');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertRouteSame('liip_monitor_health_interface');
+        $this->assertSelectorTextContains('h1', 'System Health Status');
+    }
+}

--- a/tests/Routing/SwaggerRouteTest.php
+++ b/tests/Routing/SwaggerRouteTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Routing;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class SwaggerRouteTest extends WebTestCase
+{
+    public function testSomething(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/api/doc');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertRouteSame('app.swagger_ui');
+    }
+}


### PR DESCRIPTION
This catch all route has a tendency to override others, in particular the profiler and health routes can't be hit. We skip /api things, but don't want to keep track of anything else, priority is perfect for this.

Refs #6815, the new blueprints load the attribute routes in `attributes.yml` which moves all of our declarations further up the chain.