### PR TITLE
Restrict Token Refresh

### DIFF
--- a/src/Service/JsonWebTokenManager.php
+++ b/src/Service/JsonWebTokenManager.php
@@ -26,7 +26,7 @@ class JsonWebTokenManager
     public const string USER_ID_KEY = 'user_id';
     public const string WRITEABLE_SCHOOLS_KEY = 'writeable_schools';
     public const int DEFAULT_REFRESH_LIMIT = 12;
-    public const string MAX_TIME_TO_LIVE = 'P364D';
+    public const string MAX_TIME_TO_LIVE = 'P90D';
 
     protected string $jwtKey;
 

--- a/src/Service/JsonWebTokenManager.php
+++ b/src/Service/JsonWebTokenManager.php
@@ -26,6 +26,7 @@ class JsonWebTokenManager
     public const string USER_ID_KEY = 'user_id';
     public const string WRITEABLE_SCHOOLS_KEY = 'writeable_schools';
     public const int DEFAULT_REFRESH_LIMIT = 10;
+    public const string MAX_TIME_TO_LIVE = 'P364D';
 
     protected string $jwtKey;
 
@@ -185,6 +186,13 @@ class JsonWebTokenManager
             throw new InvalidInputWithSafeUserMessageException("Refresh limit {$refreshLimit} exceeded");
         }
 
+        $issuedAt = $this->getIssuedAtFromToken($token);
+        $maximumInterval = new DateInterval(self::MAX_TIME_TO_LIVE);
+        $maximumAge = new DateTimeImmutable()->sub($maximumInterval);
+        if ($issuedAt <= $maximumAge) {
+            throw new InvalidInputWithSafeUserMessageException("Token is too old to refresh");
+        }
+
         $userId = $this->getUserIdFromToken($token);
         $sessionUser = $this->sessionUserProvider->createSessionUserFromUserId($userId);
         $arr = $this->getUserTokenDetails($sessionUser, $timeToLive, $token);
@@ -260,7 +268,7 @@ class JsonWebTokenManager
     protected function getTokenExpirationDate(DateTimeImmutable $now, string $timeToLive): DateTimeImmutable
     {
         $requestedInterval = new DateInterval($timeToLive);
-        $maximumInterval = new DateInterval('P364D');
+        $maximumInterval = new DateInterval(self::MAX_TIME_TO_LIVE);
 
         //DateIntervals are not comparable, so we have to create DateTimes first which are
         $requestedFromToday = $now->add($requestedInterval);

--- a/src/Service/JsonWebTokenManager.php
+++ b/src/Service/JsonWebTokenManager.php
@@ -25,7 +25,7 @@ class JsonWebTokenManager
     public const string TOKEN_ID_KEY = 'token_id';
     public const string USER_ID_KEY = 'user_id';
     public const string WRITEABLE_SCHOOLS_KEY = 'writeable_schools';
-    public const int DEFAULT_REFRESH_LIMIT = 10;
+    public const int DEFAULT_REFRESH_LIMIT = 12;
     public const string MAX_TIME_TO_LIVE = 'P364D';
 
     protected string $jwtKey;

--- a/src/Service/JsonWebTokenManager.php
+++ b/src/Service/JsonWebTokenManager.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Classes\ServiceTokenUserInterface;
 use App\Classes\SessionUserInterface;
+use App\Exception\InvalidInputWithSafeUserMessageException;
 use DateInterval;
 use DateTimeInterface;
 use Firebase\JWT\JWT;
@@ -25,6 +26,7 @@ class JsonWebTokenManager
     public const string TOKEN_ID_KEY = 'token_id';
     public const string USER_ID_KEY = 'user_id';
     public const string WRITEABLE_SCHOOLS_KEY = 'writeable_schools';
+    public const int DEFAULT_REFRESH_LIMIT = 10;
 
     protected string $jwtKey;
 
@@ -109,6 +111,12 @@ class JsonWebTokenManager
         return $arr['refreshCount'] ?? 0;
     }
 
