### PR TITLE
Fix badPutTest to Fail as Expected

### DIFF
--- a/tests/Endpoints/AbstractEndpoint.php
+++ b/tests/Endpoints/AbstractEndpoint.php
@@ -210,7 +210,7 @@ abstract class AbstractEndpoint extends WebTestCase
             'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
         ];
 
-        if (! empty($jwt)) {
+        if (!empty($jwt)) {
             $headers['HTTP_X-JWT-Authorization'] = 'Token ' . $jwt;
         }
 
@@ -245,7 +245,7 @@ abstract class AbstractEndpoint extends WebTestCase
     ): void {
         $headers = [];
 
-        if (! empty($jwt)) {
+        if (!empty($jwt)) {
             $headers['HTTP_X-JWT-Authorization'] = 'Token ' . $jwt;
         }
 
@@ -981,7 +981,7 @@ abstract class AbstractEndpoint extends WebTestCase
     protected function badPutTest(array $data, mixed $id, string $jwt, int $code = Response::HTTP_BAD_REQUEST): void
     {
         $endpoint = $this->getPluralName();
-        $responseKey = $this->getCamelCasedPluralName();
+        $responseKey = $this->getCamelCasedSingularName();
         $this->createJsonRequest(
             'PUT',
             $this->getUrl(
@@ -989,7 +989,7 @@ abstract class AbstractEndpoint extends WebTestCase
                 "app_api_{$endpoint}_put",
                 ['version' => $this->apiVersion, 'id' => $id]
             ),
-            json_encode([$responseKey => [$data]]),
+            json_encode([$responseKey => $data]),
             $jwt
         );
 
@@ -1586,6 +1586,6 @@ abstract class AbstractEndpoint extends WebTestCase
 
     protected function pruneData(array $data): array
     {
-        return array_filter($data, fn($v) => ! is_null($v));
+        return array_filter($data, fn($v) => !is_null($v));
     }
 }

--- a/tests/Endpoints/TermTest.php
+++ b/tests/Endpoints/TermTest.php
@@ -28,7 +28,7 @@ use App\Tests\Fixture\LoadVocabularyData;
 #[Group('api_4')]
 final class TermTest extends AbstractReadWriteEndpoint
 {
-    protected string $testName =  'terms';
+    protected string $testName = 'terms';
 
     protected function getFixtures(): array
     {
@@ -159,15 +159,6 @@ final class TermTest extends AbstractReadWriteEndpoint
         $dataLoader = $this->getDataLoader();
         $data = $dataLoader->getOne();
         $data['title'] = '';
-        $this->badPutTest($data, $data['id'], $jwt);
-    }
-
-    public function testCannotSaveTermWithNoTitle(): void
-    {
-        $jwt = $this->createJwtForRootUser($this->kernelBrowser);
-        $dataLoader = $this->getDataLoader();
-        $data = $dataLoader->getOne();
-        unset($data['title']);
         $this->badPutTest($data, $data['id'], $jwt);
     }
 

--- a/tests/Endpoints/VocabularyTest.php
+++ b/tests/Endpoints/VocabularyTest.php
@@ -15,7 +15,7 @@ use App\Tests\Fixture\LoadVocabularyData;
 #[Group('api_2')]
 final class VocabularyTest extends AbstractReadWriteEndpoint
 {
-    protected string $testName =  'vocabularies';
+    protected string $testName = 'vocabularies';
 
     protected function getFixtures(): array
     {
@@ -90,15 +90,6 @@ final class VocabularyTest extends AbstractReadWriteEndpoint
         $dataLoader = $this->getDataLoader();
         $data = $dataLoader->getOne();
         $data['title'] = '';
-        $this->badPutTest($data, $data['id'], $jwt);
-    }
-
-    public function testCannotSaveWithoutTitle(): void
-    {
-        $jwt = $this->createJwtForRootUser($this->kernelBrowser);
-        $dataLoader = $this->getDataLoader();
-        $data = $dataLoader->getOne();
-        unset($data['title']);
         $this->badPutTest($data, $data['id'], $jwt);
     }
 }


### PR DESCRIPTION
This test wasn't doing anything because the `PUT` semantics were wrong. So it failed no matter what data was sent. This caused me to remove two tests that don't meat our current API semantics. When a data field is omitted it is left unchanged instead of being unset. This may be a bug, but it is our current behavior.