### PR TITLE
Change `User::generateIcsFeedKey` to static and use for tests

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -370,7 +370,7 @@ class User implements UserInterface
         $this->userSyncIgnore = false;
         $this->root = false;
 
-        $this->generateIcsFeedKey();
+        $this->icsFeedKey = self::generateIcsFeedKey();
     }
 
     public function setLastName(string $lastName): void
@@ -508,7 +508,7 @@ class User implements UserInterface
         return $this->userSyncIgnore;
     }
 
-    public function generateIcsFeedKey(): void
+    public static function generateIcsFeedKey(): string
     {
         $random = random_bytes(128);
 
@@ -516,7 +516,7 @@ class User implements UserInterface
         $key = microtime() . '_' . $random;
 
         // hash the string to give consistent length and URL safe characters
-        $this->icsFeedKey = hash('sha256', $key);
+        return hash('sha256', $key);
     }
 
     public function setIcsFeedKey(string $icsFeedKey): void

--- a/src/Entity/UserInterface.php
+++ b/src/Entity/UserInterface.php
@@ -76,7 +76,7 @@ interface UserInterface extends
     /**
      * Generate a random string to use as the calendar feed url
      */
-    public function generateIcsFeedKey(): void;
+    public static function generateIcsFeedKey(): string;
 
     public function setIcsFeedKey(string $icsFeedKey): void;
     public function getIcsFeedKey(): string;

--- a/tests/DataLoader/UserData.php
+++ b/tests/DataLoader/UserData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\DataLoader;
 
 use App\Entity\DTO\UserDTO;
+use App\Entity\User;
 
 final class UserData extends AbstractDataLoader
 {
@@ -249,7 +250,7 @@ final class UserData extends AbstractDataLoader
             'userSyncIgnore' => false,
             'addedViaIlios' => true,
             'examined' => false,
-            'icsFeedKey' => hash('sha256', microtime()),
+            'icsFeedKey' => User::generateIcsFeedKey(),
             'root' => false,
             'reports' => [],
             'school' => "1",


### PR DESCRIPTION
Fixes ilios/ilios#6982

This fixes the issue where on some machines `icsFeedKey` generation in tests would cause a `SQLSTATE[23000]: Integrity constraint violation: 19 UNIQUE constraint failed: user.ics_feed_key"` error, most likely due to the usage of `microtime()` with no added randomness. Best way forward is to use the same method that was being used in production, instead of a direct hashing invocation.