### PR TITLE
use a different config setting to lock symfony packages into v7.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   open-pull-requests-limit: 10
   ignore:
       - dependency-name: "symfony/*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        versions: ["7.4.*"] # Ignore any attempts that would bump Symfony packages off version 7.4.
   groups:
     symfony:
       patterns:


### PR DESCRIPTION
this should be equivalent to what we currently have in place, but since dependabot is [evidently](#6964 ) not respecting the current configured version ranges it's worth a shot.