### PR TITLE
Prevent Redirect for LTI Login

### DIFF
--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -53,7 +53,13 @@ class IndexController extends AbstractController
         $response = $this->authentication->createAuthenticationResponse($request);
         if ($response instanceof RedirectResponse) {
             $crawlerDetect = new CrawlerDetect();
-            if (!$crawlerDetect->isCrawler($request->headers->get('User-Agent'))) {
+            if (
+                $crawlerDetect->isCrawler($request->headers->get('User-Agent')) ||
+                $request->getPathInfo() === '/lti-login'
+            ) {
+                // Create a new response, instead of keeping the redirect which we're ignoring
+                $response = new Response();
+            } else {
                 return $response;
             }
         }

--- a/tests/Controller/IndexControllerTest.php
+++ b/tests/Controller/IndexControllerTest.php
@@ -8,10 +8,15 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\CoversClass;
 use App\Controller\IndexController;
 use App\Command\UpdateFrontendCommand;
+use App\Service\AuthenticationInterface;
+use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 #[Group('controller')]
 #[CoversClass(IndexController::class)]
@@ -19,17 +24,22 @@ final class IndexControllerTest extends WebTestCase
 {
     use MockeryPHPUnitIntegration;
 
+    private const string BROWSER_USER_AGENT = 'Chrome';
+    private const string CRAWLER_USER_AGENT = 'NetpeakCheckerBot';
+    private const string JSON = '{"meta":[],"link":[],"script":[],"style":[],"noScript":[],"div":[]}';
+
     protected string $jsonPath;
     protected Filesystem $fileSystem;
     protected KernelBrowser $kernelBrowser;
+    protected ContainerInterface $container;
     protected array $testFiles = [];
 
     public function setUp(): void
     {
         parent::setUp();
         $this->kernelBrowser = static::createClient();
-        $container = $this->kernelBrowser->getContainer();
-        $projectDir = $container->getParameter('kernel.project_dir');
+        $this->container = $this->kernelBrowser->getContainer();
+        $projectDir = $this->container->getParameter('kernel.project_dir');
         $this->jsonPath = UpdateFrontendCommand::getActiveFrontendIndexPath($projectDir);
         $this->fileSystem = new Filesystem();
         $this->testFiles = [];
@@ -42,6 +52,7 @@ final class IndexControllerTest extends WebTestCase
     {
         parent::tearDown();
         unset($this->kernelBrowser);
+        unset($this->container);
         foreach ($this->testFiles as $path) {
             $this->fileSystem->remove($path);
         }
@@ -51,15 +62,7 @@ final class IndexControllerTest extends WebTestCase
 
     public function testIndex(): void
     {
-        $json = json_encode([
-            'meta' => [],
-            'link' => [],
-            'script' => [],
-            'style' => [],
-            'noScript' => [],
-            'div' => [],
-        ]);
-        $this->setupTestFile($this->jsonPath, $json, false);
+        $this->setupTestFile($this->jsonPath, self::JSON, false);
         $this->kernelBrowser->request('GET', '/');
         $response = $this->kernelBrowser->getResponse();
 
@@ -82,22 +85,8 @@ final class IndexControllerTest extends WebTestCase
 
     public function testGzippedWhenRequested(): void
     {
-        $json = json_encode([
-            'meta' => [],
-            'link' => [],
-            'script' => [],
-            'style' => [],
-            'noScript' => [],
-            'div' => [],
-        ]);
-        $this->setupTestFile($this->jsonPath, $json, false);
-        $this->kernelBrowser->request(
-            'GET',
-            '/',
-            [],
-            [],
-            ['HTTP_ACCEPT_ENCODING' => 'deflate, gzip, br']
-        );
+        $this->setupTestFile($this->jsonPath, self::JSON, false);
+        $this->makeRequest('/', ['HTTP_ACCEPT_ENCODING' => 'deflate, gzip, br']);
         $response = $this->kernelBrowser->getResponse();
 
 
@@ -117,23 +106,9 @@ final class IndexControllerTest extends WebTestCase
 
     public function testIndexFromCacheIsTheSameInGzippedAndUnCompressed(): void
     {
-        $json = json_encode([
-            'meta' => [],
-            'link' => [],
-            'script' => [],
-            'style' => [],
-            'noScript' => [],
-            'div' => [],
-        ]);
-        $this->setupTestFile($this->jsonPath, $json, false);
+        $this->setupTestFile($this->jsonPath, self::JSON, false);
+        $this->makeRequest('/', ['HTTP_ACCEPT_ENCODING' => 'deflate, gzip, br']);
 
-        $this->kernelBrowser->request(
-            'GET',
-            '/',
-            [],
-            [],
-            ['HTTP_ACCEPT_ENCODING' => 'deflate, gzip, br']
-        );
         $response = $this->kernelBrowser->getResponse();
         $gzipEtag = $response->getEtag();
 
@@ -146,25 +121,15 @@ final class IndexControllerTest extends WebTestCase
 
         $this->assertEquals($gzipEtag, $uncompressedEtag);
 
-
-        $this->kernelBrowser->request(
-            'GET',
+        $this->makeRequest(
             '/',
-            [],
-            [],
             ['HTTP_ACCEPT_ENCODING' => 'deflate, gzip, br', 'HTTP_IF_NONE_MATCH' => $uncompressedEtag]
         );
         $response = $this->kernelBrowser->getResponse();
         $this->assertEquals(304, $response->getStatusCode(), 'Wrong Status Code');
         $this->assertEmpty($response->getContent());
+        $this->makeRequest('/', ['HTTP_IF_NONE_MATCH' => $gzipEtag]);
 
-        $this->kernelBrowser->request(
-            'GET',
-            '/',
-            [],
-            [],
-            ['HTTP_IF_NONE_MATCH' => $gzipEtag]
-        );
         $response = $this->kernelBrowser->getResponse();
         $this->assertEquals(304, $response->getStatusCode(), 'Wrong Status Code');
         $this->assertEmpty($response->getContent());
@@ -172,17 +137,9 @@ final class IndexControllerTest extends WebTestCase
 
     public function testErrorCaptureConfiguration(): void
     {
-        $json = json_encode([
-            'meta' => [],
-            'link' => [],
-            'script' => [],
-            'style' => [],
-            'noScript' => [],
-            'div' => [],
-        ]);
         $orig = $_ENV['ILIOS_ERROR_CAPTURE_ENABLED'];
         $_ENV['ILIOS_ERROR_CAPTURE_ENABLED'] = true;
-        $this->setupTestFile($this->jsonPath, $json, false);
+        $this->setupTestFile($this->jsonPath, self::JSON, false);
         $this->kernelBrowser->request('GET', '/');
         $response = $this->kernelBrowser->getResponse();
 
@@ -193,6 +150,56 @@ final class IndexControllerTest extends WebTestCase
         $_ENV['ILIOS_ERROR_CAPTURE_ENABLED'] = $orig;
     }
 
+    public function testRedirectForBrowsers(): void
+    {
+        $this->setupTestFile($this->jsonPath, self::JSON, false);
+        $this->mockAuthenticationResponse(new RedirectResponse('/auth/login'));
+        $this->makeRequest('/', ['HTTP_USER_AGENT' => self::BROWSER_USER_AGENT]);
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+        $this->assertEquals('/auth/login', $response->headers->get('Location'));
+        $this->assertStringNotContainsString('<title>Ilios</title>', $response->getContent());
+    }
+
+    public function testProvideIndexForCrawlers(): void
+    {
+        $this->setupTestFile($this->jsonPath, self::JSON, false);
+        $this->mockAuthenticationResponse(new RedirectResponse('/auth/login'));
+        $this->makeRequest('/', ['HTTP_USER_AGENT' => self::CRAWLER_USER_AGENT]);
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertNull($response->headers->get('Location'));
+        $this->assertStringContainsString('<title>Ilios</title>', $response->getContent());
+    }
+
+    public function testProvideIndexForLtiAuth(): void
+    {
+        $this->setupTestFile($this->jsonPath, self::JSON, false);
+        $this->mockAuthenticationResponse(new RedirectResponse('/auth/login'));
+        $this->makeRequest('/lti-login', ['HTTP_USER_AGENT' => self::BROWSER_USER_AGENT]);
+
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertNull($response->headers->get('Location'));
+        $this->assertStringContainsString('<title>Ilios</title>', $response->getContent());
+    }
+
+    public function testProvideIndexForNonRedirectResponse(): void
+    {
+        $this->setupTestFile($this->jsonPath, self::JSON, false);
+        $this->mockAuthenticationResponse(new Response());
+        $this->makeRequest('/', ['HTTP_USER_AGENT' => self::BROWSER_USER_AGENT]);
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertStringContainsString('<title>Ilios</title>', $response->getContent());
+    }
+
     protected function setupTestFile(string $path, string $contents, bool $compressContents): void
     {
         $this->testFiles[] = $path;
@@ -200,5 +207,23 @@ final class IndexControllerTest extends WebTestCase
             $contents = gzencode($contents);
         }
         $this->fileSystem->dumpFile($path, $contents);
+    }
+
+    protected function makeRequest(string $url, array $headers): void
+    {
+        $this->kernelBrowser->request(
+            'GET',
+            $url,
+            [],
+            [],
+            $headers,
+        );
+    }
+
+    protected function mockAuthenticationResponse(Response $authenticationResponse): void
+    {
+        $authentication = m::mock(AuthenticationInterface::class);
+        $authentication->shouldReceive('createAuthenticationResponse')->andReturn($authenticationResponse);
+        $this->container->set(AuthenticationInterface::class, $authentication);
     }
 }


### PR DESCRIPTION
We need to load the frontend and not redirect to SSO when visiting this route. I discovered while testing that we were loading the HTML for the index, but still returning the 302 redirect. This prevented the original crawler code form doing anything useful. Both fixed here by creating a new response instead.