### PR TITLE
Make Dependabot Weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: composer
     directory: "/"
     schedule:
-      interval: daily
-      time: "02:30"
+      interval: weekly
+      day: "tuesday"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 10
     ignore:
@@ -17,8 +17,8 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
-      time: "02:30"
+      interval: weekly
+      day: "tuesday"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 10
     groups:


### PR DESCRIPTION
This matches what we have in the frontend to give us a little bit less noise as we'll catch most of our updates in the lock file update on Monday.