### PR TITLE
Provide Storage for User Preferences

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,7 +7,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
-  ilios_api_version: v3.15
+  ilios_api_version: v3.16
   env(TRUSTED_PROXIES):
   env(ILIOS_REDIS_URL):
   env(ILIOS_CACHE_DECRYPTION_KEY):

--- a/migrations/Version20260819000000.php
+++ b/migrations/Version20260819000000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilios\Migrations;
+
+use App\Classes\MysqlMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add User Preferences Table
+ */
+final class Version20260819000000 extends MysqlMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add User Preferences Table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE user_preference (json JSON NOT NULL, user_id INT NOT NULL, PRIMARY KEY (user_id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('ALTER TABLE user_preference ADD CONSTRAINT FK_FA0E76BFA76ED395 FOREIGN KEY (user_id) REFERENCES user (user_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user_preference DROP FOREIGN KEY FK_FA0E76BFA76ED395');
+        $this->addSql('DROP TABLE user_preference');
+    }
+}

--- a/src/Controller/PreferencesController.php
+++ b/src/Controller/PreferencesController.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Classes\SessionUserInterface;
+use App\Entity\UserPreference;
+use App\Repository\UserPreferenceRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+use function json_decode;
+
+class PreferencesController extends AbstractController
+{
+    #[Route(
+        '/application/preferences',
+        methods: ['GET'],
+    )]
+    public function getPreferences(
+        TokenStorageInterface $tokenStorage,
+        UserPreferenceRepository $userPreferenceRepository,
+    ): JsonResponse {
+        $token = $tokenStorage->getToken();
+        $sessionUser = $token?->getUser();
+        if (!$sessionUser instanceof SessionUserInterface) {
+            throw $this->createAccessDeniedException('Unauthorized access.');
+        }
+        $json = $userPreferenceRepository->getJsonForUser($sessionUser->getId());
+
+        if ($json === null) {
+            throw $this->createNotFoundException();
+        }
+        return new JsonResponse(json_decode($json, false, 4));
+    }
+
+    #[Route(
+        '/application/preferences',
+        methods: ['PUT'],
+    )]
+    public function putPreferences(
+        Request $request,
+        TokenStorageInterface $tokenStorage,
+        UserPreferenceRepository $userPreferenceRepository,
+        UserRepository $userRepository,
+        EntityManagerInterface $em,
+    ): JsonResponse {
+        $token = $tokenStorage->getToken();
+        $sessionUser = $token?->getUser();
+        if (!$sessionUser instanceof SessionUserInterface) {
+            throw $this->createAccessDeniedException('Unauthorized access.');
+        }
+        $preferences = $userPreferenceRepository->find($sessionUser->getId());
+
+        if (!$preferences) {
+            $user = $userRepository->findOneById($sessionUser->getId());
+            $preferences = new UserPreference();
+            $preferences->setUser($user);
+        }
+        $json = $request->getContent();
+        $preferences->setJson($json);
+        $em->persist($preferences);
+        $em->flush();
+
+        return new JsonResponse(json_decode($preferences->getJson(), false, 4));
+    }
+}

--- a/src/Entity/UserPreference.php
+++ b/src/Entity/UserPreference.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\UserPreferenceRepository;
+use Doctrine\ORM\Mapping as ORM;
+use App\Traits\StringableIdEntity;
+use App\Attributes as IA;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Table(name: 'user_preference')]
+#[ORM\Entity(repositoryClass: UserPreferenceRepository::class)]
+#[IA\Entity]
+class UserPreference implements UserPreferenceInterface
+{
+    use StringableIdEntity;
+
+    #[ORM\Column(type: 'json_object', nullable: false)]
+    #[IA\Expose]
+    #[IA\Type('string')]
+    #[Assert\Json]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 1, max: 65000)]
+    protected string $json;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'user_id')]
+    #[ORM\Id]
+    #[IA\Expose]
+    #[IA\Type('entity')]
+    #[Assert\NotNull]
+    protected UserInterface $user;
+
+    public function setUser(UserInterface $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
+
+    public function setJson(string $json): void
+    {
+        $this->json = $json;
+    }
+
+    public function getJson(): string
+    {
+        return $this->json;
+    }
+}

