### PR TITLE
Auto Install Pre Commit Hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -147,7 +147,8 @@
     ],
     "post-install-cmd": [
       "@auto-scripts",
-      "@ilios-scripts"
+      "@ilios-scripts",
+      "App\\Composer\\InstallPreCommitHook::install"
     ],
     "post-update-cmd": [
       "@auto-scripts",

--- a/src/Composer/InstallPreCommitHook.php
+++ b/src/Composer/InstallPreCommitHook.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Composer;
+
+use Composer\IO\IOInterface;
+use Composer\Script\Event;
+use DateTime;
+
+final class InstallPreCommitHook
+{
+    public static function install(Event $event): void
+    {
+        $io = $event->getIO();
+        $vendorDir = $event->getComposer()->getConfig()->get('vendor-dir');
+        $projectRoot = dirname($vendorDir);
+        $hooks = [
+            "{$vendorDir}/bin/phpcs -q",
+            "{$projectRoot}/bin/console lint:twig -q templates custom",
+            "{$vendorDir}/bin/yaml-lint -q .gitpod.yml",
+            "{$vendorDir}/bin/yaml-lint -q .github",
+            "{$vendorDir}/bin/yaml-lint -q config",
+            "{$vendorDir}/bin/yaml-lint -q docker",
+            "{$vendorDir}/bin/yaml-lint -q docs",
+            "{$vendorDir}/bin/yaml-lint -q compose.yaml",
+            "{$vendorDir}/bin/phpstan -q --no-progress",
+        ];
+        $gitPath = $projectRoot . '/.git';
+        if (is_dir($gitPath)) {
+            $preCommitHookPath = "{$gitPath}/hooks/pre-commit";
+            $hook = self::hookContents($hooks);
+            self::backupExistingHook($preCommitHookPath, $hook, $io);
+            file_put_contents($preCommitHookPath, $hook);
+            chmod($preCommitHookPath, 0755);
+        }
+    }
+    protected static function hookContents(array $hooks): string
+    {
+        $lines = [
+            '#!/bin/sh',
+            'set -e',
+            ...$hooks,
+        ];
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    protected static function backupExistingHook(
+        string $preCommitHookPath,
+        string $hook,
+        IOInterface $io,
+    ): void {
+        if (file_exists($preCommitHookPath)) {
+            $contents = file_get_contents($preCommitHookPath);
+            if ($contents !== $hook) {
+                $date = new DateTime()->format('Y-m-d_His');
+                $backupLocation = "{$preCommitHookPath}.backup.{$date}";
+                file_put_contents($backupLocation, $contents);
+                $io->write("Replacing Pre-Commit Hook");
+                $io->write("Existing Pre-Commit Hook saved to {$backupLocation}");
+            }
+        } else {
+            $io->write("Creating Pre-Commit Hook");
+        }
+    }
+}

--- a/src/Composer/InstallPreCommitHook.php
+++ b/src/Composer/InstallPreCommitHook.php
@@ -17,13 +17,6 @@ final class InstallPreCommitHook
         $projectRoot = dirname($vendorDir);
         $hooks = [
             "{$vendorDir}/bin/phpcs -q",
-            "{$projectRoot}/bin/console lint:twig -q templates custom",
-            "{$vendorDir}/bin/yaml-lint -q .gitpod.yml",
-            "{$vendorDir}/bin/yaml-lint -q .github",
-            "{$vendorDir}/bin/yaml-lint -q config",
-            "{$vendorDir}/bin/yaml-lint -q docker",
-            "{$vendorDir}/bin/yaml-lint -q docs",
-            "{$vendorDir}/bin/yaml-lint -q compose.yaml",
             "{$vendorDir}/bin/phpstan -q --no-progress",
         ];
         $gitPath = $projectRoot . '/.git';


### PR DESCRIPTION
With every composer install we execute this new method to install a pre-commit git hook with our basic linting so help prevent committing code that doesn't meet our requirements and required cleanup after CI.