### PR TITLE
Fix Deploy PR Action

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -27,6 +27,9 @@ jobs:
           - redis
           - tika
     steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v4
       with:
@@ -44,6 +47,7 @@ jobs:
       with:
         tags: |
             ilios/${{ matrix.image }}:preview-pr-${{github.event.number}}
+        context: .
         target: ${{ matrix.image }}
         push: true
         provenance: false #https://github.com/gabrieldemarmiesse/python-on-whales/issues/407


### PR DESCRIPTION
If we let docker checkout the code it will checkout master as this is a pull_request_target workflow. We need to checkout the right ref ourselves and then tell docker to build the local filesystem and not from git directly. This is a bit dangerous to do in a target action, but we've protected it with the label.