--- a/src/Entity/UserPreferenceInterface.php
+++ b/src/Entity/UserPreferenceInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Stringable;
+
+interface UserPreferenceInterface extends
+    Stringable
+{
+    public function setUser(UserInterface $user): void;
+
+    public function getUser(): UserInterface;
+
+    public function setJson(string $json): void;
+
+    public function getJson(): string;
+}

--- a/src/Repository/UserPreferenceRepository.php
+++ b/src/Repository/UserPreferenceRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\UserPreference;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class UserPreferenceRepository extends ServiceEntityRepository
+{
+    public function __construct(
+        ManagerRegistry $registry,
+    ) {
+        parent::__construct($registry, UserPreference::class);
+    }
+
+    public function getJsonForUser(int $id): ?string
+    {
+        $qb = $this->createQueryBuilder('x')
+            ->select('x.json')
+            ->where('IDENTITY(x.user) = :id')
+            ->setParameter('id', $id);
+
+        $result = $qb->getQuery()->getOneOrNullResult();
+        return $result['json'] ?? null;
+    }
+}

--- a/tests/Controller/PreferencesControllerTest.php
+++ b/tests/Controller/PreferencesControllerTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\CoversClass;
+use App\Controller\PreferencesController;
+use App\Tests\Fixture\LoadServiceTokenData;
+use App\Tests\Fixture\LoadUserData;
+use App\Tests\Fixture\LoadUserPreferenceData;
+use App\Tests\Traits\TestableJsonController;
+use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Group('controller')]
+#[CoversClass(PreferencesController::class)]
+final class PreferencesControllerTest extends WebTestCase
+{
+    use TestableJsonController;
+
+    protected KernelBrowser $kernelBrowser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->kernelBrowser = self::createClient();
+        $databaseTool = $this->kernelBrowser->getContainer()->get(DatabaseToolCollection::class)->get();
+        $databaseTool->loadFixtures([
+            LoadUserData::class,
+            LoadUserPreferenceData::class,
+            LoadServiceTokenData::class,
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->kernelBrowser);
+    }
+
+    public function testGetPreferences(): void
+    {
+        $jwt = $this->createJwtFromUserId($this->kernelBrowser, 1);
+        $this->makeJsonRequest($this->kernelBrowser, 'GET', '/application/preferences', null, $jwt);
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+        $this->assertSame(
+            ['theme' => 'dark', 'locale' => 'en'],
+            json_decode($response->getContent(), true)
+        );
+    }
+
+    public function testGetPreferencesReturnsNotFoundWhenNoneExist(): void
+    {
+        $jwt = $this->createJwtFromUserId($this->kernelBrowser, 2);
+        $this->makeJsonRequest($this->kernelBrowser, 'GET', '/application/preferences', null, $jwt);
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_NOT_FOUND, false);
+    }
+
+    public function testGetPreferencesRequiresAuthentication(): void
+    {
+        $this->makeJsonRequest($this->kernelBrowser, 'GET', '/application/preferences', null, null);
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+    }
+
+    public function testGetPreferencesWithServiceTokenIsForbidden(): void
+    {
+        $jwt = $this->createJwtForEnabledServiceToken($this->kernelBrowser);
+        $this->makeJsonRequest($this->kernelBrowser, 'GET', '/application/preferences', null, $jwt);
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function testPutPreferencesUpdatesExisting(): void
+    {
+        $jwt = $this->createJwtFromUserId($this->kernelBrowser, 1);
+        $this->makeJsonRequest(
+            $this->kernelBrowser,
+            'PUT',
+            '/application/preferences',
+            '{"theme":"light","locale":"fr"}',
+            $jwt
+        );
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+        $this->assertSame(
+            ['theme' => 'light', 'locale' => 'fr'],
+            json_decode($response->getContent(), true)
+        );
+
+        $this->makeJsonRequest($this->kernelBrowser, 'GET', '/application/preferences', null, $jwt);
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+        $this->assertSame(
+            ['theme' => 'light', 'locale' => 'fr'],
+            json_decode($response->getContent(), true)
+        );
+    }
+
+    public function testPutPreferencesCreatesWhenNoneExist(): void
+    {
+        $jwt = $this->createJwtFromUserId($this->kernelBrowser, 2);
+        $this->makeJsonRequest(
+            $this->kernelBrowser,
+            'PUT',
+            '/application/preferences',
+            '{"theme":"dark"}',
+            $jwt
+        );
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+        $this->assertSame(['theme' => 'dark'], json_decode($response->getContent(), true));
+
+        $this->makeJsonRequest($this->kernelBrowser, 'GET', '/application/preferences', null, $jwt);
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertJsonResponse($response, Response::HTTP_OK);
+        $this->assertSame(
+            ['theme' => 'dark'],
+            json_decode($response->getContent(), true)
+        );
+    }
+
+    public function testPutPreferencesRequiresAuthentication(): void
+    {
+        $this->makeJsonRequest(
+            $this->kernelBrowser,
+            'PUT',
+            '/application/preferences',
+            '{"theme":"light"}',
+            null
+        );
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+    }
+
+    public function testPutPreferencesWithServiceTokenIsForbidden(): void
+    {
+        $jwt = $this->createJwtForEnabledServiceToken($this->kernelBrowser);
+        $this->makeJsonRequest(
+            $this->kernelBrowser,
+            'PUT',
+            '/application/preferences',
+            '{"theme":"light"}',
+            $jwt
+        );
+        $response = $this->kernelBrowser->getResponse();
+
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+}

--- a/tests/DataLoader/UserPreferenceData.php
+++ b/tests/DataLoader/UserPreferenceData.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\DataLoader;
+
+use Exception;
+
+final class UserPreferenceData extends AbstractDataLoader
+{
+    protected function getData(): array
+    {
+        $arr = [];
+        $arr[] = [
+            'user' => 1,
+            'json' => '{"theme":"dark","locale":"en"}',
+        ];
+        return $arr;
+    }
+
+    public function create(): array
+    {
+        throw new Exception('not implemented');
+    }
+
+    public function createInvalid(): array
+    {
+        throw new Exception('not implemented');
+    }
+
+    public function getDtoClass(): string
+    {
+        throw new Exception('not implemented');
+    }
+}

--- a/tests/Entity/UserPreferenceTest.php
+++ b/tests/Entity/UserPreferenceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use App\Entity\UserInterface;
+use App\Entity\UserPreference;
+use Mockery as m;
+
+#[Group('model')]
+#[CoversClass(UserPreference::class)]
+final class UserPreferenceTest extends EntityBase
+{
+    protected UserPreference $object;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->object = new UserPreference();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->object);
+    }
+
+    public function testNotNullValidation(): void
+    {
+        $notNull = [
+            'user',
+            'json',
+        ];
+        $this->validateNotNulls($notNull);
+
+        $this->object->setUser(m::mock(UserInterface::class));
+        $this->object->setJson('{"key":"value"}');
+
+        $this->validate(0);
+    }
+
+    #[DataProvider('invalidJsonProvider')]
+    public function testInvalidJsonFailsValidation(string $json): void
+    {
+        $this->object->setUser(m::mock(UserInterface::class));
+        $this->object->setJson($json);
+
+        $errors = $this->validate(1);
+        $this->assertArrayHasKey('json', $errors);
+        $this->assertSame('This value should be valid JSON.', $errors['json']);
+    }
+
+    public static function invalidJsonProvider(): array
+    {
+        return [
+            'plain text' => ['not json'],
+            'unquoted key' => ['{key: "value"}'],
+            'missing closing brace' => ['{"key": "value"'],
+            'lone open brace' => ['{'],
+            'trailing comma' => ['[1, 2,]'],
+        ];
+    }
+
+    #[DataProvider('validJsonProvider')]
+    public function testValidJsonPassesValidation(string $json): void
+    {
+        $this->object->setUser(m::mock(UserInterface::class));
+        $this->object->setJson($json);
+
+        $this->validate(0);
+    }
+
+    public static function validJsonProvider(): array
+    {
+        return [
+            'object' => ['{"key":"value"}'],
+            'empty object' => ['{}'],
+            'array' => ['["a","b"]'],
+            'empty array' => ['[]'],
+            'number' => ['123'],
+            'null literal' => ['null'],
+        ];
+    }
+
+    public function testSetJson(): void
+    {
+        $this->basicSetTest('json', 'string');
+    }
+
+    public function testSetUser(): void
+    {
+        $this->entitySetTest('user', 'User');
+    }
+
+    public function getObject(): UserPreference
+    {
+        return $this->object;
+    }
+}

