### PR TITLE
Decorate GraphQL DTOs 

### DIFF
--- a/src/Attributes/ExposeGraphQL.php
+++ b/src/Attributes/ExposeGraphQL.php
@@ -9,4 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 class ExposeGraphQL
 {
+    public function __construct(public ?string $customResolver = null)
+    {
+    }
 }

--- a/src/Entity/DTO/CurriculumInventoryReportDTO.php
+++ b/src/Entity/DTO/CurriculumInventoryReportDTO.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace App\Entity\DTO;
 
 use App\Attributes as IA;
+use App\Service\GraphQL\CurriculumInventoryReportFieldResolver;
 use DateTime;
 use OpenApi\Attributes as OA;
 use Symfony\Component\Serializer\Attribute\Ignore;
 
 #[IA\DTO('curriculumInventoryReports')]
-#[IA\ExposeGraphQL]
+#[IA\ExposeGraphQL(customResolver: CurriculumInventoryReportFieldResolver::class)]
 #[OA\Schema(
     title: "CurriculumInventoryReport",
     properties: [

--- a/src/Entity/DTO/LearningMaterialDTO.php
+++ b/src/Entity/DTO/LearningMaterialDTO.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Entity\DTO;
 
 use App\Attributes as IA;
+use App\Service\GraphQL\LearningMaterialFieldResolver;
 use DateTime;
 use OpenApi\Attributes as OA;
 use Symfony\Component\Serializer\Attribute\Ignore;
@@ -14,7 +15,7 @@ use Symfony\Component\Serializer\Attribute\Ignore;
  * Data transfer object for a learning materials
  */
 #[IA\DTO('learningMaterials')]
-#[IA\ExposeGraphQL]
+#[IA\ExposeGraphQL(customResolver: LearningMaterialFieldResolver::class)]
 #[OA\Schema(
     title: "LearningMaterial",
     properties: [

--- a/src/Service/CurriculumInventoryReportDecoratorFactory.php
+++ b/src/Service/CurriculumInventoryReportDecoratorFactory.php
@@ -17,12 +17,19 @@ class CurriculumInventoryReportDecoratorFactory
 
     public function create(CurriculumInventoryReportDTO $report): CurriculumInventoryReportDTO
     {
-        $report->absoluteFileUri = $this->router->generate(
+        $report->absoluteFileUri = $this->getAbsoluteFileUriForDTO($report);
+
+        return $report;
+    }
+
+
+
+    public function getAbsoluteFileUriForDTO(CurriculumInventoryReportDTO $report): ?string
+    {
+        return $this->router->generate(
             'app_curriculuminventorydownload_get',
             ['token' => $report->token],
             UrlGenerator::ABSOLUTE_URL
         );
-
-        return $report;
     }
 }

--- a/src/Service/GraphQL/CurriculumInventoryReportFieldResolver.php
+++ b/src/Service/GraphQL/CurriculumInventoryReportFieldResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\GraphQL;
+
+use App\Entity\DTO\CurriculumInventoryReportDTO;
+use App\Service\CurriculumInventoryReportDecoratorFactory;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class CurriculumInventoryReportFieldResolver
+{
+    public function __construct(
+        protected FieldResolver $fieldResolver,
+        protected CurriculumInventoryReportDecoratorFactory $decorator,
+    ) {
+    }
+
+    public function __invoke(mixed $source, array $args, mixed $context, ResolveInfo $info): mixed
+    {
+
+        $fieldName = $info->fieldName;
+
+        if (
+            $fieldName === 'absoluteFileUri' &&
+            $source instanceof CurriculumInventoryReportDTO
+        ) {
+            return $this->decorator->getAbsoluteFileUriForDTO($source);
+        }
+
+        return $this->fieldResolver->__invoke($source, $args, $context, $info);
+    }
+}

--- a/src/Service/GraphQL/DTOInfo.php
+++ b/src/Service/GraphQL/DTOInfo.php
@@ -56,6 +56,16 @@ class DTOInfo
         return $graphQL !== [];
     }
 
+    public function getCustomResolverForType(ReflectionClass $class): ?string
+    {
+        $graphQL = $class->getAttributes(ExposeGraphQL::class);
+        if (!count($graphQL)) {
+            throw new Exception("{$class->getName()} is not enabled for GraphQL");
+        }
+        $arguments = $graphQL[0]->getArguments();
+        return $arguments['customResolver'] ?? null;
+    }
+
     public function getGraphQLExposedPropertiesForType(string $type): array
     {
         $ref = $this->getRefForType($type);

--- a/src/Service/GraphQL/FieldResolver.php
+++ b/src/Service/GraphQL/FieldResolver.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Service\GraphQL;
 
-use App\Entity\DTO\SchoolDTO;
-use App\Repository\SchoolRepository;
 use ArrayAccess;
 use Closure;
 use GraphQL\Type\Definition\ResolveInfo;

--- a/src/Service/GraphQL/LearningMaterialFieldResolver.php
+++ b/src/Service/GraphQL/LearningMaterialFieldResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\GraphQL;
+
+use App\Entity\DTO\LearningMaterialDTO;
+use App\Service\LearningMaterialDecoratorFactory;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class LearningMaterialFieldResolver
+{
+    public function __construct(
+        protected FieldResolver $fieldResolver,
+        protected LearningMaterialDecoratorFactory $learningMaterialDecorator
+    ) {
+    }
+
+    public function __invoke(mixed $source, array $args, mixed $context, ResolveInfo $info): mixed
+    {
+
+        $fieldName = $info->fieldName;
+
+        if (
+            $fieldName === 'absoluteFileUri' &&
+            $source instanceof LearningMaterialDTO
+        ) {
+            return $this->learningMaterialDecorator->getAbsoluteFileUriForDTO($source);
+        }
+
+        return $this->fieldResolver->__invoke($source, $args, $context, $info);
+    }
+}

--- a/src/Service/GraphQL/TypeRegistry.php
+++ b/src/Service/GraphQL/TypeRegistry.php
@@ -26,6 +26,8 @@ class TypeRegistry
         protected DTOInfo $dtoInfo,
         protected TypeResolver $typeResolver,
         protected FieldResolver $fieldResolver,
+        protected LearningMaterialFieldResolver $learningMaterialFieldResolver,
+        protected CurriculumInventoryReportFieldResolver $curriculumInventoryReportFieldResolver,
         protected Inflector $inflector,
     ) {
     }
@@ -107,7 +109,7 @@ class TypeRegistry
                     IA\Type::DTOS, IA\Type::STRINGS, 'array' => Type::listOf(Type::string()),
                     default => throw new Exception("Unhandled property type $type encountered."),
                 },
