### PR TITLE
Remove Security on Docs and Config

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -14,6 +14,12 @@ security:
     dev:
       pattern: ^/(_(profiler|wdt)|css|images|js)/
       security: false
+    public:
+      pattern:
+        - ^/application/config$
+        - ^/api/doc$
+        - ^/api$
+      security: false
     main:
       stateless: true
       custom_authenticators:
@@ -22,9 +28,6 @@ security:
 
   # Note: Only the *first* matching rule is applied
   access_control:
-    - { path: '^/api/doc', roles: PUBLIC_ACCESS }
-    - { path: '^/api$', roles: PUBLIC_ACCESS }
-    - { path: '^/application/config', roles: PUBLIC_ACCESS }
     - { path: '^/auth/(login|logout)', roles: PUBLIC_ACCESS }
     - { path: '^/auth', roles: IS_AUTHENTICATED_FULLY }
     - { path: '^/api', roles: IS_AUTHENTICATED_FULLY }

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -109,4 +109,14 @@ final class ConfigControllerTest extends WebTestCase
         unset($_SERVER['ILIOS_MATERIAL_STATUS_ENABLED']);
         unset($_SERVER['ILIOS_SHOW_CAMPUS_NAME_OF_RECORD']);
     }
+
+    public function testGetConfigLoadsWithBadCredentials(): void
+    {
+        $this->makeJsonRequest($this->kernelBrowser, 'GET', '/application/config', null, 'empty');
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+        $content = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('config', $content);
+    }
 }

--- a/tests/Routing/SwaggerRouteTest.php
+++ b/tests/Routing/SwaggerRouteTest.php
@@ -8,11 +8,21 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class SwaggerRouteTest extends WebTestCase
 {
-    public function testSomething(): void
+    public function testRouteWorksWithoutAuthentication(): void
     {
         $client = static::createClient();
 
         $client->request('GET', '/api/doc');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertRouteSame('app.swagger_ui');
+    }
+
+    public function testRouteWorksWithBadCredentials(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/api/doc', [], [], ['HTTP_X-JWT-Authorization' => 'Token empty']);
 
         $this->assertResponseIsSuccessful();
         $this->assertRouteSame('app.swagger_ui');


### PR DESCRIPTION
These routes are supposed to be public. While we allow public access the firewall still checks with the Token Authenticator. This check can fail if the token is present, but invalid for some reason. Instead I've moved these specific URLs into their own firewall entry, which has no security applied.

Refs #7113 