### PR TITLE
Trim Empty Strings from the Directory

### DIFF
--- a/src/Service/LdapManager.php
+++ b/src/Service/LdapManager.php
@@ -78,6 +78,10 @@ class LdapManager
                 $values = [];
                 foreach ($attributes as $ldapKey => $iliosKey) {
                     $value = $userData->hasAttribute($ldapKey) ? $userData->getAttribute($ldapKey)[0] : null;
+                    if (is_string($value)) {
+                        //trim strings to remove unprintable whitespace
+                        $value = trim($value);
+                    }
                     $values[$iliosKey] = $value;
                 }
                 $rhett[] = $values;


### PR DESCRIPTION
Occasionally directory data will contain unprintable strings that we need to trim away to prevent them from causing issues with display in the frontend.

Fixes #7326