+    public function getRefreshLimit(string $jwt): int
+    {
+        $arr = $this->decode($jwt);
+        return $arr['refreshLimit'] ?? self::DEFAULT_REFRESH_LIMIT;
+    }
+
     public function getPermissionsFromToken(string $jwt): string
     {
         $arr = $this->decode($jwt);
@@ -172,6 +180,12 @@ class JsonWebTokenManager
      */
     public function refreshToken(string $token, string $timeToLive = 'PT8H'): string
     {
+        $refreshCount = $this->getRefreshCount($token);
+        $refreshLimit = $this->getRefreshLimit($token);
+        if ($refreshCount >= $refreshLimit) {
+            throw new InvalidInputWithSafeUserMessageException("Refresh limit {$refreshLimit} exceeded");
+        }
+
         $userId = $this->getUserIdFromToken($token);
         $sessionUser = $this->sessionUserProvider->createSessionUserFromUserId($userId);
         $arr = $this->getUserTokenDetails($sessionUser, $timeToLive, $token);

--- a/src/Service/JsonWebTokenManager.php
+++ b/src/Service/JsonWebTokenManager.php
@@ -187,9 +187,10 @@ class JsonWebTokenManager
         }
 
         $issuedAt = $this->getIssuedAtFromToken($token);
+        $firstCreatedAt = $this->getFirstCreatedAt($token);
         $maximumInterval = new DateInterval(self::MAX_TIME_TO_LIVE);
         $maximumAge = new DateTimeImmutable()->sub($maximumInterval);
-        if ($issuedAt <= $maximumAge) {
+        if ($issuedAt <= $maximumAge || $firstCreatedAt <= $maximumAge) {
             throw new InvalidInputWithSafeUserMessageException("Token is too old to refresh");
         }
 

--- a/src/Service/JsonWebTokenManager.php
+++ b/src/Service/JsonWebTokenManager.php
@@ -8,10 +8,9 @@ use App\Classes\ServiceTokenUserInterface;
 use App\Classes\SessionUserInterface;
 use App\Exception\InvalidInputWithSafeUserMessageException;
 use DateInterval;
-use DateTimeInterface;
+use DateTimeImmutable;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
-use DateTime;
 use Firebase\JWT\SignatureInvalidException;
 
 use function array_key_exists;
@@ -64,16 +63,16 @@ class JsonWebTokenManager
         return array_key_exists(self::TOKEN_ID_KEY, $arr);
     }
 
-    public function getIssuedAtFromToken(string $jwt): DateTimeInterface
+    public function getIssuedAtFromToken(string $jwt): DateTimeImmutable
     {
         $arr = $this->decode($jwt);
-        return DateTime::createFromFormat('U', (string) $arr['iat']);
+        return DateTimeImmutable::createFromFormat('U', (string) $arr['iat']);
     }
 
-    public function getExpiresAtFromToken(string $jwt): DateTimeInterface
+    public function getExpiresAtFromToken(string $jwt): DateTimeImmutable
     {
         $arr = $this->decode($jwt);
-        return DateTime::createFromFormat('U', (string) $arr['exp']);
+        return DateTimeImmutable::createFromFormat('U', (string) $arr['exp']);
     }
 
     public function getIsRootFromToken(string $jwt): bool
@@ -94,13 +93,13 @@ class JsonWebTokenManager
         return $arr['can_create_or_update_user_in_any_school'];
     }
 
-    public function getFirstCreatedAt(string $jwt): DateTimeInterface
+    public function getFirstCreatedAt(string $jwt): DateTimeImmutable
     {
         $arr = $this->decode($jwt);
         if (array_key_exists('firstCreatedAt', $arr)) {
-            $rhett = DateTime::createFromFormat('U', (string) $arr['firstCreatedAt']);
+            $rhett = DateTimeImmutable::createFromFormat('U', (string) $arr['firstCreatedAt']);
         } else {
-            $rhett = new DateTime();
+            $rhett = new DateTimeImmutable();
         }
         return $rhett;
     }