-                'resolve' => $this->fieldResolver,
+                'resolve' => $this->getResolverForField($property),
             ];
         }
     }
@@ -163,5 +165,17 @@ class TypeRegistry
     {
         $id = $property->getAttributes(IA\Id::class);
         return $id !== [];
+    }
+
+    protected function getResolverForField(ReflectionProperty $property): callable
+    {
+        $typeRef = $property->getDeclaringClass();
+        $customResolver = $this->dtoInfo->getCustomResolverForType($typeRef);
+        return match ($customResolver) {
+            null => $this->fieldResolver,
+            LearningMaterialFieldResolver::class => $this->learningMaterialFieldResolver,
+            CurriculumInventoryReportFieldResolver::class => $this->curriculumInventoryReportFieldResolver,
+            default => throw new Exception("{$customResolver} resolver for {$typeRef->getName()} not implemented yet."),
+        };
     }
 }

--- a/src/Service/GraphQL/TypeResolver.php
+++ b/src/Service/GraphQL/TypeResolver.php
@@ -67,6 +67,7 @@ class TypeResolver
             $args[$idPropertyName] = $ids;
         }
 
+
         //we can pass $ars directly because our GraphQL library will reject
         //any args that aren't part of our schema
         return $this->filterValues($repository->findDTOsBy($args));

