### PR TITLE
revert dependabot ignore-list config to semver checks.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   open-pull-requests-limit: 10
   ignore:
       - dependency-name: "symfony/*"
-        versions: ["7.4.*"] # Ignore any attempts that would bump Symfony packages off version 7.4.
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
   groups:
     symfony:
       patterns:


### PR DESCRIPTION
the symfony version pinning approach didn't do what we were hoping for, let's go back to the pattern that's at least easier to maintain.

refs https://github.com/ilios/ilios/pull/6966