@@ -213,7 +212,7 @@ class JsonWebTokenManager
         string $timeToLive,
         ?string $refreshToken
     ): array {
-        $now = new DateTime();
+        $now = new DateTimeImmutable();
         $expires = $this->getTokenExpirationDate($now, $timeToLive);
         $canCreateOrUpdateUserInAnySchool = $this->permissionChecker->canCreateOrUpdateUsersInAnySchool($sessionUser);
 
@@ -221,7 +220,7 @@ class JsonWebTokenManager
             $firstCreatedAt = $this->getFirstCreatedAt($refreshToken);
             $refreshCount = $this->getRefreshCount($refreshToken) + 1;
         } else {
-            $firstCreatedAt = clone $now;
+            $firstCreatedAt = $now;
             $refreshCount = 0;
         }
 
@@ -258,20 +257,17 @@ class JsonWebTokenManager
         return $rhett;
     }
 
-    protected function getTokenExpirationDate(DateTime $now, string $timeToLive): DateTime
+    protected function getTokenExpirationDate(DateTimeImmutable $now, string $timeToLive): DateTimeImmutable
     {
         $requestedInterval = new DateInterval($timeToLive);
         $maximumInterval = new DateInterval('P364D');
 
         //DateIntervals are not comparable, so we have to create DateTimes first which are
-        $requestedFromToday = clone $now;
-        $requestedFromToday->add($requestedInterval);
-        $maximumFromToday = clone $now;
-        $maximumFromToday->add($maximumInterval);
+        $requestedFromToday = $now->add($requestedInterval);
+        $maximumFromToday = $now->add($maximumInterval);
 
         $interval = $requestedFromToday > $maximumFromToday ? $maximumInterval : $requestedInterval;
-        $expires = clone $now;
-        $expires->add($interval);
-        return $expires;
+
+        return $now->add($interval);
     }
 }

--- a/src/Service/JsonWebTokenManager.php
+++ b/src/Service/JsonWebTokenManager.php
@@ -100,7 +100,7 @@ class JsonWebTokenManager
         if (array_key_exists('firstCreatedAt', $arr)) {
             $rhett = DateTimeImmutable::createFromFormat('U', (string) $arr['firstCreatedAt']);
         } else {
-            $rhett = new DateTimeImmutable();
+            $rhett = $this->getIssuedAtFromToken($jwt);
         }
         return $rhett;
     }
@@ -192,6 +192,15 @@ class JsonWebTokenManager
         $maximumAge = new DateTimeImmutable()->sub($maximumInterval);
         if ($issuedAt <= $maximumAge || $firstCreatedAt <= $maximumAge) {
             throw new InvalidInputWithSafeUserMessageException("Token is too old to refresh");
+        }
+
+        $proposedExpiration = new DateTimeImmutable()->add(new DateInterval($timeToLive));
+        $maximumExpiration = $firstCreatedAt->add(new DateInterval(self::MAX_TIME_TO_LIVE));
+
+        if ($maximumExpiration < $proposedExpiration) {
+            throw new InvalidInputWithSafeUserMessageException(
+                "Invalid TTL value, maximum expiration date is \n{$maximumExpiration->format('c')}"
+            );
         }
 
         $userId = $this->getUserIdFromToken($token);

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -212,19 +212,43 @@ final class JsonWebTokenManagerTest extends TestCase
 
     public function testRefreshTokenThatIsTooOld(): void
     {
-        $lastYear = new DateTime('-365 days');
-        $stamp = $lastYear->format('U');
+        $before = new DateTime('-90 days');
+        $stamp = $before->format('U');
         $token = $this->buildUserJwt(['iat' => $stamp]);
         $this->expectException(InvalidInputWithSafeUserMessageException::class);
         $this->obj->refreshToken($token);
     }
     public function testRefreshTokenThatOriginatedTooLongAgo(): void
     {
-        $lastYear = new DateTime('-365 days');
-        $stamp = $lastYear->format('U');
+        $before = new DateTime('-90 days');
+        $stamp = $before->format('U');
         $token = $this->buildUserJwt(['firstCreatedAt' => $stamp]);
         $this->expectException(InvalidInputWithSafeUserMessageException::class);
         $this->obj->refreshToken($token);
+    }
+    public function testRefreshTokenForTooLong(): void
+    {
+        $token = $this->buildUserJwt();
+        $this->expectException(InvalidInputWithSafeUserMessageException::class);
+        $this->obj->refreshToken($token, 'P92D');
+    }
+
+    public function testRefreshOldTokenForTooLong(): void
+    {
+        $before = new DateTime('-89 days');
+        $stamp = $before->format('U');
+        $token = $this->buildUserJwt(['iat' => $stamp]);
+        $this->expectException(InvalidInputWithSafeUserMessageException::class);
+        $this->obj->refreshToken($token, 'P3D');
+    }
+
+    public function testRefreshOriginalOldTokenForTooLong(): void
+    {
+        $before = new DateTime('-89 days');
+        $stamp = $before->format('U');
+        $token = $this->buildUserJwt(['firstCreatedAt' => $stamp]);
+        $this->expectException(InvalidInputWithSafeUserMessageException::class);
+        $this->obj->refreshToken($token, 'P2D');
     }
 
     public function testCreateJwtFromServiceTokenUser(): void

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Service;
 
