### PR TITLE
Replace LDAP Connect Call

### DIFF
--- a/src/Service/LdapAuthentication.php
+++ b/src/Service/LdapAuthentication.php
@@ -100,7 +100,7 @@ class LdapAuthentication implements AuthenticationInterface
      */
     public function checkLdapPassword(string $username, string $password): bool
     {
-        $ldapConn = @ldap_connect($this->ldapHost, $this->ldapPort);
+        $ldapConn = @ldap_connect("{$this->ldapHost}:{$this->ldapPort}");
         if ($ldapConn) {
             $ldapRdn = sprintf($this->ldapBindTemplate, $username);
             $ldapBind = @ldap_bind($ldapConn, $ldapRdn, $password);


### PR DESCRIPTION
The old form is [deprecated as of PHP 8.3](https://www.php.net/manual/en/function.ldap-connect.php), asks for a URI string now.