### PR TITLE
Use First Class Callables

### DIFF
--- a/src/Command/SendChangeAlertsCommand.php
+++ b/src/Command/SendChangeAlertsCommand.php
@@ -104,7 +104,7 @@ class SendChangeAlertsCommand extends Command
                 );
                 continue;
             }
-            $recipients = array_map('trim', explode(',', $recipients));
+            $recipients = array_map(trim(...), explode(',', $recipients));
 
             // get change alert history from audit logs
             $history = $this->auditLogRepository->findBy([

--- a/src/Command/SendTeachingRemindersCommand.php
+++ b/src/Command/SendTeachingRemindersCommand.php
@@ -85,7 +85,7 @@ class SendTeachingRemindersCommand extends Command
             $from = new Address($sender, $senderName);
         }
         if ($schools) {
-            $schoolIds = array_map('intval', str_getcsv($schools, escape: "\\"));
+            $schoolIds = array_map(intval(...), str_getcsv($schools, escape: "\\"));
         } else {
             $schoolIds = $this->schoolRepository->getIds();
         }

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -82,11 +82,11 @@ class SearchController extends AbstractController
 
         $schools = explode('-', $schools);
         $schools = array_filter($schools); //remove any blanks, or if an empt string is passed return and empty array
-        $schools = array_map('intval', $schools);
+        $schools = array_map(intval(...), $schools);
 
         $years = explode('-', $years);
         $years = array_filter($years); //remove any blanks, or if an empt string is passed return and empty array
-        $years = array_map('intval', $years);
+        $years = array_map(intval(...), $years);
 
         $result = $this->curriculumIndex->search($q, $size, $from, $schools, $years);
 

--- a/src/Monitor/NoDefaultSecret.php
+++ b/src/Monitor/NoDefaultSecret.php
@@ -28,7 +28,7 @@ class NoDefaultSecret implements CheckInterface
             return new Warning("'ILIOS_SECRET' is not set");
         }
 
