### PR TITLE
Updated deprecated composer config.audit key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,9 +88,11 @@
     "symfony/web-profiler-bundle": "@stable"
   },
   "config": {
-    "audit": {
-      "ignore":  {
-        "PKSA-y2cr-5h3j-g3ys": "Mitigated."
+    "policy": {
+      "advisories": {
+        "ignore-id": {
+          "PKSA-y2cr-5h3j-g3ys": "Mitigated."
+        }
       }
     },
     "platform": {


### PR DESCRIPTION
Composer's `config.audit` key is deprecated: https://getcomposer.org/doc/06-config.md#audit-3

Apparently, `config.policy` is the new hotness: https://getcomposer.org/doc/06-config.md#policy

This change updates it: https://getcomposer.org/doc/06-config.md#how-config-audit-interacts-with-config-policy