### PR TITLE
explicitly allow checking out pull request heads from forks.

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -33,6 +33,7 @@ jobs:
     - uses: actions/checkout@v7
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        allow-unsafe-pr-checkout: true
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v4
       with:


### PR DESCRIPTION
actions/checkout v7 demands this flag now,
please see https://github.com/actions/checkout#checkout-v7

follow-up to #7206 