### PR TITLE
removed memory limit from admin image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,8 +190,9 @@ CMD ["ilios:update-frontend"]
 ###############################################################################
 # Multi-purpose container to run a single Ilios console command and then exit
 ###############################################################################
-FROM admin AS console-command
+FROM php-base AS console-command
 LABEL maintainer="Ilios Project Team <support@iliosproject.org>"
+COPY docker/cli/php-cli.ini $PHP_INI_DIR/conf.d/99-php-cli-overrides.ini
 ENTRYPOINT ["bin/console"]
 CMD ["list"]
 


### PR DESCRIPTION
Put memory override into admin container instead of console-command, and now the console command-derived images now branch from the `admin` target instead of `php-base`, so console-commands also have `memory_limit = -1`