--- a/tests/Fixture/LoadUserPreferenceData.php
+++ b/tests/Fixture/LoadUserPreferenceData.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Fixture;
+
+use App\Entity\User;
+use App\Entity\UserPreference;
+use App\Tests\DataLoader\UserPreferenceData;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class LoadUserPreferenceData extends AbstractFixture implements ORMFixtureInterface, DependentFixtureInterface
+{
+    public function __construct(protected UserPreferenceData $data)
+    {
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $data = $this->data->getAll();
+        foreach ($data as $arr) {
+            $entity = new UserPreference();
+            $entity->setUser($this->getReference('users' . $arr['user'], User::class));
+            $entity->setJson($arr['json']);
+            $manager->persist($entity);
+            $manager->flush();
+        }
+    }
+
+    public function getDependencies(): array
+    {
+        return [
+            LoadUserData::class,
+        ];
+    }
+}

--- a/tests/Repository/UserPreferenceRepositoryTest.php
+++ b/tests/Repository/UserPreferenceRepositoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\UserPreference;
+use App\Repository\UserPreferenceRepository;
+use App\Tests\Fixture\LoadUserPreferenceData;
+use Doctrine\Common\DataFixtures\ReferenceRepository;
+use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class UserPreferenceRepositoryTest extends KernelTestCase
+{
+    protected ReferenceRepository $fixtures;
+    protected UserPreferenceRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $databaseTool = self::$kernel->getContainer()->get(DatabaseToolCollection::class)->get();
+        $executor = $databaseTool->loadFixtures([
+            LoadUserPreferenceData::class,
+        ]);
+        $this->fixtures = $executor->getReferenceRepository();
+
+        $entityManager = self::$kernel->getContainer()->get('doctrine')->getManager();
+        /** @var UserPreferenceRepository $repository */
+        $repository = $entityManager->getRepository(UserPreference::class);
+        $this->repository = $repository;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->fixtures);
+        unset($this->repository);
+    }
+
+    public function testGetJsonForUserReturnsJsonWhenPreferenceExists(): void
+    {
+        $this->assertSame('{"theme":"dark","locale":"en"}', $this->repository->getJsonForUser(1));
+    }
+
+    public function testGetJsonForUserReturnsNullWhenNoPreferenceExists(): void
+    {
+        $this->assertNull($this->repository->getJsonForUser(2));
+    }
+
+    public function testGetJsonForUserReturnsNullForUnknownUser(): void
+    {
+        $this->assertNull($this->repository->getJsonForUser(999999));
+    }
+}


### PR DESCRIPTION
Fairly simple API endpoint /application/preferences to store and access preferences in JSON format. When no preferences exist it returns a 404. The structure of the preferences and managing creation and updating is all handled on the frontend.

Requires ilios/frontend#9475