### PR TITLE
Prehash Key for CAS Signature

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -22,5 +22,5 @@
 #ILIOS_TIKA_URL=null
 
 ###> symfony/framework-bundle ###
-ILIOS_SECRET=35d19d470bf1b44e82f84e8c74e149d8
+ILIOS_SECRET=0dbfe78d30d80c04b60821135017b2fe4f87e75938ddd83067a4c6dc058159e7
 ###< symfony/framework-bundle ###

--- a/src/Service/CasAuthentication.php
+++ b/src/Service/CasAuthentication.php
@@ -256,8 +256,14 @@ class CasAuthentication implements AuthenticationInterface
      */
     protected function generateSignature(string $value): string
     {
+        //Create a key that will fit within SODIUM_CRYPTO_GENERICHASH_KEYBYTES_MAX
+        $key = sodium_crypto_generichash(
+            $this->kernelSecret . self::REDIRECT_COOKIE,
+            '',
+            SODIUM_CRYPTO_GENERICHASH_KEYBYTES_MAX
+        );
         return sodium_bin2hex(
-            sodium_crypto_generichash($value, $this->kernelSecret . self::REDIRECT_COOKIE)
+            sodium_crypto_generichash($value, $key)
         );
     }
 }


### PR DESCRIPTION
There is a limit to the size of the key that can be used with sodium_crypto_generate_hash. On my machine it's 64 which is the new suggested length for the ILIOS_SECRET. This makes it impossible to login with CAS with a key that meets this standard. What I've done here is hash the key value into a value with a maximum length which matches the PHP built in constant SODIUM_CRYPTO_GENERICHASH_KEYBYTES_MAX so that we never end up with a key that is too long.

Fixes #6988