--- a/src/Service/LearningMaterialDecoratorFactory.php
+++ b/src/Service/LearningMaterialDecoratorFactory.php
@@ -65,15 +65,20 @@ class LearningMaterialDecoratorFactory
 
     protected function decorateDto(LearningMaterialDTO $learningMaterialDTO): LearningMaterialDTO
     {
+        $learningMaterialDTO->absoluteFileUri = $this->getAbsoluteFileUriForDTO($learningMaterialDTO);
+
+        return $learningMaterialDTO;
+    }
+
+    public function getAbsoluteFileUriForDTO(LearningMaterialDTO $learningMaterialDTO): ?string
+    {
         if ($learningMaterialDTO->filename) {
-            $link = $this->router->generate(
+            return $this->router->generate(
                 'app_download_downloadmaterials',
                 ['token' => $learningMaterialDTO->token],
                 UrlGenerator::ABSOLUTE_URL
             );
-            $learningMaterialDTO->absoluteFileUri = $link;
         }
-
-        return $learningMaterialDTO;
+        return null;
     }
 }

--- a/tests/Endpoints/CurriculumInventoryReportTest.php
+++ b/tests/Endpoints/CurriculumInventoryReportTest.php
@@ -101,6 +101,10 @@ final class CurriculumInventoryReportTest extends AbstractReadWriteEndpoint
 
     protected function compareGraphQLData(array $expected, object $result): void
     {
+        $this->assertObjectHasProperty('absoluteFileUri', $result);
+        $this->assertNotNull($result->absoluteFileUri);
+        $this->assertStringContainsString('/ci-report-dl/', $result->absoluteFileUri);
+        $this->assertGreaterThan(40, strlen($result->absoluteFileUri));
         unset($result->absoluteFileUri);
         parent::compareGraphQLData($expected, $result);
     }

--- a/tests/Endpoints/LearningMaterialTest.php
+++ b/tests/Endpoints/LearningMaterialTest.php
@@ -167,6 +167,20 @@ final class LearningMaterialTest extends AbstractReadWriteEndpoint
         parent::compareData($expected, $result);
     }
 
+    protected function compareGraphQLData(array $expected, object $result): void
+    {
+        $this->assertObjectHasProperty('absoluteFileUri', $result);
+        if ($expected['filename']) {
+            $this->assertNotNull($result->absoluteFileUri);
+            $this->assertStringContainsString('/lm/', $result->absoluteFileUri);
+            $this->assertGreaterThan(40, strlen($result->absoluteFileUri));
+        } else {
+            $this->assertNull($result->absoluteFileUri);
+        }
+        unset($result->absoluteFileUri);
+        parent::compareGraphQLData($expected, $result);
+    }
+
     /**
      * Ensure offset and limit work
      */

--- a/tests/Endpoints/ProgramTest.php
+++ b/tests/Endpoints/ProgramTest.php
@@ -13,6 +13,8 @@ use App\Tests\Fixture\LoadSchoolData;
 use App\Tests\Fixture\LoadSessionData;
 use App\Tests\Fixture\LoadTermData;
 
+use function PHPUnit\Framework\assertCount;
+
 /**
  * Program API endpoint Test.
  */
@@ -167,7 +169,9 @@ final class ProgramTest extends AbstractReadWriteEndpoint
 
         $this->createGraphQLRequest(
             json_encode([
-                'query' => "query { programs(id: {$data['id']}) { id, school { id } }}",
+                'query' => "query { programs(id: {$data['id']}) {" .
+                'id, school { id }, curriculumInventoryReports { id, absoluteFileUri } ' .
+                '}}',
             ]),
             $this->createJwtForRootUser($this->kernelBrowser)
         );
@@ -183,6 +187,24 @@ final class ProgramTest extends AbstractReadWriteEndpoint
         $this->assertTrue(property_exists($program, 'school'));
         $this->assertTrue(property_exists($program->school, 'id'));
         $this->assertEquals($data['school'], $program->school->id);
