### PR TITLE
Check and Fix Learner Group Association Issues

### DIFF
--- a/src/Command/CheckGroupSets.php
+++ b/src/Command/CheckGroupSets.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Repository\LearnerGroupRepository;
+use App\Repository\UserRepository;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,16 +26,22 @@ class CheckGroupSets extends Command
 {
     public function __construct(
         protected LearnerGroupRepository $learnerGroupRepository,
+        protected UserRepository $userRepository,
     ) {
         parent::__construct();
     }
 
-    public function __invoke(InputInterface $input, OutputInterface $output): int
-    {
+    public function __invoke(
+        InputInterface $input,
+        OutputInterface $output,
+        #[Option(
+            description: 'Automatically fix errors by adding missing users to parent groups.',
+            name: 'fix'
+        )] bool $fix = false,
+    ): int {
         $io = new SymfonyStyle($input, $output);
         $io->info('Searching groups and trees, this can take a while...');
         $errors = $this->learnerGroupRepository->findErrorsInGroupTrees();
-
 
         if (!count($errors)) {
             $io->success('All groups have been correctly provisioned.');
@@ -51,7 +60,71 @@ class CheckGroupSets extends Command
             ->setRows($errorMessages);
         $table->render();
 
+        if (!$fix) {
+            $errorCount = count($errors);
+            $fix = $io->confirm(
+                "Found {$errorCount} error(s). Auto-fix by adding missing users to parent groups?",
+                false
+            );
+        }
 
-        return Command::FAILURE;
+        if (!$fix) {
+            return Command::FAILURE;
+        }
+
+        $this->fixErrors($io, $errors);
+
+        return Command::SUCCESS;
+    }
+
+    protected function fixErrors(SymfonyStyle $io, array $errors): void
+    {
+        $io->newLine();
+        $io->text('Fixing group errors...');
+        $io->progressStart(count($errors));
+
+        $fixedUsers = 0;
+        $fixedGroups = 0;
+
+        foreach (array_chunk($errors, 25) as $chunk) {
+            foreach ($chunk as $error) {
+                $fixedUsers += $this->addMissingUsersToGroup(
+                    $error['parentId'],
+                    $error['missingFromParent']
+                );
+                $fixedGroups++;
+                $io->progressAdvance();
+            }
+
+            $this->learnerGroupRepository->flushAndClear();
+        }
+
+        $io->progressFinish();
+        $io->success(
+            "Added {$fixedUsers} missing user(s) across {$fixedGroups} parent group(s)."
+        );
+    }
+
+    protected function addMissingUsersToGroup(int $groupId, array $missingUsers): int
+    {
+        $group = $this->learnerGroupRepository->find($groupId);
+        if (!$group) {
+            throw new RuntimeException(
+                "Unable to find parent learner group #{$groupId}."
+            );
+        }
+
+        $added = 0;
+        foreach ($missingUsers as $userId) {
+            $user = $this->userRepository->find($userId);
+            if ($user) {
+                $group->addUser($user);
+                $added++;
+            }
+        }
+
+        $this->learnerGroupRepository->update($group, false);
+
+        return $added;
     }
 }

--- a/src/Command/CheckGroupSets.php
+++ b/src/Command/CheckGroupSets.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\LearnerGroupRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Checks groups to ensure members are correctly provisioned at every level
+ */
+#[AsCommand(
+    name: 'ilios:check-group-sets',
+    description: 'Checks groups to ensure members are correctly provisioned at every level.'
+)]
+class CheckGroupSets extends Command
+{
+    public function __construct(
+        protected LearnerGroupRepository $learnerGroupRepository,
+    ) {
+        parent::__construct();
+    }
+
+    public function __invoke(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->info('Searching groups and trees, this can take a while...');
+        $errors = $this->learnerGroupRepository->findErrorsInGroupTrees();
+
+
+        if (!count($errors)) {
+            $io->success('All groups have been correctly provisioned.');
+            return Command::SUCCESS;
+        }
+
+        $io->error('Errors found: ' . count($errors));
+
+        $errorMessages = array_map(fn($error) => [
+            $error['id'], $error['parentId'], count($error['missingFromParent']),
+        ], $errors);
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Group', 'Parent Group', 'Missing Users'])
+            ->setRows($errorMessages);
+        $table->render();
+
+
+        return Command::FAILURE;
+    }
+}

