### PR TITLE
rm unnecessary abstract methods.

### DIFF
--- a/src/Traits/ManagerRepository.php
+++ b/src/Traits/ManagerRepository.php
@@ -24,12 +24,6 @@ use InvalidArgumentException;
  */
 trait ManagerRepository
 {
-    // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint
-    abstract protected function getEntityName();
-    // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint
-    abstract protected function getEntityManager();
-    // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint,SlevomatCodingStandard.TypeHints.ParameterTypeHint
-    abstract public function find($id);
     abstract protected function hydrateDTOsFromIds(array $ids): array;
 
     public function getClass(): string


### PR DESCRIPTION
the classes that mix in this trait have their interface contract specified by the interfaces that they extend. not by the abstract methods coming from the trait. these abstract methods just sit between the interface and the method implementations, and don't do anything useful.