+
+        $this->assertTrue(property_exists($program, 'curriculumInventoryReports'));
+        $reports = $program->curriculumInventoryReports;
+        assertCount(3, $reports);
+        $this->assertSame('1', $reports[0]->id);
+        $this->assertTrue(property_exists($reports[0], 'absoluteFileUri'));
+        $this->assertStringContainsString('ci-report-dl', $reports[0]->absoluteFileUri);
+        $this->assertGreaterThan(40, strlen($reports[0]->absoluteFileUri));
+
+        $this->assertSame('2', $reports[1]->id);
+        $this->assertTrue(property_exists($reports[1], 'absoluteFileUri'));
+        $this->assertStringContainsString('ci-report-dl', $reports[1]->absoluteFileUri);
+        $this->assertGreaterThan(40, strlen($reports[1]->absoluteFileUri));
+
+        $this->assertSame('3', $reports[2]->id);
+        $this->assertTrue(property_exists($reports[2], 'absoluteFileUri'));
+        $this->assertStringContainsString('ci-report-dl', $reports[2]->absoluteFileUri);
+        $this->assertGreaterThan(40, strlen($reports[2]->absoluteFileUri));
     }
 
     /**

--- a/tests/Endpoints/SessionTest.php
+++ b/tests/Endpoints/SessionTest.php
@@ -305,4 +305,52 @@ final class SessionTest extends AbstractReadWriteEndpoint
         $filters = ['q' => 'sess', 'offset' => 3, 'limit' => 2];
         $this->jsonApiFilterTest($filters, [$all[4], $all[5]], $jwt);
     }
+
+    public function testGraphQLIncludedData(): void
+    {
+        $loader = $this->getDataLoader();
+        $data = $loader->getAll()[1];
+
+        $this->createGraphQLRequest(
+            json_encode([
+                'query' =>
+                    "query { sessions(id: {$data['id']}) " .
+                    '{ id, administrators { id }, course { id }, ' .
+                    'learningMaterials { id, learningMaterial { id, absoluteFileUri }}}}',
+            ]),
+            $this->createJwtForRootUser($this->kernelBrowser)
+        );
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertGraphQLResponse($response);
+
+        $content = json_decode($response->getContent());
+
+        $this->assertIsObject($content->data);
+        $this->assertIsArray($content->data->sessions);
+
+        $result = $content->data->sessions;
+        $this->assertCount(1, $result);
+
+        $session = $result[0];
+        $this->assertTrue(property_exists($session, 'id'));
+        $this->assertEquals($data['id'], $session->id);
+        $this->assertTrue(property_exists($session, 'course'));
+        $this->assertTrue(property_exists($session->course, 'id'));
+        $this->assertEquals($data['course'], $session->course->id);
+
+        $this->assertCount(1, $session->learningMaterials);
+        $this->assertTrue(property_exists($session->learningMaterials[0], 'id'));
+        $this->assertEquals(9, $session->learningMaterials[0]->id);
+
+        $this->assertTrue(property_exists($session->learningMaterials[0], 'learningMaterial'));
+        $lm = $session->learningMaterials[0]->learningMaterial;
+        $this->assertTrue(property_exists($lm, 'id'));
+        $this->assertEquals(10, $lm->id);
+        $this->assertTrue(property_exists($lm, 'absoluteFileUri'));
+        $this->assertStringStartsWith('http://localhost', $lm->absoluteFileUri);
+
+        $this->assertTrue(property_exists($session, 'administrators'));
+        $this->assertCount(0, $session->administrators);
+    }
 }


### PR DESCRIPTION
Using the existing GraphQL attribute I've unlocked the ability to do
GraphQL field resolution uniquely for our LM and CI DTOs. We take
advantage of the existing decorators for these, but it does require some
manual setup for each one. I tried to make it as readable and extensible
as possible.

Fixes #7152

wip:
- [x] Should break some tests, which will need attention