--- a/src/Repository/LearnerGroupRepository.php
+++ b/src/Repository/LearnerGroupRepository.php
@@ -54,8 +54,8 @@ class LearnerGroupRepository extends ServiceEntityRepository implements DTORepos
 
         foreach ($qb->getQuery()->getResult() as $arr) {
             $dtos[$arr['learnerGroupId']]->cohort = (int) $arr['cohortId'];
-            $dtos[$arr['learnerGroupId']]->parent = $arr['parentId'] ? (int)$arr['parentId'] : null;
-            $dtos[$arr['learnerGroupId']]->ancestor = $arr['ancestorId'] ? (int)$arr['ancestorId'] : null;
+            $dtos[$arr['learnerGroupId']]->parent = $arr['parentId'] ? (int) $arr['parentId'] : null;
+            $dtos[$arr['learnerGroupId']]->ancestor = $arr['ancestorId'] ? (int) $arr['ancestorId'] : null;
         }
 
         $dtos = $this->attachRelatedToDtos(
@@ -139,5 +139,40 @@ class LearnerGroupRepository extends ServiceEntityRepository implements DTORepos
         unset($criteria['terms']);
 
         $this->attachClosingCriteriaToQueryBuilder($qb, $criteria, $orderBy, $limit, $offset);
+    }
+
+    public function findErrorsInGroupTrees(): array
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->select('x.id')
+            ->addSelect('IDENTITY(x.parent) AS parentId')
+            ->where($qb->expr()->isNotNull('x.parent'))
+            ->from(LearnerGroup::class, 'x');
+
+        $groups = $qb->getQuery()->getArrayResult();
+
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->select('x.id AS id, u.id AS userId')
+            ->from(LearnerGroup::class, 'x')
+            ->join('x.users', 'u');
+
+        $groupMembership = [];
+        foreach ($qb->getQuery()->getArrayResult() as ['id' => $id, 'userId' => $userId]) {
+            $groupMembership[$id][] = $userId;
+        }
+
+        $errors = [];
+        foreach ($groups as ['id' => $id, 'parentId' => $parentId]) {
+            $diff = array_diff($groupMembership[$id] ?? [], $groupMembership[$parentId] ?? []);
+            if ($diff !== []) {
+                $errors[] = [
+                    'id' => $id,
+                    'parentId' => $parentId,
+                    'missingFromParent' => $diff,
+                ];
+            }
+        }
+
+        return $errors;
     }
 }

--- a/tests/Command/CheckGroupSetsTest.php
+++ b/tests/Command/CheckGroupSetsTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace App\Tests\Command;
 
 use App\Command\CheckGroupSets;
+use App\Entity\LearnerGroupInterface;
+use App\Entity\UserInterface;
 use App\Repository\LearnerGroupRepository;
+use App\Repository\UserRepository;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Command\Command;
@@ -26,12 +30,14 @@ final class CheckGroupSetsTest extends KernelTestCase
 
     protected CommandTester $commandTester;
     protected m\MockInterface $learnerGroupRepository;
+    protected m\MockInterface $userRepository;
 
     public function setUp(): void
     {
         parent::setUp();
         $this->learnerGroupRepository = m::mock(LearnerGroupRepository::class);
-        $command = new CheckGroupSets($this->learnerGroupRepository);
+        $this->userRepository = m::mock(UserRepository::class);
+        $command = new CheckGroupSets($this->learnerGroupRepository, $this->userRepository);
         $kernel = self::bootKernel();
         $application = new Application($kernel);
         $application->addCommands([$command]);
@@ -47,6 +53,7 @@ final class CheckGroupSetsTest extends KernelTestCase
         parent::tearDown();
         unset($this->commandTester);
         unset($this->learnerGroupRepository);
+        unset($this->userRepository);
     }
 
     public function testNoErrors(): void