-        $badSecrets = array_map('strtolower', [
+        $badSecrets = array_map(strtolower(...), [
             'NotSecretChangeMe',
             'ThisTokenIsNotSoSecretChangeIt',
             'ST@G1nGS3CRET12345',

--- a/src/Normalizer/DTONormalizer.php
+++ b/src/Normalizer/DTONormalizer.php
@@ -66,7 +66,7 @@ class DTONormalizer implements NormalizerInterface
         }
 
         if ($type === IA\Type::STRINGS || $type === IA\Type::INTEGERS) {
-            $stringValues = array_map('strval', $value);
+            $stringValues = array_map(strval(...), $value);
             return array_values($stringValues);
         }
 

--- a/src/Normalizer/JsonApiDTONormalizer.php
+++ b/src/Normalizer/JsonApiDTONormalizer.php
@@ -70,7 +70,7 @@ class JsonApiDTONormalizer implements NormalizerInterface
 
         if ($type === IA\Type::STRINGS || $type === IA\Type::INTEGERS) {
             $values = $object->{$property->name};
-            $stringValues = array_map('strval', $values);
+            $stringValues = array_map(strval(...), $values);
 
             return array_values($stringValues);
         }

--- a/src/Repository/CourseRepository.php
+++ b/src/Repository/CourseRepository.php
@@ -64,7 +64,7 @@ class CourseRepository extends ServiceEntityRepository implements
         $qb->addSelect('x')->from(Course::class, 'x');
 
         $terms = explode(' ', $q);
-        $terms = array_filter($terms, 'strlen');
+        $terms = array_filter($terms, strlen(...));
         if (empty($terms)) {
             return [];
         }

--- a/src/Repository/LearningMaterialRepository.php
+++ b/src/Repository/LearningMaterialRepository.php
@@ -61,7 +61,7 @@ class LearningMaterialRepository extends ServiceEntityRepository implements DTOR
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('DISTINCT x')->from(LearningMaterial::class, 'x');
         $terms = explode(' ', $q);
-        $terms = array_filter($terms, 'strlen');
+        $terms = array_filter($terms, strlen(...));
         if (empty($terms)) {
             return [];
         }
@@ -333,7 +333,7 @@ class LearningMaterialRepository extends ServiceEntityRepository implements DTOR
         $dql = 'SELECT l.id FROM App\Entity\LearningMaterial l WHERE l.relativePath IS NOT NULL';
         $results = $this->getEntityManager()->createQuery($dql)->getScalarResult();
         $ids = array_column($results, 'id');
-        return array_map('intval', $ids);
+        return array_map(intval(...), $ids);
     }
 
     /**

--- a/src/Repository/MeshDescriptorRepository.php
+++ b/src/Repository/MeshDescriptorRepository.php
@@ -134,7 +134,7 @@ class MeshDescriptorRepository extends ServiceEntityRepository implements
     protected function getTermsFromQ(string $q): array
     {
         $terms = explode(' ', $q);
-        return array_filter($terms, 'strlen');
+        return array_filter($terms, strlen(...));
     }
     protected function getQueryForFindByQ(array $terms, ?array $orderBy, ?int $offset): Query
     {

--- a/src/Repository/SchoolRepository.php
+++ b/src/Repository/SchoolRepository.php
@@ -260,7 +260,7 @@ class SchoolRepository extends ServiceEntityRepository implements
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->addSelect('x.id')->from(School::class, 'x');
         $results = $qb->getQuery()->getScalarResult();
-        return array_map('intval', array_column($results, 'id'));
+        return array_map(intval(...), array_column($results, 'id'));
     }
 
     /**

--- a/src/Repository/SessionRepository.php
+++ b/src/Repository/SessionRepository.php
@@ -46,7 +46,7 @@ class SessionRepository extends ServiceEntityRepository implements
         $qb->leftJoin('x.course', 'course');
 
         $terms = explode(' ', $q);
-        $terms = array_filter($terms, 'strlen');
+        $terms = array_filter($terms, strlen(...));
         if (empty($terms)) {
             return [];
         }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -59,7 +59,7 @@ class UserRepository extends ServiceEntityRepository implements DTORepositoryInt
         $qb->leftJoin('x.authentication', 'auth');
 
         $terms = explode(' ', $q);
-        $terms = array_filter($terms, 'strlen');
+        $terms = array_filter($terms, strlen(...));
         if (empty($terms)) {
             return [];
         }

--- a/src/Service/ApiResponseBuilder.php
+++ b/src/Service/ApiResponseBuilder.php
@@ -153,7 +153,7 @@ class ApiResponseBuilder
         };
         return array_reduce(
             array_map($dotToTree, $fields),
-            'array_merge_recursive',
+            array_merge_recursive(...),
             []
         );
     }

--- a/src/Service/Index/Curriculum.php
+++ b/src/Service/Index/Curriculum.php
@@ -80,7 +80,7 @@ class Curriculum extends OpenSearchBase
         if (!$this->enabled) {
             throw new Exception("Search is not configured, isEnabled() should be called before calling this method");
         }
-        array_walk($courseIds, 'intval');
+        array_walk($courseIds, intval(...));
 
         $skipCourseIds = $this->findSkippableCourseIds($courseIds, $requestCreatedAt);
         $idsToIndex = array_filter(
@@ -138,7 +138,7 @@ class Curriculum extends OpenSearchBase
         ];
         $results = $this->doSearch($params);
         $courseIds =  array_column($results['aggregations']['courseId']['buckets'], 'key');
-        $coursesModifiedSinceStamp = array_map('intval', $courseIds);
+        $coursesModifiedSinceStamp = array_map(intval(...), $courseIds);
 
         return array_intersect($ids, $coursesModifiedSinceStamp);
     }
@@ -556,7 +556,7 @@ class Curriculum extends OpenSearchBase
         $results = $this->doSearch($params);
         $courseIds = array_column($results['aggregations']['courseId']['buckets'], 'key');
 
-        return array_map('intval', $courseIds);
+        return array_map(intval(...), $courseIds);
     }
 
     public function getAllSessionIds(): array

--- a/tests/Command/HealthCheckCommandTest.php
+++ b/tests/Command/HealthCheckCommandTest.php
@@ -158,7 +158,7 @@ final class HealthCheckCommandTest extends KernelTestCase
         $this->assertMatchesRegularExpression('/\sCheck\s|\sStatus\s\s/', $output, 'check table headers');
         $this->assertMatchesRegularExpression('/Summary Status: (OK|KO)/', $output, 'check summary status');
         foreach ($this->allChecks as $check) {
-            $this->assertStringContainsString(get_class($check), $output);
+            $this->assertStringContainsString($check::class, $output);
         }
     }
 
@@ -168,7 +168,7 @@ final class HealthCheckCommandTest extends KernelTestCase
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Health Checks (9)', $output);
         foreach ($this->minimalChecks as $check) {
-            $this->assertStringContainsString(get_class($check), $output);
+            $this->assertStringContainsString($check::class, $output);
         }
     }
 }

--- a/tests/DataLoader/AbstractDataLoader.php
+++ b/tests/DataLoader/AbstractDataLoader.php
@@ -90,7 +90,7 @@ abstract class AbstractDataLoader implements DataLoaderInterface
     public function createBulkJsonApi(array $arr): object
     {
         $class = $this->getDtoClass();
-        $builder = Closure::fromCallable([$this, 'buildJsonApiObject']);
+        $builder = $this->buildJsonApiObject(...);
         $data = array_map(fn(array $item) => $builder($item, $class), $arr);
 
         return json_decode(json_encode(['data' => $data]), false);

--- a/tests/Endpoints/CourseTest.php
+++ b/tests/Endpoints/CourseTest.php
@@ -304,8 +304,11 @@ final class CourseTest extends AbstractReadWriteEndpoint
         $offerings = self::getContainer()->get(OfferingData::class)->getAll();
         $lastOfferingId = array_pop($offerings)['id'];
 
-        $firstSessionOfferings = array_map('strval', [$lastOfferingId + 1, $lastOfferingId + 2]);
-        $secondSessionOfferings = array_map('strval', [$lastOfferingId + 3, $lastOfferingId + 4, $lastOfferingId + 5]);
+        $firstSessionOfferings = array_map(strval(...), [$lastOfferingId + 1, $lastOfferingId + 2]);
+        $secondSessionOfferings = array_map(
+            strval(...),
+            [$lastOfferingId + 3, $lastOfferingId + 4, $lastOfferingId + 5]
+        );
 
         $this->assertEquals($firstSessionOfferings, $newSessionsData[0]['offerings']);
         $this->assertEquals($secondSessionOfferings, $newSessionsData[1]['offerings']);

--- a/tests/Service/HealthCheckRunnerTest.php
+++ b/tests/Service/HealthCheckRunnerTest.php
@@ -48,23 +48,23 @@ final class HealthCheckRunnerTest extends TestCase
 
         $data = $this->runner->run([$mockCheck1]);
         $this->assertCount(1, $data['results']);
-        $this->assertEquals(get_class($mockCheck1), $data['results'][0]['check']);
+        $this->assertEquals($mockCheck1::class, $data['results'][0]['check']);
         $this->assertEquals('Success', $data['results'][0]['status']);
         $this->assertEquals('that went well.', $data['results'][0]['message']);
         $this->assertEquals(HealthCheckRunner::STATUS_OK, $data['summary_status']);
 
         $data = $this->runner->run([$mockCheck1, $mockCheck2, $mockCheck3, $mockCheck4]);
         $this->assertCount(4, $data['results']);
-        $this->assertEquals(get_class($mockCheck1), $data['results'][0]['check']);
+        $this->assertEquals($mockCheck1::class, $data['results'][0]['check']);
         $this->assertEquals('Success', $data['results'][0]['status']);
         $this->assertEquals('that went well.', $data['results'][0]['message']);
-        $this->assertEquals(get_class($mockCheck2), $data['results'][1]['check']);
+        $this->assertEquals($mockCheck2::class, $data['results'][1]['check']);
         $this->assertEquals('Failure', $data['results'][1]['status']);
         $this->assertEquals('that did not go well.', $data['results'][1]['message']);
-        $this->assertEquals(get_class($mockCheck2), $data['results'][2]['check']);
+        $this->assertEquals($mockCheck2::class, $data['results'][2]['check']);
         $this->assertEquals('Warning', $data['results'][2]['status']);
         $this->assertEquals('achtung!', $data['results'][2]['message']);
-        $this->assertEquals(get_class($mockCheck3), $data['results'][3]['check']);
+        $this->assertEquals($mockCheck3::class, $data['results'][3]['check']);
         $this->assertEquals('Skip', $data['results'][3]['status']);
         $this->assertEquals('not today.', $data['results'][3]['message']);
         $this->assertEquals(HealthCheckRunner::STATUS_NOT_OK, $data['summary_status']);

--- a/tests/Service/Index/CurriculumTest.php
+++ b/tests/Service/Index/CurriculumTest.php
@@ -554,7 +554,7 @@ final class CurriculumTest extends TestCase
         $this->assertEquals(['headers' => ['Content-Encoding' => 'gzip']], $data['options']);
         $body = gzdecode($data['body']);
         $arr = array_map(fn ($item) => json_decode($item, true), explode("\n", $body));
-        $filtered = array_filter($arr, 'is_array');
+        $filtered = array_filter($arr, is_array(...));
         $this->assertCount(count($expected), $filtered);
         $this->assertEquals($expected, $filtered);
     }

--- a/tests/Service/Index/LearningMaterialsTest.php
+++ b/tests/Service/Index/LearningMaterialsTest.php
@@ -409,7 +409,7 @@ final class LearningMaterialsTest extends TestCase
         $this->assertEquals(['headers' => ['Content-Encoding' => 'gzip']], $data['options']);
         $body = gzdecode($data['body']);
         $arr = array_map(fn ($item) => json_decode($item, true), explode("\n", $body));
-        $filtered = array_filter($arr, 'is_array');
+        $filtered = array_filter($arr, is_array(...));
         $this->assertCount(count($expected), $filtered);
         $this->assertEquals($expected, $filtered);
     }

--- a/tests/Service/Index/UsersTest.php
+++ b/tests/Service/Index/UsersTest.php
@@ -81,7 +81,7 @@ final class UsersTest extends TestCase
             $this->assertEquals(['headers' => ['Content-Encoding' => 'gzip']], $data['options']);
             $body = gzdecode($data['body']);
             $arr = array_map(fn ($item) => json_decode($item, true), explode("\n", $body));
-            $filtered = array_filter($arr, 'is_array');
+            $filtered = array_filter($arr, is_array(...));
             $this->assertCount(4, $filtered);
 
             $this->assertEquals($user1->id, $filtered[1]['id']);


### PR DESCRIPTION
Take advantage of this [PHP language feature](https://www.php.net/manual/en/functions.first_class_callable_syntax.php) to replace our old string based calls to built in functions. This ensures we're using exactly what we expect without typos or other hard to detect issues.

I couldn't find any way to enforce this, and it's probably not necessary that we do, but I think it's pretty and fun so I updated everywhere we have right now.