+use App\Exception\InvalidInputWithSafeUserMessageException;
 use App\Service\SecretManager;
 use Firebase\JWT\ExpiredException;
 use Firebase\JWT\SignatureInvalidException;
@@ -101,6 +102,15 @@ final class JsonWebTokenManagerTest extends TestCase
         $this->assertSame(13, $this->obj->getRefreshCount($jwt));
     }
 
+    public function testGetRefreshLimitFromToken(): void
+    {
+        $jwt = $this->buildUserJwt();
+        $this->assertSame(JsonWebTokenManager::DEFAULT_REFRESH_LIMIT, $this->obj->getRefreshLimit($jwt));
+
+        $jwt = $this->buildUserJwt(['refreshLimit' => 13]);
+        $this->assertSame(13, $this->obj->getRefreshLimit($jwt));
+    }
+
     public function testUserTokensGetUserPermissions(): void
     {
         $jwt = $this->buildUserJwt();
@@ -179,6 +189,24 @@ final class JsonWebTokenManagerTest extends TestCase
         $stamp = $yesterday->format('U');
         $token = $this->buildUserJwt(['exp' => $stamp]);
         $this->expectException(ExpiredException::class);
+        $this->obj->refreshToken($token);
+    }
+
+    public function testRefreshTokenOverLimitFails(): void
+    {
+        $sessionUser = $this->getMockSessionUser(42, false, false, false);
+        $token = $this->obj->createJwtFromSessionUser($sessionUser);
+        $this->assertSame(0, $this->obj->getRefreshCount($token));
+        $this->assertSame(JsonWebTokenManager::DEFAULT_REFRESH_LIMIT, $this->obj->getRefreshLimit($token));
+
+        $this->sessionUserProvider->shouldReceive('createSessionUserFromUserId')
+            ->with(42)->andReturn($sessionUser);
+
+        for ($i = 0; $i < JsonWebTokenManager::DEFAULT_REFRESH_LIMIT; $i++) {
+            $token = $this->obj->refreshToken($token);
+            $this->assertSame($i + 1, $this->obj->getRefreshCount($token));
+        }
+        $this->expectException(InvalidInputWithSafeUserMessageException::class);
         $this->obj->refreshToken($token);
     }
 

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Service;
 
 use App\Service\SecretManager;
+use Firebase\JWT\ExpiredException;
 use Firebase\JWT\SignatureInvalidException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -91,6 +92,15 @@ final class JsonWebTokenManagerTest extends TestCase
         $this->assertSame($stamp, $this->obj->getExpiresAtFromToken($jwt)->format('U'));
     }
 