@@ -73,6 +80,7 @@ final class CheckGroupSetsTest extends KernelTestCase
                 ['id' => 4, 'parentId' => 2, 'missingFromParent' => [13]],
             ]);
 
+        $this->commandTester->setInputs(['no']);
         $this->commandTester->execute([]);
 
         $this->assertEquals(Command::FAILURE, $this->commandTester->getStatusCode());
@@ -82,5 +90,103 @@ final class CheckGroupSetsTest extends KernelTestCase
         $this->assertStringContainsString('Group', $output);
         $this->assertStringContainsString('Parent Group', $output);
         $this->assertStringContainsString('Missing Users', $output);
+    }
+
+    public function testFixWithOption(): void
+    {
+        $errors = $this->setupFixExpectations(2);
+        $this->learnerGroupRepository->shouldReceive('findErrorsInGroupTrees')
+            ->once()
+            ->andReturn($errors);
+        $this->learnerGroupRepository->shouldReceive('flushAndClear')->once();
+
+        $this->commandTester->execute(['--fix' => true]);
+
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString(
+            'Added 2 missing user(s) across 2 parent group(s).',
+            $output
+        );
+    }
+
+    public function testFixOnConfirm(): void
+    {
+        $errors = $this->setupFixExpectations(2);
+        $this->learnerGroupRepository->shouldReceive('findErrorsInGroupTrees')
+            ->once()
+            ->andReturn($errors);
+        $this->learnerGroupRepository->shouldReceive('flushAndClear')->once();
+
+        $this->commandTester->setInputs(['yes']);
+        $this->commandTester->execute([]);
+
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString(
+            'Added 2 missing user(s) across 2 parent group(s).',
+            $output
+        );
+    }
+
+    public function testFixFlushesPerChunk(): void
+    {
+        $errors = $this->setupFixExpectations(26);
+        $this->learnerGroupRepository->shouldReceive('findErrorsInGroupTrees')
+            ->once()
+            ->andReturn($errors);
+        $this->learnerGroupRepository->shouldReceive('flushAndClear')->twice();
+
+        $this->commandTester->execute(['--fix' => true]);
+
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString(
+            'Added 26 missing user(s) across 26 parent group(s).',
+            $output
+        );
+    }
+
+    public function testFixThrowsWhenGroupNotFound(): void
+    {
+        $this->learnerGroupRepository->shouldReceive('findErrorsInGroupTrees')
+            ->once()
+            ->andReturn([
+                ['id' => 3, 'parentId' => 1, 'missingFromParent' => [11]],
+            ]);
+        $this->learnerGroupRepository->shouldReceive('find')
+            ->with(1)
+            ->andReturn(null);
+
+        $this->expectException(RuntimeException::class);
+        $this->commandTester->execute(['--fix' => true]);
+    }
+
+    protected function setupFixExpectations(int $count): array
+    {
+        $errors = [];
+        for ($i = 0; $i < $count; $i++) {
+            $parentId = 100 + $i;
+            $userId = 200 + $i;
+            $group = m::mock(LearnerGroupInterface::class);
+            $group->shouldReceive('addUser')->once();
+            $this->learnerGroupRepository->shouldReceive('find')
+                ->with($parentId)
+                ->andReturn($group);
+            $user = m::mock(UserInterface::class);
+            $this->userRepository->shouldReceive('find')
+                ->with($userId)
+                ->andReturn($user);
+            $this->learnerGroupRepository->shouldReceive('update')
+                ->with($group, false)
+                ->once();
+            $errors[] = [
+                'id' => 300 + $i,
+                'parentId' => $parentId,
+                'missingFromParent' => [$userId],
+            ];
+        }
+
+        return $errors;
     }
 }

