### PR TITLE
Add Official Email to LDAP

### DIFF
--- a/src/Service/Directory.php
+++ b/src/Service/Directory.php
@@ -62,7 +62,7 @@ class Directory
     {
         $format = $this->getLdapFilterFormat();
         $filterTerms = array_map(
-            fn ($term) => sprintf($format, ldap_escape($term, "", LDAP_ESCAPE_FILTER)),
+            fn($term) => sprintf($format, ldap_escape($term, "", LDAP_ESCAPE_FILTER)),
             $searchTerms
         );
         $filterTermsString = implode('', $filterTerms);
@@ -99,6 +99,7 @@ class Directory
         $ldapMiddleNameProperty = $this->config->get('ldap_directory_middle_name_property');
         $ldapPreferredMiddleNameProperty = $this->config->get('ldap_directory_preferred_middle_name_property');
         $ldapPreferredLastNameProperty = $this->config->get('ldap_directory_preferred_last_name_property');
+        $ldapOfficialEmailProperty = $this->config->get('ldap_directory_official_email_property');
         $attributes = [
             'mail',
             $this->config->get('ldap_directory_campus_id_property'),
@@ -117,6 +118,9 @@ class Directory
         }
         if ($ldapPreferredLastNameProperty) {
             $attributes[] = $ldapPreferredLastNameProperty;
+        }
+        if ($ldapOfficialEmailProperty) {
+            $attributes[] = $ldapOfficialEmailProperty;
         }
         $filters = array_map(fn($term) => '(' . $term . '=%1$s*)', $attributes);
         return '(|' . implode('', $filters) . ')';

--- a/src/Service/LdapManager.php
+++ b/src/Service/LdapManager.php
@@ -41,6 +41,7 @@ class LdapManager
         $ldapPreferredFirstNameProperty = $this->config->get('ldap_directory_preferred_first_name_property');
         $ldapPreferredMiddleNameProperty = $this->config->get('ldap_directory_preferred_middle_name_property');
         $ldapPreferredLastNameProperty = $this->config->get('ldap_directory_preferred_last_name_property');
+        $ldapOfficialEmailProperty = $this->config->get('ldap_directory_official_email_property');
 
         $rhett = [];
         try {
@@ -68,6 +69,9 @@ class LdapManager
             }
             if ($ldapPreferredLastNameProperty) {
                 $attributes[$ldapPreferredLastNameProperty] = 'preferredLastName';
+            }
+            if ($ldapOfficialEmailProperty) {
+                $attributes[$ldapOfficialEmailProperty] = 'officialEmail';
             }
 
             foreach ($results as $userData) {

--- a/tests/Service/DirectoryTest.php
+++ b/tests/Service/DirectoryTest.php
@@ -97,23 +97,26 @@ final class DirectoryTest extends TestCase
     {
         $this->setupConfigForSearch();
         $filter = '(&' .
-            '(|(mail=a*)(cid=a*)(dn=a*)(f=a*)(l=a*)(m=a*)(pfn=a*)(pmn=a*)(pln=a*))' .
-            '(|(mail=b*)(cid=b*)(dn=b*)(f=b*)(l=b*)(m=b*)(pfn=b*)(pmn=b*)(pln=b*))' .
-        ')';
-        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1,2]);
+            '(|(mail=a*)(cid=a*)(dn=a*)(f=a*)(l=a*)(m=a*)(pfn=a*)(pmn=a*)(pln=a*)(ofm=a*))' .
+            '(|(mail=b*)(cid=b*)(dn=b*)(f=b*)(l=b*)(m=b*)(pfn=b*)(pmn=b*)(pln=b*)(ofm=b*))' .
+            ')';
+        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1, 2]);
 
         $result = $this->obj->find(['a', 'b']);
-        $this->assertSame($result, [1,2]);
+        $this->assertSame($result, [1, 2]);
     }
 
     public function testFindOutputEscaping(): void
     {
         $this->setupConfigForSearch();
-        $filter = '(&(|(mail=a\2a*)(cid=a\2a*)(dn=a\2a*)(f=a\2a*)(l=a\2a*)(m=a\2a*)(pfn=a\2a*)(pmn=a\2a*)(pln=a\2a*)))';
-        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1,2]);
+        $filter = '(&' .
+            '(|(mail=a\2a*)(cid=a\2a*)(dn=a\2a*)(f=a\2a*)(l=a\2a*)' .
+            '(m=a\2a*)(pfn=a\2a*)(pmn=a\2a*)(pln=a\2a*)(ofm=a\2a*))' .
+            ')';
+        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1, 2]);
 
         $result = $this->obj->find(['a*']);
-        $this->assertSame($result, [1,2]);
+        $this->assertSame($result, [1, 2]);
     }
 
     public function testFindWithDefaultNameFields(): void
@@ -123,11 +126,11 @@ final class DirectoryTest extends TestCase
             'ldap_directory_middle_name_property' => null,
             'ldap_directory_last_name_property' => null,
         ]);
-        $filter = '(&(|(mail=jj*)(cid=jj*)(dn=jj*)(givenName=jj*)(sn=jj*)(pfn=jj*)(pmn=jj*)(pln=jj*)))';
-        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1,2]);
+        $filter = '(&(|(mail=jj*)(cid=jj*)(dn=jj*)(givenName=jj*)(sn=jj*)(pfn=jj*)(pmn=jj*)(pln=jj*)(ofm=jj*)))';
+        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1, 2]);
 
         $result = $this->obj->find(['jj']);
-        $this->assertSame($result, [1,2]);
+        $this->assertSame($result, [1, 2]);
     }
 
     public function testFindWithoutPreferredNameFields(): void
@@ -136,21 +139,22 @@ final class DirectoryTest extends TestCase
             'ldap_directory_preferred_first_name_property' => null,
             'ldap_directory_preferred_middle_name_property' => null,
             'ldap_directory_preferred_last_name_property' => null,
+            'ldap_directory_official_email_property' => null,
         ]);
         $filter = '(&(|(mail=jj*)(cid=jj*)(dn=jj*)(f=jj*)(l=jj*)(m=jj*)))';
-        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1,2]);
+        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1, 2]);
 
         $result = $this->obj->find(['jj']);
-        $this->assertSame($result, [1,2]);
+        $this->assertSame($result, [1, 2]);
     }
 
     public function testFindByLdapFilter(): void
     {
         $filter = '(one)(two)';
-        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1,2]);
+        $this->ldapManager->shouldReceive('search')->with($filter)->andReturn([1, 2]);
 
         $result = $this->obj->findByLdapFilter($filter);
-        $this->assertSame($result, [1,2]);
+        $this->assertSame($result, [1, 2]);
     }
 
     protected function setupConfigForSearch(array $overrides = []): void
@@ -164,6 +168,7 @@ final class DirectoryTest extends TestCase
             'ldap_directory_first_name_property' => 'f',
             'ldap_directory_middle_name_property' => 'm',
             'ldap_directory_last_name_property' => 'l',
+            'ldap_directory_official_email_property' => 'ofm',
         ];
         foreach (array_merge($defaults, $overrides) as $key => $value) {
             $this->config->shouldReceive('get')->once()


### PR DESCRIPTION
Allows for a secondary email in our LDAP filters other than the one in the default mail field. This can be used by campuses when users specify a non campus email as preferred, but the campus still searches by and uses an official email value.