+    public function testGetRefreshCountFromToken(): void
+    {
+        $jwt = $this->buildUserJwt();
+        $this->assertSame(0, $this->obj->getRefreshCount($jwt));
+
+        $jwt = $this->buildUserJwt(['refreshCount' => 13]);
+        $this->assertSame(13, $this->obj->getRefreshCount($jwt));
+    }
+
     public function testUserTokensGetUserPermissions(): void
     {
         $jwt = $this->buildUserJwt();
@@ -99,14 +109,7 @@ final class JsonWebTokenManagerTest extends TestCase
 
     public function testCreateJwtFromSessionUser(): void
     {
-        $sessionUser = m::mock(SessionUserInterface::class);
-        $sessionUser->shouldReceive('getId')->andReturn(42);
-
-        $sessionUser->shouldReceive('isRoot')->once()->andReturn(true);
-        $sessionUser->shouldReceive('performsNonLearnerFunction')->once()->andReturn(true);
-        $this->permissionChecker->shouldReceive('canCreateOrUpdateUsersInAnySchool')
-            ->with($sessionUser)->once()->andReturn(true);
-
+        $sessionUser = $this->getMockSessionUser(42, true, true, true);
         $jwt = $this->obj->createJwtFromSessionUser($sessionUser);
 
         $this->assertSame(42, $this->obj->getUserIdFromToken($jwt));
@@ -117,13 +120,7 @@ final class JsonWebTokenManagerTest extends TestCase
 
     public function testCreateJwtFromSessionUserWhichExpiresNextWeek(): void
     {
-        $sessionUser = m::mock(SessionUserInterface::class);
-        $sessionUser->shouldReceive('getId')->andReturn(42);
-
-        $sessionUser->shouldReceive('isRoot')->once()->andReturn(true);
-        $sessionUser->shouldReceive('performsNonLearnerFunction')->once()->andReturn(true);
-        $this->permissionChecker->shouldReceive('canCreateOrUpdateUsersInAnySchool')
-            ->with($sessionUser)->once()->andReturn(true);
+        $sessionUser = $this->getMockSessionUser(42, true, true, true);
 
         $jwt = $this->obj->createJwtFromSessionUser($sessionUser, 'P1W');
         $now = new DateTime();
@@ -134,13 +131,7 @@ final class JsonWebTokenManagerTest extends TestCase
 
     public function testCreateJwtFromSessionUserWhichExpiresAfterMaximumTime(): void
     {
-        $sessionUser = m::mock(SessionUserInterface::class);
-        $sessionUser->shouldReceive('getId')->andReturn(42);
-
-        $sessionUser->shouldReceive('isRoot')->once()->andReturn(true);
-        $sessionUser->shouldReceive('performsNonLearnerFunction')->once()->andReturn(true);
-        $this->permissionChecker->shouldReceive('canCreateOrUpdateUsersInAnySchool')
-            ->with($sessionUser)->once()->andReturn(true);
+        $sessionUser = $this->getMockSessionUser(42, true, true, true);
 
         $jwt = $this->obj->createJwtFromSessionUser($sessionUser, 'P400D');
         $now = new DateTime();
@@ -151,13 +142,7 @@ final class JsonWebTokenManagerTest extends TestCase
 
     public function testCreateJwtFromSessionUserWithLessPrivileges(): void
     {
-        $sessionUser = m::mock(SessionUserInterface::class);
-        $sessionUser->shouldReceive('getId')->andReturn(42);
-
-        $sessionUser->shouldReceive('isRoot')->once()->andReturn(false);
-        $sessionUser->shouldReceive('performsNonLearnerFunction')->once()->andReturn(false);
-        $this->permissionChecker->shouldReceive('canCreateOrUpdateUsersInAnySchool')
-            ->with($sessionUser)->once()->andReturn(false);
+        $sessionUser = $this->getMockSessionUser(42, false, false, false);
 
         $jwt = $this->obj->createJwtFromSessionUser($sessionUser);
 
@@ -165,6 +150,36 @@ final class JsonWebTokenManagerTest extends TestCase
         $this->assertSame(false, $this->obj->getIsRootFromToken($jwt));
         $this->assertSame(false, $this->obj->getPerformsNonLearnerFunctionFromToken($jwt));
         $this->assertSame(false, $this->obj->getCanCreateOrUpdateUserInAnySchoolFromToken($jwt));
+    }
+
+    public function testRefreshSessionUserToken(): void
+    {
+        $sessionUser = $this->getMockSessionUser(42, true, true, true);
+        $token = $this->obj->createJwtFromSessionUser($sessionUser);
+        $this->assertSame(0, $this->obj->getRefreshCount($token));
+
+        $this->sessionUserProvider->shouldReceive('createSessionUserFromUserId')
+            ->with(42)->times(2)->andReturn($sessionUser);
+
+        $jwt = $this->obj->refreshToken($token);
+
+        $this->assertSame(42, $this->obj->getUserIdFromToken($jwt));
+        $this->assertSame(true, $this->obj->getPerformsNonLearnerFunctionFromToken($jwt));
+        $this->assertSame(true, $this->obj->getIsRootFromToken($jwt));
+        $this->assertSame(true, $this->obj->getCanCreateOrUpdateUserInAnySchoolFromToken($jwt));
+        $this->assertSame(1, $this->obj->getRefreshCount($jwt));
+
+        $jwt2 = $this->obj->refreshToken($jwt);
+        $this->assertSame(2, $this->obj->getRefreshCount($jwt2));
+    }
+
+    public function testRefreshExpiredTokenFails(): void
+    {
+        $yesterday = new DateTime('yesterday');
+        $stamp = $yesterday->format('U');
+        $token = $this->buildUserJwt(['exp' => $stamp]);
+        $this->expectException(ExpiredException::class);
+        $this->obj->refreshToken($token);
     }
 
     public function testCreateJwtFromServiceTokenUser(): void
@@ -285,5 +300,23 @@ final class JsonWebTokenManagerTest extends TestCase
         $merged = array_merge($default, $values);
 
         return JWT::encode($merged, $secretKey, JsonWebTokenManager::SIGNING_ALGORITHM);
+    }
+
+    protected function getMockSessionUser(
+        int $id,
+        bool $isRoot,
+        bool $performsNonLearnerFunction,
+        bool $canCreateOrUpdateUsersInAnySchool
+    ): SessionUserInterface {
+        $sessionUser = m::mock(SessionUserInterface::class);
+        $sessionUser->shouldReceive('getId')->andReturn($id);
+
+        $sessionUser->shouldReceive('isRoot')->atLeast()->once()->andReturn($isRoot);
+        $sessionUser->shouldReceive('performsNonLearnerFunction')->atLeast()->once()
+            ->andReturn($performsNonLearnerFunction);
+        $this->permissionChecker->shouldReceive('canCreateOrUpdateUsersInAnySchool')
+            ->with($sessionUser)->atLeast()->once()->andReturn($canCreateOrUpdateUsersInAnySchool);
+
+        return $sessionUser;
     }
 }

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -210,6 +210,15 @@ final class JsonWebTokenManagerTest extends TestCase
         $this->obj->refreshToken($token);
     }
 
+    public function testRefreshTokenThatIsTooOld(): void
+    {
+        $lastYear = new DateTime('-365 days');
+        $stamp = $lastYear->format('U');
+        $token = $this->buildUserJwt(['iat' => $stamp]);
+        $this->expectException(InvalidInputWithSafeUserMessageException::class);
+        $this->obj->refreshToken($token);
+    }
+
     public function testCreateJwtFromServiceTokenUser(): void
     {
         $schoolIds = [1, 3];

--- a/tests/Service/JsonWebTokenManagerTest.php
+++ b/tests/Service/JsonWebTokenManagerTest.php
@@ -218,6 +218,14 @@ final class JsonWebTokenManagerTest extends TestCase
         $this->expectException(InvalidInputWithSafeUserMessageException::class);
         $this->obj->refreshToken($token);
     }
+    public function testRefreshTokenThatOriginatedTooLongAgo(): void
+    {
+        $lastYear = new DateTime('-365 days');
+        $stamp = $lastYear->format('U');
+        $token = $this->buildUserJwt(['firstCreatedAt' => $stamp]);
+        $this->expectException(InvalidInputWithSafeUserMessageException::class);
+        $this->obj->refreshToken($token);
+    }
 
     public function testCreateJwtFromServiceTokenUser(): void
     {


### PR DESCRIPTION
Finished the work started in #4023 to limit when and how many times a token can be refreshed. Fixes #7229 

Team Discussion:
- [x] Default Token refresh count, up this to 12 refreshes.
- [x] Put a 90 day maximum on TTL
- [x] Don't allow a token to be refreshed at 89 days for more than one day