### PR TITLE
suppress install-breaking SA.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,11 @@
     "symfony/web-profiler-bundle": "7.4.*"
   },
   "config": {
+    "audit": {
+      "ignore":  {
+        "PKSA-y2cr-5h3j-g3ys": "Mitigated."
+      }
+    },
     "platform": {
       "php": "8.4"
     },


### PR DESCRIPTION
we're mitigating this issue already, without blocking this SA explicitly in config we're blocked from updating dependencies.

refs https://github.com/ilios/ilios/pull/6743