### PR TITLE
Fix deprecated (integer) to (int) casting in old migration

### DIFF
--- a/migrations/Version20170824000000.php
+++ b/migrations/Version20170824000000.php
@@ -99,7 +99,7 @@ final class Version20170824000000 extends MysqlMigration
 
         $mapped = array_map(function ($name, $value) {
             if (is_bool($value)) {
-                $value = (integer) $value;
+                $value = (int) $value;
             }
             return [
                 'name' => $name,


### PR DESCRIPTION
This is throwing an error on every local `./bin/console` I run.