### PR TITLE
Remove Broken Permission

### DIFF
--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   prevent-donotmerge-label:
     runs-on: ubuntu-latest
-    permissions:
-        pull-reqests: read
     steps:
     - uses: mheap/github-action-required-labels@v5
       with:


### PR DESCRIPTION
The [documentation says](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) this is allowed, but the runner fails with an error.