--- a/tests/Command/CheckGroupSetsTest.php
+++ b/tests/Command/CheckGroupSetsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\CheckGroupSets;
+use App\Repository\LearnerGroupRepository;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+/**
+ * @package App\Tests\Command
+ */
+#[Group('cli')]
+#[CoversClass(CheckGroupSets::class)]
+final class CheckGroupSetsTest extends KernelTestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected CommandTester $commandTester;
+    protected m\MockInterface $learnerGroupRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->learnerGroupRepository = m::mock(LearnerGroupRepository::class);
+        $command = new CheckGroupSets($this->learnerGroupRepository);
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $application->addCommands([$command]);
+        $commandInApp = $application->find('ilios:check-group-sets');
+        $this->commandTester = new CommandTester($commandInApp);
+    }
+
+    /**
+     * Remove all mock objects
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->commandTester);
+        unset($this->learnerGroupRepository);
+    }
+
+    public function testNoErrors(): void
+    {
+        $this->learnerGroupRepository->shouldReceive('findErrorsInGroupTrees')
+            ->once()
+            ->andReturn([]);
+
+        $this->commandTester->execute([]);
+
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString(
+            'All groups have been correctly provisioned.',
+            $this->commandTester->getDisplay()
+        );
+    }
+
+    public function testErrorsFound(): void
+    {
+        $this->learnerGroupRepository->shouldReceive('findErrorsInGroupTrees')
+            ->once()
+            ->andReturn([
+                ['id' => 3, 'parentId' => 1, 'missingFromParent' => [11, 12]],
+                ['id' => 4, 'parentId' => 2, 'missingFromParent' => [13]],
+            ]);
+
+        $this->commandTester->execute([]);
+
+        $this->assertEquals(Command::FAILURE, $this->commandTester->getStatusCode());
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Errors found: 2', $output);
+        $this->assertStringContainsString('Group', $output);
+        $this->assertStringContainsString('Parent Group', $output);
+        $this->assertStringContainsString('Missing Users', $output);
+    }
+}

--- a/tests/Repository/LearnerGroupRepositoryTest.php
+++ b/tests/Repository/LearnerGroupRepositoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\LearnerGroup;
+use App\Entity\User;
+use App\Repository\LearnerGroupRepository;
+use App\Tests\Fixture\LoadLearnerGroupData;
+use Doctrine\Common\DataFixtures\ReferenceRepository;
+use Doctrine\Persistence\ObjectManager;
+use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class LearnerGroupRepositoryTest extends KernelTestCase
+{
+    protected ReferenceRepository $fixtures;
+    protected LearnerGroupRepository $repository;
+    protected ObjectManager $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $databaseTool = self::$kernel->getContainer()->get(DatabaseToolCollection::class)->get();
+        $executor = $databaseTool->loadFixtures([
+            LoadLearnerGroupData::class,
+        ]);
+        $this->fixtures = $executor->getReferenceRepository();
+
+        $this->entityManager = self::$kernel->getContainer()->get('doctrine')->getManager();
+
+        /** @var LearnerGroupRepository $repository */
+        $repository = $this->entityManager->getRepository(LearnerGroup::class);
+        $this->repository = $repository;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->fixtures);
+        unset($this->repository);
+        unset($this->entityManager);
+    }
+
+    public function testFindErrorsInGroupTreesReturnsEmptyWhenChildrenAreSubsetsOfParents(): void
+    {
+        // In the fixtures everything is working
+        $errors = $this->repository->findErrorsInGroupTrees();
+        $this->assertSame([], $errors);
+    }
+
+    public function testFindErrorsInGroupTreesReportsMembersMissingFromParent(): void
+    {
+        // Add some bad data
+        $childGroup = $this->repository->find(4);
+        $missingUser = $this->entityManager->getRepository(User::class)->find(3);
+        $childGroup->addUser($missingUser);
+        $this->entityManager->flush();
+
+        $errors = $this->repository->findErrorsInGroupTrees();
+
+        $this->assertCount(1, $errors);
+        $error = $errors[0];
+        $this->assertEquals(4, $error['id']);
+        $this->assertEquals(1, $error['parentId']);
+        $this->assertEquals([3], array_values($error['missingFromParent']));
+    }
+}


### PR DESCRIPTION
It is possible to create invalid group tress through the API where a user is only in a child or grandchild group and not in the other parents in the tree. This is contrary to our expectation that groups are sets where child groups may only contain a subset of a parent group membership.

This command will check to ensure valid group membership in the entire system and has the option to